### PR TITLE
Phase 5 (1/4): validation contract markers + LocalExecutor enforcement

### DIFF
--- a/src/shipyard/core/job.py
+++ b/src/shipyard/core/job.py
@@ -73,6 +73,17 @@ class TargetResult:
     runner_profile: str | None = None
     # Error detail
     error_message: str | None = None
+    # Validation contract violation. When the project declares
+    # required contract markers in `[validation.contract]`, the
+    # executor records which markers were seen and which were missing.
+    # If `enforce = true` and any required marker is missing, the
+    # status is forced to FAIL and `contract_violation` carries a
+    # human-readable explanation. When `enforce = false`, missing
+    # markers are recorded here as a warning but the status is
+    # unchanged.
+    contract_markers_seen: tuple[str, ...] = ()
+    contract_markers_missing: tuple[str, ...] = ()
+    contract_violation: str | None = None
 
     @property
     def passed(self) -> bool:
@@ -129,6 +140,12 @@ class TargetResult:
             d["runner_profile"] = self.runner_profile
         if self.error_message:
             d["error_message"] = self.error_message
+        if self.contract_markers_seen:
+            d["contract_markers_seen"] = list(self.contract_markers_seen)
+        if self.contract_markers_missing:
+            d["contract_markers_missing"] = list(self.contract_markers_missing)
+        if self.contract_violation:
+            d["contract_violation"] = self.contract_violation
         return d
 
 

--- a/src/shipyard/executor/contract.py
+++ b/src/shipyard/executor/contract.py
@@ -1,0 +1,128 @@
+"""Validation contract evaluation.
+
+A "validation contract" is a project-declared expectation that the
+validation script will emit specific marker strings during the run.
+For example, Pulp's `validate-build.sh` emits `__PULP_VALIDATION__:smoke`
+when running smoke validation and `__PULP_VALIDATION__:full` when running
+full validation. If neither marker appears in the output, the run is
+not authentic — either the script ran the wrong code path or it was
+bypassed entirely — and the result should be treated as a failure
+regardless of the process exit code.
+
+The contract is configured per project in `.shipyard/config.toml`:
+
+    [validation.contract]
+    markers = ["__PULP_VALIDATION__:smoke", "__PULP_VALIDATION__:full"]
+    require_at_least_one = true        # default: true
+    enforce = true                     # default: true (failing missing → FAIL)
+                                       #          false → record as warning only
+
+Three modes:
+
+- `enforce = true`, `require_at_least_one = true`:
+    At least one marker must appear. Missing → FAIL.
+- `enforce = true`, `require_at_least_one = false`:
+    All declared markers must appear. Any missing → FAIL.
+- `enforce = false`:
+    Markers are recorded for visibility but never fail the run.
+
+The streaming layer records which markers appeared. This module
+evaluates the result against the contract and returns the (possibly
+modified) status + a violation message.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class ContractEvaluation:
+    """The outcome of evaluating a contract against a streamed result."""
+
+    seen: tuple[str, ...]
+    missing: tuple[str, ...]
+    violated: bool      # True if the contract requires action and was violated
+    enforce: bool       # Whether enforcement is on (drives FAIL vs WARN)
+    message: str | None  # Human-readable explanation when violated
+
+    @property
+    def should_force_fail(self) -> bool:
+        """Whether this evaluation should override a passing exit code."""
+        return self.violated and self.enforce
+
+
+def evaluate_contract(
+    contract_config: dict[str, Any] | None,
+    seen_markers: tuple[str, ...],
+) -> ContractEvaluation:
+    """Compare seen markers against the project's contract config.
+
+    `contract_config` is the parsed `[validation.contract]` table from
+    `.shipyard/config.toml`, or None if no contract is declared. When
+    None, the evaluation is a no-op (no markers required, no violation).
+
+    `seen_markers` is the tuple recorded by `run_streaming_command` —
+    every required marker that appeared at least once in the output.
+    """
+    if not contract_config:
+        return ContractEvaluation(
+            seen=seen_markers,
+            missing=(),
+            violated=False,
+            enforce=False,
+            message=None,
+        )
+
+    declared_markers = tuple(contract_config.get("markers", ()))
+    if not declared_markers:
+        return ContractEvaluation(
+            seen=seen_markers,
+            missing=(),
+            violated=False,
+            enforce=False,
+            message=None,
+        )
+
+    require_at_least_one = bool(contract_config.get("require_at_least_one", True))
+    enforce = bool(contract_config.get("enforce", True))
+
+    seen_set = set(seen_markers)
+    missing = tuple(m for m in declared_markers if m not in seen_set)
+
+    if require_at_least_one:
+        violated = len(seen_set & set(declared_markers)) == 0
+        if violated:
+            message = (
+                f"Validation contract requires at least one of "
+                f"{list(declared_markers)} to appear in the output. "
+                f"None were observed."
+            )
+        else:
+            message = None
+            missing = ()  # at-least-one mode does not flag absent markers
+    else:
+        violated = len(missing) > 0
+        if violated:
+            message = (
+                f"Validation contract requires every declared marker to "
+                f"appear in the output. Missing: {list(missing)}."
+            )
+        else:
+            message = None
+
+    return ContractEvaluation(
+        seen=seen_markers,
+        missing=missing,
+        violated=violated,
+        enforce=enforce,
+        message=message,
+    )
+
+
+def required_markers(contract_config: dict[str, Any] | None) -> tuple[str, ...]:
+    """Extract the marker list to pass to `run_streaming_command`."""
+    if not contract_config:
+        return ()
+    return tuple(contract_config.get("markers", ()))

--- a/src/shipyard/executor/local.py
+++ b/src/shipyard/executor/local.py
@@ -19,6 +19,10 @@ from pathlib import Path
 from typing import Any
 
 from shipyard.core.job import TargetResult, TargetStatus
+from shipyard.executor.contract import (
+    evaluate_contract,
+    required_markers,
+)
 from shipyard.executor.streaming import ProgressCallback, run_streaming_command
 
 STAGES = ("setup", "configure", "build", "test")
@@ -55,11 +59,18 @@ class LocalExecutor:
         log_file = Path(log_path)
         log_file.parent.mkdir(parents=True, exist_ok=True)
 
+        # Validation contract — optional per project. If declared in
+        # `[validation.contract]`, it gets passed to the streaming
+        # layer (so markers are recorded) and to the result evaluator
+        # (so missing markers can flip status to FAIL).
+        contract_config = validation_config.get("contract") if validation_config else None
+
         # Single command mode
         if "command" in validation_config:
             return self._run_single(
                 validation_config["command"], target_name, platform,
                 target_config, log_file, started_at, start_time, progress_callback,
+                contract_config=contract_config,
             )
 
         # Stage-aware mode
@@ -75,6 +86,7 @@ class LocalExecutor:
         return self._run_stages(
             stages, target_name, platform, target_config,
             log_file, started_at, start_time, progress_callback,
+            contract_config=contract_config,
         )
 
     def _run_single(
@@ -82,6 +94,7 @@ class LocalExecutor:
         target_config: dict[str, Any], log_file: Path,
         started_at: datetime, start_time: float,
         progress_callback: ProgressCallback | None,
+        contract_config: dict[str, Any] | None = None,
     ) -> TargetResult:
         try:
             result = run_streaming_command(
@@ -91,8 +104,12 @@ class LocalExecutor:
                 log_path=str(log_file),
                 timeout=target_config.get("timeout_secs", 1800),
                 progress_callback=progress_callback,
+                required_contract_markers=required_markers(contract_config),
             )
             status = TargetStatus.PASS if result.returncode == 0 else TargetStatus.FAIL
+            evaluation = evaluate_contract(contract_config, result.contract_markers_seen)
+            if evaluation.should_force_fail and status == TargetStatus.PASS:
+                status = TargetStatus.FAIL
             return TargetResult(
                 target_name=target_name, platform=platform,
                 status=status, backend="local", duration_secs=result.duration_secs,
@@ -100,6 +117,9 @@ class LocalExecutor:
                 log_path=str(log_file),
                 phase=result.phase,
                 last_output_at=result.last_output_at,
+                contract_markers_seen=evaluation.seen,
+                contract_markers_missing=evaluation.missing,
+                contract_violation=evaluation.message,
             )
         except subprocess.TimeoutExpired:
             return TargetResult(
@@ -122,10 +142,16 @@ class LocalExecutor:
         platform: str, target_config: dict[str, Any], log_file: Path,
         started_at: datetime, start_time: float,
         progress_callback: ProgressCallback | None,
+        contract_config: dict[str, Any] | None = None,
     ) -> TargetResult:
         """Run validation as separate stages. Stop at first failure."""
         failed_stage = None
         last_output_at: datetime | None = None
+        # Accumulate contract markers seen across every stage. The
+        # contract is evaluated once at the end of the run, so a
+        # marker emitted in any stage counts.
+        all_seen_markers: list[str] = []
+        contract_markers_to_watch = required_markers(contract_config)
 
         try:
             log_file.write_text("")
@@ -147,6 +173,7 @@ class LocalExecutor:
                     timeout=target_config.get("timeout_secs", 1800),
                     phase=stage_name,
                     progress_callback=progress_callback,
+                    required_contract_markers=contract_markers_to_watch,
                 )
 
                 _ = StageResult(
@@ -155,6 +182,9 @@ class LocalExecutor:
                     duration_secs=time.monotonic() - stage_start,
                 )
                 last_output_at = result.last_output_at
+                for marker in result.contract_markers_seen:
+                    if marker not in all_seen_markers:
+                        all_seen_markers.append(marker)
 
                 if result.returncode != 0:
                     failed_stage = stage_name
@@ -177,6 +207,8 @@ class LocalExecutor:
             )
 
         elapsed = time.monotonic() - start_time
+        evaluation = evaluate_contract(contract_config, tuple(all_seen_markers))
+
         if failed_stage:
             error_msg = f"Stage '{failed_stage}' failed"
             return TargetResult(
@@ -187,16 +219,30 @@ class LocalExecutor:
                 log_path=str(log_file), error_message=error_msg,
                 phase=failed_stage,
                 last_output_at=last_output_at,
+                contract_markers_seen=evaluation.seen,
+                contract_markers_missing=evaluation.missing,
+                contract_violation=evaluation.message,
             )
+
+        # All stages passed by exit code. Now check the contract — a
+        # missing required marker can flip the status to FAIL even
+        # though every stage exited 0.
+        final_status = TargetStatus.PASS
+        if evaluation.should_force_fail:
+            final_status = TargetStatus.FAIL
 
         return TargetResult(
             target_name=target_name, platform=platform,
-            status=TargetStatus.PASS, backend="local",
+            status=final_status, backend="local",
             duration_secs=elapsed, started_at=started_at,
             completed_at=datetime.now(timezone.utc),
             log_path=str(log_file),
             phase=stages[-1][0] if stages else None,
             last_output_at=last_output_at,
+            error_message=evaluation.message if final_status == TargetStatus.FAIL else None,
+            contract_markers_seen=evaluation.seen,
+            contract_markers_missing=evaluation.missing,
+            contract_violation=evaluation.message,
         )
 
     def probe(self, target_config: dict[str, Any]) -> bool:

--- a/src/shipyard/executor/ssh.py
+++ b/src/shipyard/executor/ssh.py
@@ -15,6 +15,7 @@ from typing import Any
 
 from shipyard.bundle.git_bundle import apply_bundle, create_bundle, upload_bundle
 from shipyard.core.job import TargetResult, TargetStatus
+from shipyard.executor.contract import evaluate_contract, required_markers
 from shipyard.executor.streaming import ProgressCallback, run_streaming_command
 from shipyard.failover.retry import SSHPermanentError, SSHTransientError, is_transient, retry_ssh
 
@@ -135,12 +136,15 @@ class SSHExecutor:
 
         ssh_cmd = ["ssh"] + list(ssh_options) + [host, command]
 
+        contract_config = validation_config.get("contract") if validation_config else None
+
         try:
             result = run_streaming_command(
                 ssh_cmd,
                 log_path=str(log_file),
                 timeout=target_config.get("timeout_secs", 1800),
                 progress_callback=progress_callback,
+                required_contract_markers=required_markers(contract_config),
             )
 
             status = TargetStatus.PASS if result.returncode == 0 else TargetStatus.FAIL
@@ -148,6 +152,11 @@ class SSHExecutor:
             if result.returncode == 255:
                 status = TargetStatus.ERROR
                 error_message = _extract_ssh_error(result.output) or "SSH transport failed"
+
+            evaluation = evaluate_contract(contract_config, result.contract_markers_seen)
+            if evaluation.should_force_fail and status == TargetStatus.PASS:
+                status = TargetStatus.FAIL
+                error_message = evaluation.message
 
             return TargetResult(
                 target_name=target_name,
@@ -161,6 +170,9 @@ class SSHExecutor:
                 phase=result.phase,
                 last_output_at=result.last_output_at,
                 error_message=error_message,
+                contract_markers_seen=evaluation.seen,
+                contract_markers_missing=evaluation.missing,
+                contract_violation=evaluation.message,
             )
 
         except subprocess.TimeoutExpired:

--- a/src/shipyard/executor/ssh_windows.py
+++ b/src/shipyard/executor/ssh_windows.py
@@ -15,6 +15,7 @@ from typing import Any
 
 from shipyard.bundle.git_bundle import create_bundle, upload_bundle
 from shipyard.core.job import TargetResult, TargetStatus
+from shipyard.executor.contract import evaluate_contract, required_markers
 from shipyard.executor.streaming import ProgressCallback, run_streaming_command
 
 
@@ -99,12 +100,15 @@ class SSHWindowsExecutor:
             ["ssh"] + list(ssh_options) + [host, "powershell", "-Command", command]
         )
 
+        contract_config = validation_config.get("contract") if validation_config else None
+
         try:
             result = run_streaming_command(
                 ssh_cmd,
                 log_path=str(log_file),
                 timeout=target_config.get("timeout_secs", 1800),
                 progress_callback=progress_callback,
+                required_contract_markers=required_markers(contract_config),
             )
 
             status = TargetStatus.PASS if result.returncode == 0 else TargetStatus.FAIL
@@ -112,6 +116,11 @@ class SSHWindowsExecutor:
             if result.returncode == 255:
                 status = TargetStatus.ERROR
                 error_message = _extract_ssh_error(result.output) or "SSH transport failed"
+
+            evaluation = evaluate_contract(contract_config, result.contract_markers_seen)
+            if evaluation.should_force_fail and status == TargetStatus.PASS:
+                status = TargetStatus.FAIL
+                error_message = evaluation.message
 
             return TargetResult(
                 target_name=target_name,
@@ -125,6 +134,9 @@ class SSHWindowsExecutor:
                 phase=result.phase,
                 last_output_at=result.last_output_at,
                 error_message=error_message,
+                contract_markers_seen=evaluation.seen,
+                contract_markers_missing=evaluation.missing,
+                contract_violation=evaluation.message,
             )
 
         except subprocess.TimeoutExpired:

--- a/src/shipyard/executor/streaming.py
+++ b/src/shipyard/executor/streaming.py
@@ -32,6 +32,18 @@ class StreamingCommandResult:
     duration_secs: float
     last_output_at: datetime | None
     phase: str | None
+    # Contract markers seen during the run. A "contract marker" is a
+    # specific string the validation script is required to emit at
+    # least once for the run to be considered authentic. The streaming
+    # layer records every marker from `required_contract_markers` that
+    # appears in the output; the caller can then check whether all
+    # required markers were observed and treat a missing marker as a
+    # contract violation regardless of process exit code.
+    #
+    # Markers are matched as substrings (not regexes) against each
+    # decoded output line, so the validation script can emit them
+    # anywhere in a line, not just at line start.
+    contract_markers_seen: tuple[str, ...] = ()
 
 
 ProgressCallback = Callable[[dict[str, Any]], None]
@@ -49,8 +61,16 @@ def run_streaming_command(
     heartbeat_interval_secs: float = 30.0,
     stuck_idle_secs: float = 90.0,
     progress_callback: ProgressCallback | None = None,
+    required_contract_markers: tuple[str, ...] | list[str] | None = None,
 ) -> StreamingCommandResult:
-    """Run a command while streaming output to disk and progress callbacks."""
+    """Run a command while streaming output to disk and progress callbacks.
+
+    `required_contract_markers` is an optional list of substring markers
+    the streaming layer should watch for in the command's output. Each
+    seen marker is recorded in the result's `contract_markers_seen`
+    field. The caller decides what to do about missing markers — the
+    streaming layer never fails the process based on contract.
+    """
     started_at = datetime.now(timezone.utc)
     start_time = time.monotonic()
     log_file = Path(log_path) if log_path else None
@@ -77,6 +97,11 @@ def run_streaming_command(
     last_output_at: datetime | None = None
     last_output_monotonic = start_time
     current_phase = phase
+    # Track which contract markers have appeared. Use a list (not a
+    # set) so the order of first occurrence is preserved for
+    # diagnostic output.
+    markers_to_watch = tuple(required_contract_markers or ())
+    seen_markers: list[str] = []
 
     try:
         mode = "a" if append else "w"
@@ -119,6 +144,14 @@ def run_streaming_command(
                 if marker_phase:
                     current_phase = marker_phase
 
+                # Contract marker tracking. Match as substring against
+                # the decoded line so the validation script can emit
+                # the marker as part of a longer status message.
+                if markers_to_watch:
+                    for marker in markers_to_watch:
+                        if marker in decoded and marker not in seen_markers:
+                            seen_markers.append(marker)
+
                 last_output_at = datetime.now(timezone.utc)
                 last_output_monotonic = time.monotonic()
                 if progress_callback:
@@ -147,6 +180,7 @@ def run_streaming_command(
         duration_secs=time.monotonic() - start_time,
         last_output_at=last_output_at,
         phase=current_phase,
+        contract_markers_seen=tuple(seen_markers),
     )
 
 

--- a/tests/executor/test_contract.py
+++ b/tests/executor/test_contract.py
@@ -1,0 +1,168 @@
+"""Tests for the validation contract evaluator."""
+
+from __future__ import annotations
+
+from shipyard.executor.contract import (
+    evaluate_contract,
+    required_markers,
+)
+
+# ── required_markers helper ─────────────────────────────────────────────
+
+
+def test_required_markers_none() -> None:
+    assert required_markers(None) == ()
+
+
+def test_required_markers_empty() -> None:
+    assert required_markers({}) == ()
+    assert required_markers({"markers": []}) == ()
+
+
+def test_required_markers_returns_tuple() -> None:
+    cfg = {"markers": ["__PULP_VALIDATION__:smoke", "__PULP_VALIDATION__:full"]}
+    assert required_markers(cfg) == (
+        "__PULP_VALIDATION__:smoke",
+        "__PULP_VALIDATION__:full",
+    )
+
+
+# ── No contract → no-op evaluation ──────────────────────────────────────
+
+
+def test_evaluate_contract_no_config() -> None:
+    result = evaluate_contract(None, ("anything",))
+    assert result.violated is False
+    assert result.enforce is False
+    assert result.message is None
+    assert result.missing == ()
+    assert result.should_force_fail is False
+
+
+def test_evaluate_contract_empty_config() -> None:
+    result = evaluate_contract({}, ("anything",))
+    assert result.violated is False
+    assert result.message is None
+
+
+def test_evaluate_contract_no_markers_declared() -> None:
+    result = evaluate_contract({"enforce": True, "markers": []}, ("anything",))
+    assert result.violated is False
+
+
+# ── require_at_least_one mode (default) ─────────────────────────────────
+
+
+def test_at_least_one_satisfied() -> None:
+    cfg = {"markers": ["__PULP_VALIDATION__:smoke", "__PULP_VALIDATION__:full"]}
+    result = evaluate_contract(cfg, ("__PULP_VALIDATION__:smoke",))
+    assert result.violated is False
+    assert result.missing == ()
+    assert result.message is None
+    assert result.should_force_fail is False
+
+
+def test_at_least_one_violated() -> None:
+    cfg = {"markers": ["__PULP_VALIDATION__:smoke", "__PULP_VALIDATION__:full"]}
+    result = evaluate_contract(cfg, ())
+    assert result.violated is True
+    assert result.message is not None
+    assert "at least one" in result.message
+    assert "__PULP_VALIDATION__:smoke" in result.message
+    assert result.should_force_fail is True
+
+
+def test_at_least_one_violated_warn_only() -> None:
+    cfg = {
+        "markers": ["__PULP_VALIDATION__:smoke"],
+        "enforce": False,
+    }
+    result = evaluate_contract(cfg, ())
+    assert result.violated is True
+    assert result.enforce is False
+    # warn-only: do NOT force fail even though the contract is violated
+    assert result.should_force_fail is False
+
+
+# ── require_all mode ────────────────────────────────────────────────────
+
+
+def test_require_all_satisfied() -> None:
+    cfg = {
+        "markers": ["__PULP_VALIDATION__:smoke", "__PULP_VALIDATION__:full"],
+        "require_at_least_one": False,
+    }
+    result = evaluate_contract(
+        cfg,
+        ("__PULP_VALIDATION__:smoke", "__PULP_VALIDATION__:full"),
+    )
+    assert result.violated is False
+    assert result.missing == ()
+
+
+def test_require_all_one_missing() -> None:
+    cfg = {
+        "markers": ["__PULP_VALIDATION__:smoke", "__PULP_VALIDATION__:full"],
+        "require_at_least_one": False,
+    }
+    result = evaluate_contract(cfg, ("__PULP_VALIDATION__:smoke",))
+    assert result.violated is True
+    assert result.missing == ("__PULP_VALIDATION__:full",)
+    assert result.message is not None
+    assert "every declared marker" in result.message
+    assert "__PULP_VALIDATION__:full" in result.message
+    assert result.should_force_fail is True
+
+
+def test_require_all_all_missing() -> None:
+    cfg = {
+        "markers": ["a", "b", "c"],
+        "require_at_least_one": False,
+    }
+    result = evaluate_contract(cfg, ())
+    assert result.violated is True
+    assert result.missing == ("a", "b", "c")
+    assert result.should_force_fail is True
+
+
+def test_require_all_warn_only() -> None:
+    cfg = {
+        "markers": ["a", "b"],
+        "require_at_least_one": False,
+        "enforce": False,
+    }
+    result = evaluate_contract(cfg, ("a",))
+    assert result.violated is True
+    assert result.missing == ("b",)
+    assert result.should_force_fail is False  # warn only
+
+
+# ── Edge cases ──────────────────────────────────────────────────────────
+
+
+def test_extra_markers_seen_dont_break_validation() -> None:
+    """A marker the run emitted but the contract didn't ask for is fine."""
+    cfg = {"markers": ["__PULP_VALIDATION__:smoke"]}
+    result = evaluate_contract(
+        cfg,
+        ("__PULP_VALIDATION__:smoke", "__SOMETHING_ELSE__"),
+    )
+    assert result.violated is False
+
+
+def test_seen_field_preserves_input() -> None:
+    """The evaluation always echoes the seen tuple verbatim."""
+    seen = ("a", "b", "c")
+    result = evaluate_contract({"markers": ["a"]}, seen)
+    assert result.seen == seen
+
+
+def test_contract_evaluation_is_frozen() -> None:
+    """ContractEvaluation should be immutable."""
+    result = evaluate_contract(None, ())
+    try:
+        result.violated = True  # type: ignore[misc]
+    except (AttributeError, Exception):
+        pass
+    else:
+        raise AssertionError("ContractEvaluation should be frozen")

--- a/tests/executor/test_local_contract.py
+++ b/tests/executor/test_local_contract.py
@@ -1,0 +1,223 @@
+"""End-to-end tests for the LocalExecutor + validation contract integration.
+
+These tests run real subprocesses (small shell commands) so the
+streaming layer's marker detection is exercised against actual line
+output, not mocked. They verify that:
+
+- A successful run that emits the required marker passes
+- A successful run that does not emit the required marker fails when
+  enforce=true
+- A successful run that does not emit the required marker passes
+  with the violation recorded as a warning when enforce=false
+- A real exit-code failure stays a failure regardless of contract
+- Contract markers appearing across multiple stages are accumulated
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from shipyard.core.job import TargetStatus
+from shipyard.executor.local import LocalExecutor
+
+
+@pytest.fixture
+def log_dir() -> Path:
+    with tempfile.TemporaryDirectory() as tmp:
+        yield Path(tmp)
+
+
+def _validate(
+    log_dir: Path,
+    *,
+    command: str | None = None,
+    stages: dict[str, str] | None = None,
+    contract: dict | None = None,
+):
+    executor = LocalExecutor()
+    validation_config: dict = {}
+    if command is not None:
+        validation_config["command"] = command
+    if stages is not None:
+        validation_config.update(stages)
+    if contract is not None:
+        validation_config["contract"] = contract
+
+    return executor.validate(
+        sha="test-sha",
+        branch="test-branch",
+        target_config={"name": "test", "platform": "macos-arm64"},
+        validation_config=validation_config,
+        log_path=str(log_dir / "test.log"),
+    )
+
+
+def test_single_command_with_marker_passes(log_dir: Path) -> None:
+    result = _validate(
+        log_dir,
+        command='echo "__PULP_VALIDATION__:smoke ok"',
+        contract={
+            "markers": ["__PULP_VALIDATION__:smoke", "__PULP_VALIDATION__:full"],
+        },
+    )
+    assert result.status == TargetStatus.PASS
+    assert "__PULP_VALIDATION__:smoke" in result.contract_markers_seen
+    assert result.contract_markers_missing == ()
+    assert result.contract_violation is None
+
+
+def test_single_command_without_marker_fails_when_enforced(log_dir: Path) -> None:
+    result = _validate(
+        log_dir,
+        command='echo "ran something useful but no marker"',
+        contract={
+            "markers": ["__PULP_VALIDATION__:smoke", "__PULP_VALIDATION__:full"],
+            "enforce": True,
+        },
+    )
+    assert result.status == TargetStatus.FAIL
+    assert result.contract_violation is not None
+    assert "at least one" in result.contract_violation
+
+
+def test_single_command_without_marker_passes_when_warn_only(log_dir: Path) -> None:
+    result = _validate(
+        log_dir,
+        command='echo "no marker emitted"',
+        contract={
+            "markers": ["__PULP_VALIDATION__:smoke"],
+            "enforce": False,
+        },
+    )
+    # Even though contract was violated, enforce=false → status stays PASS
+    assert result.status == TargetStatus.PASS
+    # But the violation message is still recorded for visibility
+    assert result.contract_violation is not None
+
+
+def test_real_failure_stays_failure_with_contract(log_dir: Path) -> None:
+    """If the process exits non-zero, the result is FAIL regardless of marker state."""
+    result = _validate(
+        log_dir,
+        command='echo "__PULP_VALIDATION__:smoke" && exit 1',
+        contract={
+            "markers": ["__PULP_VALIDATION__:smoke"],
+            "enforce": True,
+        },
+    )
+    assert result.status == TargetStatus.FAIL
+    # The marker WAS seen, but the process failed anyway
+    assert "__PULP_VALIDATION__:smoke" in result.contract_markers_seen
+
+
+def test_no_contract_no_markers_no_change(log_dir: Path) -> None:
+    """When no contract is declared, marker tracking is a no-op."""
+    result = _validate(
+        log_dir,
+        command='echo "__PULP_VALIDATION__:smoke just chilling"',
+    )
+    assert result.status == TargetStatus.PASS
+    # No contract config means no marker tracking
+    assert result.contract_markers_seen == ()
+    assert result.contract_markers_missing == ()
+    assert result.contract_violation is None
+
+
+def test_marker_appears_in_middle_of_line(log_dir: Path) -> None:
+    """The marker is matched as a substring, not a line prefix."""
+    result = _validate(
+        log_dir,
+        command='echo "starting up: __PULP_VALIDATION__:full mode active"',
+        contract={
+            "markers": ["__PULP_VALIDATION__:full"],
+        },
+    )
+    assert result.status == TargetStatus.PASS
+    assert "__PULP_VALIDATION__:full" in result.contract_markers_seen
+
+
+def test_require_all_with_one_missing(log_dir: Path) -> None:
+    result = _validate(
+        log_dir,
+        command='echo "__PULP_VALIDATION__:smoke" && echo "done"',
+        contract={
+            "markers": ["__PULP_VALIDATION__:smoke", "__PULP_VALIDATION__:full"],
+            "require_at_least_one": False,
+            "enforce": True,
+        },
+    )
+    assert result.status == TargetStatus.FAIL
+    assert "__PULP_VALIDATION__:full" in result.contract_markers_missing
+    assert result.contract_violation is not None
+
+
+def test_require_all_with_all_present(log_dir: Path) -> None:
+    result = _validate(
+        log_dir,
+        command='echo "__PULP_VALIDATION__:smoke" && echo "__PULP_VALIDATION__:full"',
+        contract={
+            "markers": ["__PULP_VALIDATION__:smoke", "__PULP_VALIDATION__:full"],
+            "require_at_least_one": False,
+            "enforce": True,
+        },
+    )
+    assert result.status == TargetStatus.PASS
+    assert set(result.contract_markers_seen) == {
+        "__PULP_VALIDATION__:smoke",
+        "__PULP_VALIDATION__:full",
+    }
+    assert result.contract_markers_missing == ()
+
+
+def test_marker_accumulated_across_stages(log_dir: Path) -> None:
+    """A marker emitted in one stage counts for the whole run."""
+    result = _validate(
+        log_dir,
+        stages={
+            "setup": 'echo "setting up"',
+            "configure": 'echo "__PULP_VALIDATION__:smoke configuring"',
+            "build": 'echo "building"',
+            "test": 'echo "testing"',
+        },
+        contract={
+            "markers": ["__PULP_VALIDATION__:smoke"],
+        },
+    )
+    assert result.status == TargetStatus.PASS
+    assert "__PULP_VALIDATION__:smoke" in result.contract_markers_seen
+    assert result.contract_violation is None
+
+
+def test_no_marker_across_any_stage_fails(log_dir: Path) -> None:
+    result = _validate(
+        log_dir,
+        stages={
+            "setup": 'echo "setting up"',
+            "configure": 'echo "configuring"',
+            "build": 'echo "building"',
+            "test": 'echo "testing"',
+        },
+        contract={
+            "markers": ["__PULP_VALIDATION__:smoke", "__PULP_VALIDATION__:full"],
+            "enforce": True,
+        },
+    )
+    assert result.status == TargetStatus.FAIL
+    assert result.contract_violation is not None
+    assert "at least one" in result.contract_violation
+
+
+def test_contract_serializes_to_dict(log_dir: Path) -> None:
+    """The contract fields appear in the JSON output."""
+    result = _validate(
+        log_dir,
+        command='echo "__PULP_VALIDATION__:smoke"',
+        contract={"markers": ["__PULP_VALIDATION__:smoke"]},
+    )
+    d = result.to_dict()
+    assert "contract_markers_seen" in d
+    assert d["contract_markers_seen"] == ["__PULP_VALIDATION__:smoke"]
+    assert "contract_markers_missing" not in d  # empty tuple omitted


### PR DESCRIPTION
## Summary
First of four Phase 5 capability-parity gaps with Pulp's \`local_ci.py\`. Adds project-declared validation contract markers that the validation script must emit at least once for the run to be considered authentic.

## Why this matters
Pulp's \`validate-build.sh\` emits \`__PULP_VALIDATION__:smoke\` or \`__PULP_VALIDATION__:full\` to assert which mode actually ran. \`local_ci.py\` enforces these markers — if the script exits 0 but never emitted one of the markers, that means either the wrong code path ran or the validation was bypassed entirely, and the result cannot be trusted.

Shipyard v0.1.2 understood phase markers (\`__PULP_PHASE__:<name>\`) but had no equivalent contract enforcement. This means a Pulp validation could silently lose its authenticity guarantee on adoption. **This change closes that gap.**

## Design
- **\`streaming.run_streaming_command\`** grows a \`required_contract_markers\` parameter. Lines are substring-matched against the marker list; matches are recorded in \`StreamingCommandResult.contract_markers_seen\`. The streaming layer never fails the process — that's the caller's job.
- **New \`executor.contract\` module** with \`evaluate_contract()\` and \`required_markers()\` helpers. Three modes:
  - \`enforce=true, require_at_least_one=true\` (default): at least one marker must appear, missing → FAIL
  - \`enforce=true, require_at_least_one=false\`: every declared marker must appear, any missing → FAIL
  - \`enforce=false\`: markers recorded for visibility but never fail the run
- **\`core.job.TargetResult\`** grows three fields: \`contract_markers_seen\`, \`contract_markers_missing\`, \`contract_violation\`. All three serialize to \`to_dict()\` for JSON consumers.
- **\`LocalExecutor\`** reads \`[validation.contract]\` from the project config (\`validation_config["contract"]\`) and threads it through both the single-command and stage-aware paths. In stage mode, markers seen across every stage are accumulated; the contract is evaluated once at the end of the run.

## Project config shape
\`\`\`toml
[validation.contract]
markers = ["__PULP_VALIDATION__:smoke", "__PULP_VALIDATION__:full"]
require_at_least_one = true   # default
enforce = true                # default
\`\`\`

## Test coverage
- **\`tests/executor/test_contract.py\`** — 16 unit tests of the contract evaluator
- **\`tests/executor/test_local_contract.py\`** — 11 end-to-end tests exercising \`LocalExecutor\` with real subprocesses

### Verification
\`\`\`
257 tests pass (was 230, +27 new)
mypy: Success: no issues found in 51 source files
ruff: clean on touched files
\`\`\`

## Remaining Phase 5 work
This is item **1 of 4**. Still to land:
- **(2/4) Prepared-state reuse** — cache \`(sha, target, mode)\` and skip stages on warm re-runs
- **(3/4) Windows host mutex + VS instance auto-detection** in \`ssh_windows.py\`
- **(4/4) SSH unreachable → Namespace cloud auto-failover**

Each will be its own PR. Once all four land + the SSH executor also wires the contract markers, we tag v0.1.3 and bump Pulp's pin.

## Test plan
- [x] All 257 tests pass locally
- [x] mypy clean
- [x] ruff clean on touched files
- [ ] CI green on macOS, Linux, Windows