### PR TITLE
Fix: Windows false-green (mutex wrapper + nested platform overrides)

### DIFF
--- a/src/shipyard/cli.py
+++ b/src/shipyard/cli.py
@@ -1709,16 +1709,42 @@ def _resolve_validation(config: Config, mode: ValidationMode) -> dict[str, Any]:
 def _resolve_target_validation(
     config: Config, target_name: str, base: dict[str, Any]
 ) -> dict[str, Any]:
-    """Merge target-specific and platform-specific overrides into base validation."""
+    """Merge target-specific and platform-specific overrides into base validation.
+
+    Platform overrides are read from two locations for backwards
+    compatibility:
+      1. `base["overrides"][<platform_os>]` — nested inside the
+         already-resolved mode subtable (e.g.
+         `[validation.default.overrides.windows]`). This is how
+         Pulp declares its Windows-specific build commands.
+      2. `config.validation["overrides"][<platform_os>]` — at the
+         top of the validation block. Older shape, still supported
+         for projects that want a single override list for every
+         mode.
+
+    The nested form wins if both are declared, so per-mode
+    overrides can replace top-level ones.
+    """
     result = dict(base)
 
-    # Platform override
     target_config = config.targets.get(target_name, {})
     platform = target_config.get("platform", "")
     platform_os = platform.split("-")[0] if platform else ""
-    overrides = config.validation.get("overrides", {})
-    if platform_os in overrides:
-        result.update(overrides[platform_os])
+
+    # Top-level overrides (legacy shape)
+    top_overrides = config.validation.get("overrides", {})
+    if isinstance(top_overrides, dict) and platform_os in top_overrides:
+        result.update(top_overrides[platform_os])
+
+    # Mode-nested overrides (preferred shape — matches Pulp's config)
+    nested_overrides = base.get("overrides", {})
+    if isinstance(nested_overrides, dict) and platform_os in nested_overrides:
+        result.update(nested_overrides[platform_os])
+
+    # The `overrides` key has now been applied; strip it so it
+    # doesn't leak into the downstream validation_config as if it
+    # were a stage command.
+    result.pop("overrides", None)
 
     # Target-specific override
     target_validation = target_config.get("validation", {})

--- a/src/shipyard/executor/windows_toolchain.py
+++ b/src/shipyard/executor/windows_toolchain.py
@@ -64,7 +64,26 @@ def wrap_powershell_with_host_mutex(
     # Escape single quotes in the mutex name so it can be dropped into
     # a PowerShell single-quoted string literal safely.
     safe_mutex = mutex_name.replace("'", "''")
+    # The wrapper does two things PowerShell won't do on its own:
+    #   1. `$ErrorActionPreference = 'Stop'` elevates any
+    #      command-not-found or cmdlet error to a terminating
+    #      exception, so we can CATCH them instead of silently
+    #      continuing to the next statement (PowerShell's default
+    #      behavior for "setup.sh is not a recognized command" is
+    #      to continue, which masks real failures).
+    #   2. `$__ShipyardExit` starts at 1. If the body reaches its
+    #      own `$LASTEXITCODE` assignment we overwrite with the
+    #      body's actual exit code; if it throws before that, the
+    #      catch block sets `$__ShipyardExit = 1` explicitly and
+    #      writes the exception to stderr. Either way, the final
+    #      `exit $__ShipyardExit` ALWAYS runs with an explicit
+    #      non-null code. This closes the false-green hole where a
+    #      PS exception in the body caused the wrapper to fall
+    #      through and exit 0 — the exact class of bug that made
+    #      Stage 1 attempt 5 report "pass in 0.9s" against Pulp.
     return f"""
+$ErrorActionPreference = 'Stop'
+$__ShipyardExit = 1
 $MutexName = '{safe_mutex}'
 $Mutex = New-Object System.Threading.Mutex($false, $MutexName)
 $LockAcquired = $false
@@ -84,8 +103,17 @@ try {{
         $LockAcquired = $true
     }}
 
-    {ps_body}
-    $__ShipyardExit = $LASTEXITCODE
+    try {{
+        {ps_body}
+        $__ShipyardExit = $LASTEXITCODE
+        if ($null -eq $__ShipyardExit) {{
+            $__ShipyardExit = 0
+        }}
+    }} catch {{
+        Write-Error ("Shipyard body raised: " + $_.Exception.Message)
+        Write-Error ($_.ScriptStackTrace)
+        $__ShipyardExit = 1
+    }}
 }} finally {{
     if ($LockAcquired) {{
         try {{
@@ -95,9 +123,7 @@ try {{
     }}
     $Mutex.Dispose()
 }}
-if ($null -ne $__ShipyardExit) {{
-    exit $__ShipyardExit
-}}
+exit $__ShipyardExit
 """.strip()
 
 

--- a/tests/test_windows_false_green.py
+++ b/tests/test_windows_false_green.py
@@ -1,0 +1,182 @@
+"""Regression tests for the Windows false-green bug.
+
+Stage 1 attempt 5 against Pulp reported `windows: pass` in 0.9 seconds
+with an empty log. Two stacked bugs:
+
+1. The PowerShell mutex wrapper's try/finally structure could fall
+   through to an implicit exit 0 when the wrapped body raised an
+   exception before reaching `$__ShipyardExit = $LASTEXITCODE`.
+   Any command-not-found error (e.g. running `./setup.sh` on
+   Windows PowerShell) would surface as "pass".
+
+2. `_resolve_target_validation` read platform overrides from
+   `config.validation["overrides"]` at the TOP of validation, but
+   Pulp declares them at `[validation.default.overrides.windows]`
+   — nested inside the mode subtable. Windows was running with
+   Pulp's POSIX stage commands (`./setup.sh`, cmake without -G,
+   etc.) which immediately tripped the first bug.
+"""
+
+from __future__ import annotations
+
+from shipyard.core.config import Config
+from shipyard.core.job import ValidationMode
+
+# ── Fix 1: mutex wrapper fails loud on PowerShell exceptions ──────────
+
+
+def test_mutex_wrapper_forces_explicit_exit() -> None:
+    """The wrapped PS script must always end with `exit $__ShipyardExit`."""
+    from shipyard.executor.windows_toolchain import wrap_powershell_with_host_mutex
+
+    wrapped = wrap_powershell_with_host_mutex("Write-Host ok")
+    # Every code path must reach the explicit exit — no fall-through
+    assert wrapped.rstrip().endswith("exit $__ShipyardExit")
+    # The previous false-green pattern is gone
+    assert "if ($null -ne $__ShipyardExit)" not in wrapped
+
+
+def test_mutex_wrapper_catches_body_exceptions() -> None:
+    """A PS exception in the body must be caught and reported as exit 1."""
+    from shipyard.executor.windows_toolchain import wrap_powershell_with_host_mutex
+
+    wrapped = wrap_powershell_with_host_mutex("echo hi")
+    # The body runs inside its own try/catch; the catch sets exit 1
+    assert "catch {" in wrapped or "} catch {" in wrapped
+    assert "$__ShipyardExit = 1" in wrapped
+    # Default is also 1, so a `finally` jump without body completion
+    # still fails loud
+    assert "$__ShipyardExit = 1" in wrapped.split("try {")[0]
+
+
+def test_mutex_wrapper_elevates_errors_to_terminating() -> None:
+    """ErrorActionPreference must be Stop so unknown-command errors catch."""
+    from shipyard.executor.windows_toolchain import wrap_powershell_with_host_mutex
+
+    wrapped = wrap_powershell_with_host_mutex("echo hi")
+    assert "$ErrorActionPreference = 'Stop'" in wrapped
+
+
+def test_mutex_wrapper_body_exit_code_still_wins_on_success() -> None:
+    """When the body finishes cleanly, its $LASTEXITCODE is preserved."""
+    from shipyard.executor.windows_toolchain import wrap_powershell_with_host_mutex
+
+    wrapped = wrap_powershell_with_host_mutex("Write-Host ok")
+    # The success path assigns from $LASTEXITCODE, with fallback to 0
+    # when the body ran no external process (so $LASTEXITCODE is null)
+    assert "$__ShipyardExit = $LASTEXITCODE" in wrapped
+
+
+# ── Fix 2: nested platform overrides resolve correctly ───────────────
+
+
+def test_resolve_target_validation_applies_nested_platform_overrides() -> None:
+    """Overrides inside `[validation.default.overrides.windows]` must win.
+
+    This is the Pulp config shape that was silently ignored by the
+    old `config.validation.get("overrides", {})` lookup.
+    """
+    from shipyard.cli import _resolve_target_validation, _resolve_validation
+
+    config = Config(data={
+        "validation": {
+            "default": {
+                "setup": "./setup.sh",
+                "configure": "cmake -S . -B build",
+                "build": "cmake --build build",
+                "test": "ctest --test-dir build",
+                "overrides": {
+                    "windows": {
+                        "configure": 'cmake -S . -B build -G "Visual Studio 17 2022" -A x64',
+                        "build": "cmake --build build --config Release",
+                        "test": "ctest --test-dir build -C Release",
+                    },
+                },
+            },
+        },
+        "targets": {
+            "windows": {
+                "backend": "ssh-windows",
+                "platform": "windows-x64",
+            },
+        },
+    })
+
+    base = _resolve_validation(config, ValidationMode.FULL)
+    resolved = _resolve_target_validation(config, "windows", base)
+
+    assert "Visual Studio 17 2022" in resolved["configure"]
+    assert "Config Release" in resolved["build"] or "Release" in resolved["build"]
+    assert "-C Release" in resolved["test"]
+    # setup had no override, so the POSIX default survives
+    assert resolved["setup"] == "./setup.sh"
+    # The `overrides` key is stripped so it doesn't leak into the
+    # downstream validation_config
+    assert "overrides" not in resolved
+
+
+def test_resolve_target_validation_respects_legacy_top_level_overrides() -> None:
+    """Older config shape `[validation.overrides.<os>]` still works."""
+    from shipyard.cli import _resolve_target_validation, _resolve_validation
+
+    config = Config(data={
+        "validation": {
+            "default": {"setup": "./setup.sh"},
+            "overrides": {
+                "linux": {"setup": "./setup.sh --linux"},
+            },
+        },
+        "targets": {
+            "ubuntu": {"backend": "ssh", "platform": "linux-x64"},
+        },
+    })
+
+    base = _resolve_validation(config, ValidationMode.FULL)
+    resolved = _resolve_target_validation(config, "ubuntu", base)
+    assert resolved["setup"] == "./setup.sh --linux"
+
+
+def test_resolve_target_validation_mode_nested_wins_over_top_level() -> None:
+    """When both are declared, the mode-nested override wins."""
+    from shipyard.cli import _resolve_target_validation, _resolve_validation
+
+    config = Config(data={
+        "validation": {
+            "default": {
+                "setup": "./setup.sh",
+                "overrides": {
+                    "windows": {"setup": "mode nested"},
+                },
+            },
+            "overrides": {
+                "windows": {"setup": "top level"},
+            },
+        },
+        "targets": {
+            "windows": {"backend": "ssh-windows", "platform": "windows-x64"},
+        },
+    })
+
+    base = _resolve_validation(config, ValidationMode.FULL)
+    resolved = _resolve_target_validation(config, "windows", base)
+    assert resolved["setup"] == "mode nested"
+
+
+def test_resolve_target_validation_no_overrides_unchanged() -> None:
+    """Configs without any overrides resolve to the base mode dict."""
+    from shipyard.cli import _resolve_target_validation, _resolve_validation
+
+    config = Config(data={
+        "validation": {
+            "default": {"setup": "./setup.sh", "build": "make"},
+        },
+        "targets": {
+            "mac": {"backend": "local", "platform": "macos-arm64"},
+        },
+    })
+
+    base = _resolve_validation(config, ValidationMode.FULL)
+    resolved = _resolve_target_validation(config, "mac", base)
+    assert resolved["setup"] == "./setup.sh"
+    assert resolved["build"] == "make"
+    assert "overrides" not in resolved


### PR DESCRIPTION
**Stage 1 attempt 5 against Pulp reported `windows: pass` in 0.9 seconds with an empty log file.** Investigation found two stacked bugs that together turned a genuine Windows failure into a false success.

## Bug 1 (P0): mutex wrapper silently exits 0 on PS exceptions

`wrap_powershell_with_host_mutex()` had:

```powershell
try {
    ...
    {ps_body}
    $__ShipyardExit = $LASTEXITCODE
} finally { ... }
if ($null -ne $__ShipyardExit) { exit $__ShipyardExit }
```

When the body raised any PowerShell terminating exception before reaching the `$LASTEXITCODE` assignment, `$__ShipyardExit` stayed null, the if-check failed, and the script fell through to the implicit end and exited with code 0. Shipyard reported PASS.

**Fix:** default `$__ShipyardExit = 1` before the try block, wrap the body in its own try/catch that explicitly sets the exit code on both success and failure, set `$ErrorActionPreference = 'Stop'` to elevate non-terminating errors, and **always** `exit $__ShipyardExit` unconditionally at the end.

## Bug 2 (P0): platform overrides read from wrong path

`_resolve_target_validation` looked up platform overrides at `config.validation["overrides"]`. But Pulp declares them under `[validation.default.overrides.windows]` — nested inside the mode subtable. Windows was running with Pulp's POSIX `./setup.sh` which triggered Bug 1.

**Fix:** check both the legacy top-level location AND the mode-nested location, with mode-nested winning when both are declared. Also strip `overrides` from the resolved dict so it doesn't leak downstream.

## Tests

**8 new regression tests** pin both fixes. Full suite: **471 passing** (was 463; +8).

## Why this wasn't caught earlier

Mocked unit tests can't reproduce PowerShell's exception-to-exit-code behavior — that only surfaces against real `powershell.exe`. The override bug similarly needed a live target config to hit. Both bugs are now pinned so this exact scenario fails loud at test time.

## Test plan

- [x] `ruff check` clean
- [x] `mypy` clean
- [x] `pytest tests/` — 471/471
- [ ] CI matrix
- [ ] Merge, tag v0.1.12
- [ ] Re-run Stage 1 attempt 6 against v0.1.12 — expecting all 3 targets to actually exercise the validation end-to-end