### PR TITLE
Fix: upload_bundle timeout raised to 30min + per-target override

### DIFF
--- a/src/shipyard/bundle/git_bundle.py
+++ b/src/shipyard/bundle/git_bundle.py
@@ -75,6 +75,7 @@ def upload_bundle(
     host: str,
     remote_path: str,
     ssh_options: Sequence[str] = (),
+    timeout: int = 1800,
 ) -> BundleResult:
     """Upload a bundle file to a remote host via SCP.
 
@@ -83,6 +84,12 @@ def upload_bundle(
         host: SSH host (user@host or alias).
         remote_path: Destination path on the remote host.
         ssh_options: Additional SSH/SCP options (e.g. ["-o", "StrictHostKeyChecking=no"]).
+        timeout: scp timeout in seconds. Defaults to 30 minutes to
+            accommodate large repos over slow links (e.g. Pulp's
+            ~100MB bundle to a Windows VM). Callers with known
+            small bundles can pass a shorter timeout; 5 minutes was
+            the previous default and turned out to be too
+            aggressive for real workloads.
 
     Returns:
         BundleResult indicating success or failure.
@@ -104,7 +111,7 @@ def upload_bundle(
             cmd,
             capture_output=True,
             text=True,
-            timeout=300,
+            timeout=timeout,
         )
         if result.returncode != 0:
             return BundleResult(

--- a/src/shipyard/executor/ssh.py
+++ b/src/shipyard/executor/ssh.py
@@ -115,6 +115,7 @@ class SSHExecutor:
                 host=host,
                 remote_path=remote_bundle,
                 ssh_options=ssh_options,
+                timeout=int(target_config.get("bundle_upload_timeout_secs", 1800)),
             )
             if not upload_result.success:
                 return _error_result(

--- a/src/shipyard/executor/ssh_windows.py
+++ b/src/shipyard/executor/ssh_windows.py
@@ -102,6 +102,7 @@ class SSHWindowsExecutor:
                 host=host,
                 remote_path=remote_bundle,
                 ssh_options=ssh_options,
+                timeout=int(target_config.get("bundle_upload_timeout_secs", 1800)),
             )
             if not upload_result.success:
                 return _error_result(


### PR DESCRIPTION
**Fourth Stage 1 dogfood finding.** With v0.1.9's Windows bundle path fix unblocking scp, the next Pulp Windows run died at:

```
Bundle upload failed: scp timed out
(after 316s on the windows target)
```

The 5-minute default on `upload_bundle()` is too tight for any real-world project. Pulp's repo produces a ~100MB bundle (lots of git LFS + vendored submodules), and scp-ing that to a Windows VM over a slow link legitimately takes longer than 5 minutes.

## Fix

- Default `upload_bundle(timeout=...)` raised from **300s → 1800s** (30 minutes)
- New `bundle_upload_timeout_secs` option in SSH target config for projects with slower networks or larger bundles

## Why existing tests missed this

The bundle unit tests mock `subprocess.run` with a fixed-duration response; they don't simulate scp latency. Real network behavior only shows up against live SSH hosts with real repos.

**Full suite: 453 passing.**

## Test plan

- [x] `ruff check` clean
- [x] `pytest tests/` — 453/453
- [ ] Merge, tag v0.1.10
- [ ] Re-run Stage 1 attempt 5 against v0.1.10 — expecting all three targets green end-to-end