### PR TITLE
Phase 5 (2/4): prepared-state reuse for warm validation re-runs

### DIFF
--- a/src/shipyard/core/prepared_state.py
+++ b/src/shipyard/core/prepared_state.py
@@ -1,0 +1,261 @@
+"""Per-stage prepared-state tracking for warm validation re-runs.
+
+When a validation runs successfully on a given (sha, target, mode),
+the work that the stage produced — fetched dependencies, configured
+build tree, compiled binaries — is still on disk. A subsequent
+validation against the same (sha, target, mode) does not need to
+redo that work. Pulp's local_ci.py implements this via the
+PULP_VALIDATE_REUSE_PREPARED env var: when set, the validation
+script checks for marker files and skips stages it knows already
+passed.
+
+Shipyard's prepared-state store tracks per-stage pass/fail in a
+JSON file keyed by (sha, target, mode). Before running a stage on
+a re-run, the executor consults the store and skips the stage if
+it has previously passed for the exact same key. After each stage
+runs, the executor records the result in the store.
+
+This is intentionally separate from the merge-gating EvidenceStore
+in core/evidence.py, which tracks the *overall* per-target outcome
+for each branch (used by `shipyard ship`). The prepared-state store
+tracks *per-stage* progress for the *exact* SHA, used to short-circuit
+warm re-runs.
+
+Storage layout:
+
+    <state_dir>/prepared/<sha>/<target>--<mode>.json
+
+    {
+        "sha": "abc1234",
+        "target": "ubuntu",
+        "mode": "default",
+        "stages": {
+            "setup":     "pass",
+            "configure": "pass",
+            "build":     "pass",
+            "test":      "fail"
+        },
+        "updated_at": "2026-04-09T17:00:00Z",
+        "config_hash": "0123abcd"
+    }
+
+The `config_hash` is a digest of the stage command strings at the
+time the file was written. If the strings change in the project
+config (someone edited .shipyard/config.toml), the hash differs and
+the prepared state is invalidated automatically — this prevents the
+"I edited the build command but Shipyard skipped the build because
+the old run had passed" failure mode.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import hashlib
+import json
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+    from pathlib import Path
+
+
+@dataclass(frozen=True)
+class StageOutcome:
+    """A single stage's pass/fail recorded in the prepared-state store."""
+
+    stage: str
+    status: str  # "pass" or "fail"
+
+    @property
+    def passed(self) -> bool:
+        return self.status == "pass"
+
+
+@dataclass
+class PreparedStateRecord:
+    """Per-stage outcome cache for one (sha, target, mode) tuple.
+
+    A record can be partially populated — Shipyard records each
+    stage as it completes, so a run that fails midway through writes
+    {setup: pass, configure: pass, build: fail} and stops. The next
+    re-run sees that {setup, configure} already passed and only runs
+    the {build, test} stages.
+    """
+
+    sha: str
+    target: str
+    mode: str
+    stages: dict[str, str] = field(default_factory=dict)
+    updated_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+    config_hash: str = ""
+
+    def is_passed(self, stage: str) -> bool:
+        return self.stages.get(stage) == "pass"
+
+    def mark(self, stage: str, status: str) -> None:
+        self.stages[stage] = status
+        self.updated_at = datetime.now(timezone.utc)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "sha": self.sha,
+            "target": self.target,
+            "mode": self.mode,
+            "stages": dict(self.stages),
+            "updated_at": self.updated_at.isoformat(),
+            "config_hash": self.config_hash,
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> PreparedStateRecord:
+        return cls(
+            sha=d["sha"],
+            target=d["target"],
+            mode=d["mode"],
+            stages=dict(d.get("stages", {})),
+            updated_at=datetime.fromisoformat(d["updated_at"]),
+            config_hash=d.get("config_hash", ""),
+        )
+
+
+@dataclass
+class PreparedStateStore:
+    """Persists per-stage outcomes for the prepared-state cache.
+
+    The store is opt-in: an executor only consults it when the project
+    config sets `[validation.prepared_state] enabled = true`. The
+    executor itself decides which stages to skip; this store only
+    persists and retrieves records.
+    """
+
+    path: Path
+
+    def __post_init__(self) -> None:
+        self.path.mkdir(parents=True, exist_ok=True)
+
+    def get(self, sha: str, target: str, mode: str) -> PreparedStateRecord | None:
+        record_path = self._record_path(sha, target, mode)
+        if not record_path.exists():
+            return None
+        try:
+            data = json.loads(record_path.read_text())
+            return PreparedStateRecord.from_dict(data)
+        except (json.JSONDecodeError, KeyError, ValueError):
+            # Corrupted record — treat as missing so the next run
+            # writes a fresh one.
+            return None
+
+    def save(self, record: PreparedStateRecord) -> None:
+        record_path = self._record_path(record.sha, record.target, record.mode)
+        record_path.parent.mkdir(parents=True, exist_ok=True)
+        record_path.write_text(json.dumps(record.to_dict(), indent=2) + "\n")
+
+    def delete(self, sha: str, target: str, mode: str) -> None:
+        record_path = self._record_path(sha, target, mode)
+        if record_path.exists():
+            record_path.unlink()
+
+    def delete_sha(self, sha: str) -> int:
+        """Remove every record for a SHA. Returns the number of files deleted."""
+        sha_dir = self.path / _sanitize(sha)
+        if not sha_dir.exists():
+            return 0
+        count = 0
+        for f in sha_dir.glob("*.json"):
+            f.unlink()
+            count += 1
+        with contextlib.suppress(OSError):
+            sha_dir.rmdir()
+        return count
+
+    def cleanup_other_shas(self, keep_sha: str) -> int:
+        """Remove every record except those for `keep_sha`. Returns count.
+
+        Used during housekeeping to prevent the prepared-state cache
+        from growing without bound — only the most-recent SHA is
+        worth keeping for warm reruns.
+        """
+        if not self.path.exists():
+            return 0
+        keep_dir = _sanitize(keep_sha)
+        count = 0
+        for sha_dir in self.path.iterdir():
+            if not sha_dir.is_dir() or sha_dir.name == keep_dir:
+                continue
+            for f in sha_dir.glob("*.json"):
+                f.unlink()
+                count += 1
+            with contextlib.suppress(OSError):
+                sha_dir.rmdir()
+        return count
+
+    def _record_path(self, sha: str, target: str, mode: str) -> Path:
+        return self.path / _sanitize(sha) / f"{_sanitize(target)}--{_sanitize(mode)}.json"
+
+
+def hash_stage_commands(stage_commands: Iterable[tuple[str, str]]) -> str:
+    """Compute a stable digest of the stage name + command pairs.
+
+    Two records with the same SHA but different stage commands have
+    different config hashes, so editing a build command in
+    `.shipyard/config.toml` automatically invalidates the prepared
+    state for the affected (sha, target, mode).
+    """
+    h = hashlib.sha256()
+    for stage_name, command in sorted(stage_commands):
+        h.update(stage_name.encode("utf-8"))
+        h.update(b"\x00")
+        h.update(command.encode("utf-8"))
+        h.update(b"\x00")
+    return h.hexdigest()[:16]
+
+
+def filter_stages_by_prepared_state(
+    stages: list[tuple[str, str]],
+    record: PreparedStateRecord | None,
+    *,
+    current_config_hash: str,
+) -> tuple[list[tuple[str, str]], list[str]]:
+    """Filter the requested stage list against a prepared-state record.
+
+    Returns (stages_to_run, stages_skipped).
+
+    A stage is skipped only when:
+    - The record exists
+    - The config_hash matches (same stage commands)
+    - The stage is marked "pass" in the record
+
+    The first stage in the list with no recorded "pass" causes every
+    subsequent stage to also run, regardless of cached state — this
+    matches Pulp's local_ci.py behavior, where a re-run from a failed
+    stage forces every subsequent stage to re-run too (because the
+    failed stage may have left intermediate artifacts in a broken
+    state).
+    """
+    if record is None or record.config_hash != current_config_hash:
+        return list(stages), []
+
+    skipped: list[str] = []
+    to_run: list[tuple[str, str]] = []
+    skipping_phase = True
+
+    for stage_name, command in stages:
+        if skipping_phase and record.is_passed(stage_name):
+            skipped.append(stage_name)
+            continue
+        skipping_phase = False
+        to_run.append((stage_name, command))
+
+    return to_run, skipped
+
+
+def _sanitize(value: str) -> str:
+    """Make an arbitrary identifier safe for use as a filename component."""
+    return (
+        value.replace("/", "--")
+        .replace("\\", "--")
+        .replace(":", "_")
+        .replace(" ", "_")
+    )

--- a/src/shipyard/executor/local.py
+++ b/src/shipyard/executor/local.py
@@ -19,6 +19,12 @@ from pathlib import Path
 from typing import Any
 
 from shipyard.core.job import TargetResult, TargetStatus
+from shipyard.core.prepared_state import (
+    PreparedStateRecord,
+    PreparedStateStore,
+    filter_stages_by_prepared_state,
+    hash_stage_commands,
+)
 from shipyard.executor.contract import (
     evaluate_contract,
     required_markers,
@@ -41,6 +47,16 @@ class StageResult:
 class LocalExecutor:
     """Execute validation commands locally via subprocess."""
 
+    def __init__(
+        self,
+        prepared_state_store: PreparedStateStore | None = None,
+    ) -> None:
+        # Optional store for warm-rerun stage skipping. When None,
+        # prepared-state reuse is disabled regardless of project config.
+        # Callers (cli.py / dispatch.py) supply this; tests construct
+        # the executor without it for fresh-state semantics.
+        self._prepared_state_store = prepared_state_store
+
     def validate(
         self,
         sha: str,
@@ -50,6 +66,7 @@ class LocalExecutor:
         log_path: str,
         resume_from: str | None = None,
         progress_callback: ProgressCallback | None = None,
+        mode: str = "default",
     ) -> TargetResult:
         target_name = target_config.get("name", "local")
         platform = target_config.get("platform", "unknown")
@@ -87,6 +104,9 @@ class LocalExecutor:
             stages, target_name, platform, target_config,
             log_file, started_at, start_time, progress_callback,
             contract_config=contract_config,
+            sha=sha,
+            mode=mode,
+            prepared_state_enabled=_prepared_state_enabled(validation_config),
         )
 
     def _run_single(
@@ -143,8 +163,18 @@ class LocalExecutor:
         started_at: datetime, start_time: float,
         progress_callback: ProgressCallback | None,
         contract_config: dict[str, Any] | None = None,
+        sha: str = "",
+        mode: str = "default",
+        prepared_state_enabled: bool = False,
     ) -> TargetResult:
-        """Run validation as separate stages. Stop at first failure."""
+        """Run validation as separate stages. Stop at first failure.
+
+        When `prepared_state_enabled` is True and a PreparedStateStore
+        is wired up, stages that previously passed for the exact
+        (sha, target, mode) tuple are skipped. The store is updated
+        after each stage so partial progress is preserved across
+        re-runs even on a failed pipeline.
+        """
         failed_stage = None
         last_output_at: datetime | None = None
         # Accumulate contract markers seen across every stage. The
@@ -153,8 +183,40 @@ class LocalExecutor:
         all_seen_markers: list[str] = []
         contract_markers_to_watch = required_markers(contract_config)
 
+        # ── Prepared-state filtering ────────────────────────────────
+        # If the project opts into prepared-state reuse and the
+        # executor was constructed with a store, consult the store to
+        # see whether earlier stages already passed for this exact
+        # (sha, target, mode). The hash of the current stage commands
+        # is part of the cache key — editing a build command in
+        # config invalidates the cached state automatically.
+        store = self._prepared_state_store if prepared_state_enabled else None
+        config_hash = hash_stage_commands(stages)
+        prepared_skipped: list[str] = []
+        record: PreparedStateRecord | None = None
+        if store is not None and sha:
+            record = store.get(sha=sha, target=target_name, mode=mode)
+            if record is not None and record.config_hash != config_hash:
+                # Config changed since the last run for this SHA —
+                # invalidate the cached state and start fresh.
+                store.delete(sha=sha, target=target_name, mode=mode)
+                record = None
+            stages_to_run, prepared_skipped = filter_stages_by_prepared_state(
+                stages, record, current_config_hash=config_hash,
+            )
+            if prepared_skipped:
+                stages = stages_to_run
+
         try:
             log_file.write_text("")
+            if prepared_skipped:
+                with open(log_file, "a", encoding="utf-8") as log:
+                    log.write(
+                        "=== prepared-state-reuse: skipped "
+                        f"{len(prepared_skipped)} stage(s) "
+                        f"({', '.join(prepared_skipped)}) for sha={sha} "
+                        f"target={target_name} mode={mode} ===\n"
+                    )
             for stage_name, command in stages:
                 stage_start = time.monotonic()
                 with open(log_file, "a", encoding="utf-8") as log:
@@ -185,6 +247,21 @@ class LocalExecutor:
                 for marker in result.contract_markers_seen:
                     if marker not in all_seen_markers:
                         all_seen_markers.append(marker)
+
+                # Record this stage's outcome in the prepared-state
+                # cache so a subsequent run on the same SHA can skip
+                # everything that just passed.
+                if store is not None and sha:
+                    if record is None:
+                        record = PreparedStateRecord(
+                            sha=sha, target=target_name, mode=mode,
+                            config_hash=config_hash,
+                        )
+                    record.mark(
+                        stage_name,
+                        "pass" if result.returncode == 0 else "fail",
+                    )
+                    store.save(record)
 
                 if result.returncode != 0:
                     failed_stage = stage_name
@@ -275,3 +352,20 @@ def _get_stages(
         stages.append((stage_name, cmd))
 
     return stages
+
+
+def _prepared_state_enabled(validation_config: dict[str, Any] | None) -> bool:
+    """Read the prepared-state opt-in from `[validation.prepared_state]`.
+
+    Default: False. Projects that want warm-rerun stage skipping must
+    declare it explicitly:
+
+        [validation.prepared_state]
+        enabled = true
+    """
+    if not validation_config:
+        return False
+    section = validation_config.get("prepared_state")
+    if not isinstance(section, dict):
+        return False
+    return bool(section.get("enabled", False))

--- a/tests/core/test_prepared_state.py
+++ b/tests/core/test_prepared_state.py
@@ -1,0 +1,249 @@
+"""Unit tests for the prepared-state cache."""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from shipyard.core.prepared_state import (
+    PreparedStateRecord,
+    PreparedStateStore,
+    StageOutcome,
+    filter_stages_by_prepared_state,
+    hash_stage_commands,
+)
+
+
+@pytest.fixture
+def store() -> PreparedStateStore:
+    with tempfile.TemporaryDirectory() as tmp:
+        yield PreparedStateStore(path=Path(tmp))
+
+
+# ── StageOutcome ────────────────────────────────────────────────────────
+
+
+def test_stage_outcome_passed() -> None:
+    assert StageOutcome("setup", "pass").passed is True
+    assert StageOutcome("setup", "fail").passed is False
+
+
+# ── hash_stage_commands ─────────────────────────────────────────────────
+
+
+def test_hash_stable_under_same_input() -> None:
+    a = hash_stage_commands([("setup", "./setup.sh"), ("build", "make")])
+    b = hash_stage_commands([("setup", "./setup.sh"), ("build", "make")])
+    assert a == b
+
+
+def test_hash_changes_when_command_changes() -> None:
+    a = hash_stage_commands([("build", "make")])
+    b = hash_stage_commands([("build", "ninja")])
+    assert a != b
+
+
+def test_hash_changes_when_stage_added() -> None:
+    a = hash_stage_commands([("build", "make")])
+    b = hash_stage_commands([("build", "make"), ("test", "ctest")])
+    assert a != b
+
+
+def test_hash_order_independent() -> None:
+    """Stages are sorted before hashing — order in the list doesn't matter."""
+    a = hash_stage_commands([("setup", "x"), ("build", "y")])
+    b = hash_stage_commands([("build", "y"), ("setup", "x")])
+    assert a == b
+
+
+# ── PreparedStateRecord ─────────────────────────────────────────────────
+
+
+def test_record_round_trip() -> None:
+    rec = PreparedStateRecord(
+        sha="abc1234",
+        target="ubuntu",
+        mode="default",
+        config_hash="0123",
+    )
+    rec.mark("setup", "pass")
+    rec.mark("build", "fail")
+
+    d = rec.to_dict()
+    rec2 = PreparedStateRecord.from_dict(d)
+    assert rec2.sha == rec.sha
+    assert rec2.target == rec.target
+    assert rec2.mode == rec.mode
+    assert rec2.stages == rec.stages
+    assert rec2.config_hash == rec.config_hash
+
+
+def test_record_is_passed() -> None:
+    rec = PreparedStateRecord(sha="abc", target="t", mode="m")
+    rec.mark("setup", "pass")
+    rec.mark("build", "fail")
+    assert rec.is_passed("setup") is True
+    assert rec.is_passed("build") is False
+    assert rec.is_passed("test") is False  # never recorded
+
+
+def test_record_mark_updates_timestamp() -> None:
+    rec = PreparedStateRecord(sha="a", target="t", mode="m")
+    initial = rec.updated_at
+    rec.mark("setup", "pass")
+    assert rec.updated_at >= initial
+
+
+# ── PreparedStateStore: get / save / delete ─────────────────────────────
+
+
+def test_store_get_missing(store: PreparedStateStore) -> None:
+    assert store.get("nonexistent", "ubuntu", "default") is None
+
+
+def test_store_save_and_get(store: PreparedStateStore) -> None:
+    rec = PreparedStateRecord(
+        sha="abc1234",
+        target="ubuntu",
+        mode="default",
+        config_hash="0123",
+    )
+    rec.mark("setup", "pass")
+    rec.mark("build", "fail")
+
+    store.save(rec)
+
+    loaded = store.get("abc1234", "ubuntu", "default")
+    assert loaded is not None
+    assert loaded.sha == "abc1234"
+    assert loaded.is_passed("setup") is True
+    assert loaded.is_passed("build") is False
+
+
+def test_store_save_overwrites(store: PreparedStateStore) -> None:
+    rec = PreparedStateRecord(sha="a", target="t", mode="m")
+    rec.mark("setup", "fail")
+    store.save(rec)
+
+    rec.mark("setup", "pass")
+    store.save(rec)
+
+    loaded = store.get("a", "t", "m")
+    assert loaded is not None
+    assert loaded.is_passed("setup") is True
+
+
+def test_store_delete(store: PreparedStateStore) -> None:
+    rec = PreparedStateRecord(sha="a", target="t", mode="m")
+    rec.mark("setup", "pass")
+    store.save(rec)
+
+    store.delete("a", "t", "m")
+    assert store.get("a", "t", "m") is None
+
+
+def test_store_delete_sha(store: PreparedStateStore) -> None:
+    """delete_sha removes every record under one SHA."""
+    for target in ("ubuntu", "windows", "macos"):
+        rec = PreparedStateRecord(sha="abc", target=target, mode="default")
+        rec.mark("setup", "pass")
+        store.save(rec)
+
+    count = store.delete_sha("abc")
+    assert count == 3
+    for target in ("ubuntu", "windows", "macos"):
+        assert store.get("abc", target, "default") is None
+
+
+def test_store_cleanup_other_shas(store: PreparedStateStore) -> None:
+    """cleanup_other_shas keeps the chosen SHA and removes the rest."""
+    for sha in ("old1", "old2", "current"):
+        rec = PreparedStateRecord(sha=sha, target="ubuntu", mode="default")
+        rec.mark("setup", "pass")
+        store.save(rec)
+
+    count = store.cleanup_other_shas(keep_sha="current")
+    assert count == 2
+    assert store.get("current", "ubuntu", "default") is not None
+    assert store.get("old1", "ubuntu", "default") is None
+    assert store.get("old2", "ubuntu", "default") is None
+
+
+def test_store_corrupted_record_returns_none(store: PreparedStateStore) -> None:
+    """A corrupted JSON file is treated as missing."""
+    record_path = store.path / "abc" / "ubuntu--default.json"
+    record_path.parent.mkdir(parents=True, exist_ok=True)
+    record_path.write_text("not valid json {{{")
+
+    assert store.get("abc", "ubuntu", "default") is None
+
+
+# ── filter_stages_by_prepared_state ─────────────────────────────────────
+
+
+def test_filter_no_record_runs_everything() -> None:
+    stages = [("setup", "x"), ("build", "y"), ("test", "z")]
+    to_run, skipped = filter_stages_by_prepared_state(
+        stages, None, current_config_hash="abc",
+    )
+    assert to_run == stages
+    assert skipped == []
+
+
+def test_filter_skips_passed_stages() -> None:
+    stages = [("setup", "x"), ("build", "y"), ("test", "z")]
+    rec = PreparedStateRecord(sha="s", target="t", mode="m", config_hash="abc")
+    rec.mark("setup", "pass")
+    rec.mark("build", "pass")
+
+    to_run, skipped = filter_stages_by_prepared_state(
+        stages, rec, current_config_hash="abc",
+    )
+    assert skipped == ["setup", "build"]
+    assert [name for name, _ in to_run] == ["test"]
+
+
+def test_filter_stops_skipping_at_first_failed_stage() -> None:
+    """Even if a later stage previously passed, it must re-run after a failure."""
+    stages = [("setup", "x"), ("build", "y"), ("test", "z")]
+    rec = PreparedStateRecord(sha="s", target="t", mode="m", config_hash="abc")
+    rec.mark("setup", "pass")
+    # build NOT marked → skipping_phase ends
+    rec.mark("test", "pass")
+
+    to_run, skipped = filter_stages_by_prepared_state(
+        stages, rec, current_config_hash="abc",
+    )
+    assert skipped == ["setup"]
+    # build and test BOTH must run because build wasn't cached
+    assert [name for name, _ in to_run] == ["build", "test"]
+
+
+def test_filter_invalidated_by_config_hash_mismatch() -> None:
+    """Config hash mismatch invalidates the entire cache."""
+    stages = [("setup", "x"), ("build", "y")]
+    rec = PreparedStateRecord(sha="s", target="t", mode="m", config_hash="OLD")
+    rec.mark("setup", "pass")
+    rec.mark("build", "pass")
+
+    to_run, skipped = filter_stages_by_prepared_state(
+        stages, rec, current_config_hash="NEW",
+    )
+    assert skipped == []
+    assert to_run == stages
+
+
+def test_filter_all_stages_passed() -> None:
+    """If every stage is cached as pass, the run is a no-op."""
+    stages = [("setup", "x"), ("build", "y")]
+    rec = PreparedStateRecord(sha="s", target="t", mode="m", config_hash="abc")
+    rec.mark("setup", "pass")
+    rec.mark("build", "pass")
+
+    to_run, skipped = filter_stages_by_prepared_state(
+        stages, rec, current_config_hash="abc",
+    )
+    assert skipped == ["setup", "build"]
+    assert to_run == []

--- a/tests/executor/test_local_prepared_state.py
+++ b/tests/executor/test_local_prepared_state.py
@@ -1,0 +1,241 @@
+"""End-to-end tests for LocalExecutor + prepared-state reuse.
+
+These tests run real subprocesses (small shell commands) so the
+executor's wiring to PreparedStateStore is exercised end-to-end, not
+mocked. They verify that:
+
+- A first run records every stage's outcome in the store
+- A second run on the same (sha, target, mode) skips stages that
+  previously passed
+- A failed stage stops the skip chain — later stages run even if
+  previously cached
+- Editing a stage command invalidates the cache (config_hash changes)
+- When prepared_state is disabled in config, the store is ignored
+- When no store is wired up, prepared_state_enabled is a no-op
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from shipyard.core.job import TargetStatus
+from shipyard.core.prepared_state import PreparedStateStore
+from shipyard.executor.local import LocalExecutor
+
+
+@pytest.fixture
+def log_dir() -> Path:
+    with tempfile.TemporaryDirectory() as tmp:
+        yield Path(tmp)
+
+
+@pytest.fixture
+def store_dir() -> Path:
+    with tempfile.TemporaryDirectory() as tmp:
+        yield Path(tmp)
+
+
+def _validate(
+    executor: LocalExecutor,
+    log_dir: Path,
+    *,
+    stages: dict[str, str],
+    prepared_state_enabled: bool = True,
+    sha: str = "abc1234",
+    mode: str = "default",
+):
+    validation_config: dict = dict(stages)
+    if prepared_state_enabled:
+        validation_config["prepared_state"] = {"enabled": True}
+    return executor.validate(
+        sha=sha,
+        branch="test-branch",
+        target_config={"name": "test", "platform": "macos-arm64"},
+        validation_config=validation_config,
+        log_path=str(log_dir / f"{sha}.log"),
+        mode=mode,
+    )
+
+
+def test_first_run_records_all_stages(log_dir: Path, store_dir: Path) -> None:
+    """A fresh run with no prior state records each stage's outcome."""
+    store = PreparedStateStore(path=store_dir)
+    executor = LocalExecutor(prepared_state_store=store)
+
+    result = _validate(
+        executor, log_dir,
+        stages={"setup": "true", "build": "true", "test": "true"},
+    )
+    assert result.status == TargetStatus.PASS
+
+    record = store.get(sha="abc1234", target="test", mode="default")
+    assert record is not None
+    assert record.is_passed("setup")
+    assert record.is_passed("build")
+    assert record.is_passed("test")
+
+
+def test_second_run_skips_passed_stages(log_dir: Path, store_dir: Path) -> None:
+    """A repeat run on the same sha/target/mode skips cached stages."""
+    store = PreparedStateStore(path=store_dir)
+    executor = LocalExecutor(prepared_state_store=store)
+    stages = {"setup": "true", "build": "true", "test": "true"}
+
+    # First run: records everything as pass.
+    result1 = _validate(executor, log_dir, stages=stages)
+    assert result1.status == TargetStatus.PASS
+
+    # Second run: replace build with a command that would fail if it ran.
+    # Because build was cached as "pass" and the config_hash is the
+    # same, build should be skipped — so the failure never happens.
+    # (We also keep the config_hash consistent by using the SAME stages.)
+    result2 = _validate(executor, log_dir, stages=stages)
+    assert result2.status == TargetStatus.PASS
+
+    # The log should mention the skipped stages.
+    log_text = (log_dir / "abc1234.log").read_text()
+    assert "prepared-state-reuse: skipped" in log_text
+    assert "setup" in log_text
+    assert "build" in log_text
+    assert "test" in log_text
+
+
+def test_failed_stage_is_not_cached_as_pass(log_dir: Path, store_dir: Path) -> None:
+    """A failing stage records as fail; subsequent re-runs re-execute it."""
+    store = PreparedStateStore(path=store_dir)
+    executor = LocalExecutor(prepared_state_store=store)
+
+    result1 = _validate(
+        executor, log_dir,
+        stages={"setup": "true", "build": "false", "test": "true"},
+    )
+    assert result1.status == TargetStatus.FAIL
+
+    record = store.get(sha="abc1234", target="test", mode="default")
+    assert record is not None
+    assert record.is_passed("setup") is True
+    assert record.is_passed("build") is False
+    # test was never reached, so it's not in the record at all.
+    assert record.is_passed("test") is False
+
+
+def test_re_run_skips_setup_but_re_runs_build_after_failure(
+    log_dir: Path, store_dir: Path,
+) -> None:
+    """After build fails once, a re-run skips setup but re-runs build."""
+    store = PreparedStateStore(path=store_dir)
+    executor = LocalExecutor(prepared_state_store=store)
+
+    # First run: setup passes, build fails.
+    result1 = _validate(
+        executor, log_dir,
+        stages={"setup": "true", "build": "false"},
+    )
+    assert result1.status == TargetStatus.FAIL
+
+    # Second run with build fixed. Setup should be skipped, build re-runs.
+    result2 = _validate(
+        executor, log_dir,
+        stages={"setup": "true", "build": "false"},
+    )
+    # Still fails because build is still `false`, but note that setup
+    # was skipped (visible in the log).
+    assert result2.status == TargetStatus.FAIL
+    log_text = (log_dir / "abc1234.log").read_text()
+    assert "prepared-state-reuse: skipped" in log_text
+    assert "setup" in log_text
+
+
+def test_config_hash_mismatch_invalidates_cache(
+    log_dir: Path, store_dir: Path,
+) -> None:
+    """Editing a stage command invalidates the cached state."""
+    store = PreparedStateStore(path=store_dir)
+    executor = LocalExecutor(prepared_state_store=store)
+
+    result1 = _validate(
+        executor, log_dir,
+        stages={"setup": "true", "build": "true"},
+    )
+    assert result1.status == TargetStatus.PASS
+
+    # Change the build command string → config_hash changes →
+    # everything re-runs (and a fresh record is written with the new hash).
+    result2 = _validate(
+        executor, log_dir,
+        stages={"setup": "true", "build": "echo rebuilt"},
+    )
+    assert result2.status == TargetStatus.PASS
+
+    # The second run should NOT show any "skipped" entries because
+    # the cache was invalidated.
+    log_text = (log_dir / "abc1234.log").read_text()
+    assert "prepared-state-reuse: skipped" not in log_text
+
+
+def test_prepared_state_disabled_in_config_ignores_store(
+    log_dir: Path, store_dir: Path,
+) -> None:
+    """If config doesn't opt in, the store is never consulted."""
+    store = PreparedStateStore(path=store_dir)
+    executor = LocalExecutor(prepared_state_store=store)
+
+    # First run opts in and records a pass.
+    result1 = _validate(
+        executor, log_dir,
+        stages={"setup": "true", "build": "true"},
+    )
+    assert result1.status == TargetStatus.PASS
+    assert store.get("abc1234", "test", "default") is not None
+
+    # Second run does NOT opt in — even though the cache has this
+    # sha/target/mode marked "pass", the stages should all still run.
+    result2 = _validate(
+        executor, log_dir,
+        stages={"setup": "true", "build": "true"},
+        prepared_state_enabled=False,
+    )
+    assert result2.status == TargetStatus.PASS
+    log_text = (log_dir / "abc1234.log").read_text()
+    assert "prepared-state-reuse: skipped" not in log_text
+
+
+def test_no_store_wired_up_is_a_no_op(log_dir: Path) -> None:
+    """An executor constructed without a store ignores the opt-in."""
+    executor = LocalExecutor(prepared_state_store=None)
+
+    result = _validate(
+        executor, log_dir,
+        stages={"setup": "true", "build": "true"},
+    )
+    assert result.status == TargetStatus.PASS
+    # No assertion beyond "it didn't crash" — with no store there's
+    # nothing to inspect.
+
+
+def test_different_modes_have_independent_caches(
+    log_dir: Path, store_dir: Path,
+) -> None:
+    """A cache hit on mode=default does not leak into mode=smoke."""
+    store = PreparedStateStore(path=store_dir)
+    executor = LocalExecutor(prepared_state_store=store)
+
+    # Run under mode=default.
+    _validate(
+        executor, log_dir,
+        stages={"setup": "true", "build": "true"},
+        mode="default",
+    )
+    assert store.get("abc1234", "test", "default") is not None
+    assert store.get("abc1234", "test", "smoke") is None
+
+    # Run under mode=smoke — should NOT see the default-mode skip log.
+    _validate(
+        executor, log_dir,
+        stages={"setup": "true", "build": "true"},
+        mode="smoke",
+    )
+    assert store.get("abc1234", "test", "smoke") is not None


### PR DESCRIPTION
## Summary

Ports Pulp's `PULP_VALIDATE_REUSE_PREPARED` warm-rerun behavior to Shipyard as a general per-stage state cache keyed by `(sha, target, mode)`. A re-run on the same SHA skips stages that already passed, so a dev loop of "fix one test → rerun validation" doesn't rebuild from scratch.

- **`shipyard.core.prepared_state`** — `StageOutcome`, `PreparedStateRecord`, `PreparedStateStore`, `hash_stage_commands()`, `filter_stages_by_prepared_state()`
- **`LocalExecutor`** — opt-in via `[validation.prepared_state] enabled = true`; records each stage as it completes; logs the skip decision; automatic cache invalidation when a stage command string changes
- **Tests** — 20 unit tests for prepared_state internals, 8 end-to-end tests using real subprocesses

Matches local_ci.py semantics exactly: a failed stage stops the skip chain, and every subsequent stage re-runs (because the failed stage may have left intermediate artifacts in a broken state).

Full suite: **285 passing** (was 257 before Phase 5 started).

## Test plan

- [x] `pytest tests/core/test_prepared_state.py` — 20/20
- [x] `pytest tests/executor/test_local_prepared_state.py` — 8/8
- [x] `pytest tests/` full suite — 285/285
- [x] `ruff check` clean on new files
- [x] `mypy` clean on new files
- [ ] Smoke-test against a real Pulp re-run once Shipyard is dogfooded (Phase 6)