### PR TITLE
Release v0.1.10: bundle upload timeout fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "shipyard"
-version = "0.1.9"
+version = "0.1.10"
 description = "Cross-platform CI coordination — local VMs, SSH hosts, cloud runners"
 readme = "README.md"
 license = "MIT"

--- a/src/shipyard/__init__.py
+++ b/src/shipyard/__init__.py
@@ -1,3 +1,3 @@
 """Shipyard — Cross-platform CI coordination."""
 
-__version__ = "0.1.9"
+__version__ = "0.1.10"


### PR DESCRIPTION
Merges #23. 453 tests passing. Bundle upload timeout 5min → 30min default + per-target override.