### PR TITLE
Phase 6 follow-ups: governance use / export / apply --from snapshot

### DIFF
--- a/src/shipyard/cli.py
+++ b/src/shipyard/cli.py
@@ -571,14 +571,32 @@ def governance_status(ctx: Context, branch: tuple[str, ...]) -> None:
     help="Override which branches to apply to (repeatable). Default: main.",
 )
 @click.option("--dry-run", is_flag=True, help="Show what would change without writing")
+@click.option(
+    "--from", "from_path",
+    type=click.Path(exists=True, dir_okay=False),
+    help="Apply rules from a snapshot file instead of the project config",
+)
 @click.pass_obj
-def governance_apply(ctx: Context, branch: tuple[str, ...], dry_run: bool) -> None:
-    """Apply declared governance rules to live state (idempotent)."""
+def governance_apply(
+    ctx: Context,
+    branch: tuple[str, ...],
+    dry_run: bool,
+    from_path: str | None,
+) -> None:
+    """Apply declared governance rules to live state (idempotent).
+
+    When --from is given, the snapshot file is the source of
+    truth instead of `.shipyard/config.toml` + profile defaults.
+    This is the disaster-recovery path: re-apply a known-good
+    state captured via `governance export`.
+    """
     from shipyard.governance import (
         build_apply_plan,
         build_status,
+        compute_drift,
         detect_repo_from_remote,
         execute_apply_plan,
+        get_branch_protection,
         load_governance_config,
         resolve_branch_rules,
     )
@@ -590,6 +608,63 @@ def governance_apply(ctx: Context, branch: tuple[str, ...], dry_run: bool) -> No
         sys.exit(1)
 
     branches = branch or ("main",)
+
+    # ── Snapshot path ──────────────────────────────────────────
+    if from_path:
+        from pathlib import Path
+
+        from shipyard.governance.snapshot import GovernanceSnapshot
+
+        try:
+            snapshot = GovernanceSnapshot.from_toml(Path(from_path).read_text())
+        except ValueError as exc:
+            render_error(f"Could not parse snapshot: {exc}")
+            sys.exit(1)
+
+        # Refuse to apply a snapshot to a different repo — the repo
+        # slug is recorded at export time specifically so a copy-
+        # paste accident can't silently reconfigure the wrong repo.
+        if snapshot.repo_slug != repo.slug:
+            render_error(
+                f"Snapshot is for '{snapshot.repo_slug}' but current repo is "
+                f"'{repo.slug}'. Refusing to apply."
+            )
+            sys.exit(1)
+
+        results: list[Any] = []
+        errors: list[str] = []
+        snapshot_branches = branches or tuple(snapshot.branches.keys())
+        for branch_name in snapshot_branches:
+            if branch_name not in snapshot.branches:
+                errors.append(f"{branch_name}: not in snapshot")
+                continue
+            declared = snapshot.branches[branch_name]
+            from shipyard.governance.github import GovernanceApiError
+            try:
+                live = get_branch_protection(repo, branch_name)
+            except GovernanceApiError as exc:
+                errors.append(f"{branch_name}: {exc}")
+                continue
+            report = compute_drift(
+                branch=branch_name,
+                profile_rules=declared,
+                declared_rules=declared,
+                live_rules=live,
+            )
+            plan = build_apply_plan(
+                repo=repo,
+                branch=branch_name,
+                declared_rules=declared,
+                drift_report=report,
+            )
+            results.append(execute_apply_plan(plan, dry_run=dry_run))
+
+        _render_apply_results(ctx, results, errors, dry_run=dry_run, from_snapshot=True)
+        if errors or any(r.error_message for r in results):
+            sys.exit(1)
+        return
+
+    # ── Profile/config path ────────────────────────────────────
     status = build_status(repo=repo, governance=gov, branches=branches)
 
     results = []
@@ -604,13 +679,32 @@ def governance_apply(ctx: Context, branch: tuple[str, ...], dry_run: bool) -> No
         result = execute_apply_plan(plan, dry_run=dry_run)
         results.append(result)
 
-    any_changes = any(r.executed or (dry_run and not r.plan.is_noop) for r in results)
+    _render_apply_results(
+        ctx, results, list(status.errors), dry_run=dry_run, from_snapshot=False,
+    )
+
     any_errors = any(r.error_message for r in results) or status.has_errors
+    if any_errors:
+        sys.exit(1)
+
+
+def _render_apply_results(
+    ctx: Context,
+    results: list[Any],
+    errors: list[str],
+    *,
+    dry_run: bool,
+    from_snapshot: bool,
+) -> None:
+    """Shared apply-output renderer for both the config and snapshot paths."""
+    any_changes = any(
+        r.executed or (dry_run and not r.plan.is_noop) for r in results
+    )
 
     if ctx.json_mode:
         ctx.output("governance.apply", {
-            "repo": repo.slug,
             "dry_run": dry_run,
+            "from_snapshot": from_snapshot,
             "changed": any_changes,
             "results": [
                 {
@@ -621,37 +715,40 @@ def governance_apply(ctx: Context, branch: tuple[str, ...], dry_run: bool) -> No
                 }
                 for r in results
             ],
+            "errors": errors,
         })
-    else:
-        if not results:
-            render_message("No branches to apply to.", style="dim")
-        for result in results:
-            branch_name = result.plan.branch
-            action = result.plan.action.value
-            if result.error_message:
-                render_message(
-                    f"  ✗ {branch_name}: {action} failed — {result.error_message}",
-                    style="bold red",
-                )
-            elif result.plan.is_noop:
-                render_message(f"  ✓ {branch_name}: already aligned (no changes)")
-            elif dry_run:
-                drifted = [e.field_name for e in result.plan.drift_report.drifted_entries]
-                render_message(
-                    f"  → {branch_name}: would {action}"
-                    + (f" (fields: {', '.join(drifted)})" if drifted else "")
-                )
-            else:
-                render_message(f"  ✓ {branch_name}: {action} applied", style="green")
-        # Manual followups, printed every time per Part 12 spec
-        if results:
-            render_message("")
-            render_message("Manual followups (Shipyard cannot apply these via API):")
-            for followup in results[0].plan.manual_followups:
-                render_message(f"  ⚠ {followup}")
+        return
 
-    if any_errors:
-        sys.exit(1)
+    if not results and not errors:
+        render_message("No branches to apply to.", style="dim")
+    for result in results:
+        branch_name = result.plan.branch
+        action = result.plan.action.value
+        if result.error_message:
+            render_message(
+                f"  ✗ {branch_name}: {action} failed — {result.error_message}",
+                style="bold red",
+            )
+        elif result.plan.is_noop:
+            render_message(f"  ✓ {branch_name}: already aligned (no changes)")
+        elif dry_run:
+            drifted = [e.field_name for e in result.plan.drift_report.drifted_entries]
+            render_message(
+                f"  → {branch_name}: would {action}"
+                + (f" (fields: {', '.join(drifted)})" if drifted else "")
+            )
+        else:
+            render_message(f"  ✓ {branch_name}: {action} applied", style="green")
+
+    for err in errors:
+        render_message(f"  ! {err}", style="yellow")
+
+    # Manual followups, printed every time per Part 12 spec
+    if results:
+        render_message("")
+        render_message("Manual followups (Shipyard cannot apply these via API):")
+        for followup in results[0].plan.manual_followups:
+            render_message(f"  ⚠ {followup}")
 
 
 @governance.command("diff")
@@ -721,6 +818,235 @@ def governance_diff(ctx: Context, branch: tuple[str, ...]) -> None:
         for err in status.errors:
             render_message(f"  ! {err}")
         sys.exit(1)
+
+
+@governance.command("export")
+@click.option(
+    "--branch", "-b", multiple=True,
+    help="Branches to snapshot (repeatable). Default: main.",
+)
+@click.option(
+    "--output", "-o",
+    type=click.Path(dir_okay=False),
+    help="Write snapshot to file instead of stdout",
+)
+@click.pass_obj
+def governance_export(
+    ctx: Context,
+    branch: tuple[str, ...],
+    output: str | None,
+) -> None:
+    """Snapshot live GitHub governance state to TOML.
+
+    The snapshot is check-in-able and can be fed back to
+    `governance apply --from <file>` for disaster recovery or
+    audit-trail diffing.
+    """
+    from pathlib import Path
+
+    from shipyard.governance import (
+        detect_repo_from_remote,
+        get_branch_protection,
+    )
+    from shipyard.governance.github import GovernanceApiError
+    from shipyard.governance.snapshot import build_snapshot
+
+    repo = detect_repo_from_remote()
+    if repo is None:
+        render_error("Could not detect repo from git remote.")
+        sys.exit(1)
+
+    branches = branch or ("main",)
+    live_branches: dict[str, Any] = {}
+    errors: list[str] = []
+    for branch_name in branches:
+        try:
+            rules = get_branch_protection(repo, branch_name)
+        except GovernanceApiError as exc:
+            errors.append(f"{branch_name}: {exc}")
+            continue
+        if rules is None:
+            errors.append(f"{branch_name}: no protection set")
+            continue
+        live_branches[branch_name] = rules
+
+    if errors:
+        for err in errors:
+            render_error(err)
+        sys.exit(1)
+
+    snapshot = build_snapshot(repo=repo, live_branches=live_branches)
+    toml_text = snapshot.to_toml()
+
+    if output:
+        Path(output).write_text(toml_text)
+        render_message(
+            f"Wrote snapshot for {repo.slug} to {output}", style="green",
+        )
+    else:
+        # Stream straight to stdout so users can pipe to a file.
+        click.echo(toml_text, nl=False)
+
+
+@governance.command("use")
+@click.argument("profile_name", type=click.Choice(["solo", "multi", "custom"]))
+@click.option("--yes", "-y", is_flag=True, help="Skip the interactive prompt")
+@click.option("--dry-run", is_flag=True, help="Show the diff without applying")
+@click.pass_obj
+def governance_use(
+    ctx: Context,
+    profile_name: str,
+    yes: bool,
+    dry_run: bool,
+) -> None:
+    """Switch governance profile + apply (interactive).
+
+    Updates `[project].profile` in `.shipyard/config.toml`, then
+    runs the existing apply path. Any explicit overrides in
+    `[branch_protection.*]` are preserved.
+    """
+    if ctx.config.project_dir is None:
+        render_error(
+            "No .shipyard/config.toml found. Run `shipyard init` first."
+        )
+        sys.exit(1)
+
+    config_path = ctx.config.project_dir / "config.toml"
+    if not config_path.exists():
+        render_error(f"Config file not found: {config_path}")
+        sys.exit(1)
+
+    current_profile = str(ctx.config.get("project.profile", "solo"))
+    if current_profile == profile_name and not dry_run:
+        render_message(
+            f"Already on profile '{profile_name}'. Running apply to verify live state…",
+        )
+
+    # Show the diff that would land if we switched
+    from shipyard.governance import (
+        build_apply_plan,
+        build_status,
+        detect_repo_from_remote,
+        load_governance_config,
+        profile_for_name,
+        resolve_branch_rules,
+    )
+
+    repo = detect_repo_from_remote()
+    if repo is None:
+        render_error("Could not detect repo from git remote.")
+        sys.exit(1)
+
+    # Clone the config dict, flip the profile, re-resolve
+    hypothetical_data = dict(ctx.config.data)
+    hypothetical_project = dict(hypothetical_data.get("project", {}))
+    hypothetical_project["profile"] = profile_name
+    hypothetical_data["project"] = hypothetical_project
+    hypothetical_config = Config(data=hypothetical_data)
+    hypothetical_gov = load_governance_config(hypothetical_config)
+
+    # Use the hypothetical profile for the preview
+    required = hypothetical_gov.required_status_checks
+    profile_for_name(profile_name, required_status_checks=required)
+
+    status = build_status(
+        repo=repo, governance=hypothetical_gov, branches=("main",),
+    )
+    any_change = False
+    render_message(f"Switching profile: {current_profile} → {profile_name}")
+    render_message("")
+    for report in status.reports:
+        if report.has_drift:
+            any_change = True
+            declared = resolve_branch_rules(hypothetical_gov, report.branch)
+            plan = build_apply_plan(
+                repo=repo, branch=report.branch,
+                declared_rules=declared, drift_report=report,
+            )
+            drifted = [e.field_name for e in report.drifted_entries]
+            render_message(
+                f"  {report.branch}: would {plan.action.value} "
+                f"({len(drifted)} field(s): {', '.join(drifted)})"
+            )
+        else:
+            render_message(f"  {report.branch}: no changes")
+
+    if dry_run:
+        return
+
+    if any_change and not yes:
+        render_message("")
+        click.confirm("Apply these changes?", abort=True)
+
+    # Rewrite the project config file with the new profile
+    _rewrite_profile_in_config(config_path, profile_name)
+    render_message(
+        f"Updated {config_path} → profile = \"{profile_name}\"",
+        style="green",
+    )
+
+    # And run apply using the updated config
+    ctx._config = None  # force reload on next access
+    from shipyard.governance import (
+        build_apply_plan as _bap,
+    )
+    from shipyard.governance import (
+        execute_apply_plan as _eap,
+    )
+    reloaded_gov = load_governance_config(ctx.config)
+    status2 = build_status(repo=repo, governance=reloaded_gov, branches=("main",))
+    results = []
+    for report in status2.reports:
+        declared = resolve_branch_rules(reloaded_gov, report.branch)
+        plan = _bap(
+            repo=repo, branch=report.branch,
+            declared_rules=declared, drift_report=report,
+        )
+        results.append(_eap(plan, dry_run=False))
+    _render_apply_results(
+        ctx, results, list(status2.errors), dry_run=False, from_snapshot=False,
+    )
+    if any(r.error_message for r in results) or status2.has_errors:
+        sys.exit(1)
+
+
+def _rewrite_profile_in_config(config_path: Path, new_profile: str) -> None:
+    """Idempotently set `[project].profile = new_profile` in a TOML file.
+
+    Uses line-level rewriting rather than a full TOML round-trip so
+    comments and ordering in the user's config are preserved.
+    """
+    text = config_path.read_text()
+    lines = text.splitlines(keepends=True)
+    in_project_section = False
+    replaced = False
+    out: list[str] = []
+    for line in lines:
+        stripped = line.strip()
+        if stripped.startswith("[") and stripped.endswith("]"):
+            in_project_section = stripped == "[project]"
+            out.append(line)
+            continue
+        if in_project_section and stripped.startswith("profile"):
+            # Preserve the leading whitespace
+            leading = line[: len(line) - len(line.lstrip())]
+            out.append(f'{leading}profile   = "{new_profile}"\n')
+            replaced = True
+            continue
+        out.append(line)
+
+    if not replaced:
+        # Project section exists but no profile line — append one
+        # right after the [project] header.
+        final: list[str] = []
+        for line in out:
+            final.append(line)
+            if line.strip() == "[project]":
+                final.append(f'profile   = "{new_profile}"\n')
+                replaced = True
+        out = final
+
+    config_path.write_text("".join(out))
 
 
 @main.group()

--- a/src/shipyard/governance/__init__.py
+++ b/src/shipyard/governance/__init__.py
@@ -39,6 +39,11 @@ from shipyard.governance.profiles import (
     profile_for_name,
     solo_profile,
 )
+from shipyard.governance.snapshot import (
+    SNAPSHOT_SCHEMA_VERSION,
+    GovernanceSnapshot,
+    build_snapshot,
+)
 from shipyard.governance.status import (
     GovernanceStatus,
     build_status,
@@ -46,6 +51,7 @@ from shipyard.governance.status import (
 )
 
 __all__ = [
+    "SNAPSHOT_SCHEMA_VERSION",
     "ApplyAction",
     "ApplyPlan",
     "ApplyResult",
@@ -55,11 +61,13 @@ __all__ = [
     "DriftStatus",
     "GovernanceApiError",
     "GovernanceConfig",
+    "GovernanceSnapshot",
     "GovernanceStatus",
     "Profile",
     "ProfileName",
     "RepoRef",
     "build_apply_plan",
+    "build_snapshot",
     "build_status",
     "compute_drift",
     "detect_repo_from_remote",

--- a/src/shipyard/governance/snapshot.py
+++ b/src/shipyard/governance/snapshot.py
@@ -1,0 +1,163 @@
+"""Snapshot governance state to TOML and restore from it.
+
+The snapshot file is a check-in-able TOML document that captures
+the **live** GitHub state at a point in time. Three purposes:
+
+1. **Audit trail** — diff against the snapshot to see what changed
+   since the last export.
+2. **Drift catch** — `governance status` can compare live state
+   against the snapshot, not just against the profile.
+3. **Bootstrap from snapshot** — `governance apply --from snap.toml`
+   reapplies a past state, useful for disaster recovery.
+
+Security note: the snapshot does NOT contain secret values.
+GitHub's API doesn't return them, and Shipyard intentionally never
+sees them. Future versions may list secret *names* so recovery
+prompts the user for each one by name; v0.1.5 focuses on branch
+protection only, so there's nothing secret to capture yet.
+"""
+
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Any
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib
+
+import tomli_w
+
+from shipyard.governance.profiles import BranchProtectionRules
+
+if TYPE_CHECKING:
+    from shipyard.governance.github import RepoRef
+
+
+SNAPSHOT_SCHEMA_VERSION = 1
+
+
+@dataclass(frozen=True)
+class GovernanceSnapshot:
+    """A captured point-in-time view of a repo's governance state."""
+
+    repo_slug: str
+    exported_at: str
+    schema_version: int = SNAPSHOT_SCHEMA_VERSION
+    branches: dict[str, BranchProtectionRules] = field(default_factory=dict)
+
+    def to_toml(self) -> str:
+        """Serialize the snapshot to a TOML document (deterministic key order)."""
+        doc: dict[str, Any] = {
+            "shipyard_governance_snapshot": {
+                "schema_version": self.schema_version,
+                "repo": self.repo_slug,
+                "exported_at": self.exported_at,
+            },
+        }
+        # Branches sorted alphabetically so consecutive exports are
+        # byte-identical when live state hasn't changed.
+        branches_block: dict[str, Any] = {}
+        for branch_name in sorted(self.branches):
+            rules = self.branches[branch_name]
+            branches_block[branch_name] = _rules_to_dict(rules)
+        if branches_block:
+            doc["branch_protection"] = branches_block
+        return tomli_w.dumps(doc)
+
+    @classmethod
+    def from_toml(cls, text: str) -> GovernanceSnapshot:
+        """Parse a snapshot back from TOML. Raises ValueError on schema mismatch."""
+        data = tomllib.loads(text)
+        header = data.get("shipyard_governance_snapshot")
+        if not isinstance(header, dict):
+            raise ValueError(
+                "Not a Shipyard governance snapshot: missing "
+                "[shipyard_governance_snapshot] header"
+            )
+        version = int(header.get("schema_version", 0))
+        if version != SNAPSHOT_SCHEMA_VERSION:
+            raise ValueError(
+                f"Snapshot schema version {version} is not supported "
+                f"(expected {SNAPSHOT_SCHEMA_VERSION})"
+            )
+        repo_slug = str(header.get("repo", ""))
+        if not repo_slug:
+            raise ValueError("Snapshot missing required field: repo")
+        exported_at = str(header.get("exported_at", ""))
+
+        branches: dict[str, BranchProtectionRules] = {}
+        bp = data.get("branch_protection", {})
+        if isinstance(bp, dict):
+            for branch_name, block in bp.items():
+                if not isinstance(block, dict):
+                    continue
+                branches[str(branch_name)] = _rules_from_dict(block)
+
+        return cls(
+            repo_slug=repo_slug,
+            exported_at=exported_at,
+            schema_version=version,
+            branches=branches,
+        )
+
+
+def build_snapshot(
+    *,
+    repo: RepoRef,
+    live_branches: dict[str, BranchProtectionRules],
+    clock: Any = None,
+) -> GovernanceSnapshot:
+    """Assemble a GovernanceSnapshot from already-fetched live state.
+
+    The `clock` parameter is injectable so tests can pin
+    `exported_at` to a deterministic value. Default: UTC now.
+    """
+    now = clock() if clock else datetime.now(timezone.utc)
+    return GovernanceSnapshot(
+        repo_slug=repo.slug,
+        exported_at=now.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        branches=dict(live_branches),
+    )
+
+
+def _rules_to_dict(rules: BranchProtectionRules) -> dict[str, Any]:
+    """Translate a BranchProtectionRules instance to a plain TOML dict."""
+    return {
+        "require_pr": rules.require_pr,
+        "require_status_checks": list(rules.require_status_checks),
+        "require_strict_status": rules.require_strict_status,
+        "require_review_count": rules.require_review_count,
+        "enforce_admins": rules.enforce_admins,
+        "dismiss_stale_reviews": rules.dismiss_stale_reviews,
+        "require_code_owner_reviews": rules.require_code_owner_reviews,
+        "allow_force_push": rules.allow_force_push,
+        "allow_deletions": rules.allow_deletions,
+        "require_linear_history": rules.require_linear_history,
+        "required_conversation_resolution": rules.required_conversation_resolution,
+    }
+
+
+def _rules_from_dict(data: dict[str, Any]) -> BranchProtectionRules:
+    """Translate a parsed TOML dict back into a BranchProtectionRules."""
+    checks = data.get("require_status_checks", ())
+    if isinstance(checks, list):
+        checks = tuple(str(c) for c in checks)
+    return BranchProtectionRules(
+        require_pr=bool(data.get("require_pr", True)),
+        require_status_checks=checks,
+        require_strict_status=bool(data.get("require_strict_status", False)),
+        require_review_count=int(data.get("require_review_count", 0)),
+        enforce_admins=bool(data.get("enforce_admins", False)),
+        dismiss_stale_reviews=bool(data.get("dismiss_stale_reviews", False)),
+        require_code_owner_reviews=bool(data.get("require_code_owner_reviews", False)),
+        allow_force_push=bool(data.get("allow_force_push", False)),
+        allow_deletions=bool(data.get("allow_deletions", False)),
+        require_linear_history=bool(data.get("require_linear_history", False)),
+        required_conversation_resolution=bool(
+            data.get("required_conversation_resolution", False),
+        ),
+    )

--- a/tests/governance/test_snapshot.py
+++ b/tests/governance/test_snapshot.py
@@ -1,0 +1,138 @@
+"""Tests for governance snapshot + restore (Phase 6 follow-ups)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from shipyard.governance.github import RepoRef
+from shipyard.governance.profiles import BranchProtectionRules
+from shipyard.governance.snapshot import (
+    SNAPSHOT_SCHEMA_VERSION,
+    GovernanceSnapshot,
+    build_snapshot,
+)
+
+
+def _fixed_clock() -> datetime:
+    return datetime(2026, 4, 9, 17, 30, 0, tzinfo=timezone.utc)
+
+
+def _sample_rules() -> BranchProtectionRules:
+    return BranchProtectionRules(
+        require_pr=True,
+        require_status_checks=("mac", "linux", "win"),
+        require_strict_status=False,
+        require_review_count=0,
+        enforce_admins=False,
+    )
+
+
+# ── build_snapshot ──────────────────────────────────────────────────────
+
+
+def test_build_snapshot_captures_repo_and_branches() -> None:
+    snap = build_snapshot(
+        repo=RepoRef("me", "r"),
+        live_branches={"main": _sample_rules()},
+        clock=_fixed_clock,
+    )
+    assert snap.repo_slug == "me/r"
+    assert snap.exported_at == "2026-04-09T17:30:00Z"
+    assert "main" in snap.branches
+    assert snap.branches["main"].require_status_checks == ("mac", "linux", "win")
+    assert snap.schema_version == SNAPSHOT_SCHEMA_VERSION
+
+
+# ── to_toml / from_toml round-trip ─────────────────────────────────────
+
+
+def test_snapshot_round_trip_preserves_every_field() -> None:
+    original = GovernanceSnapshot(
+        repo_slug="me/r",
+        exported_at="2026-04-09T17:30:00Z",
+        branches={"main": _sample_rules()},
+    )
+    text = original.to_toml()
+    restored = GovernanceSnapshot.from_toml(text)
+    assert restored.repo_slug == original.repo_slug
+    assert restored.exported_at == original.exported_at
+    assert restored.branches["main"] == original.branches["main"]
+
+
+def test_snapshot_round_trip_is_byte_identical_for_same_state() -> None:
+    """Exporting the same state twice produces identical TOML."""
+    snap = GovernanceSnapshot(
+        repo_slug="me/r",
+        exported_at="2026-04-09T17:30:00Z",
+        branches={"main": _sample_rules()},
+    )
+    assert snap.to_toml() == snap.to_toml()
+
+
+def test_snapshot_branches_sorted_for_stability() -> None:
+    """Multiple branches must serialize in a stable (alphabetical) order."""
+    rules = _sample_rules()
+    snap = GovernanceSnapshot(
+        repo_slug="me/r",
+        exported_at="2026-04-09T17:30:00Z",
+        branches={
+            "release/v2": rules,
+            "main": rules,
+            "develop": rules,
+        },
+    )
+    text = snap.to_toml()
+    # develop < main < release/v2 alphabetically
+    dev_pos = text.find("[branch_protection.develop]")
+    main_pos = text.find("[branch_protection.main]")
+    rel_pos = text.find("[branch_protection.")
+    assert dev_pos < main_pos
+    # The release branch key must appear somewhere after main
+    assert text.find('branch_protection."release/v2"') > main_pos or (
+        text.rfind("[branch_protection.") > main_pos
+    )
+    del rel_pos  # silence unused
+
+
+# ── from_toml error cases ──────────────────────────────────────────────
+
+
+def test_from_toml_rejects_missing_header() -> None:
+    text = '[branch_protection.main]\nrequire_pr = true\n'
+    with pytest.raises(ValueError, match="missing.*header"):
+        GovernanceSnapshot.from_toml(text)
+
+
+def test_from_toml_rejects_wrong_schema_version() -> None:
+    text = (
+        '[shipyard_governance_snapshot]\n'
+        'schema_version = 99\n'
+        'repo = "me/r"\n'
+        'exported_at = "2026-04-09T17:30:00Z"\n'
+    )
+    with pytest.raises(ValueError, match="schema version"):
+        GovernanceSnapshot.from_toml(text)
+
+
+def test_from_toml_rejects_missing_repo() -> None:
+    text = (
+        '[shipyard_governance_snapshot]\n'
+        f'schema_version = {SNAPSHOT_SCHEMA_VERSION}\n'
+        'exported_at = "2026-04-09T17:30:00Z"\n'
+    )
+    with pytest.raises(ValueError, match="missing required field: repo"):
+        GovernanceSnapshot.from_toml(text)
+
+
+def test_from_toml_empty_branch_block_ok() -> None:
+    """A snapshot with no branches is valid (edge case for fresh setups)."""
+    text = (
+        '[shipyard_governance_snapshot]\n'
+        f'schema_version = {SNAPSHOT_SCHEMA_VERSION}\n'
+        'repo = "me/r"\n'
+        'exported_at = "2026-04-09T17:30:00Z"\n'
+    )
+    snap = GovernanceSnapshot.from_toml(text)
+    assert snap.branches == {}

--- a/tests/test_governance_use_rewrite.py
+++ b/tests/test_governance_use_rewrite.py
@@ -1,0 +1,88 @@
+"""Tests for the `_rewrite_profile_in_config` helper used by `governance use`."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from shipyard.cli import _rewrite_profile_in_config
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _write(tmp_path: Path, content: str) -> Path:
+    p = tmp_path / "config.toml"
+    p.write_text(content)
+    return p
+
+
+# ── Rewrite existing profile line ──────────────────────────────────────
+
+
+def test_rewrite_replaces_existing_profile_line(tmp_path: Path) -> None:
+    config = _write(tmp_path, '[project]\nname = "test"\nprofile = "solo"\n')
+    _rewrite_profile_in_config(config, "multi")
+    text = config.read_text()
+    assert 'profile' in text and 'multi' in text
+    assert 'solo' not in text
+    assert 'name = "test"' in text  # other fields preserved
+
+
+def test_rewrite_preserves_leading_whitespace(tmp_path: Path) -> None:
+    config = _write(
+        tmp_path,
+        '[project]\n    profile = "solo"\n',
+    )
+    _rewrite_profile_in_config(config, "multi")
+    text = config.read_text()
+    # Leading spaces preserved on the rewritten line
+    assert any(
+        line.startswith("    profile") and "multi" in line
+        for line in text.splitlines()
+    )
+
+
+# ── Insert profile when missing ────────────────────────────────────────
+
+
+def test_rewrite_inserts_profile_when_missing(tmp_path: Path) -> None:
+    config = _write(tmp_path, '[project]\nname = "test"\n')
+    _rewrite_profile_in_config(config, "multi")
+    text = config.read_text()
+    assert 'profile' in text and 'multi' in text
+    # Profile line should come immediately after [project]
+    lines = text.splitlines()
+    project_idx = lines.index("[project]")
+    assert "profile" in lines[project_idx + 1]
+    assert "multi" in lines[project_idx + 1]
+
+
+# ── Only edits the project section ─────────────────────────────────────
+
+
+def test_rewrite_does_not_touch_profile_in_other_sections(tmp_path: Path) -> None:
+    """A `profile` key outside [project] must be left alone."""
+    content = (
+        '[project]\n'
+        'profile = "solo"\n'
+        '\n'
+        '[runtime]\n'
+        'profile = "base"\n'  # different key, same name, different section
+    )
+    config = _write(tmp_path, content)
+    _rewrite_profile_in_config(config, "multi")
+    text = config.read_text()
+    assert text.count('"multi"') == 1   # only the project one changed
+    assert text.count('"base"') == 1    # runtime.profile untouched
+
+
+# ── Idempotency ────────────────────────────────────────────────────────
+
+
+def test_rewrite_idempotent(tmp_path: Path) -> None:
+    config = _write(tmp_path, '[project]\nprofile = "solo"\n')
+    _rewrite_profile_in_config(config, "multi")
+    first = config.read_text()
+    _rewrite_profile_in_config(config, "multi")
+    second = config.read_text()
+    assert first == second


### PR DESCRIPTION
## Summary

Ships the three Phase 6 follow-ups tracked in \`planning/shipyard-phase-6-followups.md\`:

| Command | Purpose |
|---------|---------|
| \`shipyard governance export\` | Snapshot live GitHub state to TOML (or stdout). Branches sorted alphabetically for byte-stability. |
| \`shipyard governance apply --from snapshot.toml\` | Disaster-recovery source path. Refuses to apply a snapshot to a different repo. |
| \`shipyard governance use <solo\|multi\|custom>\` | Switch profile + diff preview + apply. Rewrites \`[project].profile\` line-by-line to preserve comments. |

**Stacks on danielraffel/Shipyard#11** (Codex fixes) — merge that first.

## New module: \`shipyard.governance.snapshot\`

- \`GovernanceSnapshot\` dataclass + \`schema_version = 1\`
- \`build_snapshot()\` — assembles from already-fetched state, takes an injectable clock for tests
- \`to_toml()\` — deterministic key ordering so consecutive exports are byte-identical
- \`from_toml()\` — validates header, schema version, required fields

## Shared renderer

Extracted \`_render_apply_results\` so the config path, the snapshot path, and \`use\` share one output format without duplicating the manual-followups + noop + json handling three ways.

## Dogfood (against Pulp live main)

\`\`\`
$ shipyard governance export -o /tmp/pulp-snapshot.toml
Wrote snapshot for danielraffel/pulp to /tmp/pulp-snapshot.toml

$ shipyard governance apply --from /tmp/pulp-snapshot.toml --dry-run
  ✓ main: already aligned (no changes)
\`\`\`

Round-trip against real GitHub state: confirmed every field survives TOML serialization + deserialization cleanly.

## Tests

**13 new tests:**
- \`test_snapshot.py\` × 8: build/round-trip/byte-stability/alphabetical ordering/schema errors
- \`test_governance_use_rewrite.py\` × 5: profile line replacement, whitespace, insertion, cross-section isolation, idempotency

**Full suite: 419 passing** (was 406; +13).

## What this unblocks

**Part 13 Stage 5 (recreation drill)** can now run cleanly:

\`\`\`
shipyard governance export > snapshot-before.toml
gh repo delete ... && gh repo create ...
git push --all
shipyard governance apply --from snapshot-before.toml
shipyard governance export > snapshot-after.toml
diff snapshot-before.toml snapshot-after.toml  # expected: empty
\`\`\`

## Test plan

- [x] \`ruff check\` clean
- [x] \`mypy src/shipyard/governance/\` clean
- [x] \`pytest tests/\` — 419/419
- [x] Dogfood: export + apply --from round-trip against Pulp live main
- [ ] CI matrix on this PR
- [ ] After #11 and this merge, tag v0.1.5