### PR TITLE
Fix Windows SSH multi-line script drop (Stage 1 false-green root cause)

### DIFF
--- a/src/shipyard/executor/ssh_windows.py
+++ b/src/shipyard/executor/ssh_windows.py
@@ -2,10 +2,22 @@
 
 Same bundle-based delivery as the POSIX SSH executor, but uses PowerShell
 semantics for remote commands and Windows-style paths.
+
+Multi-line PowerShell scripts are always sent via ``-EncodedCommand`` with
+a base64-encoded UTF-16LE payload rather than ``-Command <raw script>``.
+The naive ``-Command`` path silently drops every line after the first when
+the script reaches PowerShell through Windows OpenSSH's cmd.exe default
+shell — each newline is interpreted by cmd.exe as a command separator.
+A 60-line mutex wrapper would run only its first line (a silent
+``$ErrorActionPreference = 'Stop'`` assignment), exit 0, and return an
+empty stdout buffer. Shipyard then reported the target as ``pass`` in
+0.9 seconds with an empty log: a silent false-green. ``-EncodedCommand``
+bypasses cmd.exe entirely because the payload is a single argv token.
 """
 
 from __future__ import annotations
 
+import base64
 import subprocess
 import tempfile
 import time
@@ -156,7 +168,9 @@ class SSHWindowsExecutor:
             )
 
         ssh_cmd = (
-            ["ssh"] + list(ssh_options) + [host, "powershell", "-Command", command]
+            ["ssh"]
+            + list(ssh_options)
+            + _powershell_encoded_argv(host, command)
         )
 
         contract_config = validation_config.get("contract") if validation_config else None
@@ -304,6 +318,75 @@ def _ps_single_quote(value: str) -> str:
     return value.replace("'", "''")
 
 
+def _encode_powershell_command(script: str) -> str:
+    """Encode a PowerShell script for `powershell -EncodedCommand`.
+
+    PowerShell expects a base64-encoded UTF-16LE byte sequence. This
+    is the standard, well-documented way to send a multi-line script
+    through any transport (cmd.exe, ssh, anything else) that might
+    interpret newlines as command separators.
+    """
+    return base64.b64encode(script.encode("utf-16-le")).decode("ascii")
+
+
+def _decode_powershell_command(encoded: str) -> str:
+    """Inverse of `_encode_powershell_command`.
+
+    Used by tests so they can assert against the original PS source
+    instead of opaque base64. Not used at runtime.
+    """
+    return base64.b64decode(encoded).decode("utf-16-le")
+
+
+def decode_encoded_ssh_argv(ssh_argv: list[str]) -> str | None:
+    """Public helper: decode the `-EncodedCommand` payload from an ssh argv.
+
+    Returns the original PowerShell script if `ssh_argv` contains
+    `-EncodedCommand <payload>`, else None. Tests can use this to
+    assert against the original PS source after the executor packs
+    it through `_powershell_encoded_argv`.
+    """
+    try:
+        idx = ssh_argv.index("-EncodedCommand")
+    except ValueError:
+        return None
+    if idx + 1 >= len(ssh_argv):
+        return None
+    return _decode_powershell_command(ssh_argv[idx + 1])
+
+
+def _powershell_encoded_argv(host: str, script: str) -> list[str]:
+    """Build the `[host, powershell, ...]` tail of an ssh argv.
+
+    Always uses `-NoProfile` (skip user profile, faster startup) and
+    `-EncodedCommand` (avoids the multi-line drop bug below). Both
+    `validate()` and `_apply_bundle_windows()` route through this so
+    every PowerShell-over-SSH call goes through the same hardened
+    surface.
+
+    History: an earlier version sent the script via
+    `powershell -Command <raw>`. That worked for single-line
+    scripts but silently dropped every line after the first when
+    the script reached PowerShell through Windows OpenSSH's
+    cmd.exe shell, because cmd.exe interprets newlines as command
+    separators. The 60+-line mutex wrapper would run only its
+    first line (a silent `$ErrorActionPreference = 'Stop'`
+    assignment), exit 0, and produce zero stdout — which Shipyard
+    reported as `pass`. False-greens are the worst class of CI
+    bug; `-EncodedCommand` makes the bug structurally impossible.
+    """
+    return [
+        host,
+        "powershell",
+        "-NoProfile",
+        "-NonInteractive",
+        "-OutputFormat",
+        "Text",
+        "-EncodedCommand",
+        _encode_powershell_command(script),
+    ]
+
+
 def _apply_bundle_windows(
     host: str,
     bundle_path: str,
@@ -354,7 +437,7 @@ def _apply_bundle_windows(
         f"if ($LASTEXITCODE -ne 0) {{ exit 1 }}"
     )
 
-    cmd = ["ssh"] + list(ssh_options) + [host, "powershell", "-Command", ps_cmd]
+    cmd = ["ssh"] + list(ssh_options) + _powershell_encoded_argv(host, ps_cmd)
 
     try:
         result = subprocess.run(

--- a/src/shipyard/executor/windows_toolchain.py
+++ b/src/shipyard/executor/windows_toolchain.py
@@ -194,19 +194,31 @@ def detect_vs_toolchain(
     not "error" — Windows hosts without multiple VS installations work
     fine without this hint.
     """
+    # Send the script via -EncodedCommand (base64 UTF-16LE) rather than
+    # `-Command -` + stdin. The stdin path looks reasonable but is
+    # silently broken on Windows: PowerShell's `-Command -` reads each
+    # input line as a separate command, so multi-line constructs like
+    # `try { ... } catch { ... }`, function definitions, and `& { ... }`
+    # script blocks get parsed wrong and produce zero stdout — which
+    # this function then interpreted as "no toolchain detected" and
+    # silently fell back to CMake defaults. Empirically verified
+    # against a real Windows host: `-Command -` returns rc=0 with empty
+    # stdout for the same script that `-EncodedCommand` runs cleanly.
+    import base64
+
+    encoded = base64.b64encode(_VS_DETECT_SCRIPT.encode("utf-16-le")).decode("ascii")
     cmd = [
         "ssh",
         *list(ssh_options),
         host,
         "powershell",
         "-NoProfile",
-        "-Command",
-        "-",
+        "-EncodedCommand",
+        encoded,
     ]
     try:
         run = subprocess.run(
             cmd,
-            input=_VS_DETECT_SCRIPT,
             capture_output=True,
             text=True,
             timeout=timeout,

--- a/tests/executor/test_ssh.py
+++ b/tests/executor/test_ssh.py
@@ -8,7 +8,10 @@ from unittest.mock import MagicMock, patch
 
 from shipyard.core.job import TargetStatus
 from shipyard.executor.ssh import SSHExecutor
-from shipyard.executor.ssh_windows import SSHWindowsExecutor
+from shipyard.executor.ssh_windows import (
+    SSHWindowsExecutor,
+    decode_encoded_ssh_argv,
+)
 from shipyard.executor.streaming import StreamingCommandResult
 
 # ---------------------------------------------------------------------------
@@ -380,7 +383,14 @@ class TestSSHWindowsExecutorValidate:
 
             ssh_cmd = mock_run.call_args[0][0]
             assert "powershell" in ssh_cmd
-            assert "-Command" in ssh_cmd
+            # The command must be sent via -EncodedCommand, not
+            # -Command, because Windows OpenSSH's cmd.exe shell
+            # interprets newlines in -Command arguments as command
+            # separators and silently drops every line after the
+            # first. -EncodedCommand bypasses cmd.exe parsing.
+            assert "-EncodedCommand" in ssh_cmd
+            assert "-Command" not in ssh_cmd
+            assert "-NoProfile" in ssh_cmd
 
     def test_validate_host_mutex_default_wraps_command(self, tmp_path) -> None:
         """When windows_host_mutex is not explicitly disabled, the command is wrapped."""
@@ -417,8 +427,10 @@ class TestSSHWindowsExecutorValidate:
             )
 
             ssh_cmd = mock_run.call_args[0][0]
-            # The last argument is the PowerShell command string.
-            ps = ssh_cmd[-1]
+            # The PS script is base64-encoded inside -EncodedCommand;
+            # decode before asserting against the source.
+            ps = decode_encoded_ssh_argv(ssh_cmd)
+            assert ps is not None
             assert "System.Threading.Mutex" in ps
             assert "Global\\ShipyardValidate" in ps
 
@@ -453,7 +465,8 @@ class TestSSHWindowsExecutorValidate:
                 validation_config=_validation_config(),
                 log_path=log_path,
             )
-            ps = mock_run.call_args[0][0][-1]
+            ps = decode_encoded_ssh_argv(mock_run.call_args[0][0])
+            assert ps is not None
             assert "Global\\MyCustomLock" in ps
             assert "Global\\ShipyardValidate" not in ps
 
@@ -496,7 +509,8 @@ class TestSSHWindowsExecutorValidate:
                 validation_config=_validation_config(),
                 log_path=log_path,
             )
-            ps = mock_run.call_args[0][0][-1]
+            ps = decode_encoded_ssh_argv(mock_run.call_args[0][0])
+            assert ps is not None
             assert "$env:SHIPYARD_CMAKE_PLATFORM = 'ARM64'" in ps
             assert "C:/VS/2022/Community" in ps
 

--- a/tests/executor/test_ssh_windows_bundle_path.py
+++ b/tests/executor/test_ssh_windows_bundle_path.py
@@ -48,12 +48,15 @@ def test_apply_command_uses_home_for_relative_path() -> None:
     """A relative bundle path must be resolved via Join-Path $HOME."""
     from unittest.mock import patch
 
-    from shipyard.executor.ssh_windows import _apply_bundle_windows
+    from shipyard.executor.ssh_windows import (
+        _apply_bundle_windows,
+        decode_encoded_ssh_argv,
+    )
 
-    captured: list[str] = []
+    captured: list[list[str]] = []
 
     def fake_run(cmd, *args, **kwargs):
-        captured.append(cmd[-1])  # last arg is the PS command string
+        captured.append(list(cmd))
         import subprocess
         return subprocess.CompletedProcess(
             args=cmd, returncode=0, stdout="", stderr="",
@@ -68,7 +71,11 @@ def test_apply_command_uses_home_for_relative_path() -> None:
         )
 
     assert len(captured) == 1
-    ps_cmd = captured[0]
+    # Bundle apply now also goes through -EncodedCommand for the
+    # same multi-line-drop reason the main validate path does.
+    assert "-EncodedCommand" in captured[0]
+    ps_cmd = decode_encoded_ssh_argv(captured[0])
+    assert ps_cmd is not None
     assert "Join-Path $HOME 'shipyard.bundle'" in ps_cmd
     assert "$Bundle = " in ps_cmd
 
@@ -77,12 +84,15 @@ def test_apply_command_uses_literal_absolute_path() -> None:
     """An absolute bundle path is used verbatim, not wrapped in Join-Path."""
     from unittest.mock import patch
 
-    from shipyard.executor.ssh_windows import _apply_bundle_windows
+    from shipyard.executor.ssh_windows import (
+        _apply_bundle_windows,
+        decode_encoded_ssh_argv,
+    )
 
-    captured: list[str] = []
+    captured: list[list[str]] = []
 
     def fake_run(cmd, *args, **kwargs):
-        captured.append(cmd[-1])
+        captured.append(list(cmd))
         import subprocess
         return subprocess.CompletedProcess(
             args=cmd, returncode=0, stdout="", stderr="",
@@ -96,6 +106,7 @@ def test_apply_command_uses_literal_absolute_path() -> None:
             ssh_options=[],
         )
 
-    ps_cmd = captured[0]
+    ps_cmd = decode_encoded_ssh_argv(captured[0])
+    assert ps_cmd is not None
     assert "'C:\\Users\\me\\my.bundle'" in ps_cmd
     assert "Join-Path" not in ps_cmd

--- a/tests/executor/test_windows_toolchain.py
+++ b/tests/executor/test_windows_toolchain.py
@@ -199,3 +199,36 @@ def test_detect_returns_none_when_both_fields_empty() -> None:
     stdout = '{"platform":"","generator_instance":""}\n'
     with patch("subprocess.run", return_value=_mock_run(stdout=stdout)):
         assert detect_vs_toolchain("host", []) is None
+
+
+def test_detect_uses_encoded_command_not_stdin() -> None:
+    """The detect script must travel via -EncodedCommand, not -Command -.
+
+    Regression test: an earlier version used `powershell -Command -` +
+    stdin, which silently failed on Windows because PowerShell parses
+    stdin line-by-line and the detect script has multi-line `function`
+    and `try { ... } catch { ... }` blocks. The result was rc=0 with
+    empty stdout — silently masked by `detect_vs_toolchain` falling
+    back to None and the executor using CMake defaults. The bug was
+    invisible until the broader Windows false-green investigation
+    surfaced it.
+    """
+    captured: list[list[str]] = []
+
+    def fake_run(cmd, *args, **kwargs):
+        captured.append(list(cmd))
+        # `input=` must NOT be passed — the script travels in argv.
+        assert "input" not in kwargs, (
+            "detect_vs_toolchain must not pipe the script via stdin; "
+            "PowerShell -Command - parses stdin line-by-line and "
+            "silently drops multi-line constructs."
+        )
+        return _mock_run(stdout='{"platform":"x64","generator_instance":"C:/VS"}\n')
+
+    with patch("subprocess.run", side_effect=fake_run):
+        result = detect_vs_toolchain("host", [])
+
+    assert len(captured) == 1
+    assert "-EncodedCommand" in captured[0]
+    assert "-Command" not in captured[0]
+    assert result is not None


### PR DESCRIPTION
## Summary

Root cause fix for the Stage 1 Windows false-green that's been blocking the Shipyard migration in Pulp.

## The bug

SSH to Windows OpenSSH uses `cmd.exe` as the default shell. Passing a multi-line PowerShell script via `powershell -Command <script>` causes cmd.exe to interpret newlines as command separators — **only the first line of the script ever reaches PowerShell**.

For Pulp's validation wrapper this meant the 60+ line mutex wrapper executed exactly one statement (`$ErrorActionPreference = 'Stop'`), the assignment produced no output, PowerShell exited 0, and we logged a 0.9s "pass" with an empty stdout. Classic silent false-green — every Stage 1 attempt from attempt 5 onwards hit this.

## Reproduction (against real Windows VM)

```
Test 1 (single Write-Host):          stdout='hello\n'              ✓
Test 2 (3 lines via \n):              stdout='one\n'   (lines 2-3 dropped)
Test 3 ($EAP=Stop\nWrite-Host foo):  stdout=''        (silent false-green)
Test 4 (semicolons not newlines):    stdout='from-semicolons\n'    ✓
Test 5 (-EncodedCommand, 4 lines):   stdout='line-one\nline-two\nline-three\n' ✓
```

## Fix

Wrap every PowerShell invocation in `-EncodedCommand` with a base64 UTF-16LE payload. PowerShell decodes the payload internally, so cmd.exe never sees the script body and can't split it.

Applied to both `SSHWindowsExecutor.validate()` and `_apply_bundle_windows()` (which had the same structural bug for bundle apply).

New helpers in `src/shipyard/executor/ssh_windows.py`:
- `_encode_powershell_command` / `_decode_powershell_command`
- `decode_encoded_ssh_argv` — lets tests assert on the PS script shape after argv is base64-encoded
- `_powershell_encoded_argv` — single source of truth for the argv shape

## Verification

End-to-end smoke test against the real win VM (same config Pulp uses for Stage 1):

```
status: PASS
duration_secs: 1.29
---log---
__SHIPYARD_PHASE__:setup
STEP=setup
__SHIPYARD_PHASE__:configure
STEP=configure
__SHIPYARD_PHASE__:build
STEP=build
__SHIPYARD_PHASE__:test
STEP=test
final line
```

All 4 phases actually executed and wrote their output. This is the opposite of the empty-log 0.9s false-green we were debugging.

## Test plan
- [x] `pytest tests/` — 471 passed
- [x] `pytest tests/executor/test_ssh.py tests/executor/test_ssh_windows_bundle_path.py` — 30 passed
- [x] End-to-end validate against real win VM — all phases execute and log
- [ ] Cut v0.1.13
- [ ] Bump Pulp pin to v0.1.13
- [ ] Re-run Pulp Stage 1 attempt 7 — expecting all 3 targets genuinely green