### PR TITLE
Release v0.1.5: Codex fixes + Phase 6 follow-ups

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "shipyard"
-version = "0.1.4"
+version = "0.1.5"
 description = "Cross-platform CI coordination — local VMs, SSH hosts, cloud runners"
 readme = "README.md"
 license = "MIT"

--- a/src/shipyard/__init__.py
+++ b/src/shipyard/__init__.py
@@ -1,3 +1,3 @@
 """Shipyard — Cross-platform CI coordination."""
 
-__version__ = "0.1.4"
+__version__ = "0.1.5"


### PR DESCRIPTION
## Summary

Merges #11 (Codex fixes) and #12 (Phase 6 follow-ups) into one release.

### What ships

**Fixes (3 P1 + 4 P2 from Codex review):**
- Contract markers at \`[validation.contract]\` now actually enforce
- Doctor + \`governance diff\` no longer report false-green on gh fetch errors
- vswhere's "prefer non-BuildTools" filter actually picks the right install
- VS toolchain cache keyed on \`(host, ssh_options)\` not just host
- \`extends\` chain is fully recursive with cycle guard
- README restructured: four genuine differentiators up top, features moved to a bulleted list

**New commands:**
- \`shipyard governance export\` — snapshot live state to TOML
- \`shipyard governance apply --from <snapshot>\` — restore path
- \`shipyard governance use <profile>\` — switch profile + apply

**Tests:** 419 passing (was 392 at v0.1.4).

### Dogfood

\`\`\`
$ shipyard governance export -o /tmp/pulp-snapshot.toml
Wrote snapshot for danielraffel/pulp to /tmp/pulp-snapshot.toml

$ shipyard governance apply --from /tmp/pulp-snapshot.toml --dry-run
  ✓ main: already aligned (no changes)
\`\`\`

Full round-trip against Pulp's real GitHub state — every field serialises and deserialises cleanly.

## Test plan

- [x] Full suite green on macOS/Linux/Windows (#11 + #12 already merged green)
- [x] Dogfood export + apply --from against Pulp live main
- [ ] Merge this PR, tag v0.1.5, publish release
- [ ] Bump Pulp pin v0.1.4 → v0.1.5