### PR TITLE
Fix Codex P1 review batch: apply_bundle timeout + fallback kwargs + quoting + streaming buffer cap

### DIFF
--- a/src/shipyard/bundle/git_bundle.py
+++ b/src/shipyard/bundle/git_bundle.py
@@ -135,6 +135,7 @@ def apply_bundle(
     bundle_path: str,
     repo_path: str,
     ssh_options: Sequence[str] = (),
+    timeout: int = 1800,
 ) -> BundleResult:
     """Apply a git bundle on a remote host via SSH.
 
@@ -156,14 +157,26 @@ def apply_bundle(
         bundle_path: Path to the .bundle file on the remote host.
         repo_path: Path to the git repo on the remote host.
         ssh_options: Additional SSH options.
+        timeout: Apply timeout in seconds. Defaults to 30 minutes
+            so `git bundle verify` + `git fetch` of a large repo
+            doesn't get killed on slow Windows disks. The previous
+            120s default was fine for small repos but too tight
+            for anything with real history; raising it matched the
+            upload_bundle default.
 
     Returns:
         BundleResult indicating success or failure.
     """
+    # Quote path-like arguments that get interpolated into a shell
+    # command. `repo_path` and `bundle_path` can come from target
+    # config and may contain spaces, quotes, or shell metacharacters.
+    import shlex
+    quoted_repo = shlex.quote(repo_path)
+    quoted_bundle = shlex.quote(bundle_path)
     remote_cmd = (
-        f"cd {repo_path} && "
-        f"git bundle verify {bundle_path} && "
-        f"git fetch {bundle_path} "
+        f"cd {quoted_repo} && "
+        f"git bundle verify {quoted_bundle} && "
+        f"git fetch {quoted_bundle} "
         f"'+refs/heads/*:refs/shipyard-bundles/heads/*' "
         f"'+refs/tags/*:refs/shipyard-bundles/tags/*'"
     )
@@ -178,7 +191,7 @@ def apply_bundle(
             cmd,
             capture_output=True,
             text=True,
-            timeout=120,
+            timeout=timeout,
         )
         if result.returncode != 0:
             return BundleResult(

--- a/src/shipyard/executor/dispatch.py
+++ b/src/shipyard/executor/dispatch.py
@@ -60,12 +60,16 @@ class ExecutorDispatcher:
     ) -> TargetResult:
         executor = self.executor_for(target_config)
         if isinstance(executor, FallbackChain):
+            # Forward the same kwargs the direct path gets
+            # (progress_callback, resume_from, mode, etc.) so
+            # fallback targets don't silently lose them.
             return executor.execute(
                 job_sha=sha,
                 job_branch=branch,
                 target_config=target_config,
                 validation_config=validation_config,
                 log_path=log_path,
+                **kwargs,
             )
         return executor.validate(
             sha=sha,

--- a/src/shipyard/executor/ssh.py
+++ b/src/shipyard/executor/ssh.py
@@ -128,6 +128,7 @@ class SSHExecutor:
                 bundle_path=remote_bundle,
                 repo_path=remote_repo,
                 ssh_options=ssh_options,
+                timeout=int(target_config.get("bundle_apply_timeout_secs", 1800)),
             )
             if not apply_result.success:
                 return _error_result(
@@ -245,6 +246,8 @@ def _build_remote_command(
     validation_config: dict[str, Any],
 ) -> str | None:
     """Build the remote shell command: checkout + validate."""
+    import shlex
+
     if "command" in validation_config:
         validate_cmd = validation_config["command"]
     else:
@@ -257,7 +260,14 @@ def _build_remote_command(
             return None
         validate_cmd = " && ".join(parts)
 
-    return f"cd {remote_repo} && git checkout --force {sha} && {validate_cmd}"
+    # Quote the repo path in case it contains spaces or shell
+    # metacharacters. sha is validated upstream to be a git hash so
+    # it's shell-safe, but we quote it anyway for consistency.
+    return (
+        f"cd {shlex.quote(remote_repo)} && "
+        f"git checkout --force {shlex.quote(sha)} && "
+        f"{validate_cmd}"
+    )
 
 
 def _error_result(

--- a/src/shipyard/executor/ssh_windows.py
+++ b/src/shipyard/executor/ssh_windows.py
@@ -117,6 +117,7 @@ class SSHWindowsExecutor:
                 bundle_path=remote_bundle,
                 repo_path=remote_repo,
                 ssh_options=ssh_options,
+                timeout=int(target_config.get("bundle_apply_timeout_secs", 1800)),
             )
             if not apply_result.success:
                 return _error_result(
@@ -293,11 +294,22 @@ def _is_windows_absolute_path(path: str) -> bool:
     return len(path) >= 2 and path[1] == ":" and path[0].isalpha()
 
 
+def _ps_single_quote(value: str) -> str:
+    """Escape a string for safe use inside a PowerShell single-quoted literal.
+
+    PowerShell doubles an embedded single quote: `'it''s'`. This
+    keeps path-like target config values from breaking the
+    `$Bundle = '...'` / `cd '...'` assignments below.
+    """
+    return value.replace("'", "''")
+
+
 def _apply_bundle_windows(
     host: str,
     bundle_path: str,
     repo_path: str,
     ssh_options: list[str],
+    timeout: int = 1800,
 ) -> _ApplyResult:
     """Apply a git bundle on a remote Windows host via PowerShell.
 
@@ -313,20 +325,27 @@ def _apply_bundle_windows(
     `shipyard.bundle` lands in the SSH user's home directory (where
     scp wrote it) regardless of the working directory PowerShell
     uses after the `cd` below.
+
+    The apply timeout defaults to 30 minutes (matching
+    upload_bundle) so `git bundle verify` + `git fetch` on a large
+    repo doesn't get killed on slow Windows disks. The previous
+    120s was too tight for anything with real history.
     """
     # Expand a relative bundle path against $HOME inside PowerShell.
     # Detecting "relative" on the Windows side is simpler than on
     # the Python side because we can just check for a drive letter
     # or backslash prefix.
+    safe_bundle = _ps_single_quote(bundle_path)
+    safe_repo = _ps_single_quote(repo_path)
     resolved = (
-        f"'{bundle_path}'"
+        f"'{safe_bundle}'"
         if _is_windows_absolute_path(bundle_path)
-        else f"(Join-Path $HOME '{bundle_path}')"
+        else f"(Join-Path $HOME '{safe_bundle}')"
     )
 
     ps_cmd = (
         f"$Bundle = {resolved}; "
-        f"cd '{repo_path}'; "
+        f"cd '{safe_repo}'; "
         f"git bundle verify $Bundle; "
         f"if ($LASTEXITCODE -ne 0) {{ exit 1 }}; "
         f"git fetch $Bundle "
@@ -342,7 +361,7 @@ def _apply_bundle_windows(
             cmd,
             capture_output=True,
             text=True,
-            timeout=120,
+            timeout=timeout,
         )
         if result.returncode != 0:
             return _ApplyResult(
@@ -393,10 +412,14 @@ def _build_remote_command(
         # Chain with PowerShell error checking
         validate_cmd = "; if ($LASTEXITCODE -ne 0) { exit 1 }; ".join(parts)
 
+    # Escape single quotes in the repo path so a pathological
+    # target_config value can't break out of the PS literal.
+    safe_repo = _ps_single_quote(remote_repo)
+    safe_sha = _ps_single_quote(sha)
     return (
         f"{toolchain_env_exports(toolchain)}; "
-        f"cd '{remote_repo}'; "
-        f"git checkout --force {sha}; "
+        f"cd '{safe_repo}'; "
+        f"git checkout --force '{safe_sha}'; "
         f"if ($LASTEXITCODE -ne 0) {{ exit 1 }}; "
         f"{validate_cmd}"
     )

--- a/src/shipyard/executor/streaming.py
+++ b/src/shipyard/executor/streaming.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import collections
 import queue
 import re
 import subprocess
@@ -93,7 +94,15 @@ def run_streaming_command(
     )
     reader.start()
 
-    output_parts: list[str] = []
+    # Bounded tail buffer. A long build log (Pulp tests produce
+    # 100k+ lines) would otherwise keep every byte resident in
+    # addition to the on-disk log, for no executor-layer benefit —
+    # the only consumers of `output` are tail extraction for error
+    # messages and marker scanning, both of which work on the last
+    # few thousand lines. Cap at ~1 MB of tail and rotate by line.
+    output_tail_bytes_cap = 1_048_576  # 1 MB
+    output_parts: collections.deque[str] = collections.deque()
+    output_parts_bytes = 0
     last_output_at: datetime | None = None
     last_output_monotonic = start_time
     current_phase = phase
@@ -133,8 +142,15 @@ def run_streaming_command(
                 if chunk is None:
                     break
 
-                decoded = chunk.decode("utf-8", errors="replace")
+                decoded = chunk.decode("utf-8-sig", errors="replace")
                 output_parts.append(decoded)
+                output_parts_bytes += len(decoded)
+                # Rotate the tail buffer — pop oldest fragments
+                # until we're under the cap. Keeps memory bounded
+                # regardless of build log length; the on-disk log
+                # below still captures everything.
+                while output_parts_bytes > output_tail_bytes_cap and len(output_parts) > 1:
+                    output_parts_bytes -= len(output_parts.popleft())
                 if log:
                     log.write(decoded)
                     log.flush()

--- a/tests/test_codex_review_p1_batch.py
+++ b/tests/test_codex_review_p1_batch.py
@@ -1,0 +1,199 @@
+"""Regression tests for Codex review P1 findings (post-Stage 1 attempt 4).
+
+Codex-via-RepoPrompt flagged four P1 issues that would keep surfacing
+via the "each Stage 1 attempt finds one more bug" loop:
+
+1. apply_bundle() + _apply_bundle_windows() still hard-timed out at
+   120s even after upload_bundle was raised to 1800s in v0.1.10
+2. FallbackChain.execute() was invoked without kwargs, silently
+   dropping resume_from / mode / progress_callback on fallback
+   targets (same class as the v0.1.7 kwargs fix but in the fallback
+   code path)
+3. Remote commands used raw string concat with repo_path /
+   remote_bundle_path, so a space or quote in config would break
+   shell/PowerShell parsing
+4. Streaming layer kept the full merged build output resident in a
+   list, which could use significant memory for long build logs
+"""
+
+from __future__ import annotations
+
+import inspect
+import subprocess
+from unittest.mock import patch
+
+from shipyard.bundle.git_bundle import apply_bundle
+from shipyard.executor.dispatch import ExecutorDispatcher
+from shipyard.executor.ssh import _build_remote_command as _build_posix
+from shipyard.executor.ssh_windows import (
+    _apply_bundle_windows,
+    _ps_single_quote,
+)
+from shipyard.executor.ssh_windows import (
+    _build_remote_command as _build_windows,
+)
+
+
+def _ok():
+    return subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+
+
+# ── P1-A: apply_bundle + _apply_bundle_windows accept timeout ──────────
+
+
+def test_apply_bundle_accepts_timeout_kwarg() -> None:
+    params = inspect.signature(apply_bundle).parameters
+    assert "timeout" in params
+    # Default should be 30 min, matching upload_bundle
+    assert params["timeout"].default >= 1800
+
+
+def test_apply_bundle_uses_passed_timeout() -> None:
+    """The timeout kwarg is threaded all the way through to subprocess.run."""
+    captured: list[int] = []
+
+    def fake_run(*args, **kwargs):
+        captured.append(kwargs.get("timeout"))
+        return _ok()
+
+    with patch("subprocess.run", side_effect=fake_run):
+        apply_bundle(
+            host="ubuntu",
+            bundle_path="/tmp/foo.bundle",
+            repo_path="/home/x/repo",
+            timeout=600,
+        )
+    assert captured == [600]
+
+
+def test_windows_apply_bundle_accepts_timeout_kwarg() -> None:
+    params = inspect.signature(_apply_bundle_windows).parameters
+    assert "timeout" in params
+    assert params["timeout"].default >= 1800
+
+
+def test_windows_apply_bundle_uses_passed_timeout() -> None:
+    captured: list[int] = []
+
+    def fake_run(*args, **kwargs):
+        captured.append(kwargs.get("timeout"))
+        return _ok()
+
+    with patch("subprocess.run", side_effect=fake_run):
+        _apply_bundle_windows(
+            host="win",
+            bundle_path="shipyard.bundle",
+            repo_path="C:\\repo",
+            ssh_options=[],
+            timeout=900,
+        )
+    assert captured == [900]
+
+
+# ── P1-B: FallbackChain receives dispatch kwargs ───────────────────────
+
+
+def test_fallback_chain_forwards_kwargs() -> None:
+    """validate_target forwards kwargs through the fallback-chain branch."""
+    from shipyard.failover.chain import FallbackChain
+
+    recorded: dict = {}
+
+    class RecordingExecutor:
+        def validate(self, *, sha, branch, target_config, validation_config, log_path, **kwargs):
+            recorded.update(kwargs)
+            from shipyard.core.job import TargetResult, TargetStatus
+            return TargetResult(
+                target_name=target_config.get("name", "x"),
+                platform="linux-x64",
+                status=TargetStatus.PASS,
+                backend="stub",
+            )
+
+        def probe(self, target_config):
+            return True
+
+    fake_chain = FallbackChain(
+        backends=[{"type": "ssh", "host": "x"}],
+        executors={"ssh": RecordingExecutor()},
+    )
+
+    dispatcher = ExecutorDispatcher()
+    # Patch executor_for to return our fake chain
+    with patch.object(dispatcher, "executor_for", return_value=fake_chain):
+        dispatcher.validate_target(
+            sha="abc",
+            branch="main",
+            target_config={"name": "test", "type": "ssh", "host": "x"},
+            validation_config={"command": "true"},
+            log_path="/tmp/log",
+            resume_from="test",
+            mode="smoke",
+        )
+
+    # The fallback path must receive the same kwargs the direct path does
+    assert recorded.get("resume_from") == "test"
+    assert recorded.get("mode") == "smoke"
+
+
+# ── P1-C: Remote command builders quote path inputs ────────────────────
+
+
+def test_posix_build_quotes_repo_path_with_space() -> None:
+    cmd = _build_posix(
+        sha="deadbeef",
+        remote_repo="/home/user/with space/pulp",
+        validation_config={"command": "echo hi"},
+    )
+    # The quoted repo path must appear as a single shell token
+    assert "/home/user/with space/pulp" in cmd
+    assert "'/home/user/with space/pulp'" in cmd or \
+           "/home/user/with\\ space/pulp" in cmd
+
+
+def test_posix_build_quotes_sha() -> None:
+    cmd = _build_posix(
+        sha="abc123",
+        remote_repo="/home/user/repo",
+        validation_config={"command": "echo hi"},
+    )
+    assert "abc123" in cmd
+
+
+def test_windows_build_escapes_single_quote_in_repo_path() -> None:
+    """A single quote in repo_path must not break the PS literal."""
+    cmd = _build_windows(
+        sha="abc",
+        remote_repo="C:\\Users\\it's\\repo",
+        validation_config={"command": "Write-Output hi"},
+    )
+    # The escaped literal must contain the doubled quote
+    assert "'C:\\Users\\it''s\\repo'" in cmd
+
+
+def test_ps_single_quote_escaping() -> None:
+    assert _ps_single_quote("it's") == "it''s"
+    assert _ps_single_quote("no quotes") == "no quotes"
+    assert _ps_single_quote("multiple 'in' here") == "multiple ''in'' here"
+
+
+# ── P1-D: Streaming layer has bounded tail buffer ─────────────────────
+
+
+def test_streaming_layer_has_bounded_output_buffer() -> None:
+    """The streaming layer must NOT keep unbounded output in memory."""
+    # This test asserts the source shape of the cap, since actually
+    # running a subprocess that produces 1+ MB of output in a unit
+    # test is heavy. The cap is documented in-code as
+    # _OUTPUT_TAIL_BYTES at the top of the reader loop.
+    from shipyard.executor import streaming
+
+    src = inspect.getsource(streaming)
+    assert "output_tail_bytes_cap" in src, (
+        "Tail buffer cap missing — streaming would keep every byte "
+        "resident for the lifetime of a long build"
+    )
+    assert "collections.deque" in src or "deque()" in src, (
+        "Tail buffer should be a deque for O(1) popleft"
+    )
+    assert "popleft" in src, "Tail rotation needs to pop the oldest fragment"


### PR DESCRIPTION
**Codex (via RepoPrompt) reviewed the SSH + bundle + executor layer before Stage 1 attempt 5** to find the NEXT class of latent bugs without burning more VM time. It flagged 4 P1 items, all fixed here.

## Context

The last 4 Stage 1 dogfood attempts each surfaced exactly one latent bug — a pattern indicating Shipyard's unit tests don't cover integration-level real-infrastructure scenarios. Running Codex with `-c mcp_servers.RepoPrompt.enabled=true` and explicit instructions to use RepoPrompt's `file_search`/`get_code_structure`/`context_builder` gave it structured access to the exact files in play.

## P1 findings, all fixed

### A. `apply_bundle` timeout was still 120s
After v0.1.10 raised `upload_bundle` to 1800s, both POSIX and Windows apply paths hard-limited `git bundle verify` + `git fetch` to 120s. For a 100 MB Pulp bundle on a Windows VM that's guaranteed to be too tight — Codex called this the most likely attempt-5 failure.

**Fix:** add `timeout` kwarg to both apply paths (default 1800s), thread `bundle_apply_timeout_secs` target-config override through both SSH executors.

### B. `FallbackChain` was dropping dispatch kwargs
`ExecutorDispatcher.validate_target()` forwards `**kwargs` (`progress_callback`, `resume_from`, `mode`) on the direct-dispatch path but called `FallbackChain.execute()` without them — same class as the v0.1.7 kwargs fix, in the fallback code path.

**Fix:** forward `**kwargs` through the `FallbackChain` branch. Regression test with a recording stub executor.

### C. Remote command builders used raw string concat
Both POSIX and Windows `_build_remote_command` interpolated `repo_path`, `sha`, and (Windows) bundle paths directly into shell/PS command strings. A space, apostrophe, or $ in target config would break parsing.

**Fix:**
- POSIX: `shlex.quote()` on `repo_path` and `sha`
- Windows: new `_ps_single_quote()` helper that doubles embedded quotes, applied to repo_path, sha, bundle path literals
- `apply_bundle()` gets the same `shlex.quote` treatment

### D. Streaming layer kept full output resident in memory
`output_parts: list[str]` in `run_streaming_command` collected every chunk for the lifetime of the run. On a long Pulp build (100k+ test output lines) this could use 50+ MB for something whose only consumers look at the tail.

**Fix:** `collections.deque` with a 1 MB tail cap; rotate on each append. The on-disk log still captures everything.

**Bonus:** decoded chunks now use `utf-8-sig` to strip BOMs (addresses Codex's P2 BOM finding).

## Tests

**10 new regression tests** in `test_codex_review_p1_batch.py` covering every fix.

**Full suite: 463 passing** (was 453; +10).

## Test plan

- [x] `ruff check` clean
- [x] `mypy` clean
- [x] `pytest tests/` — 463/463
- [ ] CI matrix
- [ ] Merge, tag v0.1.11
- [ ] Re-run Stage 1 attempt 5 against v0.1.11 — expecting all 3 targets green end-to-end