### PR TITLE
Fix: Windows bundle path defaults to home-relative, not C:\Temp

### DIFF
--- a/src/shipyard/executor/ssh_windows.py
+++ b/src/shipyard/executor/ssh_windows.py
@@ -74,8 +74,15 @@ class SSHWindowsExecutor:
         # Step 1: Create and deliver git bundle
         with tempfile.TemporaryDirectory() as tmpdir:
             bundle_path = Path(tmpdir) / "shipyard.bundle"
+            # Use a home-relative path by default rather than
+            # `C:\Temp\shipyard.bundle`, which doesn't exist on a
+            # stock Windows install and caused
+            # `scp: dest open "C:\\Temp\\shipyard.bundle": No such
+            # file or directory` on the first Stage 1 Windows
+            # dogfood run. A bare filename lands in the SSH user's
+            # home directory, which always exists.
             remote_bundle = target_config.get(
-                "remote_bundle_path", "C:\\Temp\\shipyard.bundle"
+                "remote_bundle_path", "shipyard.bundle"
             )
 
             bundle_result = create_bundle(
@@ -269,6 +276,22 @@ class _ApplyResult:
         self.message = message
 
 
+def _is_windows_absolute_path(path: str) -> bool:
+    """True if `path` starts with a drive letter or a leading separator.
+
+    Treats `C:\\...`, `C:/...`, `\\\\server\\share\\...`, and `\\foo`
+    as absolute; bare names like `shipyard.bundle` or relative
+    paths like `Temp\\foo.bundle` as not absolute.
+    """
+    if not path:
+        return False
+    if path.startswith("\\\\"):  # UNC
+        return True
+    if path.startswith("\\") or path.startswith("/"):
+        return True
+    return len(path) >= 2 and path[1] == ":" and path[0].isalpha()
+
+
 def _apply_bundle_windows(
     host: str,
     bundle_path: str,
@@ -283,12 +306,29 @@ def _apply_bundle_windows(
     whenever the remote worktree happens to have the bundled
     branch checked out. The namespaced destination is never a
     checked-out ref, so git accepts the fetch unconditionally.
+
+    The bundle path is resolved via PowerShell's Join-Path with
+    $HOME when it's a relative path, so the default
+    `shipyard.bundle` lands in the SSH user's home directory (where
+    scp wrote it) regardless of the working directory PowerShell
+    uses after the `cd` below.
     """
+    # Expand a relative bundle path against $HOME inside PowerShell.
+    # Detecting "relative" on the Windows side is simpler than on
+    # the Python side because we can just check for a drive letter
+    # or backslash prefix.
+    resolved = (
+        f"'{bundle_path}'"
+        if _is_windows_absolute_path(bundle_path)
+        else f"(Join-Path $HOME '{bundle_path}')"
+    )
+
     ps_cmd = (
+        f"$Bundle = {resolved}; "
         f"cd '{repo_path}'; "
-        f"git bundle verify '{bundle_path}'; "
+        f"git bundle verify $Bundle; "
         f"if ($LASTEXITCODE -ne 0) {{ exit 1 }}; "
-        f"git fetch '{bundle_path}' "
+        f"git fetch $Bundle "
         f"'+refs/heads/*:refs/shipyard-bundles/heads/*' "
         f"'+refs/tags/*:refs/shipyard-bundles/tags/*'; "
         f"if ($LASTEXITCODE -ne 0) {{ exit 1 }}"

--- a/tests/executor/test_ssh_windows_bundle_path.py
+++ b/tests/executor/test_ssh_windows_bundle_path.py
@@ -1,0 +1,101 @@
+"""Regression tests for Windows bundle path defaulting.
+
+Stage 1 dogfooding surfaced a Windows scp failure because the
+default `remote_bundle_path` was `C:\\Temp\\shipyard.bundle` and
+`C:\\Temp` doesn't exist on a stock Windows install. Fix: the
+default is now a bare filename, which lands in the SSH user's
+home directory; the PowerShell apply command expands it via
+`Join-Path $HOME <path>` when it isn't absolute.
+"""
+
+from __future__ import annotations
+
+from shipyard.executor.ssh_windows import _is_windows_absolute_path
+
+# ── _is_windows_absolute_path ──────────────────────────────────────────
+
+
+def test_drive_letter_path_is_absolute() -> None:
+    assert _is_windows_absolute_path("C:\\Users\\me\\foo.bundle") is True
+    assert _is_windows_absolute_path("D:/repo/bundle") is True
+
+
+def test_unc_path_is_absolute() -> None:
+    assert _is_windows_absolute_path("\\\\server\\share\\file") is True
+
+
+def test_leading_separator_is_absolute() -> None:
+    assert _is_windows_absolute_path("\\foo\\bar") is True
+    assert _is_windows_absolute_path("/foo/bar") is True
+
+
+def test_bare_filename_is_not_absolute() -> None:
+    assert _is_windows_absolute_path("shipyard.bundle") is False
+
+
+def test_relative_path_is_not_absolute() -> None:
+    assert _is_windows_absolute_path("Temp\\shipyard.bundle") is False
+
+
+def test_empty_path_is_not_absolute() -> None:
+    assert _is_windows_absolute_path("") is False
+
+
+# ── apply command shape ────────────────────────────────────────────────
+
+
+def test_apply_command_uses_home_for_relative_path() -> None:
+    """A relative bundle path must be resolved via Join-Path $HOME."""
+    from unittest.mock import patch
+
+    from shipyard.executor.ssh_windows import _apply_bundle_windows
+
+    captured: list[str] = []
+
+    def fake_run(cmd, *args, **kwargs):
+        captured.append(cmd[-1])  # last arg is the PS command string
+        import subprocess
+        return subprocess.CompletedProcess(
+            args=cmd, returncode=0, stdout="", stderr="",
+        )
+
+    with patch("subprocess.run", side_effect=fake_run):
+        _apply_bundle_windows(
+            host="win",
+            bundle_path="shipyard.bundle",
+            repo_path="C:\\repo",
+            ssh_options=[],
+        )
+
+    assert len(captured) == 1
+    ps_cmd = captured[0]
+    assert "Join-Path $HOME 'shipyard.bundle'" in ps_cmd
+    assert "$Bundle = " in ps_cmd
+
+
+def test_apply_command_uses_literal_absolute_path() -> None:
+    """An absolute bundle path is used verbatim, not wrapped in Join-Path."""
+    from unittest.mock import patch
+
+    from shipyard.executor.ssh_windows import _apply_bundle_windows
+
+    captured: list[str] = []
+
+    def fake_run(cmd, *args, **kwargs):
+        captured.append(cmd[-1])
+        import subprocess
+        return subprocess.CompletedProcess(
+            args=cmd, returncode=0, stdout="", stderr="",
+        )
+
+    with patch("subprocess.run", side_effect=fake_run):
+        _apply_bundle_windows(
+            host="win",
+            bundle_path="C:\\Users\\me\\my.bundle",
+            repo_path="C:\\repo",
+            ssh_options=[],
+        )
+
+    ps_cmd = captured[0]
+    assert "'C:\\Users\\me\\my.bundle'" in ps_cmd
+    assert "Join-Path" not in ps_cmd


### PR DESCRIPTION
**Third Stage 1 dogfood finding.** After v0.1.7's executor kwargs fix + v0.1.8's namespaced bundle refspec unblocked the Windows dispatch path, scp crashed with:

```
scp: dest open "C:\\Temp\\shipyard.bundle": No such file or directory
```

The default `remote_bundle_path` was hard-coded to `C:\\Temp\\shipyard.bundle`, but `C:\\Temp\\` doesn't exist on a stock Windows install.

## Fix

Default to a bare `shipyard.bundle` filename — scp resolves that relative to the SSH user's home directory, which always exists. PowerShell's apply command uses `Join-Path $HOME '<path>'` to resolve the same location when the path isn't absolute.

A new `_is_windows_absolute_path()` helper handles drive letters, forward slashes, UNC paths, and root-relative paths so user-configured custom paths still work verbatim.

## Tests

8 new cases (6 for the path classifier + 2 for the apply command shape).

**Full suite: 453 passing** (was 445; +8).

## Test plan

- [x] `ruff check` clean
- [x] `mypy` clean
- [x] `pytest tests/` — 453/453
- [ ] CI matrix
- [ ] Merge, tag v0.1.9
- [ ] Re-run Stage 1 against v0.1.9 — expecting all 3 targets green