### PR TITLE
Land Shipyard Phases 1-4: dispatch, preflight, cloud CLI, progress

### DIFF
--- a/agents/ci.md
+++ b/agents/ci.md
@@ -1,6 +1,6 @@
 ---
 name: ci
-description: Validates code on all platforms and merges on green. Manages queue and profiles.
+description: Validates code on all platforms and merges on green. Manages queue and cloud dispatch.
 model: sonnet
 color: green
 tools:
@@ -32,7 +32,7 @@ If asked to merge to develop (not main):
 
 - Queue and active runs: `shipyard status --json`
 - What passed: `shipyard evidence --json`
-- Where things run: `shipyard targets --json`
+- Cloud routing defaults: `shipyard cloud defaults --json`
 - All jobs: `shipyard queue --json`
 
 ## Manage queue
@@ -40,13 +40,20 @@ If asked to merge to develop (not main):
 - Bump priority: `shipyard bump <job_id> high`
 - Cancel: `shipyard cancel <job_id>`
 
-## Switch profiles
+## Adjust configuration
 
-When asked to "go local", "switch to cloud", or change setup:
-- `shipyard config use local` — Mac only
-- `shipyard config use normal` — Mac + cloud
-- `shipyard config use full` — Mac + VMs + cloud fallback
-- Check current: `shipyard config profiles`
+There is no `shipyard config` subcommand yet.
+
+When asked to change setup, inspect and edit:
+
+- `.shipyard/config.toml` for shared project targets and validation settings
+- `.shipyard.local/config.toml` for machine-local hosts, paths, and overrides
+
+After a config change, verify with:
+
+- `shipyard doctor --json`
+- `shipyard cloud defaults --json` if cloud dispatch is involved
+- `shipyard status --json` after the next run starts
 
 ## Rules
 

--- a/commands/cloud.md
+++ b/commands/cloud.md
@@ -1,0 +1,24 @@
+---
+name: cloud
+description: Dispatch and inspect GitHub Actions workflows from Shipyard
+---
+
+Use Shipyard's cloud subcommands to discover workflows, inspect dispatch defaults,
+trigger workflow_dispatch runs, and inspect tracked cloud runs.
+
+```bash
+shipyard cloud workflows --json
+shipyard cloud defaults --json
+shipyard cloud run build --json
+shipyard cloud status --json
+```
+
+When dispatching a workflow:
+- Prefer the configured default workflow when the user does not specify one.
+- Pass `--provider <name>` when the user wants to override the default runner provider.
+- Pass `--wait` when the user wants the command to block until the GitHub run completes.
+
+When summarizing JSON output, report:
+- Workflow key/file/name
+- Resolved provider and dispatch fields
+- Tracked run ID, status, conclusion, and URL when available

--- a/commands/config.md
+++ b/commands/config.md
@@ -1,29 +1,30 @@
 ---
 name: config
-description: Show or switch Shipyard configuration and profiles
+description: Inspect Shipyard configuration files and effective cloud defaults
 ---
 
-Manage Shipyard configuration. Supports several subcommands:
+Shipyard does not have a `shipyard config` subcommand yet.
 
-**Show effective config:**
+Use these entry points instead:
+
+- Project config: `.shipyard/config.toml`
+- Machine-local overrides: `.shipyard.local/config.toml`
+- Environment and tool health: `shipyard doctor --json`
+- Effective cloud workflow/provider resolution: `shipyard cloud defaults --json`
+- Active job and target state: `shipyard status --json`
+
+If the user asks to "switch profiles", "go local", or "go cloud", explain that
+profile switching is not implemented in the CLI yet and make the required config
+file changes explicitly instead of invoking a nonexistent command.
+
+Examples:
+
+**Inspect cloud defaults:**
 ```bash
-shipyard config show
+shipyard cloud defaults --json
 ```
 
-**Switch profile:**
+**Inspect current job and target state:**
 ```bash
-shipyard config use <profile_name>
+shipyard status --json
 ```
-Common profiles: `local` (Mac only), `normal` (Mac + cloud), `full` (Mac + VMs + cloud fallback).
-
-**List available profiles:**
-```bash
-shipyard config profiles
-```
-
-**Set a config value:**
-```bash
-shipyard config set <key>=<value>
-```
-
-When the user asks "switch to local" or "go cloud" or "what profile am I on", use the appropriate subcommand. Always report the current profile and active targets after switching.

--- a/commands/run.md
+++ b/commands/run.md
@@ -19,8 +19,14 @@ For smoke (fast) validation:
 shipyard run --smoke --json
 ```
 
+If a repo intentionally needs to bypass preflight:
+```bash
+shipyard run --allow-root-mismatch --allow-unreachable-targets --json
+```
+
 Parse the JSON output. Report:
 - Job ID and branch/SHA being validated
+- Preflight warnings when present
 - Per-target status (pass/fail/error) with duration
 - Overall result (all green or which targets failed)
 

--- a/commands/ship.md
+++ b/commands/ship.md
@@ -9,8 +9,14 @@ Run the full ship flow: push to remote, create or find a PR, validate on all req
 shipyard ship --json
 ```
 
+If the repo needs to override preflight for a one-off run:
+```bash
+shipyard ship --allow-root-mismatch --allow-unreachable-targets --json
+```
+
 Parse the JSON output. Report:
 - PR number and URL
+- Preflight warnings when present
 - Validation status per platform (passing, missing, failing)
 - Whether the merge happened or what is still needed
 

--- a/commands/status.md
+++ b/commands/status.md
@@ -12,6 +12,7 @@ shipyard status --json
 Parse the JSON output. Report:
 - Queue state: pending jobs, running jobs, recent completions
 - Active run details if one is in progress
+- Active target phase/liveness details when present
 - Target health: which targets are configured and reachable
 
 Keep the summary concise. Highlight any issues (unreachable targets, failed recent runs).

--- a/commands/targets.md
+++ b/commands/targets.md
@@ -1,12 +1,20 @@
 ---
 name: targets
-description: Show configured targets, their backends, and reachability
+description: Inspect configured targets and live target status
 ---
 
-Show all Shipyard targets with their current status.
+Shipyard does not have a dedicated `shipyard targets` subcommand yet.
 
-```bash
-shipyard --json targets
-```
+Use these instead:
 
-This shows which targets are configured, what backend each uses (local, ssh, cloud), whether they're reachable, and what fallback chain is configured. Report the active profile if profiles are configured.
+- `shipyard status --json` for queue state, live target phase/liveness, and
+  fallback information during active jobs.
+- `.shipyard/config.toml` and `.shipyard.local/config.toml` for the configured
+  targets, backends, hosts, and fallback chains.
+- `shipyard doctor --json` to confirm the local toolchain before running jobs.
+
+When reporting target state, distinguish between:
+
+- The configured backend in the target definition.
+- The selected backend after preflight or failover, which may differ if a
+  fallback backend is used.

--- a/skills/ci/SKILL.md
+++ b/skills/ci/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ci
-description: Cross-platform CI coordination with Shipyard — validates, ships, manages queue, switches profiles
+description: Cross-platform CI coordination with Shipyard — validates, ships, manages queue, and runs cloud workflows
 ---
 
 # CI Operations with Shipyard
@@ -18,15 +18,15 @@ Shipyard coordinates validation across local, SSH, and cloud targets.
 | Ship to develop instead of main | `shipyard ship --base develop --json` |
 | Show queue and status | `shipyard status --json` |
 | Show all queued jobs | `shipyard queue --json` |
-| Show targets and reachability | `shipyard targets --json` |
 | Show run logs | `shipyard logs <job_id> --json` |
 | Show logs for one target | `shipyard logs <job_id> --target windows` |
 | Check merge readiness | `shipyard evidence --json` |
 | Bump job priority | `shipyard bump <job_id> high` |
 | Cancel a job | `shipyard cancel <job_id>` |
-| Switch profile | `shipyard config use <profile>` |
-| List profiles | `shipyard config profiles` |
-| Show config | `shipyard config show` |
+| List cloud workflows | `shipyard cloud workflows --json` |
+| Show cloud defaults | `shipyard cloud defaults --json` |
+| Dispatch a cloud workflow | `shipyard cloud run build --json` |
+| Inspect tracked cloud runs | `shipyard cloud status --json` |
 | Environment check | `shipyard doctor --json` |
 | Clean up artifacts | `shipyard cleanup --apply` |
 
@@ -40,17 +40,6 @@ Shipyard coordinates validation across local, SSH, and cloud targets.
 
 Shipyard refuses to merge unless every required platform has passing evidence
 for the exact HEAD SHA.
-
-## Profiles
-
-Profiles control which targets are active. Switch without editing config:
-
-- `shipyard config use local` — Mac only, no VMs or cloud
-- `shipyard config use normal` — Mac + cloud (Namespace)
-- `shipyard config use full` — Mac + VMs + cloud fallback
-
-Check which profile is active: `shipyard config profiles`
-See where things will run: `shipyard targets --json`
 
 ## Queue management
 
@@ -77,14 +66,19 @@ platform = "linux-x64"
 
 # Optional fallback chain
 fallback = [
-    { type = "vm", vm_name = "Ubuntu 24.04" },
-    { type = "cloud", provider = "namespace" },
+    { type = "cloud", provider = "namespace", repository = "owner/repo", workflow = "build" },
 ]
 ```
+
+There is no `shipyard config` or `shipyard targets` subcommand yet. Inspect
+target definitions in `.shipyard/config.toml` and `.shipyard.local/config.toml`,
+and use `shipyard status --json` for live target state.
 
 ## Troubleshooting
 
 - `shipyard doctor --json` — checks git, ssh, gh, nsc are installed
-- `shipyard targets --json` — shows which targets are reachable
+- `shipyard status --json` — shows configured targets, queue state, and live target status
 - `shipyard logs <id> --target <name>` — full log for a failed target
 - If a target is unreachable with no fallback, it reports unreachable
+- `shipyard run --allow-unreachable-targets --json` — override preflight if you intentionally want to queue anyway
+- `shipyard cloud defaults --json` — inspect the current cloud workflow/provider dispatch plan

--- a/src/shipyard/cli.py
+++ b/src/shipyard/cli.py
@@ -8,17 +8,21 @@ from __future__ import annotations
 
 import subprocess
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
 import click
 
 from shipyard import __version__
+from shipyard.cloud.github import find_dispatched_run, run_view, workflow_dispatch
+from shipyard.cloud.records import CloudRecordStore, CloudRunRecord
+from shipyard.cloud.registry import default_workflow_key, discover_workflows, resolve_cloud_dispatch_plan
 from shipyard.core.config import Config
 from shipyard.core.evidence import EvidenceStore
 from shipyard.core.job import Job, JobStatus, TargetResult, TargetStatus, ValidationMode
 from shipyard.core.queue import Queue
-from shipyard.executor.local import LocalExecutor
+from shipyard.executor.dispatch import ExecutorDispatcher
 from shipyard.output.human import (
     console,
     render_doctor,
@@ -30,6 +34,7 @@ from shipyard.output.human import (
 )
 from shipyard.output.json_output import render_json
 from shipyard.output.schema import OutputEnvelope
+from shipyard.preflight import run_submission_preflight
 
 
 class Context:
@@ -40,6 +45,7 @@ class Context:
         self._config: Config | None = None
         self._queue: Queue | None = None
         self._evidence: EvidenceStore | None = None
+        self._cloud_records: CloudRecordStore | None = None
 
     @property
     def config(self) -> Config:
@@ -66,6 +72,12 @@ class Context:
             render_json(OutputEnvelope(command=command, data=data))
         # Human output is handled by the calling command directly
 
+    @property
+    def cloud_records(self) -> CloudRecordStore:
+        if self._cloud_records is None:
+            self._cloud_records = CloudRecordStore(self.config.state_dir / "cloud")
+        return self._cloud_records
+
 
 pass_context = click.make_pass_decorator(Context, ensure=True)
 
@@ -90,8 +102,26 @@ def main(ctx: click.Context, json_mode: bool) -> None:
     "--resume-from", type=click.Choice(["configure", "build", "test"]),
     help="Resume from a stage (skip earlier stages that already passed)",
 )
+@click.option(
+    "--allow-root-mismatch",
+    is_flag=True,
+    help="Queue the run even if the git root does not match the Shipyard root",
+)
+@click.option(
+    "--allow-unreachable-targets",
+    is_flag=True,
+    help="Queue the run even if no backend is reachable for one or more targets",
+)
 @click.pass_obj
-def run(ctx: Context, targets: str | None, smoke: bool, fail_fast: bool, resume_from: str | None) -> None:
+def run(
+    ctx: Context,
+    targets: str | None,
+    smoke: bool,
+    fail_fast: bool,
+    resume_from: str | None,
+    allow_root_mismatch: bool,
+    allow_unreachable_targets: bool,
+) -> None:
     """Validate current HEAD on configured targets."""
     config = ctx.config
     mode = ValidationMode.SMOKE if smoke else ValidationMode.FULL
@@ -109,6 +139,19 @@ def run(ctx: Context, targets: str | None, smoke: bool, fail_fast: bool, resume_
         render_error("No targets configured. Run 'shipyard init' first.")
         sys.exit(1)
 
+    dispatcher = _make_dispatcher(config)
+    try:
+        preflight = run_submission_preflight(
+            config,
+            target_names=target_names,
+            dispatcher=dispatcher,
+            allow_root_mismatch=allow_root_mismatch,
+            allow_unreachable_targets=allow_unreachable_targets,
+        )
+    except ValueError as exc:
+        render_error(str(exc))
+        sys.exit(1)
+
     # Create and enqueue job
     job = Job.create(
         sha=sha,
@@ -120,76 +163,21 @@ def run(ctx: Context, targets: str | None, smoke: bool, fail_fast: bool, resume_
 
     if not ctx.json_mode:
         render_message(f"Queued {job.id} — {branch} @ {sha[:8]}")
+        for warning in preflight.warnings:
+            render_message(f"warning: {warning}", style="bold yellow")
 
-    # Execute (for now, just local — SSH/cloud come later)
-    job = job.start()
-    ctx.queue.update(job)
-
-    executor = LocalExecutor()
-    validation_config = _resolve_validation(config, mode)
-    had_failure = False
-
-    for name in job.target_names:
-        # Fail-fast: skip remaining targets after a failure
-        if had_failure and fail_fast:
-            job = job.with_result(TargetResult(
-                target_name=name,
-                platform=config.targets.get(name, {}).get("platform", "unknown"),
-                status=TargetStatus.CANCELLED,
-                backend="skipped",
-                error_message="Skipped (earlier target failed, --fail-fast)",
-            ))
-            ctx.queue.update(job)
-            continue
-
-        target_config = config.targets.get(name, {})
-        target_config["name"] = name
-
-        log_path = str(config.state_dir / "logs" / job.id / f"{name}.log")
-
-        result = executor.validate(
-            sha=sha,
-            branch=branch,
-            target_config=target_config,
-            validation_config=_resolve_target_validation(config, name, validation_config),
-            log_path=log_path,
-            resume_from=resume_from,
-        )
-        job = job.with_result(result)
-        ctx.queue.update(job)
-
-        if not result.passed:
-            had_failure = True
-
-        if not ctx.json_mode:
-            render_job(job)
-
-    # Complete the job
-    job = job.complete()
-    ctx.queue.update(job)
-
-    # Record evidence
-    from shipyard.core.evidence import EvidenceRecord
-
-    for name, result in job.results.items():
-        if result.is_terminal:
-            ctx.evidence.record(EvidenceRecord(
-                sha=sha,
-                branch=branch,
-                target_name=name,
-                platform=result.platform,
-                status="pass" if result.passed else "fail",
-                backend=result.backend,
-                completed_at=result.completed_at or job.completed_at,  # type: ignore[arg-type]
-                duration_secs=result.duration_secs,
-                primary_backend=result.primary_backend,
-                failover_reason=result.failover_reason,
-                provider=result.provider,
-                runner_profile=result.runner_profile,
-            ))
+    job = _execute_job(
+        ctx=ctx,
+        job=job,
+        config=config,
+        dispatcher=dispatcher,
+        mode=mode,
+        fail_fast=fail_fast,
+        resume_from=resume_from,
+    )
 
     if ctx.json_mode:
-        ctx.output("run", {"run": job.to_dict()})
+        ctx.output("run", {"run": job.to_dict(), "preflight": preflight.to_dict()})
     else:
         if job.passed:
             render_message("All green.", style="bold green")
@@ -206,13 +194,19 @@ def status(ctx: Context) -> None:
     pending = ctx.queue.pending_count
     recent = ctx.queue.get_recent()
 
-    # Probe targets (basic for now — just report config)
+    dispatcher = _make_dispatcher(ctx.config)
+
     targets_info: dict[str, dict[str, Any]] = {}
     for name, tconfig in ctx.config.targets.items():
+        target_config = dict(tconfig)
+        target_config["name"] = name
+        reachable, selected_backend = _probe_target(target_config, dispatcher)
         targets_info[name] = {
-            "backend": tconfig.get("backend", "?"),
-            "reachable": tconfig.get("backend") == "local",  # placeholder
+            "backend": dispatcher.backend_name(target_config),
+            "reachable": reachable,
         }
+        if selected_backend and selected_backend != targets_info[name]["backend"]:
+            targets_info[name]["fallback"] = selected_backend
 
     if ctx.json_mode:
         data: dict[str, Any] = {
@@ -422,10 +416,262 @@ def init_cmd(ctx: Context, discover_only: bool) -> None:
         render_message(_json.dumps(config.to_dict(), indent=2))
 
 
+@main.group()
+def cloud() -> None:
+    """Dispatch and inspect GitHub Actions workflows."""
+
+
+@cloud.command("workflows")
+@click.pass_obj
+def cloud_workflows(ctx: Context) -> None:
+    workflows = discover_workflows()
+    data = {
+        "workflows": {key: workflow.to_dict() for key, workflow in workflows.items()},
+        "default": default_workflow_key(ctx.config, workflows),
+    }
+    if ctx.json_mode:
+        ctx.output("cloud.workflows", data)
+        return
+
+    if not workflows:
+        render_message("No GitHub workflows discovered.", style="dim")
+        return
+    render_message("Discovered workflows:")
+    for key, workflow in workflows.items():
+        render_message(f"  {key}: {workflow.description}")
+
+
+@cloud.command("defaults")
+@click.pass_obj
+def cloud_defaults(ctx: Context) -> None:
+    workflows = discover_workflows()
+    default_key = default_workflow_key(ctx.config, workflows)
+    provider = ctx.config.get("cloud.provider", "github-hosted")
+    ref = _git_branch() or "main"
+    resolved_plans: dict[str, dict[str, Any]] = {}
+    for key in workflows:
+        try:
+            resolved_plans[key] = resolve_cloud_dispatch_plan(
+                config=ctx.config,
+                workflows=workflows,
+                workflow_key=key,
+                ref=ref,
+            ).to_dict()
+        except ValueError:
+            continue
+    data = {
+        "repository": ctx.config.get("cloud.repository"),
+        "default_workflow": default_key,
+        "default_provider": provider,
+        "workflows": {key: workflow.to_dict() for key, workflow in workflows.items()},
+        "resolved": resolved_plans,
+    }
+    if ctx.json_mode:
+        ctx.output("cloud.defaults", data)
+        return
+
+    render_message(f"repository: {ctx.config.get('cloud.repository') or 'current repo'}")
+    render_message(f"default workflow: {default_key or 'none'}")
+    render_message(f"default provider: {provider}")
+    if workflows:
+        render_message("workflows:")
+        for key, workflow in workflows.items():
+            resolved = resolved_plans.get(key, {})
+            fields = resolved.get("dispatch_fields", {})
+            field_summary = ", ".join(f"{name}={value}" for name, value in fields.items()) or "no dispatch fields"
+            render_message(f"  {key}: {workflow.file} ({field_summary})")
+
+
+@cloud.command("run")
+@click.argument("workflow_key", required=False)
+@click.argument("ref", required=False)
+@click.option("--provider", help="Runner provider override")
+@click.option("--wait/--no-wait", default=False, help="Wait for the dispatched workflow to complete")
+@click.option("--runner-selector", help="Generic runner selector input")
+@click.option("--linux-runner-selector", help="Linux runner selector override")
+@click.option("--windows-runner-selector", help="Windows runner selector override")
+@click.option("--macos-runner-selector", help="macOS runner selector override")
+@click.pass_obj
+def cloud_run(
+    ctx: Context,
+    workflow_key: str | None,
+    ref: str | None,
+    provider: str | None,
+    wait: bool,
+    runner_selector: str | None,
+    linux_runner_selector: str | None,
+    windows_runner_selector: str | None,
+    macos_runner_selector: str | None,
+) -> None:
+    workflows = discover_workflows()
+    workflow_key = workflow_key or default_workflow_key(ctx.config, workflows)
+    if not workflow_key:
+        render_error("No workflows discovered")
+        sys.exit(1)
+
+    resolved_ref = ref or _git_branch()
+    if not resolved_ref:
+        render_error("Not in a git repository")
+        sys.exit(1)
+
+    try:
+        plan = resolve_cloud_dispatch_plan(
+            config=ctx.config,
+            workflows=workflows,
+            workflow_key=workflow_key,
+            ref=resolved_ref,
+            provider_override=provider,
+            runner_selector=runner_selector,
+            linux_runner_selector=linux_runner_selector,
+            windows_runner_selector=windows_runner_selector,
+            macos_runner_selector=macos_runner_selector,
+        )
+    except ValueError as exc:
+        render_error(str(exc))
+        sys.exit(1)
+
+    dispatch_id = ctx.cloud_records.new_dispatch_id()
+    record = CloudRunRecord(
+        dispatch_id=dispatch_id,
+        workflow_key=plan.workflow.key,
+        workflow_file=plan.workflow.file,
+        workflow_name=plan.workflow.name,
+        repository=plan.repository,
+        requested_ref=plan.ref,
+        provider=plan.provider,
+        dispatch_fields=plan.dispatch_fields,
+        status="dispatched",
+        dispatched_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
+    )
+
+    try:
+        workflow_dispatch(
+            repository=plan.repository,
+            workflow_file=plan.workflow.file,
+            ref=plan.ref,
+            fields=plan.dispatch_fields,
+        )
+        discovered = find_dispatched_run(
+            repository=plan.repository,
+            workflow_file=plan.workflow.file,
+            ref=plan.ref,
+        )
+        record = CloudRunRecord(
+            **{
+                **record.__dict__,
+                "status": str(discovered.get("status") or "queued"),
+                "run_id": str(discovered["databaseId"]),
+                "url": discovered.get("url"),
+                "updated_at": datetime.now(timezone.utc),
+            }
+        )
+        if wait and record.run_id:
+            view = _wait_for_cloud_completion(record.repository, record.run_id)
+            record = CloudRunRecord(
+                **{
+                    **record.__dict__,
+                    "status": str(view.get("status") or "unknown"),
+                    "conclusion": view.get("conclusion"),
+                    "url": view.get("url") or record.url,
+                    "started_at": record.started_at or datetime.now(timezone.utc),
+                    "completed_at": datetime.now(timezone.utc) if view.get("status") == "completed" else None,
+                    "updated_at": datetime.now(timezone.utc),
+                }
+            )
+    except (subprocess.CalledProcessError, TimeoutError) as exc:
+        record = CloudRunRecord(
+            **{
+                **record.__dict__,
+                "status": "error",
+                "conclusion": "error",
+                "updated_at": datetime.now(timezone.utc),
+            }
+        )
+        ctx.cloud_records.save(record)
+        render_error(str(exc))
+        sys.exit(1)
+
+    ctx.cloud_records.save(record)
+    data = {"record": record.to_dict(), "plan": plan.to_dict()}
+    if ctx.json_mode:
+        ctx.output("cloud.run", data)
+        return
+
+    render_message(f"Dispatched {record.workflow_key} to {record.provider} ({record.dispatch_id})")
+    if record.run_id:
+        render_message(f"run id: {record.run_id}")
+    if record.url:
+        render_message(f"url: {record.url}")
+
+
+@cloud.command("status")
+@click.argument("identifier", required=False)
+@click.option("--limit", default=10, show_default=True, help="Number of records to show")
+@click.option("--refresh/--no-refresh", default=False, help="Refresh run state from GitHub before rendering")
+@click.pass_obj
+def cloud_status(ctx: Context, identifier: str | None, limit: int, refresh: bool) -> None:
+    records = ctx.cloud_records.list(limit=limit)
+    if identifier and identifier not in {"latest", ""}:
+        selected = ctx.cloud_records.get(identifier)
+        records = [selected] if selected else []
+    elif identifier == "latest" and records:
+        records = [records[0]]
+
+    refreshed: list[CloudRunRecord] = []
+    for record in records:
+        if record is None:
+            continue
+        updated = record
+        if refresh and record.run_id:
+            try:
+                view = run_view(repository=record.repository, run_id=record.run_id)
+                updated = CloudRunRecord(
+                    **{
+                        **record.__dict__,
+                        "status": str(view.get("status") or record.status),
+                        "conclusion": view.get("conclusion"),
+                        "url": view.get("url") or record.url,
+                        "updated_at": datetime.now(timezone.utc),
+                        "completed_at": datetime.now(timezone.utc)
+                        if view.get("status") == "completed"
+                        else record.completed_at,
+                    }
+                )
+                ctx.cloud_records.save(updated)
+            except subprocess.CalledProcessError:
+                updated = record
+        refreshed.append(updated)
+
+    data = {"records": [record.to_dict() for record in refreshed]}
+    if ctx.json_mode:
+        ctx.output("cloud.status", data)
+        return
+
+    if not refreshed:
+        render_message("No tracked cloud runs yet.", style="dim")
+        return
+    for record in refreshed:
+        render_message(
+            f"{record.dispatch_id}: {record.workflow_key} ref={record.requested_ref} "
+            f"provider={record.provider} status={record.status} conclusion={record.conclusion or '-'}"
+        )
+
+
 @main.command()
 @click.option("--base", default="main", help="Base branch for PR")
+@click.option(
+    "--allow-root-mismatch",
+    is_flag=True,
+    help="Queue the run even if the git root does not match the Shipyard root",
+)
+@click.option(
+    "--allow-unreachable-targets",
+    is_flag=True,
+    help="Queue the run even if no backend is reachable for one or more targets",
+)
 @click.pass_obj
-def ship(ctx: Context, base: str) -> None:
+def ship(ctx: Context, base: str, allow_root_mismatch: bool, allow_unreachable_targets: bool) -> None:
     """Branch -> PR -> validate -> merge on green."""
     from shipyard.ship.pr import create_pr, find_pr_for_branch, merge_pr
 
@@ -463,49 +709,42 @@ def ship(ctx: Context, base: str) -> None:
         render_error("No targets configured")
         sys.exit(1)
 
+    dispatcher = _make_dispatcher(config)
+    try:
+        preflight = run_submission_preflight(
+            config,
+            target_names=target_names,
+            dispatcher=dispatcher,
+            allow_root_mismatch=allow_root_mismatch,
+            allow_unreachable_targets=allow_unreachable_targets,
+        )
+    except ValueError as exc:
+        render_error(str(exc))
+        sys.exit(1)
+
+    if not ctx.json_mode:
+        for warning in preflight.warnings:
+            render_message(f"warning: {warning}", style="bold yellow")
+
     job = Job.create(sha=sha, branch=branch, target_names=target_names)
     job = ctx.queue.enqueue(job)
-    job = job.start()
-    ctx.queue.update(job)
-
-    executor = LocalExecutor()
-    validation_config = _resolve_validation(config, ValidationMode.FULL)
-
-    for name in job.target_names:
-        target_config = config.targets.get(name, {})
-        target_config["name"] = name
-        log_path = str(config.state_dir / "logs" / job.id / f"{name}.log")
-        result = executor.validate(
-            sha=sha, branch=branch, target_config=target_config,
-            validation_config=_resolve_target_validation(config, name, validation_config),
-            log_path=log_path,
-        )
-        job = job.with_result(result)
-        ctx.queue.update(job)
-        if not ctx.json_mode:
-            render_job(job)
-
-    job = job.complete()
-    ctx.queue.update(job)
-
-    # Record evidence
-    from shipyard.core.evidence import EvidenceRecord
-
-    for name, result in job.results.items():
-        if result.is_terminal:
-            ctx.evidence.record(EvidenceRecord(
-                sha=sha, branch=branch, target_name=name,
-                platform=result.platform,
-                status="pass" if result.passed else "fail",
-                backend=result.backend,
-                completed_at=result.completed_at or job.completed_at,  # type: ignore[arg-type]
-                duration_secs=result.duration_secs,
-            ))
+    job = _execute_job(
+        ctx=ctx,
+        job=job,
+        config=config,
+        dispatcher=dispatcher,
+        mode=ValidationMode.FULL,
+        fail_fast=False,
+        resume_from=None,
+    )
 
     if job.passed:
         merged = merge_pr(pr_info.number)
         if ctx.json_mode:
-            ctx.output("ship", {"pr": pr_info.number, "merged": merged, "run": job.to_dict()})
+            ctx.output(
+                "ship",
+                {"pr": pr_info.number, "merged": merged, "run": job.to_dict(), "preflight": preflight.to_dict()},
+            )
         else:
             if merged:
                 render_message(f"PR #{pr_info.number} merged. All green.", style="bold green")
@@ -513,7 +752,10 @@ def ship(ctx: Context, base: str) -> None:
                 render_message(f"All green but merge failed for PR #{pr_info.number}", style="bold yellow")
     else:
         if ctx.json_mode:
-            ctx.output("ship", {"pr": pr_info.number, "merged": False, "run": job.to_dict()})
+            ctx.output(
+                "ship",
+                {"pr": pr_info.number, "merged": False, "run": job.to_dict(), "preflight": preflight.to_dict()},
+            )
         else:
             render_message(f"Validation failed. PR #{pr_info.number} not merged.", style="bold red")
             sys.exit(1)
@@ -614,3 +856,154 @@ def _resolve_target_validation(
         result.update(target_validation)
 
     return result
+
+
+def _make_dispatcher(config: Config) -> ExecutorDispatcher:
+    return ExecutorDispatcher(
+        cloud_workflow=str(config.get("cloud.workflow", "ci.yml")),
+        cloud_repo=config.get("cloud.repository"),
+        cloud_poll_interval=float(config.get("cloud.poll_interval_secs", 15.0)),
+        cloud_dispatch_settle_secs=float(config.get("cloud.dispatch_settle_secs", 30.0)),
+    )
+
+
+def _probe_target(
+    target_config: dict[str, Any],
+    dispatcher: ExecutorDispatcher,
+) -> tuple[bool, str | None]:
+    primary_backend = dispatcher.backend_name(target_config)
+    if dispatcher.probe(target_config):
+        return True, primary_backend
+
+    for fallback in target_config.get("fallback", []):
+        merged_config = {**target_config, **fallback}
+        if dispatcher.probe(merged_config):
+            return True, dispatcher.backend_name(merged_config)
+
+    return False, None
+
+
+def _execute_job(
+    *,
+    ctx: Context,
+    job: Job,
+    config: Config,
+    dispatcher: ExecutorDispatcher,
+    mode: ValidationMode,
+    fail_fast: bool,
+    resume_from: str | None,
+) -> Job:
+    job = job.start()
+    ctx.queue.update(job)
+
+    validation_config = _resolve_validation(config, mode)
+    had_failure = False
+
+    for name in job.target_names:
+        if had_failure and fail_fast:
+            job = job.with_result(TargetResult(
+                target_name=name,
+                platform=config.targets.get(name, {}).get("platform", "unknown"),
+                status=TargetStatus.CANCELLED,
+                backend="skipped",
+                error_message="Skipped (earlier target failed, --fail-fast)",
+            ))
+            ctx.queue.update(job)
+            continue
+
+        target_config = dict(config.targets.get(name, {}))
+        target_config["name"] = name
+        log_path = str(config.state_dir / "logs" / job.id / f"{name}.log")
+        backend_name = dispatcher.backend_name(target_config)
+
+        running = TargetResult(
+            target_name=name,
+            platform=target_config.get("platform", "unknown"),
+            status=TargetStatus.RUNNING,
+            backend=backend_name,
+            started_at=job.started_at,
+            log_path=log_path,
+        )
+        job = job.with_result(running)
+        ctx.queue.update(job)
+
+        state: dict[str, Any] = {"job": job}
+
+        def progress_callback(
+            fields: dict[str, Any],
+            *,
+            target_name: str = name,
+            default_running: TargetResult = running,
+            progress_state: dict[str, Any] = state,
+        ) -> None:
+            current = progress_state["job"].results.get(target_name, default_running)
+            progress_state["job"] = progress_state["job"].with_result(
+                current.with_updates(
+                    status=TargetStatus.RUNNING,
+                    phase=fields.get("phase", current.phase),
+                    last_output_at=fields.get("last_output_at", current.last_output_at),
+                    last_heartbeat_at=fields.get("last_heartbeat_at", current.last_heartbeat_at),
+                    quiet_for_secs=fields.get("quiet_for_secs", current.quiet_for_secs),
+                    liveness=fields.get("liveness", current.liveness),
+                )
+            )
+            ctx.queue.update(progress_state["job"])
+
+        result = dispatcher.validate_target(
+            sha=job.sha,
+            branch=job.branch,
+            target_config=target_config,
+            validation_config=_resolve_target_validation(config, name, validation_config),
+            log_path=log_path,
+            progress_callback=progress_callback,
+            resume_from=resume_from,
+        )
+        job = state["job"].with_result(result)
+        ctx.queue.update(job)
+
+        if not result.passed:
+            had_failure = True
+
+        if not ctx.json_mode:
+            render_job(job)
+
+    job = job.complete()
+    ctx.queue.update(job)
+    _record_evidence(ctx, job)
+    return job
+
+
+def _record_evidence(ctx: Context, job: Job) -> None:
+    from shipyard.core.evidence import EvidenceRecord
+
+    for name, result in job.results.items():
+        if result.is_terminal:
+            ctx.evidence.record(EvidenceRecord(
+                sha=job.sha,
+                branch=job.branch,
+                target_name=name,
+                platform=result.platform,
+                status="pass" if result.passed else "fail",
+                backend=result.backend,
+                completed_at=result.completed_at or job.completed_at,  # type: ignore[arg-type]
+                duration_secs=result.duration_secs,
+                primary_backend=result.primary_backend,
+                failover_reason=result.failover_reason,
+                provider=result.provider,
+                runner_profile=result.runner_profile,
+            ))
+
+
+def _wait_for_cloud_completion(repository: str | None, run_id: str) -> dict[str, Any]:
+    while True:
+        view = run_view(repository=repository, run_id=run_id)
+        if view.get("status") == "completed":
+            return view
+        render_message(f"waiting for cloud run {run_id}...", style="dim")
+        import time
+
+        time.sleep(5)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/shipyard/cloud/__init__.py
+++ b/src/shipyard/cloud/__init__.py
@@ -1,0 +1,1 @@
+"""Cloud workflow helpers."""

--- a/src/shipyard/cloud/github.py
+++ b/src/shipyard/cloud/github.py
@@ -1,0 +1,74 @@
+"""GitHub CLI helpers for cloud workflow dispatch."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import time
+from typing import Any
+
+
+def workflow_dispatch(
+    *,
+    repository: str | None,
+    workflow_file: str,
+    ref: str,
+    fields: dict[str, str],
+) -> None:
+    cmd = ["gh", "workflow", "run", workflow_file, "--ref", ref]
+    if repository:
+        cmd.extend(["--repo", repository])
+    for key, value in fields.items():
+        cmd.extend(["-f", f"{key}={value}"])
+    subprocess.run(cmd, capture_output=True, check=True, timeout=30)
+
+
+def find_dispatched_run(
+    *,
+    repository: str | None,
+    workflow_file: str,
+    ref: str,
+    timeout_secs: float = 30.0,
+    poll_interval_secs: float = 5.0,
+) -> dict[str, Any]:
+    deadline = time.monotonic() + timeout_secs
+    while time.monotonic() < deadline:
+        cmd = [
+            "gh",
+            "run",
+            "list",
+            "--workflow",
+            workflow_file,
+            "--branch",
+            ref,
+            "--limit",
+            "1",
+            "--json",
+            "databaseId,status,conclusion,url,createdAt,updatedAt,workflowName,headBranch,headSha",
+        ]
+        if repository:
+            cmd.extend(["--repo", repository])
+
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=15)
+        if result.returncode == 0 and result.stdout.strip():
+            runs = json.loads(result.stdout)
+            if runs:
+                return runs[0]
+        time.sleep(poll_interval_secs)
+
+    raise TimeoutError(f"Workflow run for '{workflow_file}' on '{ref}' did not appear within {timeout_secs}s")
+
+
+def run_view(*, repository: str | None, run_id: str) -> dict[str, Any]:
+    cmd = [
+        "gh",
+        "run",
+        "view",
+        run_id,
+        "--json",
+        "databaseId,status,conclusion,url,createdAt,updatedAt,workflowName,headBranch,headSha,jobs",
+    ]
+    if repository:
+        cmd.extend(["--repo", repository])
+    result = subprocess.run(cmd, capture_output=True, text=True, check=True, timeout=30)
+    return json.loads(result.stdout)

--- a/src/shipyard/cloud/records.py
+++ b/src/shipyard/cloud/records.py
@@ -1,0 +1,119 @@
+"""Persistence for cloud workflow dispatch records."""
+
+from __future__ import annotations
+
+import json
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@dataclass(frozen=True)
+class CloudRunRecord:
+    """Persistent record for a cloud-dispatched workflow run."""
+
+    dispatch_id: str
+    workflow_key: str
+    workflow_file: str
+    workflow_name: str
+    repository: str | None
+    requested_ref: str
+    provider: str
+    dispatch_fields: dict[str, str]
+    status: str
+    conclusion: str | None = None
+    run_id: str | None = None
+    url: str | None = None
+    dispatched_at: datetime | None = None
+    started_at: datetime | None = None
+    completed_at: datetime | None = None
+    updated_at: datetime | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "dispatch_id": self.dispatch_id,
+            "workflow_key": self.workflow_key,
+            "workflow_file": self.workflow_file,
+            "workflow_name": self.workflow_name,
+            "repository": self.repository,
+            "requested_ref": self.requested_ref,
+            "provider": self.provider,
+            "dispatch_fields": dict(self.dispatch_fields),
+            "status": self.status,
+            "conclusion": self.conclusion,
+            "run_id": self.run_id,
+            "url": self.url,
+            "dispatched_at": _iso(self.dispatched_at),
+            "started_at": _iso(self.started_at),
+            "completed_at": _iso(self.completed_at),
+            "updated_at": _iso(self.updated_at),
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> CloudRunRecord:
+        return cls(
+            dispatch_id=data["dispatch_id"],
+            workflow_key=data["workflow_key"],
+            workflow_file=data["workflow_file"],
+            workflow_name=data["workflow_name"],
+            repository=data.get("repository"),
+            requested_ref=data["requested_ref"],
+            provider=data["provider"],
+            dispatch_fields=dict(data.get("dispatch_fields", {})),
+            status=data["status"],
+            conclusion=data.get("conclusion"),
+            run_id=data.get("run_id"),
+            url=data.get("url"),
+            dispatched_at=_from_iso(data.get("dispatched_at")),
+            started_at=_from_iso(data.get("started_at")),
+            completed_at=_from_iso(data.get("completed_at")),
+            updated_at=_from_iso(data.get("updated_at")),
+        )
+
+
+class CloudRecordStore:
+    """Store cloud run records in the Shipyard state dir."""
+
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self.path.mkdir(parents=True, exist_ok=True)
+
+    def new_dispatch_id(self) -> str:
+        now = datetime.now(timezone.utc)
+        return f"cloud-{now.strftime('%Y%m%d')}-{uuid.uuid4().hex[:8]}"
+
+    def save(self, record: CloudRunRecord) -> Path:
+        target = self.path / f"{record.dispatch_id}.json"
+        target.write_text(json.dumps(record.to_dict(), indent=2) + "\n")
+        return target
+
+    def get(self, dispatch_id: str) -> CloudRunRecord | None:
+        path = self.path / f"{dispatch_id}.json"
+        if not path.exists():
+            return None
+        return CloudRunRecord.from_dict(json.loads(path.read_text()))
+
+    def list(self, limit: int = 20) -> list[CloudRunRecord]:
+        records: list[CloudRunRecord] = []
+        for path in sorted(self.path.glob("*.json"), reverse=True):
+            records.append(CloudRunRecord.from_dict(json.loads(path.read_text())))
+        minimum = datetime.min.replace(tzinfo=timezone.utc)
+        records.sort(
+            key=lambda record: record.updated_at or record.dispatched_at or minimum,
+            reverse=True,
+        )
+        return records[:limit]
+
+
+def _iso(value: datetime | None) -> str | None:
+    return value.isoformat() if value else None
+
+
+def _from_iso(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    return datetime.fromisoformat(value)

--- a/src/shipyard/cloud/registry.py
+++ b/src/shipyard/cloud/registry.py
@@ -1,0 +1,299 @@
+"""Workflow discovery and dispatch defaults for `shipyard cloud`."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from shipyard.providers.github_hosted import GitHubHostedProvider
+from shipyard.providers.namespace import NamespaceProvider
+
+if TYPE_CHECKING:
+    from shipyard.core.config import Config
+
+_ALIAS_MAP = {
+    "ci": "build",
+}
+
+
+@dataclass(frozen=True)
+class WorkflowDefinition:
+    """Discovered cloud-dispatchable workflow."""
+
+    key: str
+    file: str
+    name: str
+    description: str
+    inputs: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "key": self.key,
+            "file": self.file,
+            "name": self.name,
+            "description": self.description,
+            "inputs": list(self.inputs),
+        }
+
+
+@dataclass(frozen=True)
+class CloudDispatchPlan:
+    """Resolved dispatch settings for a workflow run."""
+
+    workflow: WorkflowDefinition
+    repository: str | None
+    ref: str
+    provider: str
+    dispatch_fields: dict[str, str]
+    sources: dict[str, str]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "workflow": self.workflow.to_dict(),
+            "repository": self.repository,
+            "ref": self.ref,
+            "provider": self.provider,
+            "dispatch_fields": dict(self.dispatch_fields),
+            "sources": dict(self.sources),
+        }
+
+
+def discover_workflows(repo_root: Path | None = None) -> dict[str, WorkflowDefinition]:
+    """Discover workflow-dispatchable GitHub Actions workflows in the repo."""
+    root = (repo_root or Path.cwd()).resolve()
+    workflow_dir = root / ".github" / "workflows"
+    discovered: dict[str, WorkflowDefinition] = {}
+    if not workflow_dir.exists():
+        return discovered
+
+    for path in sorted(workflow_dir.glob("*.y*ml")):
+        inputs = _discover_workflow_inputs(path)
+        key = path.stem
+        name = _discover_workflow_name(path) or _titleize(key)
+        description = f"{name} ({path.name})"
+        definition = WorkflowDefinition(
+            key=key,
+            file=path.name,
+            name=name,
+            description=description,
+            inputs=tuple(inputs),
+        )
+        discovered[key] = definition
+        alias = _ALIAS_MAP.get(key)
+        if alias and alias not in discovered:
+            discovered[alias] = WorkflowDefinition(
+                key=alias,
+                file=definition.file,
+                name=definition.name,
+                description=definition.description,
+                inputs=definition.inputs,
+            )
+
+    return discovered
+
+
+def resolve_cloud_dispatch_plan(
+    *,
+    config: Config,
+    workflows: dict[str, WorkflowDefinition],
+    workflow_key: str,
+    ref: str,
+    provider_override: str | None = None,
+    runner_selector: str | None = None,
+    linux_runner_selector: str | None = None,
+    windows_runner_selector: str | None = None,
+    macos_runner_selector: str | None = None,
+) -> CloudDispatchPlan:
+    """Resolve provider and selector inputs for a cloud workflow dispatch."""
+    if workflow_key not in workflows:
+        raise ValueError(f"Unknown workflow '{workflow_key}'")
+
+    workflow = workflows[workflow_key]
+    repository = config.get("cloud.repository")
+
+    sources: dict[str, str] = {}
+    provider = provider_override
+    if provider:
+        sources["provider"] = "cli"
+    else:
+        provider = config.get(f"cloud.workflows.{workflow_key}.provider")
+        if provider:
+            sources["provider"] = f"config:cloud.workflows.{workflow_key}.provider"
+        else:
+            provider = config.get("cloud.provider", "github-hosted")
+            sources["provider"] = "config:cloud.provider" if config.get("cloud.provider") else "default"
+
+    dispatch_fields: dict[str, str] = {}
+    if "runner_provider" in workflow.inputs:
+        dispatch_fields["runner_provider"] = provider
+
+    overrides = {
+        "linux-x64": linux_runner_selector,
+        "windows-x64": windows_runner_selector,
+        "macos-arm64": macos_runner_selector,
+    }
+    provider_config = config.get(f"cloud.providers.{provider}", {}) or {}
+    workflow_config = config.get(f"cloud.workflows.{workflow_key}", {}) or {}
+
+    if runner_selector and "runner_selector" in workflow.inputs:
+        dispatch_fields["runner_selector"] = runner_selector
+        sources["runner_selector"] = "cli"
+    elif "runner_selector" in workflow.inputs:
+        resolved = workflow_config.get("runner_selector") or provider_config.get("runner_selector")
+        if resolved:
+            dispatch_fields["runner_selector"] = resolved
+            sources["runner_selector"] = (
+                f"config:cloud.workflows.{workflow_key}.runner_selector"
+                if workflow_config.get("runner_selector")
+                else f"config:cloud.providers.{provider}.runner_selector"
+            )
+
+    resolved_overrides = _resolve_runner_overrides(
+        provider=provider,
+        provider_config=provider_config,
+        workflow_config=workflow_config,
+        cli_overrides=overrides,
+    )
+    if resolved_overrides and "runner_overrides" in workflow.inputs:
+        import json
+
+        dispatch_fields["runner_overrides"] = json.dumps(resolved_overrides)
+        sources["runner_overrides"] = "cli/config/provider"
+    else:
+        _apply_platform_specific_inputs(
+            workflow=workflow,
+            dispatch_fields=dispatch_fields,
+            resolved_overrides=resolved_overrides,
+        )
+
+    return CloudDispatchPlan(
+        workflow=workflow,
+        repository=repository,
+        ref=ref,
+        provider=provider,
+        dispatch_fields=dispatch_fields,
+        sources=sources,
+    )
+
+
+def default_workflow_key(config: Config, workflows: dict[str, WorkflowDefinition]) -> str | None:
+    configured = config.get("cloud.default_workflow")
+    if configured and configured in workflows:
+        return configured
+    if "build" in workflows:
+        return "build"
+    if workflows:
+        return sorted(workflows)[0]
+    return None
+
+
+def _resolve_runner_overrides(
+    *,
+    provider: str,
+    provider_config: dict[str, Any],
+    workflow_config: dict[str, Any],
+    cli_overrides: dict[str, str | None],
+) -> dict[str, str]:
+    overrides: dict[str, str] = {}
+    workflow_overrides = workflow_config.get("runner_overrides", {}) or {}
+    provider_overrides = provider_config.get("runner_overrides", {}) or {}
+
+    for platform, cli_value in cli_overrides.items():
+        if cli_value:
+            overrides[platform] = cli_value
+            continue
+        if platform in workflow_overrides:
+            overrides[platform] = workflow_overrides[platform]
+            continue
+        if platform in provider_overrides:
+            overrides[platform] = provider_overrides[platform]
+            continue
+        resolved = _resolve_provider_selector(provider, platform, provider_config)
+        if resolved:
+            overrides[platform] = resolved
+
+    return overrides
+
+
+def _resolve_provider_selector(
+    provider: str,
+    platform: str,
+    provider_config: dict[str, Any],
+) -> str | None:
+    try:
+        if provider == "namespace":
+            return NamespaceProvider().resolve_selector(platform, provider_config)
+        if provider == "github-hosted":
+            return GitHubHostedProvider().resolve_selector(platform, provider_config)
+    except ValueError:
+        return None
+    return None
+
+
+def _apply_platform_specific_inputs(
+    *,
+    workflow: WorkflowDefinition,
+    dispatch_fields: dict[str, str],
+    resolved_overrides: dict[str, str],
+) -> None:
+    mapping = {
+        "linux-x64": "linux_runner_selector",
+        "windows-x64": "windows_runner_selector",
+        "macos-arm64": "macos_runner_selector",
+    }
+    for platform, input_name in mapping.items():
+        if input_name in workflow.inputs and platform in resolved_overrides:
+            dispatch_fields[input_name] = resolved_overrides[platform]
+
+
+def _discover_workflow_name(path: Path) -> str | None:
+    for line in path.read_text().splitlines():
+        match = re.match(r"^name:\s*(.+)$", line.strip())
+        if match:
+            return match.group(1).strip().strip("'\"")
+    return None
+
+
+def _discover_workflow_inputs(path: Path) -> list[str]:
+    inputs: list[str] = []
+    lines = path.read_text().splitlines()
+    in_workflow_dispatch = False
+    in_inputs = False
+    workflow_indent = None
+    inputs_indent = None
+
+    for raw_line in lines:
+        if not raw_line.strip() or raw_line.lstrip().startswith("#"):
+            continue
+
+        indent = len(raw_line) - len(raw_line.lstrip(" "))
+        stripped = raw_line.strip()
+
+        if stripped.startswith("workflow_dispatch:"):
+            in_workflow_dispatch = True
+            in_inputs = False
+            workflow_indent = indent
+            continue
+
+        if in_workflow_dispatch and workflow_indent is not None and indent <= workflow_indent and ":" in stripped:
+            in_workflow_dispatch = False
+            in_inputs = False
+
+        if in_workflow_dispatch and stripped.startswith("inputs:"):
+            in_inputs = True
+            inputs_indent = indent
+            continue
+
+        if in_inputs and inputs_indent is not None and indent <= inputs_indent:
+            in_inputs = False
+
+        if in_inputs and inputs_indent is not None and indent == inputs_indent + 2 and stripped.endswith(":"):
+            inputs.append(stripped[:-1])
+
+    return inputs
+
+
+def _titleize(key: str) -> str:
+    return key.replace("-", " ").replace("_", " ").title()

--- a/src/shipyard/core/job.py
+++ b/src/shipyard/core/job.py
@@ -7,7 +7,7 @@ Jobs are immutable once created — state transitions produce new instances.
 from __future__ import annotations
 
 import uuid
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from datetime import datetime, timezone
 from enum import Enum
 from typing import Any
@@ -61,6 +61,11 @@ class TargetResult:
     started_at: datetime | None = None
     completed_at: datetime | None = None
     log_path: str | None = None
+    phase: str | None = None
+    last_output_at: datetime | None = None
+    last_heartbeat_at: datetime | None = None
+    quiet_for_secs: float | None = None
+    liveness: str | None = None
     # Failover provenance
     primary_backend: str | None = None
     failover_reason: str | None = None
@@ -72,6 +77,10 @@ class TargetResult:
     @property
     def passed(self) -> bool:
         return self.status == TargetStatus.PASS
+
+    def with_updates(self, **kwargs: Any) -> TargetResult:
+        """Return a copy with the provided fields updated."""
+        return replace(self, **kwargs)
 
     @property
     def is_terminal(self) -> bool:
@@ -100,6 +109,16 @@ class TargetResult:
             d["completed_at"] = self.completed_at.isoformat()
         if self.log_path:
             d["log_path"] = self.log_path
+        if self.phase:
+            d["phase"] = self.phase
+        if self.last_output_at:
+            d["last_output_at"] = self.last_output_at.isoformat()
+        if self.last_heartbeat_at:
+            d["last_heartbeat_at"] = self.last_heartbeat_at.isoformat()
+        if self.quiet_for_secs is not None:
+            d["quiet_for_secs"] = round(self.quiet_for_secs, 1)
+        if self.liveness:
+            d["liveness"] = self.liveness
         if self.primary_backend:
             d["primary_backend"] = self.primary_backend
         if self.failover_reason:

--- a/src/shipyard/core/queue.py
+++ b/src/shipyard/core/queue.py
@@ -228,6 +228,15 @@ def _job_from_dict(d: dict[str, Any]) -> Job:
                 started_at=datetime.fromisoformat(rd["started_at"]) if rd.get("started_at") else None,
                 completed_at=datetime.fromisoformat(rd["completed_at"]) if rd.get("completed_at") else None,
                 log_path=rd.get("log_path"),
+                phase=rd.get("phase"),
+                last_output_at=datetime.fromisoformat(rd["last_output_at"]) if rd.get("last_output_at") else None,
+                last_heartbeat_at=(
+                    datetime.fromisoformat(rd["last_heartbeat_at"])
+                    if rd.get("last_heartbeat_at")
+                    else None
+                ),
+                quiet_for_secs=rd.get("quiet_for_secs"),
+                liveness=rd.get("liveness"),
                 primary_backend=rd.get("primary_backend"),
                 failover_reason=rd.get("failover_reason"),
                 provider=rd.get("provider"),

--- a/src/shipyard/executor/cloud.py
+++ b/src/shipyard/executor/cloud.py
@@ -12,9 +12,12 @@ import json
 import subprocess
 import time
 from datetime import datetime, timezone
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from shipyard.core.job import TargetResult, TargetStatus
+
+if TYPE_CHECKING:
+    from shipyard.executor.streaming import ProgressCallback
 
 # How long to wait between poll attempts (seconds)
 _POLL_INTERVAL = 15
@@ -44,6 +47,7 @@ class CloudExecutor:
         target_config: dict[str, Any],
         validation_config: dict[str, Any],
         log_path: str,
+        progress_callback: ProgressCallback | None = None,
     ) -> TargetResult:
         target_name = target_config.get("name", "cloud")
         platform = target_config.get("platform", "unknown")
@@ -71,6 +75,7 @@ class CloudExecutor:
         # Dispatch the workflow
         try:
             self._dispatch_workflow(branch, inputs)
+            _emit_progress(progress_callback, phase="dispatch")
         except subprocess.CalledProcessError as exc:
             return TargetResult(
                 target_name=target_name,
@@ -87,6 +92,7 @@ class CloudExecutor:
         # Wait for the run to appear and get its ID
         try:
             run_id = self._wait_for_run(branch)
+            _emit_progress(progress_callback, phase="queued")
         except TimeoutError as exc:
             return TargetResult(
                 target_name=target_name,
@@ -103,7 +109,7 @@ class CloudExecutor:
 
         # Poll for completion
         try:
-            conclusion = self._poll_run(run_id)
+            conclusion = self._poll_run(run_id, progress_callback=progress_callback)
         except subprocess.CalledProcessError as exc:
             return TargetResult(
                 target_name=target_name,
@@ -190,7 +196,12 @@ class CloudExecutor:
             f"Workflow run did not appear within {self.dispatch_settle_secs}s"
         )
 
-    def _poll_run(self, run_id: str) -> str:
+    def _poll_run(
+        self,
+        run_id: str,
+        *,
+        progress_callback: ProgressCallback | None = None,
+    ) -> str:
         """Poll a workflow run until it completes. Returns the conclusion."""
         while True:
             cmd: list[str] = [
@@ -201,8 +212,27 @@ class CloudExecutor:
 
             result = subprocess.run(cmd, capture_output=True, text=True, check=True, timeout=15)
             data = json.loads(result.stdout)
+            _emit_progress(
+                progress_callback,
+                phase=str(data.get("status") or "poll"),
+            )
 
             if data.get("status") == "completed":
                 return data.get("conclusion", "failure")
 
             time.sleep(self.poll_interval)
+
+
+def _emit_progress(progress_callback: ProgressCallback | None, *, phase: str) -> None:
+    if progress_callback is None:
+        return
+    now = datetime.now(timezone.utc)
+    progress_callback(
+        {
+            "phase": phase,
+            "last_output_at": now,
+            "last_heartbeat_at": now,
+            "quiet_for_secs": 0.0,
+            "liveness": "active",
+        }
+    )

--- a/src/shipyard/executor/dispatch.py
+++ b/src/shipyard/executor/dispatch.py
@@ -1,0 +1,137 @@
+"""Backend-aware executor dispatch for CLI commands."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, cast
+
+from shipyard.executor.cloud import CloudExecutor
+from shipyard.executor.local import LocalExecutor
+from shipyard.executor.ssh import SSHExecutor
+from shipyard.executor.ssh_windows import SSHWindowsExecutor
+from shipyard.failover.chain import FallbackChain, FallbackExecutor
+
+if TYPE_CHECKING:
+    from shipyard.core.job import TargetResult
+
+_WINDOWS_BACKENDS = {"ssh-windows", "ssh_windows"}
+
+
+class ExecutorDispatcher:
+    """Resolve target configs to concrete executor implementations."""
+
+    def __init__(
+        self,
+        *,
+        cloud_workflow: str = "ci.yml",
+        cloud_repo: str | None = None,
+        cloud_poll_interval: float = 15.0,
+        cloud_dispatch_settle_secs: float = 30.0,
+    ) -> None:
+        self.cloud_workflow = cloud_workflow
+        self.cloud_repo = cloud_repo
+        self.cloud_poll_interval = cloud_poll_interval
+        self.cloud_dispatch_settle_secs = cloud_dispatch_settle_secs
+        self._local = LocalExecutor()
+        self._ssh = SSHExecutor()
+        self._ssh_windows = SSHWindowsExecutor()
+
+    def executor_for(self, target_config: dict[str, Any]) -> Any:
+        fallback = list(target_config.get("fallback", []))
+        if fallback:
+            primary = _primary_backend_def(target_config)
+            backends = [primary, *fallback]
+            types = {_normalize_backend_name(backend) for backend in backends}
+            executors = {backend_type: self for backend_type in types if backend_type != "vm"}
+            return FallbackChain(
+                backends=backends,
+                executors=cast("dict[str, FallbackExecutor]", executors),
+            )
+        return self
+
+    def validate_target(
+        self,
+        *,
+        sha: str,
+        branch: str,
+        target_config: dict[str, Any],
+        validation_config: dict[str, Any],
+        log_path: str,
+        **kwargs: Any,
+    ) -> TargetResult:
+        executor = self.executor_for(target_config)
+        if isinstance(executor, FallbackChain):
+            return executor.execute(
+                job_sha=sha,
+                job_branch=branch,
+                target_config=target_config,
+                validation_config=validation_config,
+                log_path=log_path,
+            )
+        return executor.validate(
+            sha=sha,
+            branch=branch,
+            target_config=target_config,
+            validation_config=validation_config,
+            log_path=log_path,
+            **kwargs,
+        )
+
+    def validate(
+        self,
+        sha: str,
+        branch: str,
+        target_config: dict[str, Any],
+        validation_config: dict[str, Any],
+        log_path: str,
+        **kwargs: Any,
+    ) -> TargetResult:  # type: ignore[override]
+        executor = self._resolve_executor(target_config)
+        return executor.validate(
+            sha=sha,
+            branch=branch,
+            target_config=target_config,
+            validation_config=validation_config,
+            log_path=log_path,
+            **kwargs,
+        )
+
+    def probe(self, target_config: dict[str, Any]) -> bool:
+        executor = self._resolve_executor(target_config)
+        return executor.probe(target_config)
+
+    def backend_name(self, target_config: dict[str, Any]) -> str:
+        return _normalize_backend_name(target_config)
+
+    def _resolve_executor(self, target_config: dict[str, Any]) -> Any:
+        backend = _normalize_backend_name(target_config)
+        if backend == "local":
+            return self._local
+        if backend == "ssh":
+            return self._ssh
+        if backend in _WINDOWS_BACKENDS:
+            return self._ssh_windows
+        if backend == "cloud":
+            return CloudExecutor(
+                workflow=target_config.get("workflow", self.cloud_workflow),
+                repo=target_config.get("repository", self.cloud_repo),
+                poll_interval=float(target_config.get("poll_interval_secs", self.cloud_poll_interval)),
+                dispatch_settle_secs=float(
+                    target_config.get("dispatch_settle_secs", self.cloud_dispatch_settle_secs)
+                ),
+            )
+        raise ValueError(f"Unsupported backend '{backend}'")
+
+
+def _primary_backend_def(target_config: dict[str, Any]) -> dict[str, Any]:
+    backend = _normalize_backend_name(target_config)
+    primary = dict(target_config)
+    primary["type"] = backend
+    return primary
+
+
+def _normalize_backend_name(target_config: dict[str, Any]) -> str:
+    backend = str(target_config.get("type") or target_config.get("backend") or "local").strip().lower()
+    backend = backend.replace("_", "-")
+    if backend == "ssh" and str(target_config.get("platform", "")).startswith("windows"):
+        return "ssh-windows"
+    return backend

--- a/src/shipyard/executor/local.py
+++ b/src/shipyard/executor/local.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from typing import Any
 
 from shipyard.core.job import TargetResult, TargetStatus
+from shipyard.executor.streaming import ProgressCallback, run_streaming_command
 
 STAGES = ("setup", "configure", "build", "test")
 
@@ -44,6 +45,7 @@ class LocalExecutor:
         validation_config: dict[str, Any],
         log_path: str,
         resume_from: str | None = None,
+        progress_callback: ProgressCallback | None = None,
     ) -> TargetResult:
         target_name = target_config.get("name", "local")
         platform = target_config.get("platform", "unknown")
@@ -57,7 +59,7 @@ class LocalExecutor:
         if "command" in validation_config:
             return self._run_single(
                 validation_config["command"], target_name, platform,
-                target_config, log_file, started_at, start_time,
+                target_config, log_file, started_at, start_time, progress_callback,
             )
 
         # Stage-aware mode
@@ -72,28 +74,32 @@ class LocalExecutor:
 
         return self._run_stages(
             stages, target_name, platform, target_config,
-            log_file, started_at, start_time,
+            log_file, started_at, start_time, progress_callback,
         )
 
     def _run_single(
         self, command: str, target_name: str, platform: str,
         target_config: dict[str, Any], log_file: Path,
         started_at: datetime, start_time: float,
+        progress_callback: ProgressCallback | None,
     ) -> TargetResult:
         try:
-            with open(log_file, "w") as log:
-                result = subprocess.run(
-                    command, shell=True, cwd=target_config.get("cwd"),
-                    stdout=log, stderr=subprocess.STDOUT,
-                    timeout=target_config.get("timeout_secs", 1800),
-                )
-            elapsed = time.monotonic() - start_time
+            result = run_streaming_command(
+                command,
+                shell=True,
+                cwd=target_config.get("cwd"),
+                log_path=str(log_file),
+                timeout=target_config.get("timeout_secs", 1800),
+                progress_callback=progress_callback,
+            )
             status = TargetStatus.PASS if result.returncode == 0 else TargetStatus.FAIL
             return TargetResult(
                 target_name=target_name, platform=platform,
-                status=status, backend="local", duration_secs=elapsed,
-                started_at=started_at, completed_at=datetime.now(timezone.utc),
+                status=status, backend="local", duration_secs=result.duration_secs,
+                started_at=started_at, completed_at=result.completed_at,
                 log_path=str(log_file),
+                phase=result.phase,
+                last_output_at=result.last_output_at,
             )
         except subprocess.TimeoutExpired:
             return TargetResult(
@@ -115,34 +121,44 @@ class LocalExecutor:
         self, stages: list[tuple[str, str]], target_name: str,
         platform: str, target_config: dict[str, Any], log_file: Path,
         started_at: datetime, start_time: float,
+        progress_callback: ProgressCallback | None,
     ) -> TargetResult:
         """Run validation as separate stages. Stop at first failure."""
         failed_stage = None
-        stage_results: list[StageResult] = []
+        last_output_at: datetime | None = None
 
         try:
-            with open(log_file, "w") as log:
-                for stage_name, command in stages:
-                    stage_start = time.monotonic()
+            log_file.write_text("")
+            for stage_name, command in stages:
+                stage_start = time.monotonic()
+                with open(log_file, "a", encoding="utf-8") as log:
                     log.write(f"\n=== {stage_name} ===\n")
                     log.flush()
 
-                    result = subprocess.run(
-                        command, shell=True, cwd=target_config.get("cwd"),
-                        stdout=log, stderr=subprocess.STDOUT,
-                        timeout=target_config.get("timeout_secs", 1800),
-                    )
+                if progress_callback:
+                    progress_callback({"phase": stage_name})
 
-                    sr = StageResult(
-                        stage=stage_name,
-                        success=result.returncode == 0,
-                        duration_secs=time.monotonic() - stage_start,
-                    )
-                    stage_results.append(sr)
+                result = run_streaming_command(
+                    command,
+                    shell=True,
+                    cwd=target_config.get("cwd"),
+                    log_path=str(log_file),
+                    append=True,
+                    timeout=target_config.get("timeout_secs", 1800),
+                    phase=stage_name,
+                    progress_callback=progress_callback,
+                )
 
-                    if result.returncode != 0:
-                        failed_stage = stage_name
-                        break
+                _ = StageResult(
+                    stage=stage_name,
+                    success=result.returncode == 0,
+                    duration_secs=time.monotonic() - stage_start,
+                )
+                last_output_at = result.last_output_at
+
+                if result.returncode != 0:
+                    failed_stage = stage_name
+                    break
 
         except subprocess.TimeoutExpired:
             return TargetResult(
@@ -169,6 +185,8 @@ class LocalExecutor:
                 duration_secs=elapsed, started_at=started_at,
                 completed_at=datetime.now(timezone.utc),
                 log_path=str(log_file), error_message=error_msg,
+                phase=failed_stage,
+                last_output_at=last_output_at,
             )
 
         return TargetResult(
@@ -177,6 +195,8 @@ class LocalExecutor:
             duration_secs=elapsed, started_at=started_at,
             completed_at=datetime.now(timezone.utc),
             log_path=str(log_file),
+            phase=stages[-1][0] if stages else None,
+            last_output_at=last_output_at,
         )
 
     def probe(self, target_config: dict[str, Any]) -> bool:

--- a/src/shipyard/executor/ssh.py
+++ b/src/shipyard/executor/ssh.py
@@ -15,6 +15,8 @@ from typing import Any
 
 from shipyard.bundle.git_bundle import apply_bundle, create_bundle, upload_bundle
 from shipyard.core.job import TargetResult, TargetStatus
+from shipyard.executor.streaming import ProgressCallback, run_streaming_command
+from shipyard.failover.retry import SSHPermanentError, SSHTransientError, is_transient, retry_ssh
 
 
 class SSHExecutor:
@@ -27,6 +29,48 @@ class SSHExecutor:
         target_config: dict[str, Any],
         validation_config: dict[str, Any],
         log_path: str,
+        progress_callback: ProgressCallback | None = None,
+    ) -> TargetResult:
+        target_name = target_config.get("name", "ssh")
+        platform = target_config.get("platform", "unknown")
+        start_time = time.monotonic()
+        log_file = Path(log_path)
+        log_file.parent.mkdir(parents=True, exist_ok=True)
+
+        @retry_ssh
+        def _run() -> TargetResult:
+            result = self._validate_once(
+                sha=sha,
+                branch=branch,
+                target_config=target_config,
+                validation_config=validation_config,
+                log_path=log_path,
+                progress_callback=progress_callback,
+            )
+            if result.status == TargetStatus.ERROR and result.error_message and is_transient(result.error_message):
+                raise RuntimeError(result.error_message)
+            return result
+
+        try:
+            return _run()
+        except (SSHTransientError, SSHPermanentError) as exc:
+            return _error_result(
+                target_name,
+                platform,
+                datetime.now(timezone.utc),
+                start_time,
+                str(log_file),
+                str(exc),
+            )
+
+    def _validate_once(
+        self,
+        sha: str,
+        branch: str,
+        target_config: dict[str, Any],
+        validation_config: dict[str, Any],
+        log_path: str,
+        progress_callback: ProgressCallback | None = None,
     ) -> TargetResult:
         target_name = target_config.get("name", "ssh")
         platform = target_config.get("platform", "unknown")
@@ -92,26 +136,31 @@ class SSHExecutor:
         ssh_cmd = ["ssh"] + list(ssh_options) + [host, command]
 
         try:
-            with open(log_file, "w") as log:
-                result = subprocess.run(
-                    ssh_cmd,
-                    stdout=log,
-                    stderr=subprocess.STDOUT,
-                    timeout=target_config.get("timeout_secs", 1800),
-                )
+            result = run_streaming_command(
+                ssh_cmd,
+                log_path=str(log_file),
+                timeout=target_config.get("timeout_secs", 1800),
+                progress_callback=progress_callback,
+            )
 
-            elapsed = time.monotonic() - start_time
             status = TargetStatus.PASS if result.returncode == 0 else TargetStatus.FAIL
+            error_message = None
+            if result.returncode == 255:
+                status = TargetStatus.ERROR
+                error_message = _extract_ssh_error(result.output) or "SSH transport failed"
 
             return TargetResult(
                 target_name=target_name,
                 platform=platform,
                 status=status,
                 backend="ssh",
-                duration_secs=elapsed,
+                duration_secs=result.duration_secs,
                 started_at=started_at,
-                completed_at=datetime.now(timezone.utc),
+                completed_at=result.completed_at,
                 log_path=str(log_file),
+                phase=result.phase,
+                last_output_at=result.last_output_at,
+                error_message=error_message,
             )
 
         except subprocess.TimeoutExpired:
@@ -182,7 +231,7 @@ def _build_remote_command(
         for step in ("setup", "configure", "build", "test"):
             cmd = validation_config.get(step)
             if cmd:
-                parts.append(cmd)
+                parts.append(f"printf '__SHIPYARD_PHASE__:{step}\\n' && {cmd}")
         if not parts:
             return None
         validate_cmd = " && ".join(parts)
@@ -210,3 +259,10 @@ def _error_result(
         log_path=log_path,
         error_message=message,
     )
+
+
+def _extract_ssh_error(output: str) -> str | None:
+    for line in reversed(output.splitlines()):
+        if line.strip():
+            return line.strip()
+    return None

--- a/src/shipyard/executor/ssh_windows.py
+++ b/src/shipyard/executor/ssh_windows.py
@@ -15,6 +15,7 @@ from typing import Any
 
 from shipyard.bundle.git_bundle import create_bundle, upload_bundle
 from shipyard.core.job import TargetResult, TargetStatus
+from shipyard.executor.streaming import ProgressCallback, run_streaming_command
 
 
 class SSHWindowsExecutor:
@@ -27,6 +28,7 @@ class SSHWindowsExecutor:
         target_config: dict[str, Any],
         validation_config: dict[str, Any],
         log_path: str,
+        progress_callback: ProgressCallback | None = None,
     ) -> TargetResult:
         target_name = target_config.get("name", "windows")
         platform = target_config.get("platform", "windows-x64")
@@ -98,26 +100,31 @@ class SSHWindowsExecutor:
         )
 
         try:
-            with open(log_file, "w") as log:
-                result = subprocess.run(
-                    ssh_cmd,
-                    stdout=log,
-                    stderr=subprocess.STDOUT,
-                    timeout=target_config.get("timeout_secs", 1800),
-                )
+            result = run_streaming_command(
+                ssh_cmd,
+                log_path=str(log_file),
+                timeout=target_config.get("timeout_secs", 1800),
+                progress_callback=progress_callback,
+            )
 
-            elapsed = time.monotonic() - start_time
             status = TargetStatus.PASS if result.returncode == 0 else TargetStatus.FAIL
+            error_message = None
+            if result.returncode == 255:
+                status = TargetStatus.ERROR
+                error_message = _extract_ssh_error(result.output) or "SSH transport failed"
 
             return TargetResult(
                 target_name=target_name,
                 platform=platform,
                 status=status,
                 backend="ssh-windows",
-                duration_secs=elapsed,
+                duration_secs=result.duration_secs,
                 started_at=started_at,
-                completed_at=datetime.now(timezone.utc),
+                completed_at=result.completed_at,
                 log_path=str(log_file),
+                phase=result.phase,
+                last_output_at=result.last_output_at,
+                error_message=error_message,
             )
 
         except subprocess.TimeoutExpired:
@@ -236,7 +243,7 @@ def _build_remote_command(
         for step in ("setup", "configure", "build", "test"):
             cmd = validation_config.get(step)
             if cmd:
-                parts.append(cmd)
+                parts.append(f"Write-Output '__SHIPYARD_PHASE__:{step}'; {cmd}")
         if not parts:
             return None
         # Chain with PowerShell error checking
@@ -270,3 +277,10 @@ def _error_result(
         log_path=log_path,
         error_message=message,
     )
+
+
+def _extract_ssh_error(output: str) -> str | None:
+    for line in reversed(output.splitlines()):
+        if line.strip():
+            return line.strip()
+    return None

--- a/src/shipyard/executor/streaming.py
+++ b/src/shipyard/executor/streaming.py
@@ -1,0 +1,203 @@
+"""Shared subprocess streaming helpers for validation executors."""
+
+from __future__ import annotations
+
+import queue
+import re
+import subprocess
+import threading
+import time
+from collections.abc import Callable
+from contextlib import nullcontext
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+_PHASE_MARKERS = (
+    re.compile(r"^===\s*([a-zA-Z0-9_-]+)\s*===$"),
+    re.compile(r"^__SHIPYARD_PHASE__:(.+)$"),
+    re.compile(r"^__PULP_PHASE__:(.+)$"),
+)
+
+
+@dataclass(frozen=True)
+class StreamingCommandResult:
+    """Result of a streamed subprocess execution."""
+
+    returncode: int
+    output: str
+    started_at: datetime
+    completed_at: datetime
+    duration_secs: float
+    last_output_at: datetime | None
+    phase: str | None
+
+
+ProgressCallback = Callable[[dict[str, Any]], None]
+
+
+def run_streaming_command(
+    cmd: list[str] | str,
+    *,
+    shell: bool = False,
+    cwd: str | None = None,
+    log_path: str | None = None,
+    append: bool = False,
+    timeout: float | None = None,
+    phase: str | None = None,
+    heartbeat_interval_secs: float = 30.0,
+    stuck_idle_secs: float = 90.0,
+    progress_callback: ProgressCallback | None = None,
+) -> StreamingCommandResult:
+    """Run a command while streaming output to disk and progress callbacks."""
+    started_at = datetime.now(timezone.utc)
+    start_time = time.monotonic()
+    log_file = Path(log_path) if log_path else None
+    if log_file:
+        log_file.parent.mkdir(parents=True, exist_ok=True)
+
+    proc = subprocess.Popen(
+        cmd,
+        cwd=cwd,
+        shell=shell,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+
+    line_queue: queue.Queue[bytes | None] = queue.Queue()
+    reader = threading.Thread(
+        target=_reader_thread,
+        args=(proc.stdout, line_queue),
+        daemon=True,
+    )
+    reader.start()
+
+    output_parts: list[str] = []
+    last_output_at: datetime | None = None
+    last_output_monotonic = start_time
+    current_phase = phase
+
+    try:
+        mode = "a" if append else "w"
+        with open(log_file, mode, encoding="utf-8") if log_file else nullcontext() as log:
+            while True:
+                elapsed = time.monotonic() - start_time
+                if timeout is not None and elapsed > timeout:
+                    proc.kill()
+                    proc.wait(timeout=5)
+                    raise subprocess.TimeoutExpired(cmd, timeout)
+
+                wait_timeout = min(heartbeat_interval_secs, 0.1)
+                try:
+                    chunk = line_queue.get(timeout=wait_timeout)
+                except queue.Empty:
+                    if proc.poll() is not None and line_queue.empty():
+                        break
+                    _emit_heartbeat(
+                        progress_callback=progress_callback,
+                        last_output_at=last_output_at,
+                        last_output_monotonic=last_output_monotonic,
+                        now_monotonic=time.monotonic(),
+                        start_monotonic=start_time,
+                        current_phase=current_phase,
+                        stuck_idle_secs=stuck_idle_secs,
+                    )
+                    continue
+
+                if chunk is None:
+                    break
+
+                decoded = chunk.decode("utf-8", errors="replace")
+                output_parts.append(decoded)
+                if log:
+                    log.write(decoded)
+                    log.flush()
+
+                stripped = decoded.strip()
+                marker_phase = _parse_phase_marker(stripped)
+                if marker_phase:
+                    current_phase = marker_phase
+
+                last_output_at = datetime.now(timezone.utc)
+                last_output_monotonic = time.monotonic()
+                if progress_callback:
+                    progress_callback(
+                        {
+                            "phase": current_phase,
+                            "last_output_at": last_output_at,
+                            "quiet_for_secs": 0.0,
+                            "liveness": "active",
+                        }
+                    )
+
+            returncode = proc.wait(timeout=5)
+
+    finally:
+        if proc.poll() is None:
+            proc.kill()
+            proc.wait(timeout=5)
+
+    completed_at = datetime.now(timezone.utc)
+    return StreamingCommandResult(
+        returncode=returncode,
+        output="".join(output_parts),
+        started_at=started_at,
+        completed_at=completed_at,
+        duration_secs=time.monotonic() - start_time,
+        last_output_at=last_output_at,
+        phase=current_phase,
+    )
+
+
+def _reader_thread(stream: Any, output_queue: queue.Queue[bytes | None]) -> None:
+    try:
+        if stream is None:
+            return
+        for line in iter(stream.readline, b""):
+            output_queue.put(line)
+    finally:
+        if stream is not None:
+            stream.close()
+        output_queue.put(None)
+
+
+def _parse_phase_marker(line: str) -> str | None:
+    for pattern in _PHASE_MARKERS:
+        match = pattern.match(line)
+        if match:
+            return match.group(1).strip()
+    return None
+
+
+def _emit_heartbeat(
+    *,
+    progress_callback: ProgressCallback | None,
+    last_output_at: datetime | None,
+    last_output_monotonic: float,
+    now_monotonic: float,
+    start_monotonic: float,
+    current_phase: str | None,
+    stuck_idle_secs: float,
+) -> None:
+    if progress_callback is None:
+        return
+
+    quiet_for_secs = max(
+        0.0,
+        now_monotonic - (last_output_monotonic if last_output_at is not None else start_monotonic),
+    )
+
+    liveness = "quiet"
+    if quiet_for_secs >= stuck_idle_secs:
+        liveness = "stuck"
+
+    progress_callback(
+        {
+            "phase": current_phase,
+            "last_output_at": last_output_at,
+            "last_heartbeat_at": datetime.now(timezone.utc),
+            "quiet_for_secs": quiet_for_secs,
+            "liveness": liveness,
+        }
+    )

--- a/src/shipyard/failover/chain.py
+++ b/src/shipyard/failover/chain.py
@@ -60,6 +60,7 @@ class FallbackChain:
         target_config: dict[str, Any],
         validation_config: dict[str, Any],
         log_path: str,
+        **kwargs: Any,
     ) -> TargetResult:
         """Try each backend in order until one succeeds or all fail.
 
@@ -103,8 +104,11 @@ class FallbackChain:
                 )
                 continue
 
+            # Merge backend-specific config into the target before probing or validating.
+            merged_config = {**target_config, **backend_def}
+
             # Probe before attempting validation
-            if not executor.probe(target_config):
+            if not executor.probe(merged_config):
                 logger.info(
                     "Backend '%s' probe failed, trying next",
                     _backend_label(backend_def),
@@ -123,15 +127,13 @@ class FallbackChain:
             # Build per-attempt log path
             attempt_log = f"{log_path}.attempt-{i}" if i > 0 else log_path
 
-            # Merge backend-specific config into target_config
-            merged_config = {**target_config, **backend_def}
-
             result = executor.validate(
                 sha=job_sha,
                 branch=job_branch,
                 target_config=merged_config,
                 validation_config=validation_config,
                 log_path=attempt_log,
+                **kwargs,
             )
 
             # Test failures are authoritative — don't retry
@@ -204,4 +206,6 @@ def _backend_label(backend_def: dict[str, Any]) -> str:
         return f"cloud:{backend_def.get('provider', '?')}"
     if btype == "ssh":
         return f"ssh:{backend_def.get('host', '?')}"
+    if btype in {"ssh-windows", "ssh_windows"}:
+        return f"ssh-windows:{backend_def.get('host', '?')}"
     return btype

--- a/src/shipyard/output/human.py
+++ b/src/shipyard/output/human.py
@@ -108,6 +108,12 @@ def render_status(
             if result:
                 status = _style_status(result.status.value)
                 extra = f"  ({result.backend}"
+                if result.phase:
+                    extra += f", phase={result.phase}"
+                if result.liveness:
+                    extra += f", liveness={result.liveness}"
+                if result.quiet_for_secs is not None:
+                    extra += f", idle={int(result.quiet_for_secs)}s"
                 if result.duration_secs:
                     extra += f", {_format_duration(result.duration_secs)}"
                 extra += ")"

--- a/src/shipyard/preflight.py
+++ b/src/shipyard/preflight.py
@@ -1,0 +1,153 @@
+"""Submission preflight checks for CLI-triggered runs."""
+
+from __future__ import annotations
+
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from shipyard.core.config import Config
+    from shipyard.executor.dispatch import ExecutorDispatcher
+
+
+@dataclass(frozen=True)
+class TargetPreflight:
+    """Preflight result for a single target."""
+
+    target_name: str
+    backend: str
+    reachable: bool
+    selected_backend: str
+    message: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        data = {
+            "target": self.target_name,
+            "backend": self.backend,
+            "reachable": self.reachable,
+            "selected_backend": self.selected_backend,
+        }
+        if self.message:
+            data["message"] = self.message
+        return data
+
+
+@dataclass(frozen=True)
+class PreflightResult:
+    """Aggregate submission preflight result."""
+
+    git_root: Path | None
+    expected_root: Path | None
+    targets: dict[str, TargetPreflight] = field(default_factory=dict)
+    warnings: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "git_root": str(self.git_root) if self.git_root else None,
+            "expected_root": str(self.expected_root) if self.expected_root else None,
+            "targets": {name: state.to_dict() for name, state in self.targets.items()},
+            "warnings": list(self.warnings),
+        }
+
+
+def run_submission_preflight(
+    config: Config,
+    *,
+    target_names: list[str],
+    dispatcher: ExecutorDispatcher,
+    allow_root_mismatch: bool = False,
+    allow_unreachable_targets: bool = False,
+    cwd: Path | None = None,
+) -> PreflightResult:
+    """Check repo root and target reachability before enqueueing a job."""
+    workdir = (cwd or Path.cwd()).resolve()
+    expected_root = config.project_dir.parent.resolve() if config.project_dir else workdir
+    git_root = _git_root_for(workdir)
+
+    warnings: list[str] = []
+    if git_root and git_root != expected_root:
+        message = f"Git root {git_root} does not match Shipyard project root {expected_root}"
+        if allow_root_mismatch:
+            warnings.append(message)
+        else:
+            raise ValueError(message)
+
+    target_states: dict[str, TargetPreflight] = {}
+    for target_name in target_names:
+        target_config = dict(config.targets.get(target_name, {}))
+        target_config["name"] = target_name
+        primary_backend = dispatcher.backend_name(target_config)
+
+        probe_result = _probe_target_path(target_config, dispatcher)
+        if not probe_result.reachable:
+            message = probe_result.message or f"Target '{target_name}' is unreachable"
+            if allow_unreachable_targets:
+                warnings.append(message)
+            else:
+                raise ValueError(message)
+
+        if probe_result.selected_backend != primary_backend:
+            warnings.append(
+                f"Target '{target_name}' primary backend '{primary_backend}' is unavailable; "
+                f"preflight selected failover backend '{probe_result.selected_backend}'."
+            )
+
+        target_states[target_name] = probe_result
+
+    return PreflightResult(
+        git_root=git_root,
+        expected_root=expected_root,
+        targets=target_states,
+        warnings=warnings,
+    )
+
+
+def _probe_target_path(
+    target_config: dict[str, Any],
+    dispatcher: ExecutorDispatcher,
+) -> TargetPreflight:
+    target_name = target_config.get("name", "unknown")
+    primary_backend = dispatcher.backend_name(target_config)
+
+    if dispatcher.probe(target_config):
+        return TargetPreflight(
+            target_name=target_name,
+            backend=primary_backend,
+            reachable=True,
+            selected_backend=primary_backend,
+        )
+
+    for fallback in target_config.get("fallback", []):
+        merged_config = {**target_config, **fallback}
+        fallback_backend = dispatcher.backend_name(merged_config)
+        if dispatcher.probe(merged_config):
+            return TargetPreflight(
+                target_name=target_name,
+                backend=primary_backend,
+                reachable=True,
+                selected_backend=fallback_backend,
+                message=f"Primary backend '{primary_backend}' unreachable; failover '{fallback_backend}' is available",
+            )
+
+    return TargetPreflight(
+        target_name=target_name,
+        backend=primary_backend,
+        reachable=False,
+        selected_backend=primary_backend,
+        message=f"Target '{target_name}' has no reachable backend",
+    )
+
+
+def _git_root_for(path: Path) -> Path | None:
+    try:
+        output = subprocess.check_output(
+            ["git", "rev-parse", "--show-toplevel"],
+            cwd=path,
+            text=True,
+            stderr=subprocess.DEVNULL,
+        ).strip()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return None
+    return Path(output).resolve()

--- a/tests/cloud/test_registry.py
+++ b/tests/cloud/test_registry.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from shipyard.cloud.registry import default_workflow_key, discover_workflows, resolve_cloud_dispatch_plan
+from shipyard.core.config import Config
+
+
+def test_discover_workflows_reads_inputs_and_aliases(tmp_path: Path) -> None:
+    workflow_dir = tmp_path / ".github" / "workflows"
+    workflow_dir.mkdir(parents=True)
+    (workflow_dir / "ci.yml").write_text(
+        """
+name: CI
+on:
+  workflow_dispatch:
+    inputs:
+      runner_provider:
+        description: provider
+      runner_overrides:
+        description: overrides
+"""
+    )
+
+    workflows = discover_workflows(tmp_path)
+
+    assert "ci" in workflows
+    assert "build" in workflows
+    assert workflows["ci"].inputs == ("runner_provider", "runner_overrides")
+    assert default_workflow_key(Config(data={}), workflows) == "build"
+
+
+def test_resolve_cloud_dispatch_plan_uses_provider_resolution(tmp_path: Path) -> None:
+    workflow_dir = tmp_path / ".github" / "workflows"
+    workflow_dir.mkdir(parents=True)
+    (workflow_dir / "ci.yml").write_text(
+        """
+name: CI
+on:
+  workflow_dispatch:
+    inputs:
+      runner_provider:
+        description: provider
+      runner_overrides:
+        description: overrides
+"""
+    )
+    workflows = discover_workflows(tmp_path)
+    config = Config(
+        data={
+            "cloud": {
+                "provider": "namespace",
+                "providers": {
+                    "namespace": {
+                        "runner_overrides": {
+                            "linux-x64": "namespace-profile-linux",
+                            "windows-x64": "namespace-profile-windows",
+                        }
+                    }
+                },
+            }
+        }
+    )
+
+    plan = resolve_cloud_dispatch_plan(
+        config=config,
+        workflows=workflows,
+        workflow_key="build",
+        ref="feature/test",
+    )
+
+    assert plan.provider == "namespace"
+    assert plan.dispatch_fields["runner_provider"] == "namespace"
+    assert "runner_overrides" in plan.dispatch_fields

--- a/tests/core/test_job.py
+++ b/tests/core/test_job.py
@@ -186,3 +186,16 @@ class TestTargetResult:
         assert d["primary_backend"] == "ssh"
         assert d["failover_reason"] == "ssh_unreachable"
         assert d["provider"] == "namespace"
+
+    def test_with_updates_records_progress_fields(self) -> None:
+        r = TargetResult(
+            target_name="mac",
+            platform="macos-arm64",
+            status=TargetStatus.RUNNING,
+            backend="local",
+        ).with_updates(phase="build", quiet_for_secs=12.4, liveness="quiet")
+
+        d = r.to_dict()
+        assert d["phase"] == "build"
+        assert d["quiet_for_secs"] == 12.4
+        assert d["liveness"] == "quiet"

--- a/tests/executor/test_ssh.py
+++ b/tests/executor/test_ssh.py
@@ -3,13 +3,15 @@
 from __future__ import annotations
 
 import subprocess
-from unittest.mock import MagicMock, mock_open, patch
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from shipyard.core.job import TargetStatus
 from shipyard.executor.ssh import SSHExecutor
 from shipyard.executor.ssh_windows import SSHWindowsExecutor
+from shipyard.executor.streaming import StreamingCommandResult
 
 
 # ---------------------------------------------------------------------------
@@ -42,6 +44,19 @@ def _windows_target_config(
 
 def _validation_config(command: str = "make test") -> dict:
     return {"command": command}
+
+
+def _streaming_result(returncode: int = 0, output: str = "") -> StreamingCommandResult:
+    now = datetime.now(timezone.utc)
+    return StreamingCommandResult(
+        returncode=returncode,
+        output=output,
+        started_at=now,
+        completed_at=now,
+        duration_secs=1.0,
+        last_output_at=now if output else None,
+        phase="test" if output else None,
+    )
 
 
 def _mock_bundle_success():
@@ -140,7 +155,7 @@ class TestSSHExecutorValidate:
 
         patches = _mock_bundle_success()
         with patches[0], patches[1], patches[2], \
-             patch("subprocess.run", return_value=mock_result):
+             patch("shipyard.executor.ssh.run_streaming_command", return_value=_streaming_result(0, "ok")):
             result = executor.validate(
                 sha="abc123",
                 branch="main",
@@ -156,11 +171,9 @@ class TestSSHExecutorValidate:
     def test_validate_fail(self, tmp_path) -> None:
         executor = SSHExecutor()
         log_path = str(tmp_path / "log.txt")
-        mock_result = MagicMock(returncode=1)
-
         patches = _mock_bundle_success()
         with patches[0], patches[1], patches[2], \
-             patch("subprocess.run", return_value=mock_result):
+             patch("shipyard.executor.ssh.run_streaming_command", return_value=_streaming_result(1, "failed")):
             result = executor.validate(
                 sha="abc123",
                 branch="main",
@@ -198,7 +211,10 @@ class TestSSHExecutorValidate:
 
         patches = _mock_bundle_success()
         with patches[0], patches[1], patches[2], \
-             patch("subprocess.run", side_effect=subprocess.TimeoutExpired("ssh", 1800)):
+             patch(
+                 "shipyard.executor.ssh.run_streaming_command",
+                 side_effect=subprocess.TimeoutExpired("ssh", 1800),
+             ):
             result = executor.validate(
                 sha="abc123",
                 branch="main",
@@ -230,11 +246,12 @@ class TestSSHExecutorValidate:
     def test_validate_uses_step_commands(self, tmp_path) -> None:
         executor = SSHExecutor()
         log_path = str(tmp_path / "log.txt")
-        mock_result = MagicMock(returncode=0)
-
         patches = _mock_bundle_success()
         with patches[0], patches[1], patches[2], \
-             patch("subprocess.run", return_value=mock_result) as mock_run:
+             patch(
+                 "shipyard.executor.ssh.run_streaming_command",
+                 return_value=_streaming_result(0, "ok"),
+             ) as mock_run:
             executor.validate(
                 sha="abc123",
                 branch="main",
@@ -246,7 +263,9 @@ class TestSSHExecutorValidate:
             # The SSH command should include the chained build + test
             ssh_cmd = mock_run.call_args[0][0]
             remote_cmd = ssh_cmd[-1]
-            assert "make && make test" in remote_cmd
+            assert "__SHIPYARD_PHASE__:build" in remote_cmd
+            assert "__SHIPYARD_PHASE__:test" in remote_cmd
+            assert "make test" in remote_cmd
 
 
 # ---------------------------------------------------------------------------
@@ -278,8 +297,6 @@ class TestSSHWindowsExecutorValidate:
     def test_validate_pass(self, tmp_path) -> None:
         executor = SSHWindowsExecutor()
         log_path = str(tmp_path / "log.txt")
-        mock_result = MagicMock(returncode=0)
-
         from shipyard.bundle.git_bundle import BundleResult
 
         with patch(
@@ -291,7 +308,10 @@ class TestSSHWindowsExecutorValidate:
         ), patch(
             "shipyard.executor.ssh_windows._apply_bundle_windows",
             return_value=type("R", (), {"success": True, "message": "ok"})(),
-        ), patch("subprocess.run", return_value=mock_result):
+        ), patch(
+            "shipyard.executor.ssh_windows.run_streaming_command",
+            return_value=_streaming_result(0, "ok"),
+        ):
             result = executor.validate(
                 sha="abc123",
                 branch="main",
@@ -306,8 +326,6 @@ class TestSSHWindowsExecutorValidate:
     def test_validate_fail(self, tmp_path) -> None:
         executor = SSHWindowsExecutor()
         log_path = str(tmp_path / "log.txt")
-        mock_result = MagicMock(returncode=1)
-
         from shipyard.bundle.git_bundle import BundleResult
 
         with patch(
@@ -319,7 +337,10 @@ class TestSSHWindowsExecutorValidate:
         ), patch(
             "shipyard.executor.ssh_windows._apply_bundle_windows",
             return_value=type("R", (), {"success": True, "message": "ok"})(),
-        ), patch("subprocess.run", return_value=mock_result):
+        ), patch(
+            "shipyard.executor.ssh_windows.run_streaming_command",
+            return_value=_streaming_result(1, "failed"),
+        ):
             result = executor.validate(
                 sha="abc123",
                 branch="main",
@@ -333,8 +354,6 @@ class TestSSHWindowsExecutorValidate:
     def test_validate_uses_powershell(self, tmp_path) -> None:
         executor = SSHWindowsExecutor()
         log_path = str(tmp_path / "log.txt")
-        mock_result = MagicMock(returncode=0)
-
         from shipyard.bundle.git_bundle import BundleResult
 
         with patch(
@@ -346,7 +365,10 @@ class TestSSHWindowsExecutorValidate:
         ), patch(
             "shipyard.executor.ssh_windows._apply_bundle_windows",
             return_value=type("R", (), {"success": True, "message": "ok"})(),
-        ), patch("subprocess.run", return_value=mock_result) as mock_run:
+        ), patch(
+            "shipyard.executor.ssh_windows.run_streaming_command",
+            return_value=_streaming_result(0, "ok"),
+        ) as mock_run:
             executor.validate(
                 sha="abc123",
                 branch="main",

--- a/tests/executor/test_streaming.py
+++ b/tests/executor/test_streaming.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import sys
+
+from shipyard.executor.streaming import run_streaming_command
+
+
+def test_run_streaming_command_parses_phase_markers(tmp_path) -> None:
+    seen: list[dict] = []
+    log_path = tmp_path / "stream.log"
+
+    result = run_streaming_command(
+        [
+            sys.executable,
+            "-c",
+            "print('__SHIPYARD_PHASE__:build'); print('building')",
+        ],
+        log_path=str(log_path),
+        progress_callback=lambda fields: seen.append(dict(fields)),
+    )
+
+    assert result.returncode == 0
+    assert result.phase == "build"
+    assert "building" in result.output
+    assert any(item.get("phase") == "build" for item in seen)
+    assert "building" in log_path.read_text()
+
+
+def test_run_streaming_command_emits_stuck_heartbeat(tmp_path) -> None:
+    seen: list[dict] = []
+
+    result = run_streaming_command(
+        [
+            sys.executable,
+            "-c",
+            "import time; time.sleep(0.18); print('done')",
+        ],
+        log_path=str(tmp_path / "heartbeat.log"),
+        heartbeat_interval_secs=0.05,
+        stuck_idle_secs=0.1,
+        progress_callback=lambda fields: seen.append(dict(fields)),
+    )
+
+    assert result.returncode == 0
+    heartbeats = [item for item in seen if item.get("last_heartbeat_at")]
+    assert heartbeats
+    assert any(item.get("liveness") == "stuck" for item in heartbeats)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from shipyard.cli import main
+from shipyard.cloud.registry import WorkflowDefinition
+from shipyard.core.config import Config
+from shipyard.core.job import TargetResult, TargetStatus
+from shipyard.preflight import PreflightResult
+
+
+def _config(tmp_path: Path, targets: dict, cloud: dict | None = None) -> Config:
+    project_dir = tmp_path / ".shipyard"
+    project_dir.mkdir()
+    return Config(
+        data={
+            "project": {"name": "shipyard", "platforms": ["linux"]},
+            "validation": {"default": {"command": "pytest"}},
+            "targets": targets,
+            "cloud": cloud or {},
+        },
+        project_dir=project_dir,
+    )
+
+
+def _preflight(config: Config) -> PreflightResult:
+    return PreflightResult(
+        git_root=config.project_dir.parent if config.project_dir else None,
+        expected_root=config.project_dir.parent if config.project_dir else None,
+        targets={},
+        warnings=[],
+    )
+
+
+def test_run_dispatches_to_ssh_executor(tmp_path, monkeypatch) -> None:
+    config = _config(
+        tmp_path,
+        {"ubuntu": {"backend": "ssh", "platform": "linux-x64", "host": "ubuntu"}},
+    )
+    monkeypatch.setattr("shipyard.cli.Config.load_from_cwd", lambda cwd=None: config)
+    monkeypatch.setattr("shipyard.core.config._default_state_dir", lambda: tmp_path / "state")
+    monkeypatch.setattr("shipyard.cli._git_sha", lambda: "a" * 40)
+    monkeypatch.setattr("shipyard.cli._git_branch", lambda: "feature/dispatch")
+    monkeypatch.setattr("shipyard.cli.run_submission_preflight", lambda *args, **kwargs: _preflight(config))
+
+    calls: list[str] = []
+
+    def fake_validate(self, **kwargs):
+        calls.append(kwargs["target_config"]["host"])
+        return TargetResult(
+            target_name="ubuntu",
+            platform="linux-x64",
+            status=TargetStatus.PASS,
+            backend="ssh",
+            started_at=datetime.now(timezone.utc),
+            completed_at=datetime.now(timezone.utc),
+        )
+
+    monkeypatch.setattr("shipyard.executor.ssh.SSHExecutor.validate", fake_validate)
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["--json", "run", "--targets", "ubuntu"])
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["run"]["results"]["ubuntu"]["backend"] == "ssh"
+    assert calls == ["ubuntu"]
+
+
+def test_status_reports_reachable_fallback_backend(tmp_path, monkeypatch) -> None:
+    config = _config(
+        tmp_path,
+        {
+            "ubuntu": {
+                "backend": "ssh",
+                "platform": "linux-x64",
+                "host": "ubuntu",
+                "fallback": [{"type": "cloud", "provider": "namespace"}],
+            }
+        },
+    )
+    monkeypatch.setattr("shipyard.cli.Config.load_from_cwd", lambda cwd=None: config)
+    monkeypatch.setattr("shipyard.core.config._default_state_dir", lambda: tmp_path / "state")
+    monkeypatch.setattr(
+        "shipyard.executor.dispatch.ExecutorDispatcher.probe",
+        lambda self, target_config: str(target_config.get("type") or target_config.get("backend")) == "cloud",
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["--json", "status"])
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["targets"]["ubuntu"]["reachable"] is True
+    assert payload["targets"]["ubuntu"]["fallback"] == "cloud"
+
+
+def test_cloud_run_and_status_persist_records(tmp_path, monkeypatch) -> None:
+    config = _config(tmp_path, {"mac": {"backend": "local", "platform": "macos-arm64"}}, cloud={"provider": "github-hosted"})
+    monkeypatch.setattr("shipyard.cli.Config.load_from_cwd", lambda cwd=None: config)
+    monkeypatch.setattr("shipyard.core.config._default_state_dir", lambda: tmp_path / "state")
+    monkeypatch.setattr(
+        "shipyard.cli.discover_workflows",
+        lambda: {
+            "build": WorkflowDefinition(
+                key="build",
+                file="ci.yml",
+                name="CI",
+                description="CI (ci.yml)",
+                inputs=("runner_provider",),
+            )
+        },
+    )
+    monkeypatch.setattr("shipyard.cli.workflow_dispatch", lambda **kwargs: None)
+    monkeypatch.setattr(
+        "shipyard.cli.find_dispatched_run",
+        lambda **kwargs: {
+            "databaseId": 12345,
+            "status": "queued",
+            "url": "https://example.test/runs/12345",
+        },
+    )
+    monkeypatch.setattr(
+        "shipyard.cli._wait_for_cloud_completion",
+        lambda repository, run_id: {
+            "status": "completed",
+            "conclusion": "success",
+            "url": f"https://example.test/runs/{run_id}",
+        },
+    )
+
+    runner = CliRunner()
+    run_result = runner.invoke(main, ["--json", "cloud", "run", "build", "feature/cloud", "--wait"])
+    assert run_result.exit_code == 0, run_result.output
+
+    status_result = runner.invoke(main, ["--json", "cloud", "status", "latest"])
+    assert status_result.exit_code == 0, status_result.output
+    payload = json.loads(status_result.output)
+    assert payload["records"][0]["run_id"] == "12345"
+    assert payload["records"][0]["conclusion"] == "success"
+
+
+def test_module_entrypoint_prints_version() -> None:
+    result = subprocess.run(
+        [sys.executable, "src/shipyard/cli.py", "--version"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    assert "shipyard" in result.stdout.lower()

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from shipyard.core.config import Config
+from shipyard.executor.dispatch import ExecutorDispatcher
+from shipyard.preflight import run_submission_preflight
+
+
+def _config(tmp_path: Path, targets: dict) -> Config:
+    project_dir = tmp_path / ".shipyard"
+    project_dir.mkdir()
+    return Config(
+        data={"project": {"name": "test"}, "targets": targets},
+        project_dir=project_dir,
+    )
+
+
+def test_root_mismatch_rejected_by_default(tmp_path, monkeypatch) -> None:
+    config = _config(tmp_path, {"mac": {"backend": "local", "platform": "macos-arm64"}})
+    dispatcher = ExecutorDispatcher()
+    monkeypatch.setattr("shipyard.preflight._git_root_for", lambda _: tmp_path / "other-root")
+
+    with pytest.raises(ValueError, match="does not match"):
+        run_submission_preflight(
+            config,
+            target_names=["mac"],
+            dispatcher=dispatcher,
+            cwd=tmp_path,
+        )
+
+
+def test_fallback_backend_allows_submission(tmp_path, monkeypatch) -> None:
+    config = _config(
+        tmp_path,
+        {
+            "ubuntu": {
+                "backend": "ssh",
+                "platform": "linux-x64",
+                "host": "ubuntu",
+                "fallback": [{"type": "cloud", "provider": "namespace"}],
+            }
+        },
+    )
+    dispatcher = ExecutorDispatcher()
+    monkeypatch.setattr("shipyard.preflight._git_root_for", lambda _: tmp_path)
+    monkeypatch.setattr(
+        dispatcher,
+        "probe",
+        lambda target_config: str(target_config.get("type") or target_config.get("backend")) == "cloud",
+    )
+
+    result = run_submission_preflight(
+        config,
+        target_names=["ubuntu"],
+        dispatcher=dispatcher,
+        cwd=tmp_path,
+    )
+
+    assert result.targets["ubuntu"].reachable is True
+    assert result.targets["ubuntu"].selected_backend == "cloud"
+    assert any("failover backend 'cloud'" in warning for warning in result.warnings)
+
+
+def test_unreachable_target_rejected_without_override(tmp_path, monkeypatch) -> None:
+    config = _config(
+        tmp_path,
+        {"ubuntu": {"backend": "ssh", "platform": "linux-x64", "host": "ubuntu"}},
+    )
+    dispatcher = ExecutorDispatcher()
+    monkeypatch.setattr("shipyard.preflight._git_root_for", lambda _: tmp_path)
+    monkeypatch.setattr(dispatcher, "probe", lambda target_config: False)
+
+    with pytest.raises(ValueError, match="no reachable backend"):
+        run_submission_preflight(
+            config,
+            target_names=["ubuntu"],
+            dispatcher=dispatcher,
+            cwd=tmp_path,
+        )


### PR DESCRIPTION
## Summary
Lands the work on \`feat/shipyard-phases-1-4\` into main so v0.1.2 can be cut. This PR is a fast-forward from the existing work on the feature branch.

The full description is in commit d6fdbe2 — TL;DR:

- **Phase 1**: \`shipyard run\` and \`shipyard ship\` dispatch by target backend (local / SSH / Windows-SSH / cloud / fallback chain) instead of hardcoding local execution.
- **Phase 2**: submission preflight gates queue enqueue with root-mismatch and target-reachability checks (override flags for intentional exceptions).
- **Phase 3**: \`shipyard cloud workflows / defaults / run / status\` are implemented with workflow discovery, dispatch-plan resolution, and persisted cloud run records.
- **Phase 4**: local / SSH / Windows-SSH / cloud execution all report streaming progress, phase markers, heartbeats, and liveness through \`shipyard status\`.
- **Bonus**: PyInstaller entrypoint fix in \`src/shipyard/cli.py\` so the published binaries actually execute \`main()\` when invoked. The v0.1.1 published binary was a no-op stub because of this — Pulp's bootstrap script downloaded the binary, verified the SHA, but then \`shipyard --version\` produced no output.

## Verification
- 230 tests pass (\`python -m pytest\`)
- Static checks pass (\`python -m ruff check src\` + \`python -m mypy src\`)
- Local PyInstaller binary verified

## Why merging this matters
Pulp's downstream adoption work needs a working v0.1.2 release. Without the entrypoint fix, every Pulp checkout that runs \`./tools/install-shipyard.sh\` would download a binary that does nothing. Tagging v0.1.2 from main after this PR merges produces the first usable Shipyard release for downstream consumers.

## Test plan
- [x] Already verified upstream on the feature branch
- [ ] CI green on this PR
- [ ] After merge: tag v0.1.2, release workflow publishes 5 binaries + checksums
- [ ] Downstream Pulp \`./tools/install-shipyard.sh\` succeeds and \`shipyard --version\` reports v0.1.2