### PR TITLE
Phase 6 final: branch apply --create + ship --base auto-create-base

### DIFF
--- a/src/shipyard/cli.py
+++ b/src/shipyard/cli.py
@@ -1049,6 +1049,193 @@ def _rewrite_profile_in_config(config_path: Path, new_profile: str) -> None:
     config_path.write_text("".join(out))
 
 
+def _should_auto_create_base(base: str, flag: bool | None) -> bool:
+    """Decide whether `ship --base <x>` should auto-create-base.
+
+    Explicit --auto-create-base/--no-auto-create-base wins. When
+    the flag is unset, default to on for `develop/*` and
+    `release/*` patterns (the two cases where the planning doc
+    explicitly wants auto-creation) and off for everything else.
+    """
+    if flag is not None:
+        return flag
+    return base.startswith("develop/") or base.startswith("release/")
+
+
+def _maybe_auto_create_base_branch(ctx: Context, base: str) -> None:
+    """If `base` does not exist on origin, create it + apply its rules.
+
+    Best-effort: on any failure this prints a warning and returns.
+    The caller still tries to push and create the PR, which will
+    surface any hard failure from git/gh in the normal path rather
+    than stopping ship() early on a transient API hiccup.
+    """
+    from shipyard.governance import (
+        detect_repo_from_remote,
+        load_governance_config,
+        resolve_branch_rules,
+    )
+    from shipyard.governance.branch_create import (
+        BranchCreateStatus,
+        create_branch_and_apply_rules,
+    )
+
+    # Cheap check first: does the branch already exist on the remote?
+    check = subprocess.run(
+        ["git", "ls-remote", "--exit-code", "--heads", "origin", base],
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+    if check.returncode == 0:
+        return  # Branch already exists, nothing to do
+
+    # Branch is missing — try to create + protect it.
+    repo = detect_repo_from_remote()
+    if repo is None:
+        render_message(
+            f"warning: --base {base} does not exist on origin and the "
+            f"repo could not be detected from the git remote; skipping "
+            f"auto-create-base.",
+            style="bold yellow",
+        )
+        return
+
+    gov = load_governance_config(ctx.config)
+    rules = resolve_branch_rules(gov, base)
+    render_message(f"Creating base branch '{base}' from 'main' + applying governance rules…")
+    result = create_branch_and_apply_rules(
+        repo=repo, branch=base, base_branch="main", rules=rules,
+    )
+    if result.status == BranchCreateStatus.RULES_APPLIED or result.status == BranchCreateStatus.CREATED:
+        render_message(f"  ✓ {result.message}", style="green")
+    elif result.status == BranchCreateStatus.ALREADY_EXISTS:
+        render_message(f"  ℹ {result.message}")
+    else:
+        render_message(f"  ✗ {result.message}", style="bold red")
+        render_message(
+            "continuing with ship flow anyway; fix the branch protection "
+            "with `shipyard branch apply` after the PR is opened",
+            style="yellow",
+        )
+
+
+# ── branch commands ───────────────────────────────────────────────────
+
+
+@main.group()
+def branch() -> None:
+    """Manage branch protection for individual branches."""
+
+
+@branch.command("apply")
+@click.option(
+    "--create", "create_name",
+    help="Create the branch from --base if it doesn't exist, then apply rules",
+)
+@click.option(
+    "--base", "base_branch",
+    default="main",
+    help="Base branch to create from when --create is given (default: main)",
+)
+@click.argument("target_branch", required=False)
+@click.pass_obj
+def branch_apply(
+    ctx: Context,
+    create_name: str | None,
+    base_branch: str,
+    target_branch: str | None,
+) -> None:
+    """Apply declared governance rules to a single branch.
+
+    Two modes:
+
+      shipyard branch apply <name>
+          Apply rules to an existing branch (same as
+          `governance apply --branch <name>`, provided here for
+          symmetry with the create flow).
+
+      shipyard branch apply --create develop/foo
+          Create `develop/foo` from --base (default: main) and
+          apply the matching `[branch_protection."<glob>"]` rules
+          in one shot. Prevents the "new branch is unprotected
+          until someone runs apply later" failure mode.
+    """
+    from shipyard.governance import (
+        detect_repo_from_remote,
+        load_governance_config,
+        resolve_branch_rules,
+    )
+    from shipyard.governance.branch_create import (
+        BranchCreateStatus,
+        create_branch_and_apply_rules,
+    )
+
+    repo = detect_repo_from_remote()
+    if repo is None:
+        render_error("Could not detect repo from git remote.")
+        sys.exit(1)
+
+    # Figure out which branch we're acting on
+    name_arg = create_name or target_branch
+    if not name_arg:
+        render_error("Specify a branch name (positional) or --create <name>")
+        sys.exit(1)
+
+    gov = load_governance_config(ctx.config)
+    rules = resolve_branch_rules(gov, name_arg)
+
+    if create_name:
+        result = create_branch_and_apply_rules(
+            repo=repo,
+            branch=create_name,
+            base_branch=base_branch,
+            rules=rules,
+        )
+        if ctx.json_mode:
+            ctx.output("branch.apply", {
+                "branch": result.branch,
+                "status": result.status.value,
+                "message": result.message,
+                "ok": result.ok,
+            })
+        else:
+            if result.status == BranchCreateStatus.RULES_APPLIED or result.status == BranchCreateStatus.CREATED:
+                render_message(f"  ✓ {result.message}", style="green")
+            elif result.status == BranchCreateStatus.ALREADY_EXISTS:
+                render_message(f"  ℹ {result.message}", style="yellow")
+            else:
+                render_message(f"  ✗ {result.message}", style="bold red")
+        if not result.ok:
+            sys.exit(1)
+        return
+
+    # Existing-branch apply path — delegate to the governance
+    # apply flow for a single branch.
+    from shipyard.governance import (
+        build_apply_plan,
+        build_status,
+        execute_apply_plan,
+    )
+
+    status = build_status(
+        repo=repo, governance=gov, branches=(name_arg,),
+    )
+    results = []
+    for report in status.reports:
+        declared = resolve_branch_rules(gov, report.branch)
+        plan = build_apply_plan(
+            repo=repo, branch=report.branch,
+            declared_rules=declared, drift_report=report,
+        )
+        results.append(execute_apply_plan(plan, dry_run=False))
+    _render_apply_results(
+        ctx, results, list(status.errors), dry_run=False, from_snapshot=False,
+    )
+    if any(r.error_message for r in results) or status.has_errors:
+        sys.exit(1)
+
+
 @main.group()
 def cloud() -> None:
     """Dispatch and inspect GitHub Actions workflows."""
@@ -1303,8 +1490,24 @@ def cloud_status(ctx: Context, identifier: str | None, limit: int, refresh: bool
     is_flag=True,
     help="Queue the run even if no backend is reachable for one or more targets",
 )
+@click.option(
+    "--auto-create-base/--no-auto-create-base",
+    default=None,
+    help=(
+        "If the --base branch does not exist on the remote, create it from "
+        "main and apply matching branch_protection rules before opening the "
+        "PR. Default: on for develop/* and release/* patterns; off for "
+        "everything else."
+    ),
+)
 @click.pass_obj
-def ship(ctx: Context, base: str, allow_root_mismatch: bool, allow_unreachable_targets: bool) -> None:
+def ship(
+    ctx: Context,
+    base: str,
+    allow_root_mismatch: bool,
+    allow_unreachable_targets: bool,
+    auto_create_base: bool | None,
+) -> None:
     """Branch -> PR -> validate -> merge on green."""
     from shipyard.ship.pr import create_pr, find_pr_for_branch, merge_pr
 
@@ -1316,6 +1519,15 @@ def ship(ctx: Context, base: str, allow_root_mismatch: bool, allow_unreachable_t
     if branch == base:
         render_error(f"Already on {base}. Switch to a feature branch first.")
         sys.exit(1)
+
+    # ── Auto-create missing base branch ─────────────────────────
+    # If the user is shipping into a `develop/*` or `release/*`
+    # branch that doesn't exist yet, create it from main and apply
+    # its matching governance rules before opening the PR. This
+    # closes the "new develop branch exists unprotected until
+    # someone remembers to run branch apply" gap.
+    if _should_auto_create_base(base, auto_create_base):
+        _maybe_auto_create_base_branch(ctx, base)
 
     # Push branch
     subprocess.run(["git", "push", "-u", "origin", branch], capture_output=True)

--- a/src/shipyard/governance/branch_create.py
+++ b/src/shipyard/governance/branch_create.py
@@ -1,0 +1,178 @@
+"""Create a branch and apply its governance rules in a single atomic-feeling step.
+
+This closes the "new branch exists unprotected until someone
+remembers to apply protection" gap in the `develop/*` workflow.
+Calling `shipyard branch apply --create develop/foo` creates the
+branch from the configured root (usually `main`), pushes it to
+`origin`, and applies the matching `[branch_protection."<glob>"]`
+rules — all before the function returns.
+
+The atomicity is best-effort: if the branch is created but the
+rule apply fails, the branch is left in place (so the user can
+re-try apply) rather than deleted. The alternative — delete on
+failure — risks losing a freshly-created branch over a transient
+API glitch. The user gets a clear error telling them exactly what
+to re-run.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from dataclasses import dataclass
+from enum import Enum
+from typing import TYPE_CHECKING
+
+from shipyard.governance.github import (
+    GovernanceApiError,
+    put_branch_protection,
+)
+
+if TYPE_CHECKING:
+    from shipyard.governance.github import RepoRef
+    from shipyard.governance.profiles import BranchProtectionRules
+
+
+class BranchCreateStatus(str, Enum):
+    CREATED = "created"
+    ALREADY_EXISTS = "already_exists"
+    RULES_APPLIED = "rules_applied"
+    RULES_FAILED = "rules_failed"
+    GIT_FAILED = "git_failed"
+
+
+@dataclass(frozen=True)
+class BranchCreateResult:
+    """What `branch apply --create` actually did."""
+
+    branch: str
+    status: BranchCreateStatus
+    message: str | None = None
+    rules_applied: BranchProtectionRules | None = None
+
+    @property
+    def ok(self) -> bool:
+        return self.status in (
+            BranchCreateStatus.CREATED,
+            BranchCreateStatus.RULES_APPLIED,
+        )
+
+
+def create_branch_on_remote(
+    *,
+    branch: str,
+    base_branch: str = "main",
+    git_command: str = "git",
+) -> BranchCreateResult:
+    """Create `branch` from `base_branch` on origin, idempotently.
+
+    If the branch already exists on the remote, returns
+    `ALREADY_EXISTS` — callers can then fall through to apply rules
+    without re-creating. If git fails (network, auth, invalid ref),
+    returns `GIT_FAILED` with the stderr attached.
+    """
+    # Check whether the remote already has this branch.
+    check = subprocess.run(
+        [git_command, "ls-remote", "--exit-code", "--heads", "origin", branch],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    if check.returncode == 0:
+        return BranchCreateResult(
+            branch=branch,
+            status=BranchCreateStatus.ALREADY_EXISTS,
+            message=f"Branch '{branch}' already exists on origin",
+        )
+
+    # `ls-remote --exit-code` returns 2 when the ref doesn't exist,
+    # which is the path we want. Any other non-zero return is a
+    # real error worth surfacing.
+    if check.returncode not in (0, 2):
+        return BranchCreateResult(
+            branch=branch,
+            status=BranchCreateStatus.GIT_FAILED,
+            message=(
+                f"ls-remote failed for {branch}: "
+                f"{(check.stderr or '').strip() or 'no detail'}"
+            ),
+        )
+
+    # Create the branch from the base on origin. Use refspec syntax
+    # so no local branch is needed — this works even from a
+    # detached HEAD or a different checkout.
+    push = subprocess.run(
+        [
+            git_command,
+            "push",
+            "origin",
+            f"refs/remotes/origin/{base_branch}:refs/heads/{branch}",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    if push.returncode != 0:
+        return BranchCreateResult(
+            branch=branch,
+            status=BranchCreateStatus.GIT_FAILED,
+            message=(
+                f"git push failed creating {branch} from {base_branch}: "
+                f"{(push.stderr or '').strip() or 'no detail'}"
+            ),
+        )
+
+    return BranchCreateResult(
+        branch=branch,
+        status=BranchCreateStatus.CREATED,
+        message=f"Created '{branch}' from '{base_branch}' on origin",
+    )
+
+
+def create_branch_and_apply_rules(
+    *,
+    repo: RepoRef,
+    branch: str,
+    base_branch: str,
+    rules: BranchProtectionRules,
+    git_command: str = "git",
+    gh_command: str = "gh",
+) -> BranchCreateResult:
+    """The full flow: create the branch, then apply its rules.
+
+    If the branch already exists, skip creation and apply rules
+    anyway (idempotent — useful for fixing a prior half-completed
+    create). If rule application fails, the branch is NOT deleted.
+    """
+    create_result = create_branch_on_remote(
+        branch=branch,
+        base_branch=base_branch,
+        git_command=git_command,
+    )
+    if create_result.status == BranchCreateStatus.GIT_FAILED:
+        return create_result
+
+    # Whether we just created it or it already existed, apply rules.
+    try:
+        put_branch_protection(repo, branch, rules, gh_command=gh_command)
+    except GovernanceApiError as exc:
+        return BranchCreateResult(
+            branch=branch,
+            status=BranchCreateStatus.RULES_FAILED,
+            message=(
+                f"Branch exists but rule apply failed: {exc}. "
+                f"Re-run `shipyard governance apply --branch {branch}` "
+                f"to retry."
+            ),
+            rules_applied=None,
+        )
+
+    return BranchCreateResult(
+        branch=branch,
+        status=BranchCreateStatus.RULES_APPLIED,
+        message=(
+            f"Created '{branch}' from '{base_branch}' and applied governance rules"
+            if create_result.status == BranchCreateStatus.CREATED
+            else f"Branch '{branch}' already existed; reapplied governance rules"
+        ),
+        rules_applied=rules,
+    )

--- a/tests/governance/test_branch_create.py
+++ b/tests/governance/test_branch_create.py
@@ -1,0 +1,181 @@
+"""Tests for `shipyard branch apply --create` and the underlying helpers."""
+
+from __future__ import annotations
+
+import subprocess
+from unittest.mock import patch
+
+from shipyard.governance.branch_create import (
+    BranchCreateStatus,
+    create_branch_and_apply_rules,
+    create_branch_on_remote,
+)
+from shipyard.governance.github import GovernanceApiError, RepoRef
+from shipyard.governance.profiles import BranchProtectionRules
+
+
+def _ok(stdout: str = "", stderr: str = ""):
+    return subprocess.CompletedProcess(
+        args=[], returncode=0, stdout=stdout, stderr=stderr,
+    )
+
+
+def _fail(code: int, stderr: str = ""):
+    return subprocess.CompletedProcess(
+        args=[], returncode=code, stdout="", stderr=stderr,
+    )
+
+
+def _sample_rules() -> BranchProtectionRules:
+    return BranchProtectionRules(
+        require_pr=True,
+        require_status_checks=("mac",),
+        require_strict_status=False,
+        require_review_count=0,
+        enforce_admins=False,
+    )
+
+
+# ── create_branch_on_remote ─────────────────────────────────────────────
+
+
+def test_create_branch_already_exists() -> None:
+    """ls-remote returning 0 means the branch already exists."""
+    with patch("subprocess.run", return_value=_ok(stdout="deadbeef\trefs/heads/develop/foo\n")):
+        result = create_branch_on_remote(branch="develop/foo")
+    assert result.status == BranchCreateStatus.ALREADY_EXISTS
+    assert "already exists" in result.message
+
+
+def test_create_branch_fresh_creation() -> None:
+    """ls-remote returning 2 (ref not found) triggers the push path."""
+    run_calls = []
+
+    def fake_run(cmd, *args, **kwargs):
+        run_calls.append(cmd)
+        if "ls-remote" in cmd:
+            return _fail(2)  # not found
+        if "push" in cmd:
+            return _ok(stderr="* [new branch] refs/heads/develop/foo -> refs/heads/develop/foo")
+        return _ok()
+
+    with patch("subprocess.run", side_effect=fake_run):
+        result = create_branch_on_remote(
+            branch="develop/foo", base_branch="main",
+        )
+    assert result.status == BranchCreateStatus.CREATED
+    assert "develop/foo" in result.message
+    # Two git calls: ls-remote and push
+    assert len(run_calls) == 2
+    assert "push" in run_calls[1]
+
+
+def test_create_branch_push_fails() -> None:
+    def fake_run(cmd, *args, **kwargs):
+        if "ls-remote" in cmd:
+            return _fail(2)
+        if "push" in cmd:
+            return _fail(128, stderr="fatal: remote error")
+        return _ok()
+
+    with patch("subprocess.run", side_effect=fake_run):
+        result = create_branch_on_remote(
+            branch="develop/foo", base_branch="main",
+        )
+    assert result.status == BranchCreateStatus.GIT_FAILED
+    assert "remote error" in result.message
+
+
+def test_create_branch_ls_remote_unexpected_failure() -> None:
+    """A non-2 ls-remote failure (auth, network) surfaces as GIT_FAILED."""
+    with patch("subprocess.run", return_value=_fail(128, stderr="Permission denied")):
+        result = create_branch_on_remote(branch="develop/foo")
+    assert result.status == BranchCreateStatus.GIT_FAILED
+    assert "Permission denied" in result.message
+
+
+# ── create_branch_and_apply_rules ──────────────────────────────────────
+
+
+def test_full_flow_creates_and_applies() -> None:
+    def fake_run(cmd, *args, **kwargs):
+        if "ls-remote" in cmd:
+            return _fail(2)
+        if "push" in cmd:
+            return _ok()
+        return _ok()
+
+    with patch("subprocess.run", side_effect=fake_run), patch(
+        "shipyard.governance.branch_create.put_branch_protection",
+    ) as mock_put:
+        result = create_branch_and_apply_rules(
+            repo=RepoRef("me", "r"),
+            branch="develop/foo",
+            base_branch="main",
+            rules=_sample_rules(),
+        )
+    assert result.status == BranchCreateStatus.RULES_APPLIED
+    assert result.ok is True
+    mock_put.assert_called_once()
+
+
+def test_full_flow_branch_exists_still_applies_rules() -> None:
+    """If the branch already exists, skip creation but still apply rules (idempotent)."""
+    with patch(
+        "subprocess.run",
+        return_value=_ok(stdout="deadbeef\trefs/heads/develop/foo\n"),
+    ), patch(
+        "shipyard.governance.branch_create.put_branch_protection",
+    ) as mock_put:
+        result = create_branch_and_apply_rules(
+            repo=RepoRef("me", "r"),
+            branch="develop/foo",
+            base_branch="main",
+            rules=_sample_rules(),
+        )
+    assert result.status == BranchCreateStatus.RULES_APPLIED
+    assert "already existed; reapplied" in result.message
+    mock_put.assert_called_once()
+
+
+def test_full_flow_rules_failure_leaves_branch_in_place() -> None:
+    """A rules PUT failure must NOT delete the freshly-created branch."""
+
+    def fake_run(cmd, *args, **kwargs):
+        if "ls-remote" in cmd:
+            return _fail(2)
+        return _ok()
+
+    with patch("subprocess.run", side_effect=fake_run), patch(
+        "shipyard.governance.branch_create.put_branch_protection",
+        side_effect=GovernanceApiError("permission denied"),
+    ):
+        result = create_branch_and_apply_rules(
+            repo=RepoRef("me", "r"),
+            branch="develop/foo",
+            base_branch="main",
+            rules=_sample_rules(),
+        )
+    assert result.status == BranchCreateStatus.RULES_FAILED
+    assert result.ok is False
+    assert "permission denied" in result.message
+    assert "shipyard governance apply" in result.message  # retry hint
+
+
+def test_full_flow_git_failure_aborts_early() -> None:
+    """A git failure before rule apply skips the put entirely."""
+    with patch(
+        "subprocess.run",
+        return_value=_fail(128, stderr="network unreachable"),
+    ), patch(
+        "shipyard.governance.branch_create.put_branch_protection",
+    ) as mock_put:
+        result = create_branch_and_apply_rules(
+            repo=RepoRef("me", "r"),
+            branch="develop/foo",
+            base_branch="main",
+            rules=_sample_rules(),
+        )
+    assert result.status == BranchCreateStatus.GIT_FAILED
+    assert result.ok is False
+    mock_put.assert_not_called()

--- a/tests/test_ship_auto_create_base.py
+++ b/tests/test_ship_auto_create_base.py
@@ -1,0 +1,43 @@
+"""Tests for `shipyard ship --base` auto-create-base behavior."""
+
+from __future__ import annotations
+
+from shipyard.cli import _should_auto_create_base
+
+# ── _should_auto_create_base defaults ──────────────────────────────────
+
+
+def test_default_on_for_develop_pattern() -> None:
+    assert _should_auto_create_base("develop/foo", None) is True
+    assert _should_auto_create_base("develop/auth/rewrite", None) is True
+
+
+def test_default_on_for_release_pattern() -> None:
+    assert _should_auto_create_base("release/v1.0", None) is True
+
+
+def test_default_off_for_main() -> None:
+    assert _should_auto_create_base("main", None) is False
+
+
+def test_default_off_for_feature() -> None:
+    assert _should_auto_create_base("feature/whatever", None) is False
+
+
+def test_default_off_for_master() -> None:
+    assert _should_auto_create_base("master", None) is False
+
+
+# ── Explicit flag overrides default ────────────────────────────────────
+
+
+def test_explicit_true_overrides_default_off() -> None:
+    assert _should_auto_create_base("feature/x", True) is True
+
+
+def test_explicit_false_overrides_default_on() -> None:
+    assert _should_auto_create_base("develop/x", False) is False
+
+
+def test_explicit_false_for_main_stays_false() -> None:
+    assert _should_auto_create_base("main", False) is False


### PR DESCRIPTION
## Summary

The last two Phase 6 follow-ups pulled forward from \`shipyard-phase-6-followups.md\` so nothing governance-related is left hanging. With this, Pulp has the full Phase 6 surface available for the eventual \`develop/*\` workflow and the \`[project.profile = "solo"]\` → \`"multi"\` transition.

## What's new

### \`shipyard branch apply [--create <name>]\`

Two forms:

\`\`\`bash
shipyard branch apply develop/auth                    # apply to existing
shipyard branch apply --create develop/auth --base main   # create + apply
\`\`\`

The \`--create\` form prevents the "new develop branch is unprotected until someone remembers to run apply later" failure mode by creating the branch AND applying matching \`[branch_protection."develop/**"]\` rules in one command.

### \`shipyard ship --base develop/foo\` auto-create-base

New \`--auto-create-base/--no-auto-create-base\` flag on ship. Default: **on for \`develop/*\` and \`release/*\`**, off for everything else (so ordinary feature-branch ships into \`main\` are unaffected).

When the base branch doesn't exist, ship creates it + applies its matching rules before pushing the feature branch or opening the PR. Best-effort: a failure prints a warning and falls through to the normal ship flow.

### Atomicity + recovery

If \`branch apply --create\` successfully creates the branch but the rule PUT fails, the branch is **NOT deleted**. The returned message tells the user exactly which command to re-run for recovery (\`shipyard governance apply --branch <name>\`). Deleting on failure would risk losing a freshly-created branch over a transient API glitch.

## Tests

**16 new tests:**
- \`test_branch_create.py\` × 8: ls-remote branch-exists detection, fresh creation happy path, push failure, ls-remote unauthorised, full flow create+apply, idempotent reapply on existing branch, rules-failure leaves branch intact with retry hint, git-failure skips rules
- \`test_ship_auto_create_base.py\` × 8: default on for \`develop/\` and \`release/\`, default off for main/master/feature/, explicit \`--auto-create-base\` overrides either way

**Full suite: 435 passing** (was 419; +16).

## Dogfood

\`\`\`
$ shipyard branch apply main
  ✓ main: already aligned (no changes)

$ shipyard ship --help
...
--auto-create-base / --no-auto-create-base
    If the --base branch does not exist on the remote, create
    it from main and apply matching branch_protection rules
    before opening the PR. Default: on for develop/* and
    release/* patterns; off for everything else.
\`\`\`

## Test plan

- [x] \`ruff check\` clean
- [x] \`mypy\` clean
- [x] \`pytest tests/\` — 435/435
- [x] \`shipyard branch apply main\` against Pulp — idempotent ✓
- [ ] CI matrix on this PR
- [ ] After merge, tag v0.1.6