### PR TITLE
Fix Codex review findings (PRs #3/#5/#8/#10) + README differentiator framing

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,75 +45,78 @@ It calls your build commands and cares about one thing: did they pass?
 
 ## What Makes It Different
 
-**Exact-SHA validation.** Every target validates the specific commit you
-queued, not whatever happens to be checked out. Code is delivered to remote
-machines via git bundles — no git credentials needed on the target. Evidence
-records bind proof to the exact SHA, so stale results from a prior commit
-can't satisfy a merge gate.
+Most of what Shipyard does — exact-SHA validation, fallback chains,
+stage-aware resume, ecosystem auto-detection, JSON output — is
+table-stakes for a modern CI tool. None of those are the reason to
+adopt Shipyard. The actual differentiators are four things most
+indie developers can't easily wire up themselves:
 
-**Smart queue for parallel agents.** Multiple agents working in different
-worktrees share one machine-global queue. Jobs are prioritized (high/normal/low)
-and scheduled FIFO within priority. When you push a new commit to the same
-branch, the pending job for the old SHA is automatically replaced — but
-narrower reruns (just one failing target) and different validation modes
-(smoke vs full) coexist without interfering.
+**Safe, real cross-platform CI for AI agents.** Shipyard is designed
+for the case where an agent — Claude Code, Codex, or something
+scripted on top — opens a PR on your machine and needs real
+cross-platform proof before merging. The one-command setup for
+agents (Claude Code plugin, Codex installer) means you don't hand
+your agents the keys to your DAW, your notarization identity, or
+your publishing account. The agent runs `shipyard ship`; Shipyard
+handles the bundle delivery, the remote validation, the merge
+gate, and the audit trail. There's no equivalent off-the-shelf tool
+for an indie dev who wants to give agents real cross-platform CI
+access without rolling their own orchestration.
 
-**Fail-fast across targets.** If Mac fails, Shipyard stops immediately —
-it doesn't waste time running Windows and Linux when you already know
-you need to fix something. Remaining targets are marked as skipped. When
-you want to run everything regardless (to see the full picture), use
-`--continue`.
+**Declarative security & governance.** Pick a profile — `solo` or
+`multi` — and `shipyard governance apply` sets branch protection,
+tag protection, default workflow token permissions, and (via
+follow-ups) deployment approval + sigstore release attestations to
+match. Drift is surfaced by `shipyard governance status` and in
+`shipyard doctor`. All of the hardening practices Astral
+[documents for open-source projects](https://astral.sh/blog/open-source-security-at-astral)
+are packaged as one TOML line and one CLI command. Without this, an
+indie dev has to click through six GitHub settings pages, remember
+every knob, and hope they got it right.
 
-**Targeted re-runs.** If Windows fails but Mac and Linux passed, re-run just
-Windows. Shipyard keeps the evidence from the earlier run. When the re-run
-passes, all three platforms now have green evidence for this SHA — you don't
-re-validate what already passed.
+**Evidence-based merge gate.** `shipyard ship` refuses to merge
+unless every required platform has passing evidence **for the exact
+HEAD SHA** — not the most-recent run, not the branch tip, the SHA.
+Evidence records are bound to a commit, so a stale green from a
+prior commit cannot satisfy the gate. Standard CI plugins on GitHub
+only track the latest run per workflow; proving the *specific
+commit* is green requires wiring up something custom.
 
-**Stage-aware resume.** If your build succeeded but tests failed, you don't
-need to rebuild from scratch. Use `--resume-from test` to skip configure and
-build, running only the test stage. This works because Shipyard runs
-validation in stages (configure → build → test) and tracks which stage
-failed — so both you and your agent know exactly what broke and where to
-pick up.
+**Parallel-agent-aware queue.** Multiple agents in multiple
+worktrees share one machine-global queue. Jobs are prioritized,
+scheduled FIFO within priority, and automatically deduplicated
+when a new commit supersedes a pending job on the same branch —
+without cancelling narrower reruns (single target) or different
+validation modes (smoke vs full). This is the thing that actually
+makes parallel-agent workflows safe on a single dev machine; GitHub
+Actions doesn't know anything about your local worktrees.
 
-**Failover that knows the difference.** If a target is unreachable, Shipyard
-walks your fallback chain (boot VM → try cloud → try GitHub-hosted). But if
-your code genuinely fails a test, there's no fallback — a real test failure
-is authoritative. The result always records exactly which backend produced it,
-so you know whether proof came from your local Mac or a Namespace runner.
+### Features
 
-**Transient failure retry.** SSH connections drop. Shipyard recognizes 9
-transient SSH error patterns (connection reset, timeout, kex failure) and
-retries with exponential backoff before triggering fallback. Permanent errors
-like `Permission denied` fail immediately — no wasted retries.
+The rest of what Shipyard ships is the normal set of conveniences
+you'd want for day-to-day use:
 
-**22 ecosystem detectors.** `shipyard init` recognizes CMake, Swift, Xcode,
-Rust, Go, Node.js (pnpm > bun > yarn > npm), Python (uv > poetry > pip),
-Gradle, Maven, .NET, Flutter, Dart, Deno, Ruby, Elixir, PHP — and infers
-the right build and test commands. For polyglot repos, it detects all
-ecosystems with family deduplication (one Node detector, not four).
-
-**Structured JSON on every command.** Every command supports `--json` with a
-versioned schema (`schema_version: 1`). Agents parse the output directly —
-no screen-scraping, no fragile regex. The schema version increments when the
-format changes, so agents can check compatibility.
-
-**Target profiles for instant switching.** Define `local`, `normal`, and
-`full` profiles once. Switch with `shipyard config use local` — no config
-editing. Each profile activates a different set of targets. Global profiles
-work across all projects; project profiles override for specific needs.
-(See *Security & Governance Profiles* below for the separate set of
-profiles that control branch protection, release flow, and reviewer
-requirements.)
-
-**Merge only when proven.** `shipyard ship` refuses to merge unless every
-required platform has passing evidence for the exact HEAD SHA. It checks
-per-platform, so one missing or failing platform blocks the merge with a
-clear breakdown of what's passing, missing, and failing.
-
-**Operational cleanup.** Logs, bundles, and results don't grow forever.
-`shipyard cleanup` shows what can be reclaimed (dry-run by default). The
-queue automatically trims to the 25 most recent completed jobs.
+- **Exact-SHA remote delivery** via git bundles — no git
+  credentials on target machines.
+- **Fail-fast across targets** (with `--continue` to run everything
+  anyway).
+- **Targeted re-runs** — re-validate one platform and keep the
+  existing evidence for the others.
+- **Stage-aware resume** — `--resume-from test` skips configure
+  and build when only the test stage failed.
+- **Failover chains** with real-vs-transient error distinction
+  (9 transient SSH error patterns retry before fallback;
+  `Permission denied` fails immediately).
+- **Target profiles** for instant environment switching
+  (`shipyard config use local`).
+- **22 ecosystem detectors** — `shipyard init` recognises CMake,
+  Swift, Xcode, Rust, Go, Node (pnpm / bun / yarn / npm), Python
+  (uv / poetry / pip), Gradle, Maven, .NET, Flutter, Dart, Deno,
+  Ruby, Elixir, PHP.
+- **Structured JSON on every command** (`--json`) with a versioned
+  schema so agents parse output directly.
+- **Operational cleanup** (`shipyard cleanup`) plus automatic
+  queue trimming to the 25 most recent completed jobs.
 
 ---
 

--- a/src/shipyard/cli.py
+++ b/src/shipyard/cli.py
@@ -394,9 +394,13 @@ def doctor(ctx: Context) -> None:
     if governance_section:
         checks["Governance"] = governance_section
 
-    ready = all(
-        info.get("ok", False)
-        for info in core.values()
+    # Ready = core tools healthy AND (no governance section declared
+    # OR every governance check is ok). Informational entries (the
+    # immutable-releases line) set `ok=True` specifically because
+    # they can't lie — they report what the API exposes and nothing
+    # more — so they're allowed to contribute to the ready rollup.
+    ready = all(info.get("ok", False) for info in core.values()) and all(
+        info.get("ok", False) for info in (governance_section or {}).values()
     )
 
     if ctx.json_mode:
@@ -449,8 +453,16 @@ def _check_governance_drift(config: Config) -> dict[str, Any] | None:
             "detail": f"could not fetch live state: {exc}",
         }}
 
-    # Profile / drift summary line
-    if status.has_drift:
+    # Fetch errors from build_status must NOT be swallowed into a
+    # false-green. If gh is unauthenticated or a branch returned
+    # a 5xx, has_drift can be False even though we never actually
+    # read the live state. Treat any error as a not-aligned result.
+    if status.has_errors:
+        section["main"] = {
+            "ok": False,
+            "detail": f"could not read live state — {'; '.join(status.errors)[:200]}",
+        }
+    elif status.has_drift:
         drifted_fields = [
             f"{r.branch}:{e.field_name}"
             for r in status.reports
@@ -697,6 +709,18 @@ def governance_diff(ctx: Context, branch: tuple[str, ...]) -> None:
     if any_drift:
         render_message("")
         render_message("Run: shipyard governance apply")
+
+    # If any branch fetch failed, surface the error and exit
+    # non-zero so automation does not treat a clean diff produced
+    # from incomplete reads as "nothing to apply".
+    if status.has_errors:
+        render_message("")
+        render_error(
+            "governance diff: live state could not be read for one or more branches"
+        )
+        for err in status.errors:
+            render_message(f"  ! {err}")
+        sys.exit(1)
 
 
 @main.group()
@@ -1110,13 +1134,30 @@ def _check_command(name: str, *args: str) -> dict[str, Any]:
 
 
 def _resolve_validation(config: Config, mode: ValidationMode) -> dict[str, Any]:
-    """Get validation config for the given mode."""
+    """Get validation config for the given mode.
+
+    `[validation.contract]` and `[validation.prepared_state]` are
+    declared alongside `[validation.default]`/`[validation.smoke]`,
+    not inside them, so they live at the top of the `validation`
+    subtable. Merge them into the returned mode-specific dict so
+    downstream executors see a single unified view and don't have
+    to know about the split.
+    """
     validation = config.validation
     if mode == ValidationMode.SMOKE and "smoke" in validation:
-        return validation["smoke"]
-    if "default" in validation:
-        return validation["default"]
-    return validation
+        result = dict(validation["smoke"])
+    elif "default" in validation:
+        result = dict(validation["default"])
+    else:
+        result = dict(validation)
+
+    # Lift top-level peers into the resolved dict. Mode-specific
+    # overrides (if present inside `default`/`smoke`) still win.
+    for peer_key in ("contract", "prepared_state"):
+        if peer_key in validation and peer_key not in result:
+            result[peer_key] = validation[peer_key]
+
+    return result
 
 
 def _resolve_target_validation(

--- a/src/shipyard/executor/ssh_windows.py
+++ b/src/shipyard/executor/ssh_windows.py
@@ -30,10 +30,17 @@ class SSHWindowsExecutor:
     """Execute validation commands on a remote Windows host via SSH + PowerShell."""
 
     def __init__(self) -> None:
-        # Cache of detected VS toolchains keyed by host. Detection
-        # shells out to vswhere, which is slow enough (~1s) that we
-        # only want to do it once per Shipyard invocation per host.
-        self._vs_toolchain_cache: dict[str, VsToolchain | None] = {}
+        # Cache of detected VS toolchains keyed by (host, ssh_options
+        # tuple). Detection shells out to vswhere, which is slow
+        # enough (~1s) that we want to reuse it within a single
+        # Shipyard invocation — but two targets with the same
+        # hostname and different ssh options (e.g. different users,
+        # ports, or bastion jump hosts) can land on completely
+        # different machines, so the cache key must include the
+        # full connection identity, not just the host string.
+        self._vs_toolchain_cache: dict[
+            tuple[str, tuple[str, ...]], VsToolchain | None
+        ] = {}
 
     def validate(
         self,
@@ -204,13 +211,20 @@ class SSHWindowsExecutor:
         Respects `windows_vs_detect = false` in the target config to
         opt out entirely. Detection failures are cached as None so a
         missing vswhere doesn't re-probe on every run.
+
+        The cache key is `(host, tuple(ssh_options))` so two targets
+        that share a hostname but connect with different SSH options
+        (different ports, users, bastions) get independent cache
+        entries. Using only the hostname would let the first probe
+        pollute subsequent runs against a completely different box.
         """
         if target_config.get("windows_vs_detect", True) is False:
             return None
-        if host in self._vs_toolchain_cache:
-            return self._vs_toolchain_cache[host]
+        cache_key = (host, tuple(ssh_options))
+        if cache_key in self._vs_toolchain_cache:
+            return self._vs_toolchain_cache[cache_key]
         toolchain = detect_vs_toolchain(host, ssh_options)
-        self._vs_toolchain_cache[host] = toolchain
+        self._vs_toolchain_cache[cache_key] = toolchain
         return toolchain
 
     def probe(self, target_config: dict[str, Any]) -> bool:

--- a/src/shipyard/executor/windows_toolchain.py
+++ b/src/shipyard/executor/windows_toolchain.py
@@ -115,7 +115,12 @@ function Resolve-VisualStudioInstance {
         return ''
     }
     try {
-        $raw = (& $vswhere -latest -products * -format json) -join "`n"
+        # Do NOT pass -latest here — vswhere -latest returns only the
+        # single newest install, which defeats the "prefer non-
+        # BuildTools" filter below when Build Tools happens to be the
+        # most recently installed product. Enumerate every install and
+        # let the Where-Object filter pick a real IDE first.
+        $raw = (& $vswhere -products * -format json) -join "`n"
         if (-not $raw) {
             return ''
         }
@@ -123,6 +128,10 @@ function Resolve-VisualStudioInstance {
         if ($instances -isnot [System.Array]) {
             $instances = @($instances)
         }
+        # Sort by installDate descending so "prefer newest" still
+        # applies within each category — Where-Object only filters,
+        # Sort-Object imposes the tiebreak.
+        $instances = $instances | Sort-Object -Property installDate -Descending
         # Prefer a full VS install over BuildTools when both exist.
         $preferred = $instances | Where-Object {
             $_.productId -and $_.productId -ne 'Microsoft.VisualStudio.Product.BuildTools'

--- a/src/shipyard/governance/config.py
+++ b/src/shipyard/governance/config.py
@@ -158,19 +158,55 @@ def _resolve_overrides_for(
     """Walk the branch_overrides dict, apply extends, merge matching globs.
 
     A later matching glob wins over an earlier one.
+
+    `extends` is resolved recursively so chains like
+    `release/** → develop/** → main` fully inherit from every
+    ancestor, not just the direct parent. A cycle detector breaks
+    out on self-reference or on any extend that's already been
+    visited in the current chain.
     """
     merged: dict[str, Any] = {}
-    for glob, overrides in branch_overrides.items():
+    for glob in branch_overrides:
         if not fnmatch.fnmatchcase(branch_name, glob):
             continue
-        # Apply parent's overrides first if `extends` is set
-        parent_name = overrides.get("extends")
-        if parent_name and parent_name in branch_overrides:
-            parent = branch_overrides[parent_name]
-            for k, v in parent.items():
-                if k != "extends":
-                    merged[k] = v
-        for k, v in overrides.items():
-            if k != "extends":
-                merged[k] = v
+        inherited = _flatten_extends_chain(glob, branch_overrides)
+        for k, v in inherited.items():
+            merged[k] = v
+    return merged
+
+
+def _flatten_extends_chain(
+    glob: str,
+    branch_overrides: dict[str, dict[str, Any]],
+    *,
+    _visited: frozenset[str] | None = None,
+) -> dict[str, Any]:
+    """Recursively flatten a glob's own fields plus every `extends` ancestor.
+
+    Fields from ancestors are applied first, so the glob's own
+    fields win on conflict — matching the planning doc's
+    "overrides are cumulative, with the child overriding the parent"
+    contract.
+    """
+    if _visited is None:
+        _visited = frozenset()
+    if glob in _visited:
+        return {}  # cycle guard
+    overrides = branch_overrides.get(glob)
+    if not overrides:
+        return {}
+
+    merged: dict[str, Any] = {}
+    parent_name = overrides.get("extends")
+    if isinstance(parent_name, str) and parent_name:
+        ancestor = _flatten_extends_chain(
+            parent_name,
+            branch_overrides,
+            _visited=_visited | {glob},
+        )
+        merged.update(ancestor)
+
+    for k, v in overrides.items():
+        if k != "extends":
+            merged[k] = v
     return merged

--- a/tests/executor/test_ssh_windows_cache_key.py
+++ b/tests/executor/test_ssh_windows_cache_key.py
@@ -1,0 +1,84 @@
+"""Regression test: VS toolchain cache must key on (host, ssh_options)."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from shipyard.executor.ssh_windows import SSHWindowsExecutor
+from shipyard.executor.windows_toolchain import VsToolchain
+
+
+def _arm_toolchain() -> VsToolchain:
+    return VsToolchain(
+        cmake_platform="ARM64",
+        cmake_generator_instance="C:/VS/ARM64",
+    )
+
+
+def _x64_toolchain() -> VsToolchain:
+    return VsToolchain(
+        cmake_platform="x64",
+        cmake_generator_instance="C:/VS/x64",
+    )
+
+
+def test_same_host_different_ssh_options_are_cached_separately() -> None:
+    """Two targets on the same hostname with different SSH options don't share cache.
+
+    Codex flagged that keying by host alone lets the first detected
+    toolchain pollute subsequent runs against a completely different
+    endpoint that happens to share the hostname (e.g., different
+    users, ports, or jump hosts).
+    """
+    executor = SSHWindowsExecutor()
+
+    calls = []
+
+    def fake_detect(host, ssh_options, *, timeout=60):
+        calls.append((host, tuple(ssh_options)))
+        if "-p2222" in ssh_options:
+            return _x64_toolchain()
+        return _arm_toolchain()
+
+    with patch(
+        "shipyard.executor.ssh_windows.detect_vs_toolchain",
+        side_effect=fake_detect,
+    ):
+        # Two targets with the same hostname but different port
+        t1 = executor._get_vs_toolchain(
+            host="build.example.com",
+            ssh_options=["-p1111"],
+            target_config={"windows_vs_detect": True},
+        )
+        t2 = executor._get_vs_toolchain(
+            host="build.example.com",
+            ssh_options=["-p2222"],
+            target_config={"windows_vs_detect": True},
+        )
+
+    assert t1 is not None and t1.cmake_platform == "ARM64"
+    assert t2 is not None and t2.cmake_platform == "x64"
+    assert len(calls) == 2  # Both probed; no cache collision
+
+
+def test_same_host_same_ssh_options_is_cached() -> None:
+    """Within the same (host, options) tuple, the cache still deduplicates."""
+    executor = SSHWindowsExecutor()
+
+    calls = []
+
+    def fake_detect(host, ssh_options, *, timeout=60):
+        calls.append(host)
+        return _arm_toolchain()
+
+    with patch(
+        "shipyard.executor.ssh_windows.detect_vs_toolchain",
+        side_effect=fake_detect,
+    ):
+        for _ in range(3):
+            executor._get_vs_toolchain(
+                host="build.example.com",
+                ssh_options=["-p1111"],
+                target_config={"windows_vs_detect": True},
+            )
+    assert len(calls) == 1

--- a/tests/executor/test_windows_toolchain.py
+++ b/tests/executor/test_windows_toolchain.py
@@ -108,6 +108,34 @@ def test_env_exports_escapes_single_quotes_in_path() -> None:
     assert "'C:/it''s/weird/vs'" in snippet
 
 
+# ── vswhere script sanity ──────────────────────────────────────────────
+
+
+def test_vswhere_script_does_not_pass_latest_flag() -> None:
+    """Regression for Codex finding on PR #5.
+
+    `-latest` returns only one install, which would defeat the
+    "prefer non-BuildTools" Where-Object filter when Build Tools is
+    the most-recently installed product. The script must enumerate
+    every install and let the filter pick.
+
+    Check the actual vswhere invocation line, not the surrounding
+    comment which is allowed to mention the flag for context.
+    """
+    from shipyard.executor.windows_toolchain import _VS_DETECT_SCRIPT
+    # Extract the actual vswhere invocation line
+    vswhere_lines = [
+        line for line in _VS_DETECT_SCRIPT.splitlines()
+        if "& $vswhere" in line
+    ]
+    assert len(vswhere_lines) == 1, f"expected one vswhere call, got: {vswhere_lines}"
+    assert "-latest" not in vswhere_lines[0]
+    assert "-products" in vswhere_lines[0]
+    assert "-format json" in vswhere_lines[0]
+    assert "vswhere.exe" in _VS_DETECT_SCRIPT
+    assert "Microsoft.VisualStudio.Product.BuildTools" in _VS_DETECT_SCRIPT
+
+
 # ── detect_vs_toolchain ─────────────────────────────────────────────────
 
 

--- a/tests/governance/test_config_extends.py
+++ b/tests/governance/test_config_extends.py
@@ -1,0 +1,91 @@
+"""Regression tests for nested `extends` chain resolution.
+
+Codex flagged that the original `_resolve_overrides_for` copied
+only the direct parent's override map without recursing into the
+parent's own `extends`, so multi-level inheritance was truncated.
+Example: `release/** → develop/** → main` would drop `main` fields
+when resolving `release/*`.
+"""
+
+from __future__ import annotations
+
+from shipyard.core.config import Config
+from shipyard.governance.config import (
+    load_governance_config,
+    resolve_branch_rules,
+)
+
+
+def _config(data: dict) -> Config:
+    return Config(data=data)
+
+
+def test_three_level_extends_chain_inherits_all_ancestors() -> None:
+    """release/** extends develop/** which extends main — all three must flow."""
+    cfg = _config({
+        "project": {"profile": "solo"},
+        "branch_protection": {
+            "main": {
+                "enforce_admins": True,                # grandparent field
+            },
+            "develop/**": {
+                "extends": "main",
+                "dismiss_stale_reviews": True,         # parent field
+            },
+            "release/**": {
+                "extends": "develop/**",
+                "require_review_count": 2,             # child field
+            },
+        },
+    })
+    gov = load_governance_config(cfg)
+    rules = resolve_branch_rules(gov, "release/v1.0")
+    # All three ancestors contribute
+    assert rules.enforce_admins is True             # from main
+    assert rules.dismiss_stale_reviews is True      # from develop/**
+    assert rules.require_review_count == 2          # from release/**
+
+
+def test_child_field_overrides_parent() -> None:
+    """The child's own override wins over an ancestor's."""
+    cfg = _config({
+        "branch_protection": {
+            "main": {"require_review_count": 1},
+            "develop/**": {
+                "extends": "main",
+                "require_review_count": 3,  # wins
+            },
+        },
+    })
+    gov = load_governance_config(cfg)
+    rules = resolve_branch_rules(gov, "develop/auth")
+    assert rules.require_review_count == 3
+
+
+def test_extends_cycle_is_broken_not_infinite() -> None:
+    """A self-referential or cyclic extends must not infinite-loop."""
+    cfg = _config({
+        "branch_protection": {
+            "a/**": {"extends": "b/**", "enforce_admins": True},
+            "b/**": {"extends": "a/**", "dismiss_stale_reviews": True},
+        },
+    })
+    gov = load_governance_config(cfg)
+    # Should terminate and not raise. The exact result of a cycle is
+    # not prescribed beyond "terminates and resolves as much as
+    # possible", but these two assertions guarantee the child's own
+    # field survives.
+    rules = resolve_branch_rules(gov, "a/feature")
+    assert rules.enforce_admins is True
+
+
+def test_extends_pointing_at_unknown_glob_is_ignored() -> None:
+    """`extends = "nonexistent"` is a no-op, not an error."""
+    cfg = _config({
+        "branch_protection": {
+            "main": {"extends": "ghost", "enforce_admins": True},
+        },
+    })
+    gov = load_governance_config(cfg)
+    rules = resolve_branch_rules(gov, "main")
+    assert rules.enforce_admins is True  # own field still applies

--- a/tests/test_cli_codex_regressions.py
+++ b/tests/test_cli_codex_regressions.py
@@ -1,0 +1,148 @@
+"""Regression tests for Codex review findings on PRs #3, #5, #8, #10.
+
+Each test pins a specific bug the Codex connector flagged during
+review so the fix doesn't silently regress.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from shipyard.cli import _check_governance_drift, _resolve_validation
+from shipyard.core.config import Config
+from shipyard.core.job import ValidationMode
+
+# ── PR #3: contract config must be read from top-level validation ─────
+
+
+def test_resolve_validation_lifts_contract_from_top_level() -> None:
+    """`[validation.contract]` must survive into the resolved mode dict.
+
+    Codex flagged that the executor reads `validation_config.get("contract")`
+    on the already-resolved `default`/`smoke` subtable, so a project
+    using the documented `[validation.contract]` layout would have
+    contract enforcement silently skipped.
+    """
+    config = Config(data={
+        "validation": {
+            "default": {"command": "pytest"},
+            "contract": {"markers": ["__PULP_VALIDATION__:smoke"]},
+        },
+    })
+    resolved = _resolve_validation(config, ValidationMode.FULL)
+    assert resolved["command"] == "pytest"
+    assert resolved["contract"] == {"markers": ["__PULP_VALIDATION__:smoke"]}
+
+
+def test_resolve_validation_lifts_prepared_state_from_top_level() -> None:
+    """Same fix covers `[validation.prepared_state]`."""
+    config = Config(data={
+        "validation": {
+            "default": {"command": "pytest"},
+            "prepared_state": {"enabled": True},
+        },
+    })
+    resolved = _resolve_validation(config, ValidationMode.FULL)
+    assert resolved["prepared_state"] == {"enabled": True}
+
+
+def test_resolve_validation_mode_override_beats_top_level() -> None:
+    """An explicit contract inside `default` overrides the top-level one."""
+    config = Config(data={
+        "validation": {
+            "default": {
+                "command": "pytest",
+                "contract": {"markers": ["inner"]},
+            },
+            "contract": {"markers": ["outer"]},
+        },
+    })
+    resolved = _resolve_validation(config, ValidationMode.FULL)
+    assert resolved["contract"] == {"markers": ["inner"]}
+
+
+def test_resolve_validation_smoke_mode_inherits_top_level() -> None:
+    """Smoke mode also lifts top-level peers."""
+    config = Config(data={
+        "validation": {
+            "smoke": {"command": "pytest -k smoke"},
+            "contract": {"markers": ["smoke"]},
+            "prepared_state": {"enabled": True},
+        },
+    })
+    resolved = _resolve_validation(config, ValidationMode.SMOKE)
+    assert resolved["command"] == "pytest -k smoke"
+    assert resolved["contract"] == {"markers": ["smoke"]}
+    assert resolved["prepared_state"] == {"enabled": True}
+
+
+# ── PR #8: doctor must NOT report "aligned" on fetch errors ────────────
+
+
+def test_doctor_governance_reports_fetch_error_not_aligned() -> None:
+    """When build_status returns errors but no drift, doctor must flag it.
+
+    Codex flagged that `has_drift` is False when every fetch failed,
+    so doctor currently emits "aligned with <profile>" even though
+    the live state was never actually read. Must treat
+    `status.has_errors` as a not-aligned path.
+    """
+    config = Config(data={
+        "project": {"profile": "solo"},
+        "governance": {"required_status_checks": ["mac"]},
+    })
+
+    from shipyard.governance.github import RepoRef
+    from shipyard.governance.status import GovernanceStatus
+
+    fake_status = GovernanceStatus(
+        repo=RepoRef("me", "r"),
+        profile_name="solo",
+        reports=(),
+        errors=("main: permission denied",),
+    )
+
+    with patch(
+        "shipyard.governance.detect_repo_from_remote",
+        return_value=RepoRef("me", "r"),
+    ), patch(
+        "shipyard.governance.build_status",
+        return_value=fake_status,
+    ):
+        section = _check_governance_drift(config)
+
+    assert section is not None
+    assert section["main"]["ok"] is False
+    assert "could not read live state" in section["main"]["detail"]
+    assert "permission denied" in section["main"]["detail"]
+
+
+def test_doctor_governance_reports_aligned_on_clean_no_drift() -> None:
+    """Sanity check — when there are no errors and no drift, aligned is OK."""
+    config = Config(data={
+        "project": {"profile": "solo"},
+        "governance": {"required_status_checks": ["mac"]},
+    })
+
+    from shipyard.governance.github import RepoRef
+    from shipyard.governance.status import GovernanceStatus
+
+    fake_status = GovernanceStatus(
+        repo=RepoRef("me", "r"),
+        profile_name="solo",
+        reports=(),
+        errors=(),
+    )
+
+    with patch(
+        "shipyard.governance.detect_repo_from_remote",
+        return_value=RepoRef("me", "r"),
+    ), patch(
+        "shipyard.governance.build_status",
+        return_value=fake_status,
+    ):
+        section = _check_governance_drift(config)
+
+    assert section is not None
+    assert section["main"]["ok"] is True
+    assert "aligned with solo profile" in section["main"]["detail"]

--- a/tests/test_cli_governance_diff.py
+++ b/tests/test_cli_governance_diff.py
@@ -1,0 +1,52 @@
+"""Regression tests for `governance diff` error handling.
+
+Codex flagged that `governance diff` iterates only `status.reports`
+and never checks `status.errors`, so a permission failure on every
+branch would still print a clean diff and exit 0. Fix: surface
+errors and exit non-zero.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from shipyard.cli import main
+from shipyard.governance.github import RepoRef
+from shipyard.governance.status import GovernanceStatus
+
+
+def _fake_status_with_errors() -> GovernanceStatus:
+    return GovernanceStatus(
+        repo=RepoRef("me", "r"),
+        profile_name="solo",
+        reports=(),
+        errors=("main: gh api timeout/missing",),
+    )
+
+
+def test_governance_diff_exits_nonzero_on_fetch_errors(tmp_path) -> None:
+    """A diff that can't read live state must NOT exit 0 with a clean report."""
+    # Minimal config in a temp .shipyard dir
+    (tmp_path / ".shipyard").mkdir()
+    (tmp_path / ".shipyard" / "config.toml").write_text(
+        '[project]\nprofile = "solo"\n'
+        '[governance]\nrequired_status_checks = ["mac"]\n'
+    )
+
+    runner = CliRunner()
+    with patch(
+        "shipyard.governance.detect_repo_from_remote",
+        return_value=RepoRef("me", "r"),
+    ), patch(
+        "shipyard.governance.build_status",
+        return_value=_fake_status_with_errors(),
+    ), runner.isolated_filesystem(temp_dir=str(tmp_path)):
+        # Inside isolated_filesystem, cwd has no .shipyard — copy it in.
+        import shutil as _shutil
+        _shutil.copytree(tmp_path / ".shipyard", ".shipyard")
+        result = runner.invoke(main, ["governance", "diff"])
+
+    assert result.exit_code == 1, result.output
+    assert "could not be read" in result.output.lower() or "timeout" in result.output.lower()


### PR DESCRIPTION
## Summary

Codex connector surfaced seven legitimate issues across the recent Phase 5/6 PRs. All fixed in one change because they share a release cycle (all land in v0.1.5) and several share test infrastructure.

## P1 — correctness bugs

| # | Issue | Fix |
|---|-------|-----|
| #3 | \`[validation.contract]\` silently ignored because executors read from already-resolved \`default\`/\`smoke\` subtable | \`_resolve_validation()\` now lifts top-level \`contract\` and \`prepared_state\` peers into the returned mode dict; mode-specific overrides still win |
| #8 | Doctor reports \`✓ main aligned\` when gh fetch fails because \`has_drift\` is False with empty reports | Treat \`status.has_errors\` as not-aligned path; doctor's \`ready\` rollup now includes Governance section, so \`doctor --json\` cannot report \`ready: true\` with drift or fetch errors |
| #8 | \`governance diff\` silently drops branches that fail live fetch | Surface \`status.errors\`, exit 1 on any fetch failure |

## P2 — robustness bugs

| # | Issue | Fix |
|---|-------|-----|
| #5 | vswhere \`-latest\` returns only one install, defeating the "prefer non-BuildTools" \`Where-Object\` filter | Drop \`-latest\`, enumerate all installs, sort by \`installDate\` descending, then filter |
| #5 | VS toolchain cache keyed by host only — same hostname with different ssh_options shares cache | Cache key is \`(host, tuple(ssh_options))\` |
| #8 | \`extends\` chain only one level deep — \`release/** → develop/** → main\` drops \`main\` fields | Recursive \`_flatten_extends_chain\` with visited-set cycle guard |
| #10 | README claimed doctor gives single pass/fail, but \`ready\` excluded governance | Fix #8 above makes the claim true |

## README restructure: "What Makes It Different" vs "Features"

Per the user's feedback: most of the original "What Makes It Different" bullets are table-stakes for a modern CI tool, not actual differentiators. Trimmed to the four things indie developers genuinely can't wire up easily on their own:

1. **Safe real cross-platform CI for AI agents** — Claude Code plugin + Codex installer. Agents don't need the keys to signing / notarization / publishing.
2. **Declarative security & governance** — Astral-inspired hardening packaged as one TOML line + one CLI command.
3. **Evidence-based merge gate** — exact SHA proof, not "latest run".
4. **Parallel-agent-aware queue** — worktree-safe supersedence GitHub Actions can't match.

Everything else (fail-fast, targeted reruns, stage resume, transient retry, ecosystem detection, JSON output, target profiles, cleanup) moved into a bulleted **Features** list. Net: stronger pitch at the top, same details below for readers who want them.

## Tests

**14 new regression tests:**
- 6 for \`_resolve_validation\` + doctor error handling (PR #3, #8)
- 1 for \`governance diff\` exits non-zero on errors (PR #8)
- 4 for \`extends\` chain (three-level, child override, cycle guard, unknown parent) (PR #8)
- 2 for VS cache keying by (host, ssh_options) (PR #5)
- 1 for vswhere script no longer passing \`-latest\` (PR #5)

**Full suite: 406 passing** (was 392; +14 regressions).

Re-dogfooded against Pulp main: \`shipyard governance status\` still reports "aligned with profile", \`doctor\` still reports "ready".

## Test plan

- [x] \`ruff check\` clean
- [x] \`mypy\` clean
- [x] \`pytest tests/\` — 406/406
- [x] \`shipyard governance status\` against Pulp — zero drift
- [x] \`shipyard doctor\` — Governance section reports ✓
- [ ] CI matrix on this PR
- [ ] Tag v0.1.5 (fixes + Phase 6 follow-ups) after merge