### PR TITLE
Release v0.1.4: governance profiles + branch protection CLI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "shipyard"
-version = "0.1.3"
+version = "0.1.4"
 description = "Cross-platform CI coordination — local VMs, SSH hosts, cloud runners"
 readme = "README.md"
 license = "MIT"

--- a/src/shipyard/__init__.py
+++ b/src/shipyard/__init__.py
@@ -1,3 +1,3 @@
 """Shipyard — Cross-platform CI coordination."""
 
-__version__ = "0.1.3"
+__version__ = "0.1.4"


### PR DESCRIPTION
## Summary

Phase 6 minimum — ships enough governance surface to run Pulp's Part 13 Stage 4 (drift detection) and Stage 5 (recreation drill, in degraded form without export) against its \`main\` branch.

**Dogfooded against real Pulp state before tagging:** \`shipyard governance status\` reports \`✓ main: aligned with solo profile\` on \`danielraffel/pulp\`. Every governance knob round-trips cleanly between the \`BranchProtectionRules\` dataclass and GitHub's REST API.

## What v0.1.4 ships

| Feature | Status |
|---------|--------|
| solo / multi / custom profiles | ✅ |
| \`[project.profile]\` config | ✅ |
| \`[branch_protection."<glob>"]\` overrides with \`extends\` | ✅ |
| \`shipyard governance status\` | ✅ |
| \`shipyard governance diff\` | ✅ |
| \`shipyard governance apply\` (idempotent, \`--dry-run\`) | ✅ |
| Doctor "Governance" section | ✅ |
| Honest immutable-releases info row (no API, no claims) | ✅ |

## What v0.1.5 / v0.1.6 will ship

Tracked in \`planning/shipyard-phase-6-followups.md\` on the Pulp planning repo:

- \`governance use <profile>\` — v0.1.5
- \`governance export\` + \`apply --from snapshot.toml\` — v0.1.5 (required for Stage 5 full)
- \`branch apply --create\` — v0.1.5 or v0.1.6
- \`ship --base\` auto-create-base — v0.1.6

## Tests

**392 passing** (327 Phase 5 baseline + 65 Phase 6 governance).

## Test plan

- [x] Full suite green
- [x] Dogfood against Pulp live state shows zero drift
- [x] Doctor section renders correctly on Pulp
- [ ] Merge, tag v0.1.4, publish release
- [ ] Bump Pulp pin from v0.1.3 → v0.1.4