### PR TITLE
Release v0.1.8: bundle apply refspec fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "shipyard"
-version = "0.1.7"
+version = "0.1.8"
 description = "Cross-platform CI coordination — local VMs, SSH hosts, cloud runners"
 readme = "README.md"
 license = "MIT"

--- a/src/shipyard/__init__.py
+++ b/src/shipyard/__init__.py
@@ -1,3 +1,3 @@
 """Shipyard — Cross-platform CI coordination."""
 
-__version__ = "0.1.7"
+__version__ = "0.1.8"


### PR DESCRIPTION
Merges #18. 445 tests passing. Fix for the 'refusing to fetch into branch X' error on long-lived SSH validation VMs.