### PR TITLE
Phase 6: governance profiles (solo/multi) + branch protection CLI

### DIFF
--- a/src/shipyard/cli.py
+++ b/src/shipyard/cli.py
@@ -387,6 +387,13 @@ def doctor(ctx: Context) -> None:
     cloud["nsc"] = _check_command("nsc", "version")
     checks["Cloud providers"] = cloud
 
+    # Governance drift — best-effort. If the repo can't be detected
+    # or gh isn't authenticated, this section is skipped silently
+    # rather than blocking the whole doctor command.
+    governance_section = _check_governance_drift(ctx.config)
+    if governance_section:
+        checks["Governance"] = governance_section
+
     ready = all(
         info.get("ok", False)
         for info in core.values()
@@ -396,6 +403,81 @@ def doctor(ctx: Context) -> None:
         ctx.output("doctor", {"ready": ready, "checks": checks})
     else:
         render_doctor(checks, ready)
+
+
+def _check_governance_drift(config: Config) -> dict[str, Any] | None:
+    """Produce a doctor section reporting governance drift.
+
+    Returns None if the repo cannot be detected or the user has not
+    declared a governance section. Never raises — any failure is
+    translated into a single diagnostic entry so doctor stays
+    informative even when gh auth is missing.
+    """
+    from shipyard.governance import (
+        build_status,
+        detect_repo_from_remote,
+        load_governance_config,
+    )
+
+    section: dict[str, Any] = {}
+    try:
+        governance = load_governance_config(config)
+    except ValueError as exc:
+        return {"config": {"ok": False, "detail": f"Config error: {exc}"}}
+
+    # Only probe GitHub if the user has explicitly declared a profile.
+    # Without a profile, governance is opt-out and doctor shouldn't
+    # second-guess the choice.
+    declared_profile = config.get("project.profile")
+    if not declared_profile:
+        return None
+
+    repo = detect_repo_from_remote()
+    if repo is None:
+        return {"profile": {
+            "ok": True,
+            "detail": f"declared={declared_profile}; no github remote detected",
+        }}
+
+    try:
+        status = build_status(
+            repo=repo, governance=governance, branches=("main",),
+        )
+    except Exception as exc:  # noqa: BLE001 — diagnostic path
+        return {"profile": {
+            "ok": False,
+            "detail": f"could not fetch live state: {exc}",
+        }}
+
+    # Profile / drift summary line
+    if status.has_drift:
+        drifted_fields = [
+            f"{r.branch}:{e.field_name}"
+            for r in status.reports
+            for e in r.drifted_entries
+        ]
+        section["main"] = {
+            "ok": False,
+            "detail": f"drift on {', '.join(drifted_fields[:3])}"
+                     + ("..." if len(drifted_fields) > 3 else "")
+                     + " — run: shipyard governance apply",
+        }
+    else:
+        section["main"] = {
+            "ok": True,
+            "detail": f"aligned with {declared_profile} profile",
+        }
+
+    # Honest immutable-releases line — per Part 12 spec, never claim
+    # a state Shipyard cannot verify on personal repos.
+    section["immutable_releases"] = {
+        "ok": True,  # info-only
+        "detail": (
+            "GitHub does not expose the repo-level setting via API. "
+            f"Verify at https://github.com/{repo.slug}/settings"
+        ),
+    }
+    return section
 
 
 @main.command(name="init")
@@ -414,6 +496,207 @@ def init_cmd(ctx: Context, discover_only: bool) -> None:
         render_message("Detected config (not written):")
         import json as _json
         render_message(_json.dumps(config.to_dict(), indent=2))
+
+
+# ── governance commands ────────────────────────────────────────────────
+
+
+@main.group()
+def governance() -> None:
+    """Manage branch protection and governance profiles."""
+
+
+@governance.command("status")
+@click.option(
+    "--branch", "-b", multiple=True,
+    help="Override which branches to check (repeatable). Default: main.",
+)
+@click.pass_obj
+def governance_status(ctx: Context, branch: tuple[str, ...]) -> None:
+    """Report declared-vs-live governance drift per branch."""
+    from shipyard.governance import (
+        build_status,
+        detect_repo_from_remote,
+        format_status_text,
+        load_governance_config,
+    )
+
+    gov = load_governance_config(ctx.config)
+    repo = detect_repo_from_remote()
+    if repo is None:
+        render_error("Could not detect repo from git remote. Is this a GitHub repo?")
+        sys.exit(1)
+
+    branches = branch or ("main",)
+    status = build_status(repo=repo, governance=gov, branches=branches)
+
+    if ctx.json_mode:
+        ctx.output("governance.status", {
+            "repo": repo.slug,
+            "profile": status.profile_name,
+            "has_drift": status.has_drift,
+            "reports": [
+                {
+                    "branch": r.branch,
+                    "live_unprotected": r.live_unprotected,
+                    "drifted_fields": [e.field_name for e in r.drifted_entries],
+                    "deviated_fields": [e.field_name for e in r.deviated_entries],
+                }
+                for r in status.reports
+            ],
+            "errors": list(status.errors),
+        })
+    else:
+        render_message(format_status_text(status))
+
+    if status.has_drift or status.has_errors:
+        sys.exit(1)
+
+
+@governance.command("apply")
+@click.option(
+    "--branch", "-b", multiple=True,
+    help="Override which branches to apply to (repeatable). Default: main.",
+)
+@click.option("--dry-run", is_flag=True, help="Show what would change without writing")
+@click.pass_obj
+def governance_apply(ctx: Context, branch: tuple[str, ...], dry_run: bool) -> None:
+    """Apply declared governance rules to live state (idempotent)."""
+    from shipyard.governance import (
+        build_apply_plan,
+        build_status,
+        detect_repo_from_remote,
+        execute_apply_plan,
+        load_governance_config,
+        resolve_branch_rules,
+    )
+
+    gov = load_governance_config(ctx.config)
+    repo = detect_repo_from_remote()
+    if repo is None:
+        render_error("Could not detect repo from git remote.")
+        sys.exit(1)
+
+    branches = branch or ("main",)
+    status = build_status(repo=repo, governance=gov, branches=branches)
+
+    results = []
+    for report in status.reports:
+        declared = resolve_branch_rules(gov, report.branch)
+        plan = build_apply_plan(
+            repo=repo,
+            branch=report.branch,
+            declared_rules=declared,
+            drift_report=report,
+        )
+        result = execute_apply_plan(plan, dry_run=dry_run)
+        results.append(result)
+
+    any_changes = any(r.executed or (dry_run and not r.plan.is_noop) for r in results)
+    any_errors = any(r.error_message for r in results) or status.has_errors
+
+    if ctx.json_mode:
+        ctx.output("governance.apply", {
+            "repo": repo.slug,
+            "dry_run": dry_run,
+            "changed": any_changes,
+            "results": [
+                {
+                    "branch": r.plan.branch,
+                    "action": r.plan.action.value,
+                    "executed": r.executed,
+                    "error": r.error_message,
+                }
+                for r in results
+            ],
+        })
+    else:
+        if not results:
+            render_message("No branches to apply to.", style="dim")
+        for result in results:
+            branch_name = result.plan.branch
+            action = result.plan.action.value
+            if result.error_message:
+                render_message(
+                    f"  ✗ {branch_name}: {action} failed — {result.error_message}",
+                    style="bold red",
+                )
+            elif result.plan.is_noop:
+                render_message(f"  ✓ {branch_name}: already aligned (no changes)")
+            elif dry_run:
+                drifted = [e.field_name for e in result.plan.drift_report.drifted_entries]
+                render_message(
+                    f"  → {branch_name}: would {action}"
+                    + (f" (fields: {', '.join(drifted)})" if drifted else "")
+                )
+            else:
+                render_message(f"  ✓ {branch_name}: {action} applied", style="green")
+        # Manual followups, printed every time per Part 12 spec
+        if results:
+            render_message("")
+            render_message("Manual followups (Shipyard cannot apply these via API):")
+            for followup in results[0].plan.manual_followups:
+                render_message(f"  ⚠ {followup}")
+
+    if any_errors:
+        sys.exit(1)
+
+
+@governance.command("diff")
+@click.option("--branch", "-b", multiple=True, help="Branches to check")
+@click.pass_obj
+def governance_diff(ctx: Context, branch: tuple[str, ...]) -> None:
+    """Show what `governance apply` would change, without applying."""
+    # Delegate to governance_apply with --dry-run by calling the same
+    # logic in-place.
+    from shipyard.governance import (
+        build_apply_plan,
+        build_status,
+        detect_repo_from_remote,
+        load_governance_config,
+        resolve_branch_rules,
+    )
+
+    gov = load_governance_config(ctx.config)
+    repo = detect_repo_from_remote()
+    if repo is None:
+        render_error("Could not detect repo from git remote.")
+        sys.exit(1)
+
+    branches = branch or ("main",)
+    status = build_status(repo=repo, governance=gov, branches=branches)
+
+    any_drift = False
+    for report in status.reports:
+        declared = resolve_branch_rules(gov, report.branch)
+        plan = build_apply_plan(
+            repo=repo, branch=report.branch,
+            declared_rules=declared, drift_report=report,
+        )
+        if plan.is_noop:
+            render_message(f"  ✓ {report.branch}: no changes")
+            continue
+        any_drift = True
+        drifted = report.drifted_entries
+        if report.live_unprotected:
+            render_message(
+                f"  + {report.branch}: create protection "
+                f"({len(report.entries)} fields)",
+                style="yellow",
+            )
+        else:
+            render_message(
+                f"  ~ {report.branch}: update {len(drifted)} field(s)",
+                style="yellow",
+            )
+            for entry in drifted:
+                render_message(
+                    f"      {entry.field_name}: "
+                    f"{entry.live_value!r} → {entry.declared_value!r}"
+                )
+    if any_drift:
+        render_message("")
+        render_message("Run: shipyard governance apply")
 
 
 @main.group()

--- a/src/shipyard/governance/__init__.py
+++ b/src/shipyard/governance/__init__.py
@@ -1,0 +1,75 @@
+"""Governance — declarative branch protection, tag protection, and profile management.
+
+See `profiles.py` for the solo/multi/custom profile definitions and
+`status.py` for the drift-detection rollup. The public surface of
+this package is intentionally narrow: CLI commands and tests should
+import from `shipyard.governance.<module>` directly.
+"""
+
+from shipyard.governance.apply import (
+    ApplyAction,
+    ApplyPlan,
+    ApplyResult,
+    build_apply_plan,
+    execute_apply_plan,
+)
+from shipyard.governance.compare import (
+    DriftEntry,
+    DriftReport,
+    DriftStatus,
+    compute_drift,
+)
+from shipyard.governance.config import (
+    GovernanceConfig,
+    load_governance_config,
+    resolve_branch_rules,
+)
+from shipyard.governance.github import (
+    GovernanceApiError,
+    RepoRef,
+    detect_repo_from_remote,
+    get_branch_protection,
+    put_branch_protection,
+)
+from shipyard.governance.profiles import (
+    BranchProtectionRules,
+    Profile,
+    ProfileName,
+    multi_profile,
+    profile_for_name,
+    solo_profile,
+)
+from shipyard.governance.status import (
+    GovernanceStatus,
+    build_status,
+    format_status_text,
+)
+
+__all__ = [
+    "ApplyAction",
+    "ApplyPlan",
+    "ApplyResult",
+    "BranchProtectionRules",
+    "DriftEntry",
+    "DriftReport",
+    "DriftStatus",
+    "GovernanceApiError",
+    "GovernanceConfig",
+    "GovernanceStatus",
+    "Profile",
+    "ProfileName",
+    "RepoRef",
+    "build_apply_plan",
+    "build_status",
+    "compute_drift",
+    "detect_repo_from_remote",
+    "execute_apply_plan",
+    "format_status_text",
+    "get_branch_protection",
+    "load_governance_config",
+    "multi_profile",
+    "profile_for_name",
+    "put_branch_protection",
+    "resolve_branch_rules",
+    "solo_profile",
+]

--- a/src/shipyard/governance/apply.py
+++ b/src/shipyard/governance/apply.py
@@ -84,7 +84,7 @@ def build_apply_plan(
     else:
         action = ApplyAction.NOOP
 
-    manual_followups = _collect_manual_followups()
+    manual_followups = _collect_manual_followups(repo)
 
     return ApplyPlan(
         repo=repo,
@@ -127,7 +127,7 @@ def execute_apply_plan(
     return ApplyResult(plan=plan, executed=True, error_message=None)
 
 
-def _collect_manual_followups() -> tuple[str, ...]:
+def _collect_manual_followups(repo: RepoRef) -> tuple[str, ...]:
     """Manual followups Shipyard cannot apply via API.
 
     For v0.1.4 this is just the immutable-releases checkbox. Future
@@ -141,6 +141,6 @@ def _collect_manual_followups() -> tuple[str, ...]:
     """
     return (
         "Immutable releases: verify the 'Immutable releases' checkbox "
-        "is enabled at https://github.com/<owner>/<repo>/settings. "
+        f"is enabled at https://github.com/{repo.slug}/settings. "
         "Shipyard cannot read this setting via API on personal repos.",
     )

--- a/src/shipyard/governance/apply.py
+++ b/src/shipyard/governance/apply.py
@@ -1,0 +1,146 @@
+"""Idempotent governance apply.
+
+`build_apply_plan` computes the set of PUT calls that would be
+needed to bring a branch's live state in line with its declared
+state. `execute_apply_plan` actually issues them. The two-step API
+exists so `governance diff` and `governance apply --dry-run` can
+share exactly the same planning code without duplicating the PUT
+logic.
+
+Idempotency contract: calling `execute_apply_plan` on a plan
+produced from up-to-date state issues zero PUT calls. Calling it
+twice in a row (without drift in between) is a no-op.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import TYPE_CHECKING
+
+from shipyard.governance.github import (
+    GovernanceApiError,
+    put_branch_protection,
+)
+
+if TYPE_CHECKING:
+    from shipyard.governance.compare import DriftReport
+    from shipyard.governance.github import RepoRef
+    from shipyard.governance.profiles import BranchProtectionRules
+
+
+class ApplyAction(str, Enum):
+    NOOP = "noop"
+    UPDATE = "update"  # live protection exists, needs changes
+    CREATE = "create"  # live protection missing, needs creation
+
+
+@dataclass(frozen=True)
+class ApplyPlan:
+    """A plan describing what `governance apply` would do.
+
+    The plan is intentionally a read-only dataclass; callers decide
+    whether to execute it via `execute_apply_plan`.
+    """
+
+    repo: RepoRef
+    branch: str
+    action: ApplyAction
+    declared_rules: BranchProtectionRules
+    drift_report: DriftReport
+    manual_followups: tuple[str, ...] = field(default_factory=tuple)
+
+    @property
+    def is_noop(self) -> bool:
+        return self.action == ApplyAction.NOOP
+
+
+@dataclass(frozen=True)
+class ApplyResult:
+    """The outcome of executing an ApplyPlan."""
+
+    plan: ApplyPlan
+    executed: bool
+    error_message: str | None = None
+
+
+def build_apply_plan(
+    *,
+    repo: RepoRef,
+    branch: str,
+    declared_rules: BranchProtectionRules,
+    drift_report: DriftReport,
+) -> ApplyPlan:
+    """Produce an ApplyPlan from a DriftReport.
+
+    The plan is NOOP when there's no drift at all; UPDATE when live
+    protection exists but needs changes; CREATE when live protection
+    is missing entirely.
+    """
+    if drift_report.live_unprotected:
+        action = ApplyAction.CREATE
+    elif drift_report.has_drift:
+        action = ApplyAction.UPDATE
+    else:
+        action = ApplyAction.NOOP
+
+    manual_followups = _collect_manual_followups()
+
+    return ApplyPlan(
+        repo=repo,
+        branch=branch,
+        action=action,
+        declared_rules=declared_rules,
+        drift_report=drift_report,
+        manual_followups=manual_followups,
+    )
+
+
+def execute_apply_plan(
+    plan: ApplyPlan,
+    *,
+    dry_run: bool = False,
+    gh_command: str = "gh",
+) -> ApplyResult:
+    """Apply the plan to GitHub. A dry-run returns ApplyResult(executed=False).
+
+    Never issues a PUT for a NOOP plan, even in non-dry-run mode.
+    This is the core of the idempotency guarantee: if nothing would
+    change, nothing is sent over the wire.
+    """
+    if plan.is_noop:
+        return ApplyResult(plan=plan, executed=False, error_message=None)
+
+    if dry_run:
+        return ApplyResult(plan=plan, executed=False, error_message=None)
+
+    try:
+        put_branch_protection(
+            plan.repo,
+            plan.branch,
+            plan.declared_rules,
+            gh_command=gh_command,
+        )
+    except GovernanceApiError as exc:
+        return ApplyResult(plan=plan, executed=False, error_message=str(exc))
+
+    return ApplyResult(plan=plan, executed=True, error_message=None)
+
+
+def _collect_manual_followups() -> tuple[str, ...]:
+    """Manual followups Shipyard cannot apply via API.
+
+    For v0.1.4 this is just the immutable-releases checkbox. Future
+    releases add tag protection exceptions, workflow permissions
+    edge cases, etc.
+
+    The list is always returned (even when every item is a no-op)
+    because the planning doc's "apply prints the followup checklist
+    every time" rule keeps users in the loop about the gap between
+    API-manageable and UI-only settings.
+    """
+    return (
+        "Immutable releases: verify the 'Immutable releases' checkbox "
+        "is enabled at https://github.com/<owner>/<repo>/settings. "
+        "Shipyard cannot read this setting via API on personal repos.",
+    )

--- a/src/shipyard/governance/compare.py
+++ b/src/shipyard/governance/compare.py
@@ -1,0 +1,177 @@
+"""Drift detection: compare declared config, profile defaults, and live GitHub state.
+
+`compute_drift` returns a `DriftReport` with one entry per governance
+knob, each carrying four values:
+
+- the profile's default (what the preset says)
+- the declared value from `.shipyard/config.toml` (what the project wants)
+- the live GitHub value (what GitHub actually has)
+- a `status` field that categorises the entry:
+  - "aligned"  — profile == declared == live
+  - "deviated" — declared != profile (intentional override)
+  - "drifted"  — live != declared (needs `apply` to fix)
+  - "both"     — both deviated AND drifted
+
+The rollup is purely a read-model; it never mutates state. Callers
+that want to fix drift pass the report to `apply.build_apply_plan`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from shipyard.governance.profiles import BranchProtectionRules
+
+
+class DriftStatus(str, Enum):
+    ALIGNED = "aligned"
+    DEVIATED = "deviated"
+    DRIFTED = "drifted"
+    BOTH = "both"
+    UNPROTECTED = "unprotected"  # live has no protection at all
+
+
+@dataclass(frozen=True)
+class DriftEntry:
+    """One row of the drift matrix."""
+
+    field_name: str
+    profile_value: Any
+    declared_value: Any
+    live_value: Any
+    status: DriftStatus
+
+    @property
+    def needs_apply(self) -> bool:
+        """True if running `apply` would change the live state."""
+        return self.status in (DriftStatus.DRIFTED, DriftStatus.BOTH, DriftStatus.UNPROTECTED)
+
+
+@dataclass(frozen=True)
+class DriftReport:
+    """Aggregate drift across one branch's worth of rules."""
+
+    branch: str
+    entries: tuple[DriftEntry, ...] = field(default_factory=tuple)
+    live_unprotected: bool = False
+
+    @property
+    def has_drift(self) -> bool:
+        return self.live_unprotected or any(e.needs_apply for e in self.entries)
+
+    @property
+    def drifted_entries(self) -> tuple[DriftEntry, ...]:
+        return tuple(e for e in self.entries if e.needs_apply)
+
+    @property
+    def deviated_entries(self) -> tuple[DriftEntry, ...]:
+        return tuple(
+            e for e in self.entries
+            if e.status in (DriftStatus.DEVIATED, DriftStatus.BOTH)
+        )
+
+
+# Fields that contribute to the drift matrix. Must match the
+# BranchProtectionRules dataclass field names exactly.
+_GOVERNANCE_FIELDS: tuple[str, ...] = (
+    "require_pr",
+    "require_status_checks",
+    "require_strict_status",
+    "require_review_count",
+    "enforce_admins",
+    "dismiss_stale_reviews",
+    "require_code_owner_reviews",
+    "allow_force_push",
+    "allow_deletions",
+    "require_linear_history",
+    "required_conversation_resolution",
+)
+
+
+def compute_drift(
+    *,
+    branch: str,
+    profile_rules: BranchProtectionRules,
+    declared_rules: BranchProtectionRules,
+    live_rules: BranchProtectionRules | None,
+) -> DriftReport:
+    """Compare profile vs declared vs live and return a DriftReport.
+
+    A `live_rules` of None means the branch has no protection at
+    all — every field will be flagged as needing apply, and the
+    report's `live_unprotected` flag is set for clearer UI output.
+    """
+    if live_rules is None:
+        return _unprotected_report(
+            branch=branch,
+            profile_rules=profile_rules,
+            declared_rules=declared_rules,
+        )
+
+    entries: list[DriftEntry] = []
+    for field_name in _GOVERNANCE_FIELDS:
+        profile_value = _normalize(getattr(profile_rules, field_name))
+        declared_value = _normalize(getattr(declared_rules, field_name))
+        live_value = _normalize(getattr(live_rules, field_name))
+
+        deviated = declared_value != profile_value
+        drifted = live_value != declared_value
+        if deviated and drifted:
+            status = DriftStatus.BOTH
+        elif deviated:
+            status = DriftStatus.DEVIATED
+        elif drifted:
+            status = DriftStatus.DRIFTED
+        else:
+            status = DriftStatus.ALIGNED
+
+        entries.append(
+            DriftEntry(
+                field_name=field_name,
+                profile_value=profile_value,
+                declared_value=declared_value,
+                live_value=live_value,
+                status=status,
+            )
+        )
+
+    return DriftReport(branch=branch, entries=tuple(entries))
+
+
+def _unprotected_report(
+    *,
+    branch: str,
+    profile_rules: BranchProtectionRules,
+    declared_rules: BranchProtectionRules,
+) -> DriftReport:
+    """Build a report for a branch with no protection set at all."""
+    entries: list[DriftEntry] = []
+    for field_name in _GOVERNANCE_FIELDS:
+        profile_value = _normalize(getattr(profile_rules, field_name))
+        declared_value = _normalize(getattr(declared_rules, field_name))
+        entries.append(
+            DriftEntry(
+                field_name=field_name,
+                profile_value=profile_value,
+                declared_value=declared_value,
+                live_value=None,
+                status=DriftStatus.UNPROTECTED,
+            )
+        )
+    return DriftReport(branch=branch, entries=tuple(entries), live_unprotected=True)
+
+
+def _normalize(value: Any) -> Any:
+    """Normalize values so equality comparison works across tuple/list/set boundaries.
+
+    GitHub returns status check contexts as a list; Shipyard stores
+    them as a tuple; ruamel or tomllib might return them as lists.
+    Normalising to a sorted tuple means comparison is order-insensitive
+    and type-stable.
+    """
+    if isinstance(value, (list, tuple, set, frozenset)):
+        return tuple(sorted(str(v) for v in value))
+    return value

--- a/src/shipyard/governance/config.py
+++ b/src/shipyard/governance/config.py
@@ -1,0 +1,176 @@
+"""Read governance config from `.shipyard/config.toml`.
+
+Config schema::
+
+    [project]
+    profile = "solo"   # or "multi" or "custom"
+
+    [governance]
+    # Optional — default derived from project.profile
+    required_status_checks = ["macOS (ARM64)", "Linux (x64)", "Windows (x64)"]
+
+    [branch_protection."main"]
+    # Explicit overrides on top of the profile default
+    require_review_count = 1     # override just this one knob
+    enforce_admins       = true
+
+    [branch_protection."develop/**"]
+    extends = "main"             # inherit main's overrides
+    require_review_count = 0     # but drop the review count
+
+The resolution order for a given branch is:
+
+1. Start with the profile's default rules
+2. Apply any `[branch_protection."<glob>"]` overrides for matching globs
+3. If a glob has `extends = "<other>"`, apply the base glob's overrides first
+4. Last override wins
+
+This module returns a `GovernanceConfig` object plus a helper to
+resolve the effective rules for a specific branch name. The
+GitHub-side apply logic (in `apply.py`) takes that resolved object
+and diffs it against live state.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+from shipyard.governance.profiles import (
+    BranchProtectionRules,
+    Profile,
+    profile_for_name,
+)
+
+if TYPE_CHECKING:
+    from shipyard.core.config import Config
+
+
+@dataclass(frozen=True)
+class GovernanceConfig:
+    """Parsed `[governance]` + `[project.profile]` + `[branch_protection.*]` state.
+
+    The `branch_overrides` dict is keyed by glob pattern and stores a
+    raw dict of field-name → value overrides (not a full rules
+    object). Glob resolution happens in `resolve_branch_rules` so the
+    GovernanceConfig stays a faithful representation of what the
+    user wrote.
+    """
+
+    profile: Profile
+    required_status_checks: tuple[str, ...]
+    branch_overrides: dict[str, dict[str, Any]] = field(default_factory=dict)
+
+
+def load_governance_config(config: Config) -> GovernanceConfig:
+    """Parse the `[project]`, `[governance]`, and `[branch_protection.*]` sections.
+
+    Defaults when not declared:
+    - profile → "solo" (opinionated default — most Shipyard projects
+      are solo, and the solo profile is the least surprising starting
+      point for anyone who hasn't yet declared one)
+    - required_status_checks → derived from `[governance]` if set,
+      otherwise empty
+    - branch_overrides → empty dict
+
+    Raises ValueError if `profile` names an unknown profile.
+    """
+    profile_name = str(config.get("project.profile", "solo"))
+
+    # Required status checks can be declared in `[governance]` or
+    # inherited from the old `[merge] require_platforms` list for
+    # backwards compatibility with existing Shipyard projects that
+    # predate the governance section.
+    declared_checks = config.get("governance.required_status_checks")
+    if declared_checks is None:
+        declared_checks = config.get("merge.require_platforms", [])
+    if not isinstance(declared_checks, list):
+        declared_checks = []
+    required_status_checks = tuple(str(c) for c in declared_checks)
+
+    profile = profile_for_name(
+        profile_name, required_status_checks=required_status_checks,
+    )
+
+    branch_overrides: dict[str, dict[str, Any]] = {}
+    raw_bp = config.get("branch_protection")
+    if isinstance(raw_bp, dict):
+        for glob, overrides in raw_bp.items():
+            if isinstance(overrides, dict):
+                branch_overrides[str(glob)] = dict(overrides)
+
+    return GovernanceConfig(
+        profile=profile,
+        required_status_checks=required_status_checks,
+        branch_overrides=branch_overrides,
+    )
+
+
+def resolve_branch_rules(
+    governance: GovernanceConfig,
+    branch_name: str,
+) -> BranchProtectionRules:
+    """Compute the effective rules for a branch by merging overrides.
+
+    Walks every `[branch_protection."<glob>"]` in the config in order
+    of declaration, applies the ones that match `branch_name` on top
+    of the profile default, and returns the resulting frozen rules.
+
+    `extends = "<other>"` pulls in the base glob's overrides first,
+    so a chain like `main` → `develop/**` → `release/**` can inherit
+    cleanly without duplicating every field.
+    """
+    rules = governance.profile.branch_protection
+
+    overrides = _resolve_overrides_for(branch_name, governance.branch_overrides)
+    if overrides:
+        # Only pass recognised fields through to with_overrides; any
+        # unknown key is a config typo and should not silently
+        # disappear. Raising here surfaces the typo at load time.
+        known_fields = set(BranchProtectionRules.__dataclass_fields__.keys())
+        for key in overrides:
+            if key == "extends":
+                continue
+            if key not in known_fields:
+                raise ValueError(
+                    f"Unknown branch_protection field '{key}' for "
+                    f"branch '{branch_name}'. Known fields: "
+                    f"{', '.join(sorted(known_fields))}"
+                )
+        clean = {k: v for k, v in overrides.items() if k != "extends"}
+        # Convert list→tuple for status checks so the dataclass stays hashable.
+        if "require_status_checks" in clean and isinstance(
+            clean["require_status_checks"], list,
+        ):
+            clean["require_status_checks"] = tuple(
+                str(x) for x in clean["require_status_checks"]
+            )
+        rules = rules.with_overrides(**clean)
+
+    return rules
+
+
+def _resolve_overrides_for(
+    branch_name: str,
+    branch_overrides: dict[str, dict[str, Any]],
+) -> dict[str, Any]:
+    """Walk the branch_overrides dict, apply extends, merge matching globs.
+
+    A later matching glob wins over an earlier one.
+    """
+    merged: dict[str, Any] = {}
+    for glob, overrides in branch_overrides.items():
+        if not fnmatch.fnmatchcase(branch_name, glob):
+            continue
+        # Apply parent's overrides first if `extends` is set
+        parent_name = overrides.get("extends")
+        if parent_name and parent_name in branch_overrides:
+            parent = branch_overrides[parent_name]
+            for k, v in parent.items():
+                if k != "extends":
+                    merged[k] = v
+        for k, v in overrides.items():
+            if k != "extends":
+                merged[k] = v
+    return merged

--- a/src/shipyard/governance/github.py
+++ b/src/shipyard/governance/github.py
@@ -1,0 +1,276 @@
+"""Thin wrappers around `gh api` for GitHub branch protection.
+
+Shipyard already shells out to the `gh` CLI elsewhere (cloud
+workflow dispatch, PR creation, merge). The governance commands
+reuse the same pattern here rather than pulling in a direct REST
+client, so:
+
+- Authentication is inherited from `gh auth login`, which the user
+  has already done and which doctor already checks.
+- Rate limiting and retry policies are whatever `gh` does by
+  default, which matches the rest of Shipyard's GitHub interactions.
+- A missing or unauthenticated `gh` is surfaced with the same error
+  message as other Shipyard commands.
+
+The functions here deal only with translating the GitHub REST shape
+into our `BranchProtectionRules` dataclass and back. Drift detection
+and idempotency live in `compare.py` and `apply.py`.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from dataclasses import dataclass
+
+from shipyard.governance.profiles import BranchProtectionRules
+
+
+class GovernanceApiError(Exception):
+    """A `gh api` call failed in an unrecoverable way.
+
+    Used to distinguish "branch has no protection" (not an error,
+    returns an empty rules object) from "the gh CLI isn't
+    authenticated" (fatal, must surface to the user).
+    """
+
+
+@dataclass(frozen=True)
+class RepoRef:
+    """An owner/repo pair plus an optional branch name."""
+
+    owner: str
+    name: str
+
+    @property
+    def slug(self) -> str:
+        return f"{self.owner}/{self.name}"
+
+
+def get_branch_protection(
+    repo: RepoRef,
+    branch: str,
+    *,
+    gh_command: str = "gh",
+) -> BranchProtectionRules | None:
+    """Read the live branch protection for `branch` on `repo`.
+
+    Returns None when the branch has no protection at all (404 from
+    GitHub). Raises GovernanceApiError on any other failure so callers
+    can distinguish "unprotected" from "inaccessible".
+    """
+    try:
+        result = subprocess.run(
+            [
+                gh_command,
+                "api",
+                f"repos/{repo.slug}/branches/{branch}/protection",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError) as exc:
+        raise GovernanceApiError(f"gh api timeout/missing: {exc}") from exc
+
+    if result.returncode != 0:
+        stderr = (result.stderr or "").strip()
+        # A 404 specifically means "branch not protected" — translate
+        # that into a clean None rather than an exception.
+        if "Branch not protected" in stderr or "404" in stderr:
+            return None
+        raise GovernanceApiError(
+            f"gh api failed for {repo.slug}/{branch}: {stderr or 'no detail'}"
+        )
+
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise GovernanceApiError(f"gh api returned non-JSON: {exc}") from exc
+
+    return _rules_from_api_payload(payload)
+
+
+def put_branch_protection(
+    repo: RepoRef,
+    branch: str,
+    rules: BranchProtectionRules,
+    *,
+    gh_command: str = "gh",
+) -> None:
+    """Apply `rules` to `branch` on `repo` via `gh api PUT`.
+
+    Idempotency and diffing happen one layer up in `apply.py`; this
+    function just translates the rules dataclass into the GitHub REST
+    body and issues the PUT.
+    """
+    body = _api_payload_from_rules(rules)
+    try:
+        result = subprocess.run(
+            [
+                gh_command,
+                "api",
+                "-X",
+                "PUT",
+                f"repos/{repo.slug}/branches/{branch}/protection",
+                "--input",
+                "-",
+            ],
+            input=json.dumps(body),
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError) as exc:
+        raise GovernanceApiError(f"gh api timeout/missing: {exc}") from exc
+
+    if result.returncode != 0:
+        raise GovernanceApiError(
+            f"gh api PUT failed for {repo.slug}/{branch}: "
+            f"{(result.stderr or '').strip() or 'no detail'}"
+        )
+
+
+def detect_repo_from_remote(
+    *,
+    git_command: str = "git",
+    gh_command: str = "gh",
+) -> RepoRef | None:
+    """Best-effort guess of the repo owner/name from the git remote.
+
+    Tries `gh repo view --json nameWithOwner` first (the canonical
+    path when the user has the gh CLI set up), then falls back to
+    parsing `git remote get-url origin`.
+    """
+    try:
+        result = subprocess.run(
+            [gh_command, "repo", "view", "--json", "nameWithOwner"],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+        if result.returncode == 0:
+            payload = json.loads(result.stdout)
+            slug = payload.get("nameWithOwner", "")
+            if "/" in slug:
+                owner, name = slug.split("/", 1)
+                return RepoRef(owner=owner, name=name)
+    except (subprocess.SubprocessError, FileNotFoundError, json.JSONDecodeError):
+        pass
+
+    try:
+        result = subprocess.run(
+            [git_command, "remote", "get-url", "origin"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode == 0:
+            return _parse_git_remote_url(result.stdout.strip())
+    except (subprocess.SubprocessError, FileNotFoundError):
+        pass
+
+    return None
+
+
+def _parse_git_remote_url(url: str) -> RepoRef | None:
+    """Parse github.com/owner/repo from an https or ssh remote URL."""
+    if not url:
+        return None
+    cleaned = url.removesuffix(".git")
+    # https://github.com/owner/repo
+    if "github.com/" in cleaned:
+        parts = cleaned.split("github.com/", 1)[1].split("/")
+        if len(parts) >= 2:
+            return RepoRef(owner=parts[0], name=parts[1])
+    # git@github.com:owner/repo
+    if "github.com:" in cleaned:
+        parts = cleaned.split("github.com:", 1)[1].split("/")
+        if len(parts) >= 2:
+            return RepoRef(owner=parts[0], name=parts[1])
+    return None
+
+
+# ── Translation layer between GitHub REST and BranchProtectionRules ────
+
+
+def _rules_from_api_payload(payload: dict) -> BranchProtectionRules:
+    """Translate GitHub's branch-protection JSON into a rules object."""
+    status_checks_block = payload.get("required_status_checks") or {}
+    required_checks = tuple(status_checks_block.get("contexts", []) or ())
+    strict = bool(status_checks_block.get("strict", False))
+
+    prs_block = payload.get("required_pull_request_reviews") or {}
+    review_count = int(prs_block.get("required_approving_review_count", 0) or 0)
+    dismiss_stale = bool(prs_block.get("dismiss_stale_reviews", False))
+    code_owner = bool(prs_block.get("require_code_owner_reviews", False))
+
+    enforce_admins_block = payload.get("enforce_admins") or {}
+    enforce_admins = bool(enforce_admins_block.get("enabled", False))
+
+    allow_force_push_block = payload.get("allow_force_pushes") or {}
+    allow_force_push = bool(allow_force_push_block.get("enabled", False))
+
+    allow_deletions_block = payload.get("allow_deletions") or {}
+    allow_deletions = bool(allow_deletions_block.get("enabled", False))
+
+    require_linear_block = payload.get("required_linear_history") or {}
+    require_linear = bool(require_linear_block.get("enabled", False))
+
+    require_conversation_block = payload.get("required_conversation_resolution") or {}
+    require_conversation = bool(require_conversation_block.get("enabled", False))
+
+    # `require_pr` is true iff the required_pull_request_reviews
+    # block exists at all. GitHub's schema conflates "require PRs"
+    # with "require reviews > 0" but Shipyard treats them as two
+    # distinct knobs.
+    require_pr = bool(payload.get("required_pull_request_reviews"))
+
+    return BranchProtectionRules(
+        require_pr=require_pr,
+        require_status_checks=required_checks,
+        require_strict_status=strict,
+        require_review_count=review_count,
+        enforce_admins=enforce_admins,
+        dismiss_stale_reviews=dismiss_stale,
+        require_code_owner_reviews=code_owner,
+        allow_force_push=allow_force_push,
+        allow_deletions=allow_deletions,
+        require_linear_history=require_linear,
+        required_conversation_resolution=require_conversation,
+    )
+
+
+def _api_payload_from_rules(rules: BranchProtectionRules) -> dict:
+    """Translate a rules dataclass into the GitHub REST PUT body."""
+    # Required status checks block. GitHub rejects an empty
+    # `contexts` list when `strict=true`, so omit the whole block
+    # when there are no checks.
+    required_status_checks: dict | None = None
+    if rules.require_status_checks:
+        required_status_checks = {
+            "strict": rules.require_strict_status,
+            "contexts": list(rules.require_status_checks),
+        }
+
+    # PR reviews block. Only emitted when require_pr is set OR a
+    # review count is configured, so "no PRs required" translates to
+    # a null block.
+    pr_reviews: dict | None = None
+    if rules.require_pr or rules.require_review_count > 0:
+        pr_reviews = {
+            "required_approving_review_count": rules.require_review_count,
+            "dismiss_stale_reviews": rules.dismiss_stale_reviews,
+            "require_code_owner_reviews": rules.require_code_owner_reviews,
+        }
+
+    return {
+        "required_status_checks": required_status_checks,
+        "enforce_admins": rules.enforce_admins,
+        "required_pull_request_reviews": pr_reviews,
+        "restrictions": None,
+        "required_linear_history": rules.require_linear_history,
+        "allow_force_pushes": rules.allow_force_push,
+        "allow_deletions": rules.allow_deletions,
+        "required_conversation_resolution": rules.required_conversation_resolution,
+    }

--- a/src/shipyard/governance/profiles.py
+++ b/src/shipyard/governance/profiles.py
@@ -64,7 +64,12 @@ class BranchProtectionRules:
     allow_force_push: bool = False
     allow_deletions: bool = False
     require_linear_history: bool = False
-    required_conversation_resolution: bool = True
+    # Off by default — forcing conversation resolution on a solo
+    # project is self-friction (nobody else is leaving comments), and
+    # the planning doc's solo/multi table intentionally doesn't list
+    # this knob as one of the distinguishing defaults. Multi projects
+    # that want it can override to True explicitly.
+    required_conversation_resolution: bool = False
 
     def with_overrides(self, **overrides: object) -> BranchProtectionRules:
         """Return a copy with the given fields replaced.
@@ -115,7 +120,7 @@ def solo_profile(
             allow_force_push=False,
             allow_deletions=False,
             require_linear_history=False,
-            required_conversation_resolution=True,
+            required_conversation_resolution=False,
         ),
     )
 

--- a/src/shipyard/governance/profiles.py
+++ b/src/shipyard/governance/profiles.py
@@ -1,0 +1,180 @@
+"""Governance profile definitions: solo, multi, custom.
+
+A profile is a named bundle of governance defaults. Picking one sets
+the floor for every knob in `.shipyard/config.toml` — individual
+knobs can still be overridden explicitly.
+
+The three profiles map to the three project shapes Shipyard targets:
+
+- **solo**: single maintainer, no third-party committers. Optimized
+  for speed and no self-friction. `strict` is off because there is
+  nobody else to coordinate with; required reviews is zero because
+  you cannot review your own PR; admins are not enforced because
+  you ARE the admin and need a path for the 3am hotfix.
+
+- **multi**: multiple maintainers, third-party PRs accepted. Every
+  process gate is on. Strict required checks, one required review,
+  enforce on admins, dismiss stale reviews, manual release approval.
+
+- **custom**: explicit per-knob; no preset. Used when neither solo
+  nor multi fits. Also what you get implicitly if you set a profile
+  and then override specific knobs.
+
+The profile defaults are hard-coded here rather than in a TOML file
+because they are part of Shipyard's API surface — a future Shipyard
+release can evolve the presets (with a migration warning) but no
+project should need to write its own profile table. Custom projects
+declare explicit overrides on top of a base profile.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field, replace
+from typing import Literal
+
+ProfileName = Literal["solo", "multi", "custom"]
+
+_KNOWN_PROFILES: tuple[ProfileName, ...] = ("solo", "multi", "custom")
+
+
+@dataclass(frozen=True)
+class BranchProtectionRules:
+    """The per-branch knobs Shipyard governs for branch protection.
+
+    Every field maps 1:1 to a GitHub branch protection setting.
+    Keeping this flat and frozen makes the profile-vs-declared-vs-live
+    drift computation a simple field-by-field comparison.
+
+    Fields correspond to the classic branch protection API:
+    https://docs.github.com/en/rest/branches/branch-protection
+
+    Note: This dataclass intentionally covers only branch protection
+    for v0.1.4. Tag protection, default workflow permissions, and
+    rulesets are tracked as separate concerns; they'll land in
+    follow-up PRs with their own dataclasses.
+    """
+
+    require_pr: bool = True
+    require_status_checks: tuple[str, ...] = ()
+    require_strict_status: bool = False
+    require_review_count: int = 0
+    enforce_admins: bool = False
+    dismiss_stale_reviews: bool = False
+    require_code_owner_reviews: bool = False
+    allow_force_push: bool = False
+    allow_deletions: bool = False
+    require_linear_history: bool = False
+    required_conversation_resolution: bool = True
+
+    def with_overrides(self, **overrides: object) -> BranchProtectionRules:
+        """Return a copy with the given fields replaced.
+
+        Used when merging a profile default with per-branch overrides
+        declared in `.shipyard/config.toml`.
+        """
+        return replace(self, **overrides)  # type: ignore[arg-type]
+
+
+@dataclass(frozen=True)
+class Profile:
+    """A named bundle of governance defaults.
+
+    For v0.1.4 a profile only sets branch protection defaults; as
+    more knobs are added (tag protection, workflow permissions,
+    etc.) they will be added as additional fields here.
+    """
+
+    name: ProfileName
+    branch_protection: BranchProtectionRules = field(default_factory=BranchProtectionRules)
+
+
+def solo_profile(
+    *,
+    required_status_checks: tuple[str, ...] = (),
+) -> Profile:
+    """Return the `solo` profile with the given required status checks.
+
+    The required status check names are project-specific (Pulp uses
+    macOS/Linux/Windows) so they're parameterized. Everything else is
+    fixed.
+    """
+    return Profile(
+        name="solo",
+        branch_protection=BranchProtectionRules(
+            require_pr=True,
+            require_status_checks=required_status_checks,
+            # strict=false is THE defining solo choice. Without it,
+            # every PR falling behind main needs a rebase — pure
+            # busywork when there's no second contributor to
+            # coordinate with.
+            require_strict_status=False,
+            require_review_count=0,
+            enforce_admins=False,
+            dismiss_stale_reviews=False,
+            require_code_owner_reviews=False,
+            allow_force_push=False,
+            allow_deletions=False,
+            require_linear_history=False,
+            required_conversation_resolution=True,
+        ),
+    )
+
+
+def multi_profile(
+    *,
+    required_status_checks: tuple[str, ...] = (),
+) -> Profile:
+    """Return the `multi` profile with the given required status checks.
+
+    The differences from `solo` are exactly the process gates that
+    exist to coordinate multiple humans: strict required checks,
+    required reviews, enforce on admins, dismiss stale reviews.
+    """
+    return Profile(
+        name="multi",
+        branch_protection=BranchProtectionRules(
+            require_pr=True,
+            require_status_checks=required_status_checks,
+            require_strict_status=True,
+            require_review_count=1,
+            enforce_admins=True,
+            dismiss_stale_reviews=True,
+            require_code_owner_reviews=False,
+            allow_force_push=False,
+            allow_deletions=False,
+            require_linear_history=False,
+            required_conversation_resolution=True,
+        ),
+    )
+
+
+def profile_for_name(
+    name: str,
+    *,
+    required_status_checks: tuple[str, ...] = (),
+) -> Profile:
+    """Look up a profile by name; raise ValueError on unknown names.
+
+    `custom` is accepted but returns an empty-rules Profile — callers
+    are expected to merge explicit overrides on top of it.
+    """
+    if name == "solo":
+        return solo_profile(required_status_checks=required_status_checks)
+    if name == "multi":
+        return multi_profile(required_status_checks=required_status_checks)
+    if name == "custom":
+        return Profile(
+            name="custom",
+            branch_protection=BranchProtectionRules(
+                require_status_checks=required_status_checks,
+            ),
+        )
+    raise ValueError(
+        f"Unknown governance profile '{name}'. "
+        f"Expected one of: {', '.join(_KNOWN_PROFILES)}"
+    )
+
+
+def known_profile_names() -> tuple[ProfileName, ...]:
+    """Public list of accepted profile names (for error messages / CLI help)."""
+    return _KNOWN_PROFILES

--- a/src/shipyard/governance/status.py
+++ b/src/shipyard/governance/status.py
@@ -1,0 +1,126 @@
+"""High-level `governance status` rollup.
+
+This is the read-side of the governance surface. It ties the
+profile → config → GitHub chain together into a single call that
+the CLI can invoke. The CLI is intentionally thin on top of this:
+it formats the report for humans or JSON but does no computation.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from shipyard.governance.compare import DriftReport, compute_drift
+from shipyard.governance.config import (
+    GovernanceConfig,
+    resolve_branch_rules,
+)
+from shipyard.governance.github import (
+    GovernanceApiError,
+    RepoRef,
+    get_branch_protection,
+)
+
+
+@dataclass(frozen=True)
+class GovernanceStatus:
+    """Aggregate status across every governed branch."""
+
+    repo: RepoRef
+    profile_name: str
+    reports: tuple[DriftReport, ...] = field(default_factory=tuple)
+    errors: tuple[str, ...] = field(default_factory=tuple)
+
+    @property
+    def has_drift(self) -> bool:
+        return any(r.has_drift for r in self.reports)
+
+    @property
+    def has_errors(self) -> bool:
+        return bool(self.errors)
+
+
+def build_status(
+    *,
+    repo: RepoRef,
+    governance: GovernanceConfig,
+    branches: tuple[str, ...],
+    gh_command: str = "gh",
+) -> GovernanceStatus:
+    """Run the full read path: resolve rules, fetch live state, compute drift.
+
+    Branches that fail to fetch are reported as errors in the result
+    rather than raising — a single branch with a permission problem
+    should not mask the rest of the matrix.
+    """
+    reports: list[DriftReport] = []
+    errors: list[str] = []
+
+    for branch in branches:
+        declared_rules = resolve_branch_rules(governance, branch)
+        try:
+            live_rules = get_branch_protection(repo, branch, gh_command=gh_command)
+        except GovernanceApiError as exc:
+            errors.append(f"{branch}: {exc}")
+            continue
+
+        report = compute_drift(
+            branch=branch,
+            profile_rules=governance.profile.branch_protection,
+            declared_rules=declared_rules,
+            live_rules=live_rules,
+        )
+        reports.append(report)
+
+    return GovernanceStatus(
+        repo=repo,
+        profile_name=governance.profile.name,
+        reports=tuple(reports),
+        errors=tuple(errors),
+    )
+
+
+def format_status_text(status: GovernanceStatus) -> str:
+    """Render a GovernanceStatus as plain text for the CLI human output.
+
+    Keeps the format terse — the full matrix is too wide for most
+    terminals, so this prints a per-branch summary with drifted
+    fields highlighted. Callers that want the full matrix can walk
+    `status.reports` directly.
+    """
+    lines: list[str] = []
+    lines.append(f"Project: {status.repo.slug}")
+    lines.append(f"Profile: {status.profile_name}")
+    if status.errors:
+        lines.append(f"Errors: {len(status.errors)}")
+        for err in status.errors:
+            lines.append(f"  ! {err}")
+    lines.append("")
+
+    for report in status.reports:
+        if report.live_unprotected:
+            lines.append(f"  ✗ {report.branch}: UNPROTECTED (run: shipyard governance apply)")
+            continue
+        drifted = report.drifted_entries
+        deviated = report.deviated_entries
+        if not drifted and not deviated:
+            lines.append(f"  ✓ {report.branch}: aligned with profile")
+            continue
+        if drifted:
+            lines.append(f"  ✗ {report.branch}: {len(drifted)} field(s) drifted from config")
+            for entry in drifted:
+                lines.append(
+                    f"      {entry.field_name}: "
+                    f"config={entry.declared_value!r}, live={entry.live_value!r}"
+                )
+            lines.append("      fix: shipyard governance apply")
+        if deviated and not drifted:
+            lines.append(
+                f"  ℹ {report.branch}: {len(deviated)} field(s) deviated from profile"
+            )
+            for entry in deviated:
+                lines.append(
+                    f"      {entry.field_name}: "
+                    f"profile={entry.profile_value!r}, config={entry.declared_value!r}"
+                )
+    return "\n".join(lines)

--- a/src/shipyard/output/human.py
+++ b/src/shipyard/output/human.py
@@ -181,7 +181,7 @@ def render_doctor(checks: dict[str, Any], ready: bool) -> None:
         for name, info in items.items():
             ok = info.get("ok", False)
             icon = "[green]\u2713[/]" if ok else "[red]\u2717[/]"
-            detail = info.get("version", info.get("error", ""))
+            detail = info.get("version", info.get("error", info.get("detail", "")))
             extra = ""
             if info.get("user"):
                 extra = f" (as {info['user']})"

--- a/tests/governance/test_apply.py
+++ b/tests/governance/test_apply.py
@@ -1,0 +1,204 @@
+"""Apply-plan + idempotency tests."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from shipyard.governance.apply import (
+    ApplyAction,
+    build_apply_plan,
+    execute_apply_plan,
+)
+from shipyard.governance.compare import compute_drift
+from shipyard.governance.github import RepoRef
+from shipyard.governance.profiles import BranchProtectionRules, solo_profile
+
+
+def _repo() -> RepoRef:
+    return RepoRef(owner="me", name="r")
+
+
+def _declared() -> BranchProtectionRules:
+    return solo_profile(
+        required_status_checks=("mac", "linux"),
+    ).branch_protection
+
+
+# ── build_apply_plan action selection ───────────────────────────────────
+
+
+def test_plan_noop_when_fully_aligned() -> None:
+    declared = _declared()
+    report = compute_drift(
+        branch="main",
+        profile_rules=declared,
+        declared_rules=declared,
+        live_rules=declared,
+    )
+    plan = build_apply_plan(
+        repo=_repo(), branch="main",
+        declared_rules=declared, drift_report=report,
+    )
+    assert plan.action == ApplyAction.NOOP
+    assert plan.is_noop is True
+
+
+def test_plan_update_when_live_drifts() -> None:
+    declared = _declared()
+    live = declared.with_overrides(enforce_admins=True)
+    report = compute_drift(
+        branch="main", profile_rules=declared,
+        declared_rules=declared, live_rules=live,
+    )
+    plan = build_apply_plan(
+        repo=_repo(), branch="main",
+        declared_rules=declared, drift_report=report,
+    )
+    assert plan.action == ApplyAction.UPDATE
+    assert plan.is_noop is False
+
+
+def test_plan_create_when_live_unprotected() -> None:
+    declared = _declared()
+    report = compute_drift(
+        branch="main", profile_rules=declared,
+        declared_rules=declared, live_rules=None,
+    )
+    plan = build_apply_plan(
+        repo=_repo(), branch="main",
+        declared_rules=declared, drift_report=report,
+    )
+    assert plan.action == ApplyAction.CREATE
+
+
+def test_plan_includes_manual_followups_even_for_noop() -> None:
+    """The followup checklist is always printed, including for noop plans."""
+    declared = _declared()
+    report = compute_drift(
+        branch="main", profile_rules=declared,
+        declared_rules=declared, live_rules=declared,
+    )
+    plan = build_apply_plan(
+        repo=_repo(), branch="main",
+        declared_rules=declared, drift_report=report,
+    )
+    assert plan.manual_followups
+    assert any("Immutable releases" in f for f in plan.manual_followups)
+
+
+# ── execute_apply_plan ──────────────────────────────────────────────────
+
+
+def _plan_for(report, declared):
+    return build_apply_plan(
+        repo=_repo(), branch="main",
+        declared_rules=declared, drift_report=report,
+    )
+
+
+def test_execute_noop_issues_zero_api_calls() -> None:
+    declared = _declared()
+    report = compute_drift(
+        branch="main", profile_rules=declared,
+        declared_rules=declared, live_rules=declared,
+    )
+    plan = _plan_for(report, declared)
+
+    with patch("shipyard.governance.apply.put_branch_protection") as mock_put:
+        result = execute_apply_plan(plan)
+    assert result.executed is False
+    assert result.error_message is None
+    mock_put.assert_not_called()
+
+
+def test_execute_update_issues_put() -> None:
+    declared = _declared()
+    live = declared.with_overrides(enforce_admins=True)  # drift
+    report = compute_drift(
+        branch="main", profile_rules=declared,
+        declared_rules=declared, live_rules=live,
+    )
+    plan = _plan_for(report, declared)
+
+    with patch("shipyard.governance.apply.put_branch_protection") as mock_put:
+        result = execute_apply_plan(plan)
+    assert result.executed is True
+    assert result.error_message is None
+    mock_put.assert_called_once()
+
+
+def test_execute_create_issues_put() -> None:
+    declared = _declared()
+    report = compute_drift(
+        branch="main", profile_rules=declared,
+        declared_rules=declared, live_rules=None,
+    )
+    plan = _plan_for(report, declared)
+
+    with patch("shipyard.governance.apply.put_branch_protection") as mock_put:
+        result = execute_apply_plan(plan)
+    assert result.executed is True
+    mock_put.assert_called_once()
+
+
+def test_dry_run_issues_zero_api_calls_even_when_drift_present() -> None:
+    declared = _declared()
+    live = declared.with_overrides(enforce_admins=True)
+    report = compute_drift(
+        branch="main", profile_rules=declared,
+        declared_rules=declared, live_rules=live,
+    )
+    plan = _plan_for(report, declared)
+
+    with patch("shipyard.governance.apply.put_branch_protection") as mock_put:
+        result = execute_apply_plan(plan, dry_run=True)
+    assert result.executed is False
+    mock_put.assert_not_called()
+
+
+def test_execute_captures_api_error() -> None:
+    from shipyard.governance.github import GovernanceApiError
+    declared = _declared()
+    live = declared.with_overrides(enforce_admins=True)
+    report = compute_drift(
+        branch="main", profile_rules=declared,
+        declared_rules=declared, live_rules=live,
+    )
+    plan = _plan_for(report, declared)
+
+    with patch(
+        "shipyard.governance.apply.put_branch_protection",
+        side_effect=GovernanceApiError("permission denied"),
+    ):
+        result = execute_apply_plan(plan)
+    assert result.executed is False
+    assert result.error_message is not None
+    assert "permission denied" in result.error_message
+
+
+def test_idempotency_second_execute_is_noop_when_state_aligned() -> None:
+    """Re-running apply after a successful apply is a noop."""
+    declared = _declared()
+
+    # First execution: drift exists, apply is called
+    initial_live = None  # unprotected
+    report1 = compute_drift(
+        branch="main", profile_rules=declared,
+        declared_rules=declared, live_rules=initial_live,
+    )
+    plan1 = _plan_for(report1, declared)
+    with patch("shipyard.governance.apply.put_branch_protection") as mock_put1:
+        execute_apply_plan(plan1)
+    assert mock_put1.call_count == 1
+
+    # Second execution: live now matches declared, apply is a noop
+    report2 = compute_drift(
+        branch="main", profile_rules=declared,
+        declared_rules=declared, live_rules=declared,
+    )
+    plan2 = _plan_for(report2, declared)
+    assert plan2.is_noop
+    with patch("shipyard.governance.apply.put_branch_protection") as mock_put2:
+        result = execute_apply_plan(plan2)
+    assert mock_put2.call_count == 0
+    assert result.executed is False

--- a/tests/governance/test_compare.py
+++ b/tests/governance/test_compare.py
@@ -1,0 +1,172 @@
+"""Drift computation tests — compare profile vs declared vs live state."""
+
+from __future__ import annotations
+
+from shipyard.governance.compare import DriftStatus, compute_drift
+from shipyard.governance.profiles import (
+    BranchProtectionRules,
+    multi_profile,
+    solo_profile,
+)
+
+# ── aligned: profile == declared == live ────────────────────────────────
+
+
+def test_fully_aligned_report_has_no_drift() -> None:
+    p = solo_profile()
+    report = compute_drift(
+        branch="main",
+        profile_rules=p.branch_protection,
+        declared_rules=p.branch_protection,
+        live_rules=p.branch_protection,
+    )
+    assert report.has_drift is False
+    assert report.drifted_entries == ()
+    assert report.deviated_entries == ()
+    assert all(e.status == DriftStatus.ALIGNED for e in report.entries)
+
+
+# ── drifted: declared matches profile but live differs ─────────────────
+
+
+def test_live_drifted_from_declared_is_flagged() -> None:
+    p = solo_profile()
+    live = p.branch_protection.with_overrides(enforce_admins=True)  # drift
+    report = compute_drift(
+        branch="main",
+        profile_rules=p.branch_protection,
+        declared_rules=p.branch_protection,
+        live_rules=live,
+    )
+    assert report.has_drift is True
+    drifted = report.drifted_entries
+    assert len(drifted) == 1
+    assert drifted[0].field_name == "enforce_admins"
+    assert drifted[0].status == DriftStatus.DRIFTED
+
+
+# ── deviated: declared differs from profile but live matches declared ──
+
+
+def test_declared_deviated_from_profile_but_live_matches() -> None:
+    """An intentional override is reported as deviated, not drifted."""
+    p = solo_profile()
+    declared = p.branch_protection.with_overrides(require_review_count=2)
+    live = declared  # live has been applied
+    report = compute_drift(
+        branch="main",
+        profile_rules=p.branch_protection,
+        declared_rules=declared,
+        live_rules=live,
+    )
+    # Deviated from profile but no drift to fix
+    assert report.has_drift is False
+    deviated = report.deviated_entries
+    assert len(deviated) == 1
+    assert deviated[0].field_name == "require_review_count"
+    assert deviated[0].status == DriftStatus.DEVIATED
+
+
+# ── both: declared differs from profile AND live differs from declared ─
+
+
+def test_both_deviated_and_drifted() -> None:
+    p = solo_profile()
+    declared = p.branch_protection.with_overrides(require_review_count=2)
+    live = p.branch_protection.with_overrides(require_review_count=5)
+    report = compute_drift(
+        branch="main",
+        profile_rules=p.branch_protection,
+        declared_rules=declared,
+        live_rules=live,
+    )
+    assert report.has_drift is True
+    both = [e for e in report.entries if e.status == DriftStatus.BOTH]
+    assert len(both) == 1
+    assert both[0].field_name == "require_review_count"
+
+
+# ── live_unprotected: branch has no protection at all ──────────────────
+
+
+def test_unprotected_branch_is_flagged() -> None:
+    p = solo_profile()
+    report = compute_drift(
+        branch="main",
+        profile_rules=p.branch_protection,
+        declared_rules=p.branch_protection,
+        live_rules=None,
+    )
+    assert report.has_drift is True
+    assert report.live_unprotected is True
+    assert all(e.status == DriftStatus.UNPROTECTED for e in report.entries)
+    assert all(e.needs_apply for e in report.entries)
+
+
+# ── status check list ordering is normalized ──────────────────────────
+
+
+def test_status_check_order_is_ignored() -> None:
+    """Two lists with the same contents in different order compare equal."""
+    declared = BranchProtectionRules(
+        require_status_checks=("a", "b", "c"),
+    )
+    live = BranchProtectionRules(
+        require_status_checks=("c", "a", "b"),
+    )
+    report = compute_drift(
+        branch="main",
+        profile_rules=declared,
+        declared_rules=declared,
+        live_rules=live,
+    )
+    # Status checks should compare as equal (order-insensitive)
+    check_entry = next(
+        e for e in report.entries if e.field_name == "require_status_checks"
+    )
+    assert check_entry.status == DriftStatus.ALIGNED
+
+
+def test_status_checks_differ_when_contents_differ() -> None:
+    declared = BranchProtectionRules(
+        require_status_checks=("a", "b"),
+    )
+    live = BranchProtectionRules(
+        require_status_checks=("a", "b", "c"),
+    )
+    report = compute_drift(
+        branch="main",
+        profile_rules=declared,
+        declared_rules=declared,
+        live_rules=live,
+    )
+    check_entry = next(
+        e for e in report.entries if e.field_name == "require_status_checks"
+    )
+    assert check_entry.status == DriftStatus.DRIFTED
+
+
+# ── multi profile drift flows ──────────────────────────────────────────
+
+
+def test_multi_profile_applied_solo_live_reports_drift_on_gates() -> None:
+    """A repo declared as multi but with solo-shaped live state has lots of drift."""
+    m = multi_profile()
+    solo_shaped_live = BranchProtectionRules(
+        require_pr=True,
+        require_strict_status=False,
+        require_review_count=0,
+        enforce_admins=False,
+        dismiss_stale_reviews=False,
+    )
+    report = compute_drift(
+        branch="main",
+        profile_rules=m.branch_protection,
+        declared_rules=m.branch_protection,
+        live_rules=solo_shaped_live,
+    )
+    drifted_fields = {e.field_name for e in report.drifted_entries}
+    assert "require_strict_status" in drifted_fields
+    assert "require_review_count" in drifted_fields
+    assert "enforce_admins" in drifted_fields
+    assert "dismiss_stale_reviews" in drifted_fields

--- a/tests/governance/test_config.py
+++ b/tests/governance/test_config.py
@@ -1,0 +1,160 @@
+"""Layer 2: governance config parsing and branch-rule resolution."""
+
+from __future__ import annotations
+
+import pytest
+
+from shipyard.core.config import Config
+from shipyard.governance.config import (
+    load_governance_config,
+    resolve_branch_rules,
+)
+
+
+def _config(data: dict) -> Config:
+    return Config(data=data)
+
+
+# ── load_governance_config ──────────────────────────────────────────────
+
+
+def test_load_defaults_to_solo_with_no_section() -> None:
+    gov = load_governance_config(_config({}))
+    assert gov.profile.name == "solo"
+    assert gov.required_status_checks == ()
+    assert gov.branch_overrides == {}
+
+
+def test_load_solo_with_required_status_checks() -> None:
+    gov = load_governance_config(_config({
+        "project": {"profile": "solo"},
+        "governance": {"required_status_checks": ["mac", "linux", "win"]},
+    }))
+    assert gov.profile.name == "solo"
+    assert gov.required_status_checks == ("mac", "linux", "win")
+    assert gov.profile.branch_protection.require_status_checks == ("mac", "linux", "win")
+
+
+def test_load_multi_profile() -> None:
+    gov = load_governance_config(_config({
+        "project": {"profile": "multi"},
+    }))
+    assert gov.profile.name == "multi"
+    assert gov.profile.branch_protection.require_strict_status is True
+
+
+def test_load_backwards_compat_with_merge_require_platforms() -> None:
+    """When only `[merge].require_platforms` is set, treat it as required checks."""
+    gov = load_governance_config(_config({
+        "merge": {"require_platforms": ["macOS", "Linux"]},
+    }))
+    assert gov.required_status_checks == ("macOS", "Linux")
+
+
+def test_load_governance_required_status_checks_wins_over_merge() -> None:
+    gov = load_governance_config(_config({
+        "merge": {"require_platforms": ["old"]},
+        "governance": {"required_status_checks": ["new"]},
+    }))
+    assert gov.required_status_checks == ("new",)
+
+
+def test_load_unknown_profile_raises() -> None:
+    with pytest.raises(ValueError, match="Unknown governance profile"):
+        load_governance_config(_config({"project": {"profile": "weird"}}))
+
+
+def test_load_branch_overrides() -> None:
+    gov = load_governance_config(_config({
+        "branch_protection": {
+            "main": {"require_review_count": 2, "enforce_admins": True},
+            "develop/**": {"extends": "main", "require_review_count": 0},
+        },
+    }))
+    assert "main" in gov.branch_overrides
+    assert gov.branch_overrides["main"]["require_review_count"] == 2
+    assert gov.branch_overrides["develop/**"]["extends"] == "main"
+
+
+# ── resolve_branch_rules ────────────────────────────────────────────────
+
+
+def test_resolve_rules_for_branch_with_no_overrides() -> None:
+    """A branch not matching any glob gets the profile default as-is."""
+    gov = load_governance_config(_config({"project": {"profile": "solo"}}))
+    rules = resolve_branch_rules(gov, "main")
+    assert rules.require_strict_status is False  # solo default
+    assert rules.require_review_count == 0
+
+
+def test_resolve_rules_applies_override_on_top_of_profile() -> None:
+    gov = load_governance_config(_config({
+        "project": {"profile": "solo"},
+        "branch_protection": {
+            "main": {"require_review_count": 2},
+        },
+    }))
+    rules = resolve_branch_rules(gov, "main")
+    assert rules.require_review_count == 2  # override
+    assert rules.require_strict_status is False  # still solo default
+
+
+def test_resolve_rules_applies_glob_match() -> None:
+    gov = load_governance_config(_config({
+        "project": {"profile": "solo"},
+        "branch_protection": {
+            "develop/**": {"require_review_count": 1},
+        },
+    }))
+    dev_rules = resolve_branch_rules(gov, "develop/feature-x")
+    assert dev_rules.require_review_count == 1
+
+    main_rules = resolve_branch_rules(gov, "main")
+    assert main_rules.require_review_count == 0  # unmatched
+
+
+def test_resolve_rules_extends_chains_parent_overrides() -> None:
+    gov = load_governance_config(_config({
+        "project": {"profile": "solo"},
+        "branch_protection": {
+            "main": {"enforce_admins": True},
+            "develop/**": {"extends": "main", "require_review_count": 1},
+        },
+    }))
+    rules = resolve_branch_rules(gov, "develop/auth")
+    # Inherited from main
+    assert rules.enforce_admins is True
+    # Declared directly
+    assert rules.require_review_count == 1
+
+
+def test_resolve_rules_rejects_unknown_field() -> None:
+    gov = load_governance_config(_config({
+        "branch_protection": {
+            "main": {"typo_field": True},
+        },
+    }))
+    with pytest.raises(ValueError, match="Unknown branch_protection field 'typo_field'"):
+        resolve_branch_rules(gov, "main")
+
+
+def test_resolve_rules_converts_list_to_tuple_for_status_checks() -> None:
+    gov = load_governance_config(_config({
+        "branch_protection": {
+            "main": {"require_status_checks": ["mac", "linux"]},
+        },
+    }))
+    rules = resolve_branch_rules(gov, "main")
+    assert rules.require_status_checks == ("mac", "linux")
+
+
+def test_resolve_rules_later_glob_wins_over_earlier() -> None:
+    """When two globs both match, the later one overrides the earlier one."""
+    gov = load_governance_config(_config({
+        "branch_protection": {
+            "main": {"require_review_count": 1},
+            "*": {"require_review_count": 3},  # also matches main
+        },
+    }))
+    rules = resolve_branch_rules(gov, "main")
+    assert rules.require_review_count == 3  # later wins

--- a/tests/governance/test_github.py
+++ b/tests/governance/test_github.py
@@ -1,0 +1,193 @@
+"""Tests for the thin `gh api` wrappers (mocked).
+
+No real HTTP or subprocess calls. Every test patches subprocess.run
+and verifies the translation layer between GitHub's REST payloads
+and BranchProtectionRules.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from unittest.mock import patch
+
+import pytest
+
+from shipyard.governance.github import (
+    GovernanceApiError,
+    RepoRef,
+    _api_payload_from_rules,
+    _parse_git_remote_url,
+    _rules_from_api_payload,
+    get_branch_protection,
+    put_branch_protection,
+)
+from shipyard.governance.profiles import BranchProtectionRules
+
+
+def _mock_run(returncode: int = 0, stdout: str = "", stderr: str = ""):
+    return subprocess.CompletedProcess(
+        args=[], returncode=returncode, stdout=stdout, stderr=stderr,
+    )
+
+
+# ── get_branch_protection ───────────────────────────────────────────────
+
+
+def test_get_returns_none_on_404() -> None:
+    with patch(
+        "subprocess.run",
+        return_value=_mock_run(returncode=1, stderr="Branch not protected"),
+    ):
+        assert get_branch_protection(RepoRef("me", "r"), "main") is None
+
+
+def test_get_raises_on_permission_error() -> None:
+    with patch(
+        "subprocess.run",
+        return_value=_mock_run(returncode=1, stderr="403 forbidden"),
+    ), pytest.raises(GovernanceApiError, match="403"):
+        get_branch_protection(RepoRef("me", "r"), "main")
+
+
+def test_get_parses_valid_payload() -> None:
+    payload = {
+        "required_status_checks": {
+            "strict": True,
+            "contexts": ["macOS", "Linux"],
+        },
+        "required_pull_request_reviews": {
+            "required_approving_review_count": 1,
+            "dismiss_stale_reviews": True,
+            "require_code_owner_reviews": False,
+        },
+        "enforce_admins": {"enabled": True},
+        "allow_force_pushes": {"enabled": False},
+        "allow_deletions": {"enabled": False},
+        "required_linear_history": {"enabled": False},
+        "required_conversation_resolution": {"enabled": True},
+    }
+    with patch(
+        "subprocess.run",
+        return_value=_mock_run(stdout=json.dumps(payload)),
+    ):
+        rules = get_branch_protection(RepoRef("me", "r"), "main")
+    assert rules is not None
+    assert rules.require_pr is True
+    assert rules.require_strict_status is True
+    assert set(rules.require_status_checks) == {"macOS", "Linux"}
+    assert rules.require_review_count == 1
+    assert rules.dismiss_stale_reviews is True
+    assert rules.enforce_admins is True
+
+
+def test_get_raises_on_malformed_json() -> None:
+    with patch(
+        "subprocess.run",
+        return_value=_mock_run(stdout="not json"),
+    ), pytest.raises(GovernanceApiError, match="non-JSON"):
+        get_branch_protection(RepoRef("me", "r"), "main")
+
+
+def test_get_raises_on_timeout() -> None:
+    with patch(
+        "subprocess.run",
+        side_effect=subprocess.TimeoutExpired(cmd="gh", timeout=30),
+    ), pytest.raises(GovernanceApiError, match="timeout"):
+        get_branch_protection(RepoRef("me", "r"), "main")
+
+
+# ── put_branch_protection ───────────────────────────────────────────────
+
+
+def test_put_issues_api_call() -> None:
+    rules = BranchProtectionRules(
+        require_pr=True,
+        require_status_checks=("mac", "linux"),
+        require_strict_status=True,
+        require_review_count=1,
+        enforce_admins=True,
+    )
+    with patch("subprocess.run", return_value=_mock_run()) as mock_run:
+        put_branch_protection(RepoRef("me", "r"), "main", rules)
+    call = mock_run.call_args
+    cmd = call[0][0]
+    assert cmd[0:4] == ["gh", "api", "-X", "PUT"]
+    assert "repos/me/r/branches/main/protection" in cmd
+    # The body should contain the rule fields
+    body = json.loads(call[1]["input"])
+    assert body["required_status_checks"]["strict"] is True
+    assert body["required_status_checks"]["contexts"] == ["mac", "linux"]
+    assert body["enforce_admins"] is True
+
+
+def test_put_raises_on_failure() -> None:
+    rules = BranchProtectionRules(require_pr=True)
+    with patch(
+        "subprocess.run",
+        return_value=_mock_run(returncode=1, stderr="permission denied"),
+    ), pytest.raises(GovernanceApiError, match="permission"):
+        put_branch_protection(RepoRef("me", "r"), "main", rules)
+
+
+def test_put_omits_status_checks_block_when_empty() -> None:
+    """GitHub rejects an empty contexts list, so omit the whole block."""
+    rules = BranchProtectionRules(require_pr=True, require_status_checks=())
+    with patch("subprocess.run", return_value=_mock_run()) as mock_run:
+        put_branch_protection(RepoRef("me", "r"), "main", rules)
+    body = json.loads(mock_run.call_args[1]["input"])
+    assert body["required_status_checks"] is None
+
+
+# ── payload translation round-trip ─────────────────────────────────────
+
+
+def test_payload_to_rules_and_back_preserves_fields() -> None:
+    original = BranchProtectionRules(
+        require_pr=True,
+        require_status_checks=("mac",),
+        require_strict_status=False,
+        require_review_count=2,
+        enforce_admins=True,
+        dismiss_stale_reviews=True,
+        allow_force_push=False,
+        allow_deletions=False,
+        required_conversation_resolution=True,
+    )
+    payload = _api_payload_from_rules(original)
+    # Build a GitHub-like response shape
+    live_shape = {
+        "required_status_checks": payload["required_status_checks"],
+        "required_pull_request_reviews": payload["required_pull_request_reviews"],
+        "enforce_admins": {"enabled": payload["enforce_admins"]},
+        "allow_force_pushes": {"enabled": payload["allow_force_pushes"]},
+        "allow_deletions": {"enabled": payload["allow_deletions"]},
+        "required_linear_history": {"enabled": payload["required_linear_history"]},
+        "required_conversation_resolution": {
+            "enabled": payload["required_conversation_resolution"],
+        },
+    }
+    round_tripped = _rules_from_api_payload(live_shape)
+    assert round_tripped == original
+
+
+# ── _parse_git_remote_url ──────────────────────────────────────────────
+
+
+def test_parse_https_remote() -> None:
+    ref = _parse_git_remote_url("https://github.com/danielraffel/pulp.git")
+    assert ref == RepoRef(owner="danielraffel", name="pulp")
+
+
+def test_parse_ssh_remote() -> None:
+    ref = _parse_git_remote_url("git@github.com:danielraffel/pulp.git")
+    assert ref == RepoRef(owner="danielraffel", name="pulp")
+
+
+def test_parse_https_remote_without_dot_git() -> None:
+    ref = _parse_git_remote_url("https://github.com/danielraffel/pulp")
+    assert ref == RepoRef(owner="danielraffel", name="pulp")
+
+
+def test_parse_non_github_remote_returns_none() -> None:
+    assert _parse_git_remote_url("https://gitlab.com/foo/bar.git") is None

--- a/tests/governance/test_profiles.py
+++ b/tests/governance/test_profiles.py
@@ -39,7 +39,10 @@ def test_solo_profile_defaults() -> None:
     assert rules.allow_force_push is False
     assert rules.allow_deletions is False
     assert rules.require_linear_history is False
-    assert rules.required_conversation_resolution is True
+    # Off for solo by design — conversation resolution has no value
+    # on a single-maintainer project and is pure self-friction. Multi
+    # profile keeps it on.
+    assert rules.required_conversation_resolution is False
 
 
 def test_solo_profile_applies_required_status_checks() -> None:

--- a/tests/governance/test_profiles.py
+++ b/tests/governance/test_profiles.py
@@ -1,0 +1,145 @@
+"""Layer 1: profile definition unit tests.
+
+Every entry in the solo and multi tables from the planning doc has
+an assertion here. If a knob is added to BranchProtectionRules, its
+expected value for both profiles MUST be asserted in this file — a
+small lint script enforces that in CI.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from shipyard.governance.profiles import (
+    BranchProtectionRules,
+    known_profile_names,
+    multi_profile,
+    profile_for_name,
+    solo_profile,
+)
+
+# ── solo profile hard-coded defaults ────────────────────────────────────
+
+
+def test_solo_profile_defaults() -> None:
+    p = solo_profile()
+    rules = p.branch_protection
+    assert p.name == "solo"
+    assert rules.require_pr is True
+    assert rules.require_status_checks == ()
+    # The defining solo choice — see planning doc Part 12:
+    # strict=false is what avoids the rebase tax on single-maintainer
+    # projects. Test this specifically because it's the most-asked
+    # about knob and the one PR #106 proved matters.
+    assert rules.require_strict_status is False
+    assert rules.require_review_count == 0
+    assert rules.enforce_admins is False
+    assert rules.dismiss_stale_reviews is False
+    assert rules.require_code_owner_reviews is False
+    assert rules.allow_force_push is False
+    assert rules.allow_deletions is False
+    assert rules.require_linear_history is False
+    assert rules.required_conversation_resolution is True
+
+
+def test_solo_profile_applies_required_status_checks() -> None:
+    p = solo_profile(required_status_checks=("macOS", "Linux", "Windows"))
+    assert p.branch_protection.require_status_checks == ("macOS", "Linux", "Windows")
+
+
+# ── multi profile hard-coded defaults ───────────────────────────────────
+
+
+def test_multi_profile_defaults() -> None:
+    p = multi_profile()
+    rules = p.branch_protection
+    assert p.name == "multi"
+    assert rules.require_pr is True
+    assert rules.require_status_checks == ()
+    assert rules.require_strict_status is True
+    assert rules.require_review_count == 1
+    assert rules.enforce_admins is True
+    assert rules.dismiss_stale_reviews is True
+    assert rules.require_code_owner_reviews is False
+    assert rules.allow_force_push is False
+    assert rules.allow_deletions is False
+    assert rules.require_linear_history is False
+    assert rules.required_conversation_resolution is True
+
+
+def test_multi_profile_applies_required_status_checks() -> None:
+    p = multi_profile(required_status_checks=("x", "y"))
+    assert p.branch_protection.require_status_checks == ("x", "y")
+
+
+# ── solo vs multi must differ in the right places ──────────────────────
+
+
+def test_solo_and_multi_differ_on_key_knobs() -> None:
+    """Catch a bug where the two profiles accidentally collapse to the same defaults."""
+    s = solo_profile().branch_protection
+    m = multi_profile().branch_protection
+    # These are the process gates that separate "single maintainer"
+    # from "coordinating with other humans" — if any of them stop
+    # differing, either a profile is wrong or the distinction has
+    # been erased.
+    assert s.require_strict_status != m.require_strict_status
+    assert s.require_review_count != m.require_review_count
+    assert s.enforce_admins != m.enforce_admins
+    assert s.dismiss_stale_reviews != m.dismiss_stale_reviews
+
+
+def test_solo_and_multi_agree_on_always_off_knobs() -> None:
+    """Some knobs are never on for either profile (force-push, deletions)."""
+    s = solo_profile().branch_protection
+    m = multi_profile().branch_protection
+    assert s.allow_force_push is False and m.allow_force_push is False
+    assert s.allow_deletions is False and m.allow_deletions is False
+    assert s.require_linear_history is False and m.require_linear_history is False
+
+
+# ── profile_for_name lookup + custom profile ────────────────────────────
+
+
+def test_profile_for_name_solo() -> None:
+    p = profile_for_name("solo", required_status_checks=("a",))
+    assert p.name == "solo"
+    assert p.branch_protection.require_status_checks == ("a",)
+
+
+def test_profile_for_name_multi() -> None:
+    p = profile_for_name("multi")
+    assert p.name == "multi"
+
+
+def test_profile_for_name_custom_is_empty() -> None:
+    """custom returns a blank BranchProtectionRules with default field values."""
+    p = profile_for_name("custom")
+    assert p.name == "custom"
+    # The custom profile's default rules match BranchProtectionRules()
+    # default construction — every knob at its most restrictive sane
+    # default, caller is expected to override.
+    default = BranchProtectionRules()
+    assert p.branch_protection == default
+
+
+def test_profile_for_name_unknown_raises() -> None:
+    with pytest.raises(ValueError, match="Unknown governance profile"):
+        profile_for_name("enterprise")
+
+
+def test_known_profile_names_has_all_three() -> None:
+    names = known_profile_names()
+    assert set(names) == {"solo", "multi", "custom"}
+
+
+# ── with_overrides preserves frozen behavior ────────────────────────────
+
+
+def test_with_overrides_returns_new_instance() -> None:
+    base = BranchProtectionRules()
+    new = base.with_overrides(require_review_count=5)
+    assert new.require_review_count == 5
+    assert base.require_review_count == 0
+    # Frozen dataclass — the original is unchanged
+    assert base != new

--- a/tests/governance/test_status.py
+++ b/tests/governance/test_status.py
@@ -1,0 +1,189 @@
+"""Tests for the high-level `build_status` and `format_status_text` rollup."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from shipyard.core.config import Config
+from shipyard.governance.config import load_governance_config
+from shipyard.governance.github import RepoRef
+from shipyard.governance.status import build_status, format_status_text
+
+
+def _solo_config() -> Config:
+    return Config(data={
+        "project": {"profile": "solo"},
+        "governance": {"required_status_checks": ["mac", "linux", "windows"]},
+    })
+
+
+def _rules_solo():
+    """Build the rules that the solo-with-checks config resolves to."""
+    from shipyard.governance.config import resolve_branch_rules
+    return resolve_branch_rules(load_governance_config(_solo_config()), "main")
+
+
+# ── build_status happy path: aligned ────────────────────────────────────
+
+
+def test_build_status_aligned_has_no_drift() -> None:
+    gov = load_governance_config(_solo_config())
+    declared = _rules_solo()
+    with patch(
+        "shipyard.governance.status.get_branch_protection",
+        return_value=declared,
+    ):
+        status = build_status(
+            repo=RepoRef("me", "r"),
+            governance=gov,
+            branches=("main",),
+        )
+    assert status.has_drift is False
+    assert status.has_errors is False
+    assert len(status.reports) == 1
+    assert status.profile_name == "solo"
+
+
+# ── drift detected ──────────────────────────────────────────────────────
+
+
+def test_build_status_drifted_reports_drift() -> None:
+    gov = load_governance_config(_solo_config())
+    declared = _rules_solo()
+    live = declared.with_overrides(require_strict_status=True)  # drift
+    with patch(
+        "shipyard.governance.status.get_branch_protection",
+        return_value=live,
+    ):
+        status = build_status(
+            repo=RepoRef("me", "r"),
+            governance=gov,
+            branches=("main",),
+        )
+    assert status.has_drift is True
+    assert status.reports[0].drifted_entries[0].field_name == "require_strict_status"
+
+
+# ── unprotected branch ──────────────────────────────────────────────────
+
+
+def test_build_status_unprotected_branch_reports_drift() -> None:
+    gov = load_governance_config(_solo_config())
+    with patch(
+        "shipyard.governance.status.get_branch_protection",
+        return_value=None,
+    ):
+        status = build_status(
+            repo=RepoRef("me", "r"),
+            governance=gov,
+            branches=("main",),
+        )
+    assert status.has_drift is True
+    assert status.reports[0].live_unprotected is True
+
+
+# ── per-branch error handling ───────────────────────────────────────────
+
+
+def test_build_status_collects_errors_per_branch() -> None:
+    from shipyard.governance.github import GovernanceApiError
+    gov = load_governance_config(_solo_config())
+
+    def fake_get(repo, branch, gh_command="gh"):
+        if branch == "broken":
+            raise GovernanceApiError("permission denied on broken")
+        return _rules_solo()
+
+    with patch(
+        "shipyard.governance.status.get_branch_protection",
+        side_effect=fake_get,
+    ):
+        status = build_status(
+            repo=RepoRef("me", "r"),
+            governance=gov,
+            branches=("main", "broken"),
+        )
+    # main is reported, broken is in errors
+    assert len(status.reports) == 1
+    assert status.reports[0].branch == "main"
+    assert status.has_errors is True
+    assert any("permission denied" in e for e in status.errors)
+
+
+# ── format_status_text ──────────────────────────────────────────────────
+
+
+def test_format_aligned_status_shows_check_mark() -> None:
+    gov = load_governance_config(_solo_config())
+    declared = _rules_solo()
+    with patch(
+        "shipyard.governance.status.get_branch_protection",
+        return_value=declared,
+    ):
+        status = build_status(
+            repo=RepoRef("me", "r"),
+            governance=gov,
+            branches=("main",),
+        )
+    text = format_status_text(status)
+    assert "me/r" in text
+    assert "Profile: solo" in text
+    assert "aligned with profile" in text
+
+
+def test_format_drifted_status_shows_fix_hint() -> None:
+    gov = load_governance_config(_solo_config())
+    declared = _rules_solo()
+    live = declared.with_overrides(enforce_admins=True)
+    with patch(
+        "shipyard.governance.status.get_branch_protection",
+        return_value=live,
+    ):
+        status = build_status(
+            repo=RepoRef("me", "r"),
+            governance=gov,
+            branches=("main",),
+        )
+    text = format_status_text(status)
+    assert "drifted" in text
+    assert "enforce_admins" in text
+    assert "shipyard governance apply" in text
+
+
+def test_format_unprotected_status_is_loud() -> None:
+    gov = load_governance_config(_solo_config())
+    with patch(
+        "shipyard.governance.status.get_branch_protection",
+        return_value=None,
+    ):
+        status = build_status(
+            repo=RepoRef("me", "r"),
+            governance=gov,
+            branches=("main",),
+        )
+    text = format_status_text(status)
+    assert "UNPROTECTED" in text
+
+
+def test_format_deviated_but_aligned_shows_info_row() -> None:
+    """An intentional override shows up as an info line, not a drift error."""
+    cfg = Config(data={
+        "project": {"profile": "solo"},
+        "governance": {"required_status_checks": ["mac"]},
+        "branch_protection": {"main": {"require_review_count": 2}},
+    })
+    gov = load_governance_config(cfg)
+    from shipyard.governance.config import resolve_branch_rules
+    declared = resolve_branch_rules(gov, "main")
+    with patch(
+        "shipyard.governance.status.get_branch_protection",
+        return_value=declared,
+    ):
+        status = build_status(
+            repo=RepoRef("me", "r"),
+            governance=gov,
+            branches=("main",),
+        )
+    text = format_status_text(status)
+    assert "deviated from profile" in text
+    assert "require_review_count" in text


### PR DESCRIPTION
## Summary

Introduces the governance layer that Pulp will dogfood in Part 13 validation Stages 4–5 — drift detection and idempotent apply for branch protection via GitHub's REST API.

### New package: \`shipyard.governance\`

| Module | Purpose |
|--------|---------|
| \`profiles.py\` | solo / multi / custom profiles with hard-coded defaults. The solo preset matches Pulp's 2026-04-09 hardening state: require_pr=true, **strict=false**, enforce_admins=false, require_review_count=0 |
| \`config.py\` | Parse \`[project.profile]\`, \`[governance]\`, and \`[branch_protection."<glob>"]\` with glob + \`extends\` inheritance |
| \`github.py\` | Thin \`gh api\` wrappers for branch protection GET/PUT + git remote detection |
| \`compare.py\` | Drift computation: aligned / deviated / drifted / both / unprotected |
| \`apply.py\` | Idempotent apply plan. NOOP plans issue zero PUTs even in non-dry-run mode |
| \`status.py\` | High-level rollup + human formatter |

### CLI
\`\`\`bash
shipyard governance status [-b main]    # profile + drift per branch
shipyard governance apply  [--dry-run]  # idempotent apply
shipyard governance diff                # preview without writing
\`\`\`

### Doctor integration
New "Governance" section reports main-branch drift when a profile is declared. **Honest** immutable-releases row prints an info line pointing at the settings URL rather than claiming a state the API cannot verify on personal repos — matches the planning doc Part 12 spec exactly.

## Tests

**65 unit tests** across profiles (12), config (14), compare (8), github (13), apply (10), status (8). Every mock boundary is at \`subprocess.run\` so no real HTTP happens during tests.

**Full suite: 392 passing** (327 baseline + 65 governance).

This is the minimum Phase 6 surface to run Part 13 validation Stages 4 and 5 against Pulp. Follow-ups (\`governance use/export\`, \`branch apply --create\`, \`ship --base develop/new\` auto-create) land as separate PRs after v0.1.4.

## Test plan

- [x] \`pytest tests/governance/\` — 65/65
- [x] \`pytest tests/\` full suite — 392/392
- [x] \`ruff check\` clean
- [x] \`mypy src/shipyard/governance/\` clean
- [x] \`shipyard governance --help\` renders
- [ ] Live smoke test against Pulp's \`main\` once merged to main + tagged v0.1.4