### PR TITLE
Phase 5 (4/4): auto-inject cloud fallback for unreachable SSH targets

### DIFF
--- a/src/shipyard/failover/auto.py
+++ b/src/shipyard/failover/auto.py
@@ -1,0 +1,132 @@
+"""Auto-inject a cloud fallback for unreachable SSH targets.
+
+Pulp's local_ci.py implements this via its `[failover] namespace_auto`
+flag: when the default cloud provider is `namespace` and
+`namespace_auto = true`, every SSH target that would otherwise be
+marked unreachable gets an implicit failover to Namespace before the
+run is rejected. This lets a solo developer keep their Windows VM
+shut down most of the time and still ship PRs — Shipyard dispatches
+the unreachable target to the cloud automatically instead of
+erroring out.
+
+Shipyard already has a `FallbackChain` that walks through a
+per-target `fallback = [...]` list in order, probing each backend and
+skipping the ones that fail. This module just materializes the
+"implicit cloud fallback" that users would otherwise have to write
+by hand on every SSH target.
+
+Config schema::
+
+    [failover.cloud_auto]
+    enabled = true           # opt-in
+    provider = "namespace"   # one of the cloud provider names
+    workflow = "ci.yml"      # workflow file to dispatch
+    repository = "owner/repo"  # optional; defaults to origin
+
+When enabled, this helper walks `config.targets` and, for each SSH or
+ssh-windows target that has no explicit `fallback` entry, appends a
+synthetic cloud fallback. Explicit fallbacks are left alone — users
+who know what they want stay in control.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from shipyard.core.config import Config
+
+
+_SSH_BACKENDS = frozenset({"ssh", "ssh-windows", "ssh_windows"})
+
+
+def auto_cloud_fallback_config(config: Config) -> dict[str, Any] | None:
+    """Return the `[failover.cloud_auto]` section when enabled, else None.
+
+    Tolerates missing sections and typos gracefully — if the config
+    isn't opted in, this returns None and callers skip injection.
+    """
+    section = config.get("failover.cloud_auto")
+    if not isinstance(section, dict):
+        return None
+    if not section.get("enabled", False):
+        return None
+    return section
+
+
+def build_cloud_fallback_entry(
+    auto_config: dict[str, Any],
+    *,
+    target_config: dict[str, Any],
+) -> dict[str, Any]:
+    """Materialize the cloud fallback dict to append to a target's chain.
+
+    Inherits `platform`, `runner_provider`, and `runner_selector`
+    from the auto-config, but lets the target override them by having
+    `cloud_runner_provider` etc. already set in the target config.
+    """
+    provider = auto_config.get("provider", "namespace")
+    workflow = auto_config.get("workflow", "ci.yml")
+    repository = auto_config.get("repository")
+
+    entry: dict[str, Any] = {
+        "type": "cloud",
+        "workflow": workflow,
+        "runner_provider": target_config.get(
+            "cloud_runner_provider", provider,
+        ),
+    }
+    if repository:
+        entry["repository"] = repository
+    if "cloud_runner_selector" in target_config:
+        entry["runner_selector"] = target_config["cloud_runner_selector"]
+    elif "runner_selector" in auto_config:
+        entry["runner_selector"] = auto_config["runner_selector"]
+    return entry
+
+
+def apply_auto_cloud_fallback(config: Config) -> list[str]:
+    """Mutate the config in place, appending cloud fallbacks where missing.
+
+    Returns the list of target names that got a fallback injected.
+    Targets that already have a `fallback = [...]` are left alone —
+    users who declare their own chain stay in control of the order.
+    A target is considered SSH if its `type`/`backend` is `ssh` or
+    `ssh-windows`.
+    """
+    auto_config = auto_cloud_fallback_config(config)
+    if auto_config is None:
+        return []
+
+    targets = config.data.get("targets")
+    if not isinstance(targets, dict):
+        return []
+
+    injected: list[str] = []
+    for name, target_config in targets.items():
+        if not isinstance(target_config, dict):
+            continue
+        backend = _normalize_backend(target_config)
+        if backend not in _SSH_BACKENDS:
+            continue
+        if target_config.get("fallback"):
+            continue
+        entry = build_cloud_fallback_entry(
+            auto_config, target_config=target_config,
+        )
+        target_config["fallback"] = [entry]
+        injected.append(name)
+    return injected
+
+
+def _normalize_backend(target_config: dict[str, Any]) -> str:
+    backend = str(
+        target_config.get("type")
+        or target_config.get("backend")
+        or "local"
+    ).strip().lower().replace("_", "-")
+    if backend == "ssh" and str(
+        target_config.get("platform", "")
+    ).startswith("windows"):
+        return "ssh-windows"
+    return backend

--- a/src/shipyard/preflight.py
+++ b/src/shipyard/preflight.py
@@ -7,6 +7,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from shipyard.failover.auto import apply_auto_cloud_fallback
+
 if TYPE_CHECKING:
     from shipyard.core.config import Config
     from shipyard.executor.dispatch import ExecutorDispatcher
@@ -73,6 +75,18 @@ def run_submission_preflight(
             warnings.append(message)
         else:
             raise ValueError(message)
+
+    # Inject an implicit cloud fallback on SSH targets when the
+    # project opts into [failover.cloud_auto]. Targets that already
+    # declare their own `fallback = [...]` are left alone. This
+    # matches Pulp's local_ci.py namespace_auto behavior — a solo
+    # developer can leave their Windows VM shut down and Shipyard
+    # will route the run through the cloud instead of erroring.
+    injected = apply_auto_cloud_fallback(config)
+    if injected:
+        warnings.append(
+            "auto-cloud-failover injected for: " + ", ".join(injected),
+        )
 
     target_states: dict[str, TargetPreflight] = {}
     for target_name in target_names:

--- a/tests/failover/test_auto.py
+++ b/tests/failover/test_auto.py
@@ -1,0 +1,258 @@
+"""Unit tests for auto cloud fallback injection."""
+
+from __future__ import annotations
+
+from shipyard.core.config import Config
+from shipyard.failover.auto import (
+    apply_auto_cloud_fallback,
+    auto_cloud_fallback_config,
+    build_cloud_fallback_entry,
+)
+
+
+def _make_config(data: dict) -> Config:
+    """Build a Config instance directly from a dict."""
+    return Config(data=data)
+
+
+# ── auto_cloud_fallback_config ──────────────────────────────────────────
+
+
+def test_auto_config_returns_none_when_section_missing() -> None:
+    config = _make_config({})
+    assert auto_cloud_fallback_config(config) is None
+
+
+def test_auto_config_returns_none_when_disabled() -> None:
+    config = _make_config({
+        "failover": {"cloud_auto": {"enabled": False, "provider": "namespace"}},
+    })
+    assert auto_cloud_fallback_config(config) is None
+
+
+def test_auto_config_returns_none_when_enabled_omitted() -> None:
+    """Without `enabled = true` the section is a no-op — opt-in only."""
+    config = _make_config({
+        "failover": {"cloud_auto": {"provider": "namespace"}},
+    })
+    assert auto_cloud_fallback_config(config) is None
+
+
+def test_auto_config_returns_section_when_enabled() -> None:
+    config = _make_config({
+        "failover": {
+            "cloud_auto": {
+                "enabled": True,
+                "provider": "namespace",
+                "workflow": "ci.yml",
+            }
+        },
+    })
+    section = auto_cloud_fallback_config(config)
+    assert section is not None
+    assert section["provider"] == "namespace"
+
+
+def test_auto_config_tolerates_wrong_section_type() -> None:
+    """A non-dict section (e.g. misconfigured TOML) returns None."""
+    config = _make_config({"failover": {"cloud_auto": "enabled"}})
+    assert auto_cloud_fallback_config(config) is None
+
+
+# ── build_cloud_fallback_entry ──────────────────────────────────────────
+
+
+def test_build_entry_uses_auto_defaults() -> None:
+    entry = build_cloud_fallback_entry(
+        {"provider": "namespace", "workflow": "ci.yml"},
+        target_config={},
+    )
+    assert entry["type"] == "cloud"
+    assert entry["workflow"] == "ci.yml"
+    assert entry["runner_provider"] == "namespace"
+
+
+def test_build_entry_includes_repository_when_set() -> None:
+    entry = build_cloud_fallback_entry(
+        {
+            "provider": "namespace",
+            "workflow": "ci.yml",
+            "repository": "myorg/myrepo",
+        },
+        target_config={},
+    )
+    assert entry["repository"] == "myorg/myrepo"
+
+
+def test_build_entry_omits_repository_when_unset() -> None:
+    entry = build_cloud_fallback_entry(
+        {"provider": "namespace", "workflow": "ci.yml"},
+        target_config={},
+    )
+    assert "repository" not in entry
+
+
+def test_build_entry_target_overrides_provider() -> None:
+    """A per-target cloud_runner_provider beats the auto default."""
+    entry = build_cloud_fallback_entry(
+        {"provider": "namespace", "workflow": "ci.yml"},
+        target_config={"cloud_runner_provider": "github-hosted"},
+    )
+    assert entry["runner_provider"] == "github-hosted"
+
+
+def test_build_entry_target_overrides_selector() -> None:
+    entry = build_cloud_fallback_entry(
+        {
+            "provider": "namespace",
+            "workflow": "ci.yml",
+            "runner_selector": "base",
+        },
+        target_config={"cloud_runner_selector": "macos-arm64-large"},
+    )
+    assert entry["runner_selector"] == "macos-arm64-large"
+
+
+def test_build_entry_inherits_auto_selector_when_no_override() -> None:
+    entry = build_cloud_fallback_entry(
+        {
+            "provider": "namespace",
+            "workflow": "ci.yml",
+            "runner_selector": "base",
+        },
+        target_config={},
+    )
+    assert entry["runner_selector"] == "base"
+
+
+# ── apply_auto_cloud_fallback ───────────────────────────────────────────
+
+
+def test_apply_noop_when_disabled() -> None:
+    config = _make_config({
+        "targets": {
+            "ubuntu": {"type": "ssh", "host": "ubuntu"},
+        },
+    })
+    injected = apply_auto_cloud_fallback(config)
+    assert injected == []
+    assert "fallback" not in config.data["targets"]["ubuntu"]
+
+
+def test_apply_injects_on_ssh_targets_when_enabled() -> None:
+    config = _make_config({
+        "failover": {
+            "cloud_auto": {
+                "enabled": True,
+                "provider": "namespace",
+                "workflow": "ci.yml",
+            }
+        },
+        "targets": {
+            "ubuntu": {"type": "ssh", "host": "ubuntu"},
+            "windows": {
+                "type": "ssh",
+                "host": "win",
+                "platform": "windows-x64",
+            },
+        },
+    })
+    injected = apply_auto_cloud_fallback(config)
+    assert set(injected) == {"ubuntu", "windows"}
+    for name in ("ubuntu", "windows"):
+        target = config.data["targets"][name]
+        assert "fallback" in target
+        assert len(target["fallback"]) == 1
+        entry = target["fallback"][0]
+        assert entry["type"] == "cloud"
+        assert entry["workflow"] == "ci.yml"
+
+
+def test_apply_skips_local_targets() -> None:
+    config = _make_config({
+        "failover": {
+            "cloud_auto": {"enabled": True, "provider": "namespace"},
+        },
+        "targets": {
+            "mac": {"type": "local", "platform": "macos-arm64"},
+            "ubuntu": {"type": "ssh", "host": "ubuntu"},
+        },
+    })
+    injected = apply_auto_cloud_fallback(config)
+    assert injected == ["ubuntu"]
+    assert "fallback" not in config.data["targets"]["mac"]
+
+
+def test_apply_preserves_explicit_fallback() -> None:
+    """A target with an explicit fallback chain is left alone."""
+    existing_fallback = [{"type": "vm", "vm_name": "Ubuntu 24.04"}]
+    config = _make_config({
+        "failover": {
+            "cloud_auto": {"enabled": True, "provider": "namespace"},
+        },
+        "targets": {
+            "ubuntu": {
+                "type": "ssh",
+                "host": "ubuntu",
+                "fallback": existing_fallback,
+            },
+        },
+    })
+    injected = apply_auto_cloud_fallback(config)
+    assert injected == []
+    assert config.data["targets"]["ubuntu"]["fallback"] == existing_fallback
+
+
+def test_apply_skips_ssh_target_with_empty_fallback_list() -> None:
+    """An empty explicit fallback list is still opt-out, not opt-in."""
+    config = _make_config({
+        "failover": {
+            "cloud_auto": {"enabled": True, "provider": "namespace"},
+        },
+        "targets": {
+            # `fallback = []` is falsy, so the auto-inject treats it
+            # as "no explicit fallback" and adds one. This matches
+            # the intuitive "opt-in by declaring anything" UX.
+            "ubuntu": {"type": "ssh", "host": "ubuntu", "fallback": []},
+        },
+    })
+    injected = apply_auto_cloud_fallback(config)
+    assert injected == ["ubuntu"]
+
+
+def test_apply_detects_windows_platform_with_ssh_backend() -> None:
+    """type=ssh + platform=windows-* is treated as an SSH target."""
+    config = _make_config({
+        "failover": {
+            "cloud_auto": {"enabled": True, "provider": "namespace"},
+        },
+        "targets": {
+            "win": {
+                "type": "ssh",
+                "host": "win",
+                "platform": "windows-arm64",
+            },
+        },
+    })
+    injected = apply_auto_cloud_fallback(config)
+    assert injected == ["win"]
+
+
+def test_apply_handles_missing_targets_section() -> None:
+    config = _make_config({
+        "failover": {"cloud_auto": {"enabled": True, "provider": "namespace"}},
+    })
+    assert apply_auto_cloud_fallback(config) == []
+
+
+def test_apply_handles_non_dict_target_entry() -> None:
+    """A malformed target entry should be skipped, not crash."""
+    config = _make_config({
+        "failover": {"cloud_auto": {"enabled": True, "provider": "namespace"}},
+        "targets": {
+            "good": {"type": "ssh", "host": "ubuntu"},
+            "broken": "not-a-dict",
+        },
+    })
+    injected = apply_auto_cloud_fallback(config)
+    assert injected == ["good"]

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
-from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pytest
 
 from shipyard.core.config import Config
 from shipyard.executor.dispatch import ExecutorDispatcher
 from shipyard.preflight import run_submission_preflight
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 def _config(tmp_path: Path, targets: dict) -> Config:
@@ -80,3 +83,80 @@ def test_unreachable_target_rejected_without_override(tmp_path, monkeypatch) -> 
             dispatcher=dispatcher,
             cwd=tmp_path,
         )
+
+
+def test_auto_cloud_failover_rescues_unreachable_ssh(tmp_path, monkeypatch) -> None:
+    """When [failover.cloud_auto] is on, SSH→cloud failover rescues the run."""
+    config = _config(
+        tmp_path,
+        {"ubuntu": {"backend": "ssh", "platform": "linux-x64", "host": "ubuntu"}},
+    )
+    config.data["failover"] = {
+        "cloud_auto": {
+            "enabled": True,
+            "provider": "namespace",
+            "workflow": "ci.yml",
+        }
+    }
+    dispatcher = ExecutorDispatcher()
+    monkeypatch.setattr("shipyard.preflight._git_root_for", lambda _: tmp_path)
+    # SSH probe fails; cloud probe succeeds. The preflight should
+    # inject the cloud fallback, then find it reachable, and accept.
+    monkeypatch.setattr(
+        dispatcher,
+        "probe",
+        lambda target_config: str(
+            target_config.get("type") or target_config.get("backend")
+        ) == "cloud",
+    )
+
+    result = run_submission_preflight(
+        config,
+        target_names=["ubuntu"],
+        dispatcher=dispatcher,
+        cwd=tmp_path,
+    )
+
+    assert result.targets["ubuntu"].reachable is True
+    assert result.targets["ubuntu"].selected_backend == "cloud"
+    assert any("auto-cloud-failover injected" in w for w in result.warnings)
+    # And the injection was applied to the config in place
+    assert config.data["targets"]["ubuntu"]["fallback"][0]["type"] == "cloud"
+
+
+def test_auto_cloud_failover_respects_explicit_fallback(tmp_path, monkeypatch) -> None:
+    """When a user already declared a fallback chain, the auto path is a no-op."""
+    explicit = [{"type": "vm", "vm_name": "Ubuntu 24.04"}]
+    config = _config(
+        tmp_path,
+        {
+            "ubuntu": {
+                "backend": "ssh",
+                "platform": "linux-x64",
+                "host": "ubuntu",
+                "fallback": explicit,
+            }
+        },
+    )
+    config.data["failover"] = {
+        "cloud_auto": {"enabled": True, "provider": "namespace"},
+    }
+    dispatcher = ExecutorDispatcher()
+    monkeypatch.setattr("shipyard.preflight._git_root_for", lambda _: tmp_path)
+    monkeypatch.setattr(
+        dispatcher,
+        "probe",
+        lambda target_config: str(
+            target_config.get("type") or target_config.get("backend")
+        ) == "vm",
+    )
+
+    run_submission_preflight(
+        config,
+        target_names=["ubuntu"],
+        dispatcher=dispatcher,
+        cwd=tmp_path,
+    )
+
+    # The user's VM fallback was preserved, no cloud appended.
+    assert config.data["targets"]["ubuntu"]["fallback"] == explicit


### PR DESCRIPTION
## Summary

Pulp's `local_ci.py` implements this via `[failover] namespace_auto`: when the default cloud provider is \`namespace\` and auto-failover is enabled, every SSH target that would otherwise be rejected as unreachable gets an implicit failover to the cloud before the submission is rejected. A solo developer can keep their Windows VM shut down most of the time and still ship PRs — Shipyard routes the unreachable target through the cloud automatically.

Shipyard already has a \`FallbackChain\` that walks a per-target \`fallback = [...]\` list in order, probing each backend and skipping unreachable ones. This PR just materializes the "implicit cloud fallback" that users would otherwise have to hand-write on every SSH target.

## Config schema

\`\`\`toml
[failover.cloud_auto]
enabled = true
provider = "namespace"
workflow = "ci.yml"
repository = "owner/repo"  # optional
runner_selector = "base"   # optional
\`\`\`

## What changes

### New: \`shipyard.failover.auto\`
- \`auto_cloud_fallback_config()\` — reads and validates \`[failover.cloud_auto]\`
- \`build_cloud_fallback_entry()\` — materializes the cloud backend dict from the auto-config. Per-target \`cloud_runner_provider\` / \`cloud_runner_selector\` beat the auto defaults so mixed-provider setups still work.
- \`apply_auto_cloud_fallback()\` — walks every target, injects a cloud fallback on every SSH / ssh-windows target that doesn't already have one. Explicit chains are left alone.

### \`shipyard.preflight\`
\`run_submission_preflight()\` now calls \`apply_auto_cloud_fallback()\` before probing targets. Injection emits a visible warning so users can see which targets got rescued.

## Tests
- **19 unit tests** for \`failover/auto.py\` (section parsing, entry building, explicit fallback preservation, backend filtering, malformed input edge cases)
- **2 preflight integration tests** (SSH→cloud rescue path end-to-end, explicit fallback is respected)

Full suite: **278 passing** (257 baseline + 19 auto + 2 preflight).

## Test plan

- [x] \`pytest tests/failover/test_auto.py\` — 19/19
- [x] \`pytest tests/test_preflight.py\` — 5/5
- [x] \`pytest tests/\` full suite — 278/278
- [x] \`ruff check\` clean
- [x] \`mypy\` clean
- [ ] Smoke-test against real SSH-down scenario once Shipyard is dogfooded