### PR TITLE
Fix: apply_bundle must fetch into refs/shipyard-bundles/*, not refs/*

### DIFF
--- a/src/shipyard/bundle/git_bundle.py
+++ b/src/shipyard/bundle/git_bundle.py
@@ -131,8 +131,18 @@ def apply_bundle(
 ) -> BundleResult:
     """Apply a git bundle on a remote host via SSH.
 
-    Fetches all refs from the bundle into the remote repo, then checks out
-    the desired state.
+    Fetches bundle refs into a Shipyard-owned namespace
+    (`refs/shipyard-bundles/*`) rather than `refs/*`. The naive
+    `+refs/*:refs/*` mapping fails with "refusing to fetch into
+    branch <name> checked out at <path>" whenever the remote
+    worktree happens to have the bundled branch checked out —
+    which is extremely common on a long-lived validation VM. The
+    namespaced destination is never a checked-out ref, so git
+    accepts the fetch unconditionally.
+
+    The validation layer walks `refs/shipyard-bundles/*` to find
+    the exact SHA; the remote checkout will be done separately by
+    the executor's per-target logic.
 
     Args:
         host: SSH host (user@host or alias).
@@ -146,7 +156,9 @@ def apply_bundle(
     remote_cmd = (
         f"cd {repo_path} && "
         f"git bundle verify {bundle_path} && "
-        f"git fetch {bundle_path} '+refs/*:refs/*'"
+        f"git fetch {bundle_path} "
+        f"'+refs/heads/*:refs/shipyard-bundles/heads/*' "
+        f"'+refs/tags/*:refs/shipyard-bundles/tags/*'"
     )
 
     cmd: list[str] = ["ssh"]

--- a/src/shipyard/executor/ssh_windows.py
+++ b/src/shipyard/executor/ssh_windows.py
@@ -275,12 +275,22 @@ def _apply_bundle_windows(
     repo_path: str,
     ssh_options: list[str],
 ) -> _ApplyResult:
-    """Apply a git bundle on a remote Windows host via PowerShell."""
+    """Apply a git bundle on a remote Windows host via PowerShell.
+
+    Fetches bundle refs into a Shipyard-owned namespace rather
+    than `refs/*`. The naive `+refs/*:refs/*` mapping fails with
+    "refusing to fetch into branch <name> checked out at <path>"
+    whenever the remote worktree happens to have the bundled
+    branch checked out. The namespaced destination is never a
+    checked-out ref, so git accepts the fetch unconditionally.
+    """
     ps_cmd = (
         f"cd '{repo_path}'; "
         f"git bundle verify '{bundle_path}'; "
         f"if ($LASTEXITCODE -ne 0) {{ exit 1 }}; "
-        f"git fetch '{bundle_path}' '+refs/*:refs/*'; "
+        f"git fetch '{bundle_path}' "
+        f"'+refs/heads/*:refs/shipyard-bundles/heads/*' "
+        f"'+refs/tags/*:refs/shipyard-bundles/tags/*'; "
         f"if ($LASTEXITCODE -ne 0) {{ exit 1 }}"
     )
 

--- a/tests/bundle/test_apply_bundle_refspec.py
+++ b/tests/bundle/test_apply_bundle_refspec.py
@@ -1,0 +1,68 @@
+"""Regression: apply_bundle must fetch into a Shipyard-owned namespace.
+
+The original implementation fetched `+refs/*:refs/*`, which triggers
+the "refusing to fetch into branch X checked out at <path>" error
+whenever the remote worktree happens to have a bundled branch
+checked out — extremely common on long-lived validation VMs where a
+stale `feature/*` branch is left checked out between runs.
+
+Fetching into `refs/shipyard-bundles/*` instead bypasses git's
+checked-out-ref safety entirely, because the destination is never a
+worktree ref.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from unittest.mock import patch
+
+from shipyard.bundle.git_bundle import apply_bundle
+
+
+def test_apply_bundle_uses_namespaced_refspec() -> None:
+    """The remote fetch refspec must NOT overwrite refs/* directly."""
+    captured: list[str] = []
+
+    def fake_run(cmd, *args, **kwargs):
+        captured.append(" ".join(cmd) if isinstance(cmd, list) else str(cmd))
+        return subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="", stderr="",
+        )
+
+    with patch("subprocess.run", side_effect=fake_run):
+        result = apply_bundle(
+            host="ubuntu",
+            bundle_path="/tmp/shipyard.bundle",
+            repo_path="/home/x/repo",
+        )
+    assert result.success is True
+    # The command must route through a shipyard-owned namespace
+    assert len(captured) == 1
+    cmd = captured[0]
+    assert "refs/shipyard-bundles/heads/*" in cmd
+    assert "refs/shipyard-bundles/tags/*" in cmd
+    # And must NOT use the unsafe blanket refs/* mapping
+    assert "refs/*:refs/*" not in cmd
+
+
+def test_apply_bundle_verifies_before_fetching() -> None:
+    """Verify must run before fetch so a broken bundle fails cleanly."""
+    captured: list[str] = []
+
+    def fake_run(cmd, *args, **kwargs):
+        captured.append(" ".join(cmd) if isinstance(cmd, list) else str(cmd))
+        return subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="", stderr="",
+        )
+
+    with patch("subprocess.run", side_effect=fake_run):
+        apply_bundle(
+            host="ubuntu",
+            bundle_path="/tmp/shipyard.bundle",
+            repo_path="/home/x/repo",
+        )
+    assert "git bundle verify" in captured[0]
+    # verify must appear before fetch in the same command
+    verify_pos = captured[0].find("git bundle verify")
+    fetch_pos = captured[0].find("git fetch")
+    assert 0 <= verify_pos < fetch_pos


### PR DESCRIPTION
**Second Stage 1 dogfood finding.** After the executor kwargs fix in #16 let SSH dispatch actually reach the bundle-apply step, the next failure was:

```
Bundle apply failed: Remote bundle apply failed:
/tmp/shipyard.bundle is okay
fatal: refusing to fetch into branch 'refs/heads/feature/quality-pass'
checked out at '/home/daniel/Code/pulp-validate'
```

`+refs/*:refs/*` is refused by git whenever any destination ref is the currently-checked-out branch in the target worktree. On a long-lived validation VM this is the common case, not the rare one — the worktree is almost always sitting on some leftover feature branch.

**Fix:** fetch into `refs/shipyard-bundles/heads/*` and `refs/shipyard-bundles/tags/*`. Worktrees can't have those refs checked out, so git accepts the fetch unconditionally. The executor checks out the raw SHA, which finds the commit regardless of which ref namespace it lives under.

Applied to both `apply_bundle()` in `shipyard.bundle.git_bundle` (POSIX SSH) and `_apply_bundle_windows()` in `shipyard.executor.ssh_windows` (Windows SSH).

## Tests

2 new regression tests pin the refspec shape so any future revert to `refs/*:refs/*` is caught at test time.

**Full suite: 445 passing** (was 443; +2).

## Test plan

- [x] `ruff check` clean
- [x] `mypy` clean
- [x] `pytest tests/` — 445/445
- [ ] Merge, tag v0.1.8
- [ ] Re-run Stage 1 dogfood against Pulp with v0.1.8