### PR TITLE
Release v0.1.3: Phase 5 capability parity

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "shipyard"
-version = "0.1.1"
+version = "0.1.3"
 description = "Cross-platform CI coordination — local VMs, SSH hosts, cloud runners"
 readme = "README.md"
 license = "MIT"

--- a/src/shipyard/__init__.py
+++ b/src/shipyard/__init__.py
@@ -1,3 +1,3 @@
 """Shipyard — Cross-platform CI coordination."""
 
-__version__ = "0.1.1"
+__version__ = "0.1.3"


### PR DESCRIPTION
## Summary

Tags v0.1.3 once merged. This release lands the four capability-parity features that Pulp's \`local_ci.py\` has and that Shipyard needed before Pulp could migrate:

| # | Feature | PR |
|---|---------|-----|
| 1 | Validation contract markers | #3 |
| 2 | Prepared-state reuse | #4 |
| 3 | Windows host mutex + VS detection | #5 |
| 4 | SSH→cloud auto-failover | #6 |

**Full test suite: 327 passing.**

Bumps \`shipyard.__version__\` and \`pyproject.toml\` from 0.1.1 → 0.1.3.

Note: 0.1.2 was published from a fix branch without a corresponding source bump, so source jumps from 0.1.1 to 0.1.3 in one step.

## Test plan

- [x] Full suite green on macOS, Linux, Windows (all four Phase 5 PRs were already green)
- [ ] Merge this PR, tag v0.1.3, publish release + PyInstaller binary
- [ ] Bump Pulp's \`tools/shipyard.toml\` pin from v0.1.2 → v0.1.3