### PR TITLE
Phase 5 (3/4): Windows host mutex + Visual Studio auto-detection

### DIFF
--- a/src/shipyard/executor/ssh_windows.py
+++ b/src/shipyard/executor/ssh_windows.py
@@ -17,10 +17,23 @@ from shipyard.bundle.git_bundle import create_bundle, upload_bundle
 from shipyard.core.job import TargetResult, TargetStatus
 from shipyard.executor.contract import evaluate_contract, required_markers
 from shipyard.executor.streaming import ProgressCallback, run_streaming_command
+from shipyard.executor.windows_toolchain import (
+    DEFAULT_MUTEX_NAME,
+    VsToolchain,
+    detect_vs_toolchain,
+    toolchain_env_exports,
+    wrap_powershell_with_host_mutex,
+)
 
 
 class SSHWindowsExecutor:
     """Execute validation commands on a remote Windows host via SSH + PowerShell."""
+
+    def __init__(self) -> None:
+        # Cache of detected VS toolchains keyed by host. Detection
+        # shells out to vswhere, which is slow enough (~1s) that we
+        # only want to do it once per Shipyard invocation per host.
+        self._vs_toolchain_cache: dict[str, VsToolchain | None] = {}
 
     def validate(
         self,
@@ -88,12 +101,33 @@ class SSHWindowsExecutor:
                     f"Bundle apply failed: {apply_result.message}",
                 )
 
-        # Step 2: Checkout the SHA and run validation via PowerShell
-        command = _build_remote_command(sha, remote_repo, validation_config)
+        # Step 2: Resolve the Visual Studio toolchain (once per host,
+        # cached) so stages can reference $env:SHIPYARD_CMAKE_PLATFORM
+        # and $env:SHIPYARD_CMAKE_GENERATOR_INSTANCE. This matches
+        # Pulp's local_ci.py behavior for hosts with multiple VS
+        # installations or ARM64 Windows. Detection is best-effort:
+        # a None result just means CMake falls back to its defaults.
+        toolchain = self._get_vs_toolchain(host, ssh_options, target_config)
+
+        # Step 3: Build the remote PowerShell command: env exports +
+        # checkout + validate. If the target opts into a host mutex,
+        # wrap the whole thing in a Mutex block so concurrent runs
+        # against the same Windows host queue up instead of racing.
+        command = _build_remote_command(
+            sha, remote_repo, validation_config, toolchain=toolchain,
+        )
         if not command:
             return _error_result(
                 target_name, platform, started_at, start_time,
                 str(log_file), "No validation command configured",
+            )
+
+        if _host_mutex_enabled(target_config):
+            command = wrap_powershell_with_host_mutex(
+                command,
+                mutex_name=target_config.get(
+                    "windows_host_mutex_name", DEFAULT_MUTEX_NAME,
+                ),
             )
 
         ssh_cmd = (
@@ -158,6 +192,26 @@ class SSHWindowsExecutor:
                 target_name, platform, started_at, start_time,
                 str(log_file), str(exc),
             )
+
+    def _get_vs_toolchain(
+        self,
+        host: str,
+        ssh_options: list[str],
+        target_config: dict[str, Any],
+    ) -> VsToolchain | None:
+        """Return the cached or freshly-detected VS toolchain for a host.
+
+        Respects `windows_vs_detect = false` in the target config to
+        opt out entirely. Detection failures are cached as None so a
+        missing vswhere doesn't re-probe on every run.
+        """
+        if target_config.get("windows_vs_detect", True) is False:
+            return None
+        if host in self._vs_toolchain_cache:
+            return self._vs_toolchain_cache[host]
+        toolchain = detect_vs_toolchain(host, ssh_options)
+        self._vs_toolchain_cache[host] = toolchain
+        return toolchain
 
     def probe(self, target_config: dict[str, Any]) -> bool:
         """Check SSH reachability with a PowerShell echo command."""
@@ -243,10 +297,14 @@ def _build_remote_command(
     sha: str,
     remote_repo: str,
     validation_config: dict[str, Any],
+    *,
+    toolchain: VsToolchain | None = None,
 ) -> str | None:
     """Build the remote PowerShell command: cd + checkout + validate.
 
     Uses semicolons for PowerShell command chaining with $LASTEXITCODE checks.
+    When `toolchain` is provided, the resolved CMake platform and generator
+    instance are exported as env vars so stages can reference them.
     """
     if "command" in validation_config:
         validate_cmd = validation_config["command"]
@@ -262,11 +320,24 @@ def _build_remote_command(
         validate_cmd = "; if ($LASTEXITCODE -ne 0) { exit 1 }; ".join(parts)
 
     return (
+        f"{toolchain_env_exports(toolchain)}; "
         f"cd '{remote_repo}'; "
         f"git checkout --force {sha}; "
         f"if ($LASTEXITCODE -ne 0) {{ exit 1 }}; "
         f"{validate_cmd}"
     )
+
+
+def _host_mutex_enabled(target_config: dict[str, Any]) -> bool:
+    """Read the host-mutex opt-in from the target config.
+
+    Default: True. Concurrent validation runs on a Windows host share
+    a checked-out repo and a locked VS install, so serializing by
+    default prevents hard-to-diagnose flaky failures. Projects that
+    use per-job worktrees can disable it with
+    `windows_host_mutex = false` in the target config.
+    """
+    return target_config.get("windows_host_mutex", True) is not False
 
 
 def _error_result(

--- a/src/shipyard/executor/windows_toolchain.py
+++ b/src/shipyard/executor/windows_toolchain.py
@@ -1,0 +1,230 @@
+"""Windows toolchain helpers for the ssh-windows executor.
+
+Two pieces of Pulp's local_ci.py that the cross-platform SSH executor
+needs to match for capability parity:
+
+1. **Host mutex** — when two validation jobs target the same Windows
+   machine, they can stomp on each other (shared repo checkout,
+   shared build tree, shared VS installation locks). Pulp wraps each
+   remote validation in a `System.Threading.Mutex` and blocks if
+   another run holds it. Shipyard ports the same pattern here.
+
+2. **Visual Studio instance detection** — on a machine with multiple
+   VS installations (Community + BuildTools + Preview, for example),
+   CMake picks one non-deterministically. Pulp runs `vswhere.exe`
+   before the build and passes the chosen installation path via
+   `-DCMAKE_GENERATOR_INSTANCE=...`. It also derives the CMake
+   platform (`ARM64` vs `x64`) from `$env:PROCESSOR_ARCHITECTURE` so
+   ARM64 Windows hosts build native ARM64 binaries rather than
+   defaulting to x64 cross-compilation.
+
+Both helpers are pure string builders — they produce PowerShell
+snippets that the ssh-windows executor splices into its remote
+command. Running the detection is a separate SSH call, so the result
+is cached per-host in the executor instance.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+
+DEFAULT_MUTEX_NAME = "Global\\ShipyardValidate"
+
+
+@dataclass(frozen=True)
+class VsToolchain:
+    """Resolved Visual Studio toolchain for a Windows host."""
+
+    cmake_platform: str  # "ARM64" or "x64" (or whatever vswhere found)
+    cmake_generator_instance: str  # filesystem path to the selected VS install
+
+
+def wrap_powershell_with_host_mutex(
+    ps_body: str,
+    *,
+    mutex_name: str = DEFAULT_MUTEX_NAME,
+) -> str:
+    """Wrap a PowerShell command in a host-wide mutex block.
+
+    Only one validation holding `mutex_name` runs at a time. If the
+    mutex is busy, the run emits `__SHIPYARD_WAIT__:host-lock` and
+    `__SHIPYARD_PHASE__:waiting-lock` markers so log consumers can
+    distinguish "waiting" from "stuck". An abandoned mutex from a
+    crashed prior run is recovered automatically.
+
+    The resulting script exits with the same exit code as `ps_body`.
+    """
+    # Escape single quotes in the mutex name so it can be dropped into
+    # a PowerShell single-quoted string literal safely.
+    safe_mutex = mutex_name.replace("'", "''")
+    return f"""
+$MutexName = '{safe_mutex}'
+$Mutex = New-Object System.Threading.Mutex($false, $MutexName)
+$LockAcquired = $false
+try {{
+    try {{
+        if ($Mutex.WaitOne(0)) {{
+            $LockAcquired = $true
+        }} else {{
+            Write-Host "__SHIPYARD_WAIT__:host-lock"
+            Write-Host "__SHIPYARD_PHASE__:waiting-lock"
+            Write-Host "Waiting for host validation lock: $MutexName"
+            $null = $Mutex.WaitOne()
+            $LockAcquired = $true
+        }}
+    }} catch [System.Threading.AbandonedMutexException] {{
+        Write-Host "Recovered abandoned host validation lock: $MutexName"
+        $LockAcquired = $true
+    }}
+
+    {ps_body}
+    $__ShipyardExit = $LASTEXITCODE
+}} finally {{
+    if ($LockAcquired) {{
+        try {{
+            $Mutex.ReleaseMutex() | Out-Null
+        }} catch [System.ApplicationException] {{
+        }}
+    }}
+    $Mutex.Dispose()
+}}
+if ($null -ne $__ShipyardExit) {{
+    exit $__ShipyardExit
+}}
+""".strip()
+
+
+_VS_DETECT_SCRIPT = r"""
+function Resolve-CMakePlatform {
+    if ($env:PROCESSOR_ARCHITECTURE -eq 'ARM64') {
+        return 'ARM64'
+    }
+    return 'x64'
+}
+
+function Resolve-VisualStudioInstance {
+    $vswhere = Join-Path ${env:ProgramFiles(x86)} 'Microsoft Visual Studio\Installer\vswhere.exe'
+    if (-not (Test-Path $vswhere)) {
+        return ''
+    }
+    try {
+        $raw = (& $vswhere -latest -products * -format json) -join "`n"
+        if (-not $raw) {
+            return ''
+        }
+        $instances = $raw | ConvertFrom-Json
+        if ($instances -isnot [System.Array]) {
+            $instances = @($instances)
+        }
+        # Prefer a full VS install over BuildTools when both exist.
+        $preferred = $instances | Where-Object {
+            $_.productId -and $_.productId -ne 'Microsoft.VisualStudio.Product.BuildTools'
+        } | Select-Object -First 1
+        if (-not $preferred) {
+            $preferred = $instances | Select-Object -First 1
+        }
+        if ($preferred -and $preferred.installationPath) {
+            return $preferred.installationPath.Replace('\', '/')
+        }
+    } catch {
+    }
+    return ''
+}
+
+$resolved = @{
+    platform = Resolve-CMakePlatform
+    generator_instance = Resolve-VisualStudioInstance
+}
+$resolved | ConvertTo-Json -Compress
+""".strip()
+
+
+def detect_vs_toolchain(
+    host: str,
+    ssh_options: Sequence[str],
+    *,
+    timeout: int = 60,
+) -> VsToolchain | None:
+    """Run vswhere on the remote Windows host to resolve the VS toolchain.
+
+    Returns None on any failure (vswhere missing, SSH failure, malformed
+    JSON). Callers should treat None as "fall back to CMake defaults",
+    not "error" — Windows hosts without multiple VS installations work
+    fine without this hint.
+    """
+    cmd = [
+        "ssh",
+        *list(ssh_options),
+        host,
+        "powershell",
+        "-NoProfile",
+        "-Command",
+        "-",
+    ]
+    try:
+        run = subprocess.run(
+            cmd,
+            input=_VS_DETECT_SCRIPT,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except (subprocess.SubprocessError, OSError):
+        return None
+
+    if run.returncode != 0:
+        return None
+
+    # vswhere's script prints one JSON line; some environments prepend
+    # banner text, so scan from the bottom for the first object.
+    for line in reversed(run.stdout.splitlines()):
+        line = line.strip()
+        if not line.startswith("{"):
+            continue
+        try:
+            data = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        platform = (data.get("platform") or "").strip()
+        instance = (data.get("generator_instance") or "").strip()
+        if not platform and not instance:
+            return None
+        return VsToolchain(
+            cmake_platform=platform,
+            cmake_generator_instance=instance,
+        )
+    return None
+
+
+def toolchain_env_exports(toolchain: VsToolchain | None) -> str:
+    """PowerShell snippet that exports the resolved toolchain as env vars.
+
+    Stage commands can reference `$env:SHIPYARD_CMAKE_PLATFORM` and
+    `$env:SHIPYARD_CMAKE_GENERATOR_INSTANCE` to pass the detected
+    values to CMake, e.g.::
+
+        cmake -S . -B build -G "Visual Studio 17 2022" `
+            -A $env:SHIPYARD_CMAKE_PLATFORM `
+            "-DCMAKE_GENERATOR_INSTANCE=$env:SHIPYARD_CMAKE_GENERATOR_INSTANCE"
+
+    When `toolchain` is None, the env vars are set to empty strings so
+    stage commands can guard on them with `if ($env:... ) { ... }`.
+    """
+    if toolchain is None:
+        return (
+            "$env:SHIPYARD_CMAKE_PLATFORM = ''; "
+            "$env:SHIPYARD_CMAKE_GENERATOR_INSTANCE = ''"
+        )
+    safe_platform = toolchain.cmake_platform.replace("'", "''")
+    safe_instance = toolchain.cmake_generator_instance.replace("'", "''")
+    return (
+        f"$env:SHIPYARD_CMAKE_PLATFORM = '{safe_platform}'; "
+        f"$env:SHIPYARD_CMAKE_GENERATOR_INSTANCE = '{safe_instance}'"
+    )

--- a/tests/executor/test_ssh.py
+++ b/tests/executor/test_ssh.py
@@ -6,13 +6,10 @@ import subprocess
 from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
 
-import pytest
-
 from shipyard.core.job import TargetStatus
 from shipyard.executor.ssh import SSHExecutor
 from shipyard.executor.ssh_windows import SSHWindowsExecutor
 from shipyard.executor.streaming import StreamingCommandResult
-
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -33,11 +30,16 @@ def _windows_target_config(
     name: str = "windows",
     **extra: object,
 ) -> dict:
+    # `windows_vs_detect` defaults to True in production, but tests
+    # that don't exercise toolchain detection disable it so they
+    # don't shell out to a real `ssh <host>` during unit runs.
     return {
         "host": host,
         "platform": platform,
         "name": name,
         "repo_path": "C:\\repo",
+        "windows_vs_detect": False,
+        "windows_host_mutex": False,
         **extra,
     }
 
@@ -151,7 +153,6 @@ class TestSSHExecutorValidate:
     def test_validate_pass(self, tmp_path) -> None:
         executor = SSHExecutor()
         log_path = str(tmp_path / "log.txt")
-        mock_result = MagicMock(returncode=0)
 
         patches = _mock_bundle_success()
         with patches[0], patches[1], patches[2], \
@@ -380,3 +381,163 @@ class TestSSHWindowsExecutorValidate:
             ssh_cmd = mock_run.call_args[0][0]
             assert "powershell" in ssh_cmd
             assert "-Command" in ssh_cmd
+
+    def test_validate_host_mutex_default_wraps_command(self, tmp_path) -> None:
+        """When windows_host_mutex is not explicitly disabled, the command is wrapped."""
+        executor = SSHWindowsExecutor()
+        log_path = str(tmp_path / "log.txt")
+        from shipyard.bundle.git_bundle import BundleResult
+
+        # Enable the mutex but keep VS detection disabled so no real
+        # SSH call is made.
+        target = _windows_target_config(
+            windows_vs_detect=False,
+            windows_host_mutex=True,
+        )
+
+        with patch(
+            "shipyard.executor.ssh_windows.create_bundle",
+            return_value=BundleResult(success=True, message="ok", path="/tmp/b"),
+        ), patch(
+            "shipyard.executor.ssh_windows.upload_bundle",
+            return_value=BundleResult(success=True, message="ok", path="/tmp/b"),
+        ), patch(
+            "shipyard.executor.ssh_windows._apply_bundle_windows",
+            return_value=type("R", (), {"success": True, "message": "ok"})(),
+        ), patch(
+            "shipyard.executor.ssh_windows.run_streaming_command",
+            return_value=_streaming_result(0, "ok"),
+        ) as mock_run:
+            executor.validate(
+                sha="abc123",
+                branch="main",
+                target_config=target,
+                validation_config=_validation_config(),
+                log_path=log_path,
+            )
+
+            ssh_cmd = mock_run.call_args[0][0]
+            # The last argument is the PowerShell command string.
+            ps = ssh_cmd[-1]
+            assert "System.Threading.Mutex" in ps
+            assert "Global\\ShipyardValidate" in ps
+
+    def test_validate_host_mutex_custom_name(self, tmp_path) -> None:
+        executor = SSHWindowsExecutor()
+        log_path = str(tmp_path / "log.txt")
+        from shipyard.bundle.git_bundle import BundleResult
+
+        target = _windows_target_config(
+            windows_vs_detect=False,
+            windows_host_mutex=True,
+            windows_host_mutex_name="Global\\MyCustomLock",
+        )
+
+        with patch(
+            "shipyard.executor.ssh_windows.create_bundle",
+            return_value=BundleResult(success=True, message="ok", path="/tmp/b"),
+        ), patch(
+            "shipyard.executor.ssh_windows.upload_bundle",
+            return_value=BundleResult(success=True, message="ok", path="/tmp/b"),
+        ), patch(
+            "shipyard.executor.ssh_windows._apply_bundle_windows",
+            return_value=type("R", (), {"success": True, "message": "ok"})(),
+        ), patch(
+            "shipyard.executor.ssh_windows.run_streaming_command",
+            return_value=_streaming_result(0, "ok"),
+        ) as mock_run:
+            executor.validate(
+                sha="abc123",
+                branch="main",
+                target_config=target,
+                validation_config=_validation_config(),
+                log_path=log_path,
+            )
+            ps = mock_run.call_args[0][0][-1]
+            assert "Global\\MyCustomLock" in ps
+            assert "Global\\ShipyardValidate" not in ps
+
+    def test_validate_vs_detection_injects_env_vars(self, tmp_path) -> None:
+        """Detected toolchain is exported to the remote command as env vars."""
+        from shipyard.executor.windows_toolchain import VsToolchain
+
+        executor = SSHWindowsExecutor()
+        log_path = str(tmp_path / "log.txt")
+        from shipyard.bundle.git_bundle import BundleResult
+
+        target = _windows_target_config(
+            windows_vs_detect=True,
+            windows_host_mutex=False,
+        )
+
+        with patch(
+            "shipyard.executor.ssh_windows.detect_vs_toolchain",
+            return_value=VsToolchain(
+                cmake_platform="ARM64",
+                cmake_generator_instance="C:/VS/2022/Community",
+            ),
+        ), patch(
+            "shipyard.executor.ssh_windows.create_bundle",
+            return_value=BundleResult(success=True, message="ok", path="/tmp/b"),
+        ), patch(
+            "shipyard.executor.ssh_windows.upload_bundle",
+            return_value=BundleResult(success=True, message="ok", path="/tmp/b"),
+        ), patch(
+            "shipyard.executor.ssh_windows._apply_bundle_windows",
+            return_value=type("R", (), {"success": True, "message": "ok"})(),
+        ), patch(
+            "shipyard.executor.ssh_windows.run_streaming_command",
+            return_value=_streaming_result(0, "ok"),
+        ) as mock_run:
+            executor.validate(
+                sha="abc123",
+                branch="main",
+                target_config=target,
+                validation_config=_validation_config(),
+                log_path=log_path,
+            )
+            ps = mock_run.call_args[0][0][-1]
+            assert "$env:SHIPYARD_CMAKE_PLATFORM = 'ARM64'" in ps
+            assert "C:/VS/2022/Community" in ps
+
+    def test_validate_vs_detection_cache_reuses_result(self, tmp_path) -> None:
+        """The toolchain is detected once per host and cached on the executor."""
+        from shipyard.executor.windows_toolchain import VsToolchain
+
+        executor = SSHWindowsExecutor()
+        log_path = str(tmp_path / "log.txt")
+        from shipyard.bundle.git_bundle import BundleResult
+
+        target = _windows_target_config(
+            windows_vs_detect=True,
+            windows_host_mutex=False,
+        )
+
+        with patch(
+            "shipyard.executor.ssh_windows.detect_vs_toolchain",
+            return_value=VsToolchain(
+                cmake_platform="x64",
+                cmake_generator_instance="C:/VS/2022/BuildTools",
+            ),
+        ) as mock_detect, patch(
+            "shipyard.executor.ssh_windows.create_bundle",
+            return_value=BundleResult(success=True, message="ok", path="/tmp/b"),
+        ), patch(
+            "shipyard.executor.ssh_windows.upload_bundle",
+            return_value=BundleResult(success=True, message="ok", path="/tmp/b"),
+        ), patch(
+            "shipyard.executor.ssh_windows._apply_bundle_windows",
+            return_value=type("R", (), {"success": True, "message": "ok"})(),
+        ), patch(
+            "shipyard.executor.ssh_windows.run_streaming_command",
+            return_value=_streaming_result(0, "ok"),
+        ):
+            for _ in range(3):
+                executor.validate(
+                    sha="abc123",
+                    branch="main",
+                    target_config=target,
+                    validation_config=_validation_config(),
+                    log_path=log_path,
+                )
+            assert mock_detect.call_count == 1

--- a/tests/executor/test_windows_toolchain.py
+++ b/tests/executor/test_windows_toolchain.py
@@ -1,0 +1,173 @@
+"""Unit tests for the Windows toolchain helpers.
+
+These tests don't shell out to a real Windows host — they exercise
+the pure PowerShell-builder functions and the JSON-parsing branch of
+`detect_vs_toolchain` via mocks.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from unittest.mock import patch
+
+from shipyard.executor.windows_toolchain import (
+    DEFAULT_MUTEX_NAME,
+    VsToolchain,
+    detect_vs_toolchain,
+    toolchain_env_exports,
+    wrap_powershell_with_host_mutex,
+)
+
+# ── wrap_powershell_with_host_mutex ─────────────────────────────────────
+
+
+def test_mutex_wrapper_includes_default_name() -> None:
+    wrapped = wrap_powershell_with_host_mutex("echo hello")
+    assert DEFAULT_MUTEX_NAME in wrapped
+    # Global\\ prefix is preserved (with backslash intact inside
+    # the emitted PS single-quoted literal).
+    assert "Global\\ShipyardValidate" in wrapped
+
+
+def test_mutex_wrapper_accepts_custom_name() -> None:
+    wrapped = wrap_powershell_with_host_mutex(
+        "echo hello",
+        mutex_name="Global\\MyProjectCI",
+    )
+    assert "Global\\MyProjectCI" in wrapped
+
+
+def test_mutex_wrapper_escapes_single_quotes_in_name() -> None:
+    """A mutex name containing ' must not break out of its literal."""
+    wrapped = wrap_powershell_with_host_mutex(
+        "echo hello",
+        mutex_name="Local\\it's-fine",
+    )
+    # PowerShell escapes single quotes by doubling them inside a
+    # single-quoted string. The original ' should never appear
+    # unescaped in the emitted literal.
+    assert "'Local\\it''s-fine'" in wrapped
+
+
+def test_mutex_wrapper_preserves_body_and_exits_with_its_code() -> None:
+    wrapped = wrap_powershell_with_host_mutex("cmake --build build")
+    assert "cmake --build build" in wrapped
+    # The wrapper captures $LASTEXITCODE and re-exits with it.
+    assert "$__ShipyardExit = $LASTEXITCODE" in wrapped
+    assert "exit $__ShipyardExit" in wrapped
+
+
+def test_mutex_wrapper_emits_wait_markers() -> None:
+    wrapped = wrap_powershell_with_host_mutex("echo hi")
+    # These two markers let log readers distinguish "blocked on the
+    # host lock" from "stuck somewhere during build".
+    assert "__SHIPYARD_WAIT__:host-lock" in wrapped
+    assert "__SHIPYARD_PHASE__:waiting-lock" in wrapped
+
+
+def test_mutex_wrapper_handles_abandoned_mutex() -> None:
+    """A crashed prior run leaves an abandoned mutex; we must recover."""
+    wrapped = wrap_powershell_with_host_mutex("echo hi")
+    assert "AbandonedMutexException" in wrapped
+    assert "Recovered abandoned host validation lock" in wrapped
+
+
+def test_mutex_wrapper_releases_and_disposes() -> None:
+    wrapped = wrap_powershell_with_host_mutex("echo hi")
+    assert "$Mutex.ReleaseMutex()" in wrapped
+    assert "$Mutex.Dispose()" in wrapped
+
+
+# ── toolchain_env_exports ───────────────────────────────────────────────
+
+
+def test_env_exports_none_toolchain_sets_empty_vars() -> None:
+    """A None toolchain exports empty strings so stages can still guard on them."""
+    snippet = toolchain_env_exports(None)
+    assert "$env:SHIPYARD_CMAKE_PLATFORM = ''" in snippet
+    assert "$env:SHIPYARD_CMAKE_GENERATOR_INSTANCE = ''" in snippet
+
+
+def test_env_exports_arm64_toolchain() -> None:
+    toolchain = VsToolchain(
+        cmake_platform="ARM64",
+        cmake_generator_instance="C:/Program Files/Microsoft Visual Studio/2022/Community",
+    )
+    snippet = toolchain_env_exports(toolchain)
+    assert "$env:SHIPYARD_CMAKE_PLATFORM = 'ARM64'" in snippet
+    assert "Community" in snippet
+
+
+def test_env_exports_escapes_single_quotes_in_path() -> None:
+    """An install path with a single quote must not break the literal."""
+    toolchain = VsToolchain(
+        cmake_platform="x64",
+        cmake_generator_instance="C:/it's/weird/vs",
+    )
+    snippet = toolchain_env_exports(toolchain)
+    assert "'C:/it''s/weird/vs'" in snippet
+
+
+# ── detect_vs_toolchain ─────────────────────────────────────────────────
+
+
+def _mock_run(returncode: int = 0, stdout: str = "", stderr: str = ""):
+    return subprocess.CompletedProcess(
+        args=[], returncode=returncode, stdout=stdout, stderr=stderr,
+    )
+
+
+def test_detect_returns_none_when_ssh_fails() -> None:
+    with patch("subprocess.run", side_effect=OSError("ssh boom")):
+        assert detect_vs_toolchain("host", []) is None
+
+
+def test_detect_returns_none_when_powershell_exits_nonzero() -> None:
+    with patch("subprocess.run", return_value=_mock_run(returncode=1)):
+        assert detect_vs_toolchain("host", []) is None
+
+
+def test_detect_returns_none_when_timeout() -> None:
+    with patch(
+        "subprocess.run",
+        side_effect=subprocess.TimeoutExpired(cmd="ssh", timeout=60),
+    ):
+        assert detect_vs_toolchain("host", []) is None
+
+
+def test_detect_parses_valid_json_output() -> None:
+    stdout = (
+        "some preamble\n"
+        '{"platform":"ARM64","generator_instance":"C:/VS/2022/Community"}\n'
+    )
+    with patch("subprocess.run", return_value=_mock_run(stdout=stdout)):
+        toolchain = detect_vs_toolchain("host", [])
+    assert toolchain is not None
+    assert toolchain.cmake_platform == "ARM64"
+    assert toolchain.cmake_generator_instance == "C:/VS/2022/Community"
+
+
+def test_detect_ignores_banner_lines() -> None:
+    """Some PowerShell profiles print a banner — we scan from the bottom."""
+    stdout = (
+        "Windows PowerShell\nCopyright (C) Microsoft\n"
+        '{"platform":"x64","generator_instance":""}\n'
+    )
+    with patch("subprocess.run", return_value=_mock_run(stdout=stdout)):
+        toolchain = detect_vs_toolchain("host", [])
+    assert toolchain is not None
+    assert toolchain.cmake_platform == "x64"
+    assert toolchain.cmake_generator_instance == ""
+
+
+def test_detect_returns_none_on_malformed_json() -> None:
+    stdout = "this is not json at all\n"
+    with patch("subprocess.run", return_value=_mock_run(stdout=stdout)):
+        assert detect_vs_toolchain("host", []) is None
+
+
+def test_detect_returns_none_when_both_fields_empty() -> None:
+    """A vswhere-less host returns both fields empty → not useful, return None."""
+    stdout = '{"platform":"","generator_instance":""}\n'
+    with patch("subprocess.run", return_value=_mock_run(stdout=stdout)):
+        assert detect_vs_toolchain("host", []) is None


### PR DESCRIPTION
## Summary

Two pieces of Pulp's `local_ci.py` that the ssh-windows executor needs for capability parity:

### 1. Host mutex
Wraps the remote PowerShell script in a `System.Threading.Mutex` so concurrent Shipyard runs on the same Windows host queue up instead of stomping on each other. Emits `__SHIPYARD_WAIT__:host-lock` and `__SHIPYARD_PHASE__:waiting-lock` markers while blocked. Recovers abandoned mutexes from crashed prior runs. Mutex name defaults to `Global\ShipyardValidate`, overridable per-target with `windows_host_mutex_name`. **Default: on.**

### 2. Visual Studio auto-detection
Runs `vswhere.exe` on the remote host via SSH+PowerShell before validation. Picks the preferred VS installation (prefers a full VS install over BuildTools), and resolves the CMake platform (ARM64 vs x64 from `$env:PROCESSOR_ARCHITECTURE`). Results are cached on the executor instance so the probe runs once per host per Shipyard invocation. Exports `$env:SHIPYARD_CMAKE_PLATFORM` and `$env:SHIPYARD_CMAKE_GENERATOR_INSTANCE` into the remote command so stage commands can reference them:

\`\`\`powershell
cmake -S . -B build -G "Visual Studio 17 2022" \`
      -A \$env:SHIPYARD_CMAKE_PLATFORM \`
      "-DCMAKE_GENERATOR_INSTANCE=\$env:SHIPYARD_CMAKE_GENERATOR_INSTANCE"
\`\`\`

**Default: on.** Disable per-target with `windows_vs_detect = false`.

### New module: \`shipyard.executor.windows_toolchain\`
- \`wrap_powershell_with_host_mutex()\`
- \`detect_vs_toolchain()\`
- \`toolchain_env_exports()\`
- \`VsToolchain\`, \`DEFAULT_MUTEX_NAME\`

### Tests
- 17 unit tests (mutex wrapping edge cases, env var escaping, vswhere JSON parsing)
- 4 integration tests on \`SSHWindowsExecutor\` (mutex default, custom name, VS injection, cache reuse)
- Pre-existing ssh_windows tests updated to opt out of detection/mutex so they stay deterministic

Full suite: **278 passing** on this branch (257 baseline + 17 toolchain + 4 integration).

## Test plan

- [x] \`pytest tests/executor/test_windows_toolchain.py\` — 17/17
- [x] \`pytest tests/executor/test_ssh.py\` — 22/22 (incl. 4 new)
- [x] \`pytest tests/\` full suite — 278/278
- [x] \`ruff check\` clean
- [x] \`mypy\` clean
- [ ] Smoke-test against real Windows host once Shipyard is dogfooded