### PR TITLE
Harden Shipyard: incremental bundles, SSH resume, cloud timeout, slim README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,638 +1,38 @@
-[Blog post about Shipyard](https://danielraffel.me/2026/04/09/shipyard-is-a-cross-platform-ci-orchestration-layer-that-coordinates-validation-for-ai-agents-working-across-parallel-worktrees/)
-
 # Shipyard
 
-Shipyard is a cross-platform CI orchestration layer for projects that already build and test. It validates the exact commit across local machines, VMs, SSH hosts, and cloud runners, then gives AI agents structured results they can use to fix failures, retry, and merge only when everything is green.
+**Cross-platform CI for AI agents.** Validates the exact commit on every
+machine you configure — local Mac, SSH-reachable VMs, cloud runners — and
+merges only when everything is green.
 
 ```bash
 curl -fsSL https://generouscorp.com/Shipyard/install.sh | sh
 cd my-project
 shipyard init        # detects your project, probes your machines
 shipyard run         # validates on every platform you configured
+shipyard ship        # validate, open PR, merge on green
 ```
 
----
-
-## Who This Is For
-
-You have AI agents writing code across parallel worktrees. When they finish, you want them to validate builds, run tests, open a PR, and merge automatically — only when everything passes.
-
-If something fails, the agent should read the logs, fix the issue, and retry. No babysitting.
-
-Shipyard makes this reliable. Agents commit; Shipyard coordinates validation across platforms; code lands on main  only when all targets are green.
-
-You test with what you already have: your Mac, a UTM or Parallels VM for
-Windows and Linux, maybe a Namespace or GitHub Actions account for cloud
-runners. Shipyard ties them together — you don't need to set up Jenkins,
-maintain a self-hosted runner fleet, or write workflow YAML. Just point it
-at your machines and go.
-
-## How It Works
-
-- **Local builds** run directly on your host machine — fast, no network
-- **Remote builds** run in separate environments you control — VMs, containers, or machines over SSH (local or on your network; physical location doesn’t matter)
-- **Cloud builds** run on managed infrastructure — Namespace, GitHub Actions, etc., for neutral or on-demand capacity
-
-`shipyard run` delivers the exact commit to each machine, runs your build
-and test commands, and reports what passed. If a machine is unreachable,
-Shipyard can try the next option automatically — boot a VM, or dispatch
-to cloud. Or it just reports unreachable and stops. You choose.
-
-`shipyard ship` validates and then creates a PR and merges it.
-
-Shipyard is not a [CI service](https://en.wikipedia.org/wiki/Continuous_integration), not a [build system](https://en.wikipedia.org/wiki/Build_automation), not a [workflow engine](https://en.wikipedia.org/wiki/Workflow_engine).
-It calls your build commands and cares about one thing: did they pass?
-
-## What Makes It Different
-
-Most of what Shipyard does — exact-SHA validation, fallback chains,
-stage-aware resume, ecosystem auto-detection, JSON output — is
-table-stakes for a modern CI tool. None of those are the reason to
-adopt Shipyard. The actual differentiators are four things most
-indie developers can't easily wire up themselves:
-
-**Safe, real cross-platform CI for AI agents.** Shipyard is designed
-for the case where an agent — Claude Code, Codex, or something
-scripted on top — opens a PR on your machine and needs real
-cross-platform proof before merging. The one-command setup for
-agents (Claude Code plugin, Codex installer) means you don't hand
-your agents the keys to your DAW, your notarization identity, or
-your publishing account. The agent runs `shipyard ship`; Shipyard
-handles the bundle delivery, the remote validation, the merge
-gate, and the audit trail. There's no equivalent off-the-shelf tool
-for an indie dev who wants to give agents real cross-platform CI
-access without rolling their own orchestration.
-
-**Declarative security & governance.** Pick a profile — `solo` or
-`multi` — and `shipyard governance apply` sets branch protection,
-tag protection, default workflow token permissions, and (via
-follow-ups) deployment approval + sigstore release attestations to
-match. Drift is surfaced by `shipyard governance status` and in
-`shipyard doctor`. All of the hardening practices Astral
-[documents for open-source projects](https://astral.sh/blog/open-source-security-at-astral)
-are packaged as one TOML line and one CLI command. Without this, an
-indie dev has to click through six GitHub settings pages, remember
-every knob, and hope they got it right.
-
-**Evidence-based merge gate.** `shipyard ship` refuses to merge
-unless every required platform has passing evidence **for the exact
-HEAD SHA** — not the most-recent run, not the branch tip, the SHA.
-Evidence records are bound to a commit, so a stale green from a
-prior commit cannot satisfy the gate. Standard CI plugins on GitHub
-only track the latest run per workflow; proving the *specific
-commit* is green requires wiring up something custom.
-
-**Parallel-agent-aware queue.** Multiple agents in multiple
-worktrees share one machine-global queue. Jobs are prioritized,
-scheduled FIFO within priority, and automatically deduplicated
-when a new commit supersedes a pending job on the same branch —
-without cancelling narrower reruns (single target) or different
-validation modes (smoke vs full). This is the thing that actually
-makes parallel-agent workflows safe on a single dev machine; GitHub
-Actions doesn't know anything about your local worktrees.
-
-### Features
-
-The rest of what Shipyard ships is the normal set of conveniences
-you'd want for day-to-day use:
-
-- **Exact-SHA remote delivery** via git bundles — no git
-  credentials on target machines.
-- **Fail-fast across targets** (with `--continue` to run everything
-  anyway).
-- **Targeted re-runs** — re-validate one platform and keep the
-  existing evidence for the others.
-- **Stage-aware resume** — `--resume-from test` skips configure
-  and build when only the test stage failed.
-- **Failover chains** with real-vs-transient error distinction
-  (9 transient SSH error patterns retry before fallback;
-  `Permission denied` fails immediately).
-- **Target profiles** for instant environment switching
-  (`shipyard config use local`).
-- **22 ecosystem detectors** — `shipyard init` recognises CMake,
-  Swift, Xcode, Rust, Go, Node (pnpm / bun / yarn / npm), Python
-  (uv / poetry / pip), Gradle, Maven, .NET, Flutter, Dart, Deno,
-  Ruby, Elixir, PHP.
-- **Structured JSON on every command** (`--json`) with a versioned
-  schema so agents parse output directly.
-- **Operational cleanup** (`shipyard cleanup`) plus automatic
-  queue trimming to the 25 most recent completed jobs.
-
----
-
-## Security & Governance Profiles
-
-Shipyard manages a project's GitHub-side governance settings —
-branch protection on `main`, tag protection on release tags, default
-workflow token permissions, release approval gates — declaratively from
-`.shipyard/config.toml`. Pick a profile, run `shipyard governance apply`,
-and the live GitHub state matches the profile. Drift between the declared
-config and the live state is reported by `shipyard governance status`.
-
-### Pick a profile
-
-```toml
-# .shipyard/config.toml
-[project]
-profile = "solo"   # one of: solo, multi, custom
-```
-
-The two presets cover the most common shapes: a single maintainer who
-takes occasional third-party PRs, and a multi-contributor team with real
-review requirements. `custom` lets you declare every knob explicitly.
-
-### What each profile sets
-
-| Setting | `solo` | `multi` | Why the difference |
-|---|---|---|---|
-| Branch protection: require PR | ✅ | ✅ | Catches stray pushes either way |
-| Branch protection: required status checks | ✅ (configured) | ✅ (configured) | The whole point of CI |
-| Branch protection: strict status checks | ❌ | ✅ | Solo doesn't need rebase coordination |
-| Branch protection: required reviews | 0 | 1 | Solo can't review their own PR |
-| Branch protection: enforce on admins | ❌ | ✅ | Solo needs a 3 AM hotfix path |
-| Branch protection: dismiss stale reviews | ❌ | ✅ | Force re-review on rebase in multi |
-| Tag protection: forbid update / delete / force | ✅ | ✅ | Trivy-style attack prevention |
-| Tag protection: forbid creation by non-admins | ❌ | ✅ | Solo creates release tags directly |
-| Default workflow token | read | read | Both — pure win, zero friction |
-| Forbid sensitive branch patterns | ❌ | ✅ | Solo has no co-maintainers to coordinate disclosure with |
-| Release approval gate | `off` (or `auto`) | `manual` | Solo doesn't gain from approving themselves |
-| Sigstore release attestations | ✅ | ✅ | Free, no friction, helps downstream verifiers |
-| Immutable releases | ✅ | ✅ | Free, no friction |
-| Action SHA pinning (Renovate) | ✅ | ✅ | Same — managed by Renovate |
-| `zizmor` workflow lint in CI | ✅ | ✅ | Same — runs automatically |
-| Renovate cooldown (third-party / first-party days) | 3 / 0 | 3 / 0 | Same |
-
-The pattern: **anything that's an "attacker-side" guardrail is on for
-both profiles** (free security), and **anything that's a "process
-correctness" guardrail varies** (solo doesn't gain from rules that
-exist to coordinate multiple humans).
-
-### Commands
-
-```bash
-shipyard governance status     # show declared vs live drift per branch
-shipyard governance diff       # what `apply` would change (dry run)
-shipyard governance apply      # bring live GitHub state in line with config
-```
-
-`status` is the rollup view that shows where things stand without
-clicking through six GitHub settings pages. `diff` is the dry-run
-before any mutation. `apply` is the idempotent apply — re-running
-it on an aligned repo issues zero API writes.
-
-`shipyard doctor` grows a "Governance" section that folds main-branch
-drift into the same health check as git, ssh, and cloud auth, so CI
-scripts and agents get a single pass/fail answer about whether the
-repo is in the expected state.
-
-Shipyard's profile table is the governance **target**. Branch
-protection is enforced via the GitHub REST API today; tag protection,
-rulesets, deployment environments, sigstore attestations, and the
-immutable-releases row are partly API-manageable and partly
-UI-only — the planning repo tracks which pieces land in which
-release. Shipyard never claims a state it cannot verify: the
-immutable-releases row in `doctor` and `governance status` prints
-an informational line pointing at the settings URL rather than a
-check or cross, because GitHub does not expose the repo-level
-toggle via API on personal repos.
-
-### Inspired by Astral
-
-The governance profiles, the action SHA pinning workflow, the tag
-protection, immutable releases, default read-only workflow tokens, and
-the deployment approval pattern all follow practices documented in
-[Astral's open-source security post](https://astral.sh/blog/open-source-security-at-astral).
-Astral built and maintains uv, Ruff, and ty — millions of developers
-depend on those tools, so they had to figure out the security baseline
-for cross-platform Python tooling under real attacker pressure. The
-post is the canonical reference for *why* each of these settings
-matters, and Shipyard packages the *how* into a one-command profile
-switch so you don't have to figure it out from first principles.
-
-Pulp ([github.com/danielraffel/pulp](https://github.com/danielraffel/pulp))
-is the first project to adopt Shipyard's governance profile system.
-Pulp runs on the `solo` profile because it has a single maintainer
-today; switching to `multi` would be a single-line edit to
-`[project].profile` in `.shipyard/config.toml` plus a `shipyard
-governance apply`, with no other config changes.
-
----
-
-## Examples
-
-### What your project needs
-
-Shipyard runs your existing build and test commands on each platform. It
-assumes your project already has:
-
-- A build system (CMake, Xcode, Cargo, npm, Gradle, Swift, etc.)
-- Test commands that exit 0 on success and non-zero on failure
-
-If your project builds and has tests, Shipyard can validate it. If it
-doesn't have tests yet, Shipyard still validates that the build succeeds.
-
----
-
-### Scenario 1: You're building a macOS and iOS app
-
-You have an Xcode project. You want to make sure it builds and tests pass
-on your Mac before merging. Both targets run locally — no VMs or cloud needed.
-
-```
-$ shipyard init
-
-Detecting project...
-  Found: MyApp.xcodeproj (Xcode project)
-  Platforms detected: macOS, iOS
-
-What platforms do you want to validate?
-  [x] macOS    (local Mac — Xcode 16.2 found)
-  [x] iOS      (local simulator — iPhone 16 Pro available)
-
-Writing .shipyard/config.toml... done
-```
-
-Now every time you run `shipyard run`, it builds and tests on your Mac:
-
-```
-$ shipyard run
-  macos   = pass  (local, 1m42s)     ← built and tested on your Mac
-  ios-sim = pass  (local, 2m15s)     ← ran on the local iOS simulator
-  All green.
-```
-
-Both targets say `local` because everything runs on your machine. No network,
-no VMs, no cloud accounts needed. This is the simplest Shipyard setup.
-
----
-
-### Scenario 2: You're building a cross-platform audio plugin
-
-You're using JUCE, Pulp, or another C++ framework. Your plugin needs to
-compile and pass tests on macOS, Windows, and Linux — because DAW users are
-on all three.
-
-You have UTM running a Windows 11 VM and an Ubuntu VM on your Mac. Shipyard
-detects them and uses SSH to send your code to each one:
-
-```
-$ shipyard init
-
-Detecting project...
-  Found: CMakeLists.txt (CMake C++ project)
-  Platforms detected: macOS, Windows, Linux
-
-What platforms do you want to validate?
-  [x] macOS    (local Mac)
-  [x] Windows  (SSH host "win" — reachable, 23ms)
-  [x] Linux    (SSH host "ubuntu" — reachable, 847ms)
-
-Cloud failover: fall back to Namespace when VMs are down? [Y/n]
-
-Writing .shipyard/config.toml... done
-```
-
-When you run validation, your Mac builds locally while your VMs build over SSH
-— all three in parallel:
-
-```
-$ shipyard run
-  mac     = pass  (local, 3m12s)     ← built on your Mac
-  windows = pass  (ssh, 5m30s)       ← built on your Windows VM via SSH
-  ubuntu  = pass  (ssh, 4m18s)       ← built on your Ubuntu VM via SSH
-  All green.
-```
-
-If your VMs are powered off or unreachable, Shipyard automatically falls back
-to Namespace cloud runners — you don't have to do anything:
-
-```
-$ shipyard run
-  mac     = pass  (local, 3m12s)
-  windows → SSH unreachable → dispatching to Namespace...
-          = pass  (namespace-failover, 8m45s)    ← cloud runner took over
-  ubuntu  = pass  (ssh, 4m18s)
-  All green.
-```
-
----
-
-### Scenario 3: You're building a macOS desktop app with agents running in parallel in multiple worktrees
-
-Single platform, single machine. You still get Shipyard's queue (so agents running in parallel in multiple
-worktrees don't collide), evidence tracking (so you know what SHA last
-passed), and one-command merge:
-
-```
-$ shipyard init
-
-Detecting project...
-  Found: Package.swift (Swift package)
-  Platforms detected: macOS
-
-Writing .shipyard/config.toml... done
-
-$ shipyard run
-  macos = pass  (local, 45s)
-
-$ shipyard ship
-  Created PR #7. Validated. Merged.
-```
-
-If you later need Windows or Linux builds, just add targets — no re-init:
-
-```
-$ shipyard targets add ubuntu
-  SSH host "ubuntu" — reachable. Added.
-```
-
----
-
-### Scenario 4: You're building a cross-platform Tauri app
-
-Tauri apps ship native Rust binaries on macOS, Windows, and Linux. Shipyard
-validates all three in parallel:
-
-```
-$ shipyard init
-
-Detecting project...
-  Found: Cargo.toml (Rust project)
-  Found: package.json (Node.js frontend)
-  Found: src-tauri/ (Tauri app detected)
-  Platforms detected: macOS, Windows, Linux
-
-Writing .shipyard/config.toml... done
-
-$ shipyard run
-  mac     = pass  (local, 2m08s)
-  ubuntu  = pass  (ssh, 3m45s)
-  windows → SSH unreachable → booting VM "Windows 11"...
-          = pass  (utm-fallback, 6m30s)    ← Shipyard booted the VM automatically
-  All green.
-```
-
-The Windows VM was asleep. Shipyard booted it via UTM, waited for SSH to come
-up, ran the build, and reported the result.
-
----
-
-## How Targets Work
-
-A target is a real machine where your code gets validated. You name them
-whatever you want and can have as many as you need:
-
-| Target name | Platform | Backend | What it is |
-|------------|----------|---------|------------|
-| `mac` | macos-arm64 | local | Your Apple Silicon Mac |
-| `mac-intel` | macos-x64 | local | Your Intel Mac (if you have one) |
-| `ubuntu` | linux-x64 | ssh | Ubuntu VM running on your Mac |
-| `ubuntu-arm` | linux-arm64 | ssh | ARM64 Linux server |
-| `windows` | windows-x64 | ssh | Windows VM running on your Mac |
-| `cloud-linux` | linux-x64 | cloud | A Namespace runner |
-
-You don't need all of these. Use what matches your project — one target
-is fine, six is fine. Add more any time with `shipyard targets add`.
-
-### What happens when a machine is down
-
-Each target can have a fallback chain. When the primary is unreachable,
-Shipyard tries the next option automatically:
-
-```
-1. Try SSH to your VM → unreachable (VM is off)
-2. Boot the VM via UTM → wait for SSH to come up → success
-3. If that also fails → dispatch to Namespace cloud runners
-4. If cloud fails too → dispatch to GitHub-hosted runners (last resort)
-```
-
-The chain is configurable per target. You can skip VMs, skip cloud, 
-or make cloud the primary. An indie developer just having a play with
-a project might use: local first, VM fallback, cloud last resort.
-
-### What Shipyard checks on setup
-
-`shipyard doctor` checks what you have and tells you what's missing:
-
-```
-$ shipyard doctor
-
-  Core:
-    ✓ git 2.44.0
-    ✓ ssh (OpenSSH 9.7)
-
-  Cloud providers:
-    ✓ gh 2.62.0 (authenticated as danielraffel)
-    ✗ nsc — not installed
-      → Install with: brew install namespace-cli
-
-  SSH targets:
-    ✓ ubuntu — reachable (847ms)
-    ✗ windows — unreachable
-      → Check: ssh win
-
-  Overall: ready (1 optional item missing)
-```
-
-If something is missing, Shipyard tells you exactly what to install and how.
-In the future, `shipyard doctor --fix` will offer to install missing tools
-for you.
-
----
-
-## Agent Integration
-
-### `shipyard init` handles this for you
-
-When you run `shipyard init`, it detects whether you’re using Claude Code
-or Codex and offers to set up agent integration automatically:
-
-```
-$ shipyard init
-
-  ...detecting project, configuring targets...
-
-  Agent setup:
-    Found: Claude Code (.claude/ directory detected)
-
-    How should your agent handle merging?
-      [1] Auto-merge — agent validates and merges to main automatically
-      [2] Auto-merge to develop — agent merges to develop, you promote to main
-      [3] Validate only — agent runs CI, you click merge manually
-      [4] Skip agent setup
-
-  Choice [1]: 1
-
-  → Writing .claude/skills/ci.md
-  → Adding CI instructions to CLAUDE.md
-
-  Done. Your agent will now validate and merge automatically.
-```
-
-You don’t need to copy files or edit configs. Init writes the right files
-for your choice. You can re-run `shipyard init` later to change the setup.
-
-### How it works after setup
-
-Once configured, your agent handles CI end-to-end:
-
-1. You: "Implement the reverb effect and ship it"
-2. Agent writes code, commits to a feature branch
-3. Agent runs `shipyard ship` which:
-   - Pushes the branch
-   - Creates a PR
-   - Validates on all configured platforms
-   - If all green, merges automatically
-4. You come back, it’s on main
-
-This is how [Pulp](https://github.com/danielraffel/pulp) (the project
-Shipyard was extracted from) operates daily.
-
-### If you prefer manual merging
-
-Option 3 during init sets up "validate only" — the agent runs
-`shipyard run` to validate, but doesn’t merge. You review the PR and
-click squash-and-merge yourself. You still get cross-platform validation
-without giving up control over what lands on main.
-
-### Merging to develop instead of main
-
-Option 2 during init sets up a develop branch flow. Agents merge to
-`develop` automatically. You promote `develop` to `main` when ready:
-
-```bash
-git checkout develop
-shipyard ship --base main    # validate develop, merge to main
-```
-
-### What init writes
-
-Depending on your choice, init creates:
-
-| File | What it does |
-|------|-------------|
-| `.claude/skills/ci.md` | Teaches Claude how to validate and ship |
-| `CLAUDE.md` addition | CI instructions for Claude |
-| `AGENTS.md` addition | CI instructions for Codex |
-
-These are standard files in your repo. You can edit them, version them,
-or delete them. Nothing hidden.
-
----
-
-## Workflow Scenarios
-
-<details>
-<summary><strong>CLI workflows for manual use and troubleshooting</strong></summary>
-
-<br>
-
-Most of the time your agent handles CI automatically. These scenarios are
-for when you want to run things manually, debug a failure, or manage the
-queue.
-
-### You finished a feature and want to merge
-
-You've been working on a feature branch. Everything looks good. Time to
-validate across platforms and merge.
-
-```
-$ shipyard run
-  mac     = pass  (local, 3m12s)
-  ubuntu  = pass  (ssh, 5m30s)
-  windows = pass  (ssh, 4m18s)
-  All green.
-
-$ shipyard ship
-  PR #42 created → Validated → Merged to main
-```
-
-Or in one step: `shipyard ship` does the validation and merge together.
-
-### CI fails on one platform
-
-You ran validation and Windows failed. You don't want to re-validate
-macOS and Linux (they already passed) — just fix and re-run Windows.
-
-```
-$ shipyard run
-  mac = pass, ubuntu = pass, windows = FAIL
-
-$ shipyard logs sy-001 --target windows
-  MSVC error C2065: 'M_PI' undeclared in reverb.cpp:42
-
-# Fix the issue, commit
-$ shipyard run --targets windows
-  windows = pass
-
-$ shipyard ship
-  PR #42 → Merged
-```
-
-Shipyard remembers the evidence from the previous run. When you re-run
-just Windows and it passes, all three platforms now have green evidence
-for this SHA.
-
-### Multiple agents working in parallel
-
-You have two agents working in separate worktrees — one on reverb,
-one on delay. Both need CI, and your machine has one Windows VM.
-
-Shipyard's queue handles this automatically. The first agent's run starts
-immediately. The second agent's run queues behind it. When the first
-finishes, the second starts.
-
-```
-Agent 1 (worktree: ~/Code/my-plugin-reverb):
-  shipyard ship → queued → running → PR #42 merged
-
-Agent 2 (worktree: ~/Code/my-plugin-delay):
-  shipyard ship → queued → waiting → running → PR #43 merged
-```
-
-No collisions. No manual coordination. The queue is machine-global.
-
-### Prioritizing one job over another
-
-Two jobs are queued. The delay feature is urgent. Bump it up.
-
-```
-$ shipyard queue
-  Running: sy-001 feature/reverb  [normal]
-  Pending: sy-002 feature/delay   [low]
-
-$ shipyard bump sy-002 high
-  Bumped sy-002 to high
-```
-
-When the current job finishes, the high-priority job runs next.
-
-### Merging to develop, not main
-
-Your team uses a develop branch as a staging area. Ship to develop first,
-promote to main later when stable.
-
-```
-$ shipyard ship --base develop
-  PR #44 → Validated → Merged to develop
-
-# Later, when develop is stable:
-$ git checkout develop
-$ shipyard ship --base main
-  PR #45 → Validated → Merged to main
-```
-
-</details>
-
----
-
-## Install
-
-### For Claude Code users (recommended)
-
-Install the Shipyard plugin. It gives you natural language CI commands
-and will prompt to install the CLI binary if it's not already on your
-machine.
+## Highlights
+
+- **Designed for AI agents.** Claude Code and Codex one-command setup;
+  agents validate and merge without you handing them notarization keys
+  or publishing accounts.
+- **Evidence-based merge gate.** `shipyard ship` refuses to merge unless
+  every required platform has passing evidence **for the exact HEAD SHA** —
+  not the most-recent run, not the branch tip, the SHA.
+- **Parallel-agent-aware queue.** Multiple agents in multiple worktrees
+  share one machine-global queue with priorities, FIFO scheduling, and
+  automatic deduplication.
+- **Declarative security & governance.** One TOML line picks a profile
+  (`solo` or `multi`); one CLI command makes GitHub branch protection,
+  tag protection, and workflow token permissions match.
+- **22 ecosystem detectors.** `shipyard init` recognises CMake, Swift,
+  Xcode, Rust, Go, Node (pnpm/bun/yarn/npm), Python (uv/poetry/pip),
+  Gradle, Maven, .NET, Flutter, Dart, Deno, Ruby, Elixir, PHP.
+
+## Installation
+
+### Claude Code (recommended)
 
 **Step 1:** Add the Shipyard marketplace to `~/.claude/settings.json`:
 
@@ -649,7 +49,7 @@ machine.
 }
 ```
 
-**Step 2:** Install the plugin in Claude Code:
+**Step 2:** Install the plugin:
 
 ```
 /plugin install shipyard@shipyard
@@ -662,37 +62,54 @@ machine.
 ```
 
 The plugin uses the CLI under the hood. If the `shipyard` binary isn't
-installed, the plugin will detect that and offer to install it for you.
+installed, the plugin will offer to install it for you.
 
-### For Codex / CLI users
-
-### Quick start
+### Codex / CLI
 
 ```bash
 curl -fsSL https://generouscorp.com/Shipyard/install.sh | sh
+shipyard init
 ```
 
-Downloads a standalone binary for your platform. No runtime needed.
+Downloads a standalone binary for your platform. No runtime needed. See
+[install details](docs/install.md) for binary table and build-from-source.
 
-| OS | Architecture | Binary |
-|----|-------------|--------|
-| macOS | Apple Silicon (ARM64) | `shipyard-macos-arm64` |
-| macOS | Intel (x64) | `shipyard-macos-x64` |
-| Windows | x64 | `shipyard-windows-x64.exe` |
-| Linux | x64 | `shipyard-linux-x64` |
-| Linux | ARM64 | `shipyard-linux-arm64` |
+## How it works
 
-### Build from source (for contributors)
+- **Local builds** run on your host machine — fast, no network.
+- **Remote builds** run on machines you control via SSH — VMs, containers,
+  or hosts on your network.
+- **Cloud builds** run on managed infrastructure (Namespace, GitHub
+  Actions) for neutral or on-demand capacity.
 
-```bash
-git clone https://github.com/danielraffel/Shipyard.git
-cd Shipyard
-python3 -m venv .venv && source .venv/bin/activate
-pip install -e ".[dev]"
-pytest                         # verify everything works
-```
+`shipyard run` delivers the exact commit to each machine, runs your build
+and test commands, and reports what passed. `shipyard ship` does the same,
+then opens a PR and merges when every required platform is green.
 
-### Requirements
+Shipyard is not a [CI service](https://en.wikipedia.org/wiki/Continuous_integration),
+not a [build system](https://en.wikipedia.org/wiki/Build_automation),
+not a [workflow engine](https://en.wikipedia.org/wiki/Workflow_engine).
+It calls your build commands and cares about one thing: did they pass?
+
+## Documentation
+
+- [Examples & Scenarios](docs/examples.md) — real-world setups for Xcode,
+  CMake, Swift, Tauri, etc.
+- [Targets & Fallback Chains](docs/targets.md) — how local/SSH/cloud
+  targets work and how to chain them.
+- [Agent Integration](docs/agent-integration.md) — Claude Code / Codex
+  setup, merge strategies.
+- [Security & Governance](docs/governance.md) — `solo` vs `multi`
+  profiles, branch protection, tag protection.
+- [Profiles & Configuration](docs/profiles.md) — switch between local /
+  cloud / full setups with one command.
+- [Manual CLI Workflows](docs/workflows.md) — debugging failed runs,
+  managing the queue, partial reruns.
+- [CLI Reference](docs/cli-reference.md) — every command and flag.
+- [Install details](docs/install.md) — binaries, build from source,
+  optional dependencies.
+
+## Requirements
 
 You don't need everything — just what matches your setup:
 
@@ -700,172 +117,23 @@ You don't need everything — just what matches your setup:
 |------|-----------|---------------|---------|
 | [git](https://github.com/git-guides/install-git) | Yes | Version control | Pre-installed on macOS |
 | [gh](https://github.com/cli/cli) | Yes (for PRs) | GitHub integration | `brew install gh` |
-| `ssh` | For remote targets | Connect to VMs | Pre-installed on macOS not on [Ubuntu / etc](https://ubuntu.com/server/docs/how-to/security/openssh-server/) / [Windows](https://learn.microsoft.com/en-us/windows-server/administration/openssh/openssh_install_firstuse?tabs=gui&pivots=windows-11) |
+| `ssh` | For remote targets | Connect to VMs | Pre-installed on macOS / [Ubuntu](https://ubuntu.com/server/docs/how-to/security/openssh-server/) / [Windows](https://learn.microsoft.com/en-us/windows-server/administration/openssh/openssh_install_firstuse?tabs=gui&pivots=windows-11) |
 | [nsc](https://namespace.so/docs/reference/cli/installation) | For [Namespace](https://namespace.so) | Cloud runners | `brew install namespace-cli` |
 | [UTM](https://mac.getutm.app) / [Parallels](https://www.parallels.com/products/desktop/) | For VM fallback | Auto-boot VMs | `brew install --cask utm` |
 
 `shipyard doctor` checks all of this and tells you what's missing.
 
----
+## This repo uses Shipyard
 
-## Quick Reference
-
-```bash
-# Setup
-shipyard init                  # configure project
-shipyard doctor                # check environment + suggest fixes
-shipyard targets               # show targets + reachability
-
-# Validate
-shipyard run                   # full validation, all targets
-shipyard run --smoke           # fast smoke check
-shipyard run --targets mac     # single target
-
-# Ship
-shipyard ship                  # PR → validate → merge on green
-shipyard ship --base develop   # target a different branch
-
-# Monitor
-shipyard status                # dashboard: queue + targets + evidence
-shipyard queue                 # show all jobs with priorities
-shipyard logs <id>             # per-target logs
-shipyard evidence              # last-good SHA per platform
-
-# Manage
-shipyard bump <id> high        # reprioritize a pending job
-shipyard cancel <id>           # cancel a job
-shipyard cleanup --apply       # prune old logs and artifacts
-```
-
----
-
-## Profiles
-
-Once you're comfortable with Shipyard, profiles let you switch between
-different setups with one command.
-
-### The problem they solve
-
-Some days you want local-only validation (fast, free). Other days you need
-the full cross-platform proof (Mac + Windows + Linux via cloud). Editing
-your config every time is annoying.
-
-### Define profiles once
-
-```toml
-# .shipyard/config.toml
-
-[profiles.local]
-# Just your Mac. Fast. Free. No network.
-targets = ["mac"]
-
-[profiles.normal]
-# Mac local + cloud for Windows and Linux
-targets = ["mac", "ubuntu-cloud", "windows-cloud"]
-
-[profiles.full]
-# Mac local + VMs with cloud fallback for everything
-targets = ["mac", "ubuntu", "windows"]
-```
-
-### Switch instantly
-
-```bash
-$ shipyard config use local          # just my Mac
-$ shipyard config use normal         # Mac + Namespace cloud
-$ shipyard config use full           # Mac + VMs + cloud fallback
-```
-
-### See what's active
-
-```bash
-$ shipyard config profiles
-
-  local     mac                                          ← active
-  normal    mac, ubuntu-cloud, windows-cloud
-  full      mac, ubuntu, windows (+fallback)
-
-$ shipyard targets
-
-  Profile: local
-
-  mac              local        macos-arm64      reachable
-
-  (ubuntu and windows are disabled in this profile)
-```
-
-### Global vs project profiles
-
-Profiles work at both levels:
-
-- **Global** (`~/.config/shipyard/config.toml`) — your default setups, shared
-  across all projects. Define `local`, `normal`, `full` here once.
-- **Project** (`.shipyard/config.toml`) — project-specific profiles that
-  override or extend global ones. A project that needs ARM Linux testing
-  can add a `release` profile with extra targets.
-
-Switch profiles globally or per-project. `shipyard status` always shows
-which profile is active and exactly where each target will run.
-
-### Fallback is opt-in
-
-By default, if a target is unreachable, it just reports unreachable. No
-automatic VM booting, no cloud dispatch. You add fallback chains only if
-you want them:
-
-```toml
-# No fallback — unreachable means unreachable
-[targets.ubuntu]
-backend = "ssh"
-host = "ubuntu"
-
-# With fallback — tries VM, then cloud
-[targets.ubuntu]
-backend = "ssh"
-host = "ubuntu"
-fallback = [
-    { type = "vm", vm_name = "Ubuntu 24.04" },
-    { type = "cloud", provider = "namespace" },
-]
-```
-
-This keeps things predictable. You always know exactly what Shipyard will
-do because you configured it.
-
----
-
-## This Repo Uses Shipyard
-
-Shipyard validates and ships itself. The config is at
-[`.shipyard/config.toml`](.shipyard/config.toml):
-
-```toml
-[project]
-name = "shipyard"
-type = "python"
-platforms = ["macos", "linux", "windows"]
-
-[validation.default]
-command = "pip install -e '.[dev]' && pytest && ruff check src/"
-
-[targets.mac]
-backend = "local"
-platform = "macos-arm64"
-```
-
-The CI workflow at [`.github/workflows/ci.yml`](.github/workflows/ci.yml)
-runs tests on macOS, Linux, and Windows on every push. The release workflow
-at [`.github/workflows/release.yml`](.github/workflows/release.yml) builds
+Shipyard validates and ships itself. The config is in
+[`.shipyard/config.toml`](.shipyard/config.toml). The CI workflow at
+[`.github/workflows/ci.yml`](.github/workflows/ci.yml) runs tests on
+macOS, Linux, and Windows on every push. The release workflow at
+[`.github/workflows/release.yml`](.github/workflows/release.yml) builds
 binaries on 5 platforms when a version is tagged.
 
-```bash
-# How we validate
-shipyard run                    # runs pytest + ruff on local Mac
+## Learn more
 
-# How we release
-git tag v0.1.0
-git push origin v0.1.0          # triggers binary builds on 5 platforms
-                                # → GitHub Release with binaries + checksums
-```
-
-218 tests. 0.3 seconds. The release builds itself.
+- [Blog post: Shipyard is a cross-platform CI orchestration layer](https://danielraffel.me/2026/04/09/shipyard-is-a-cross-platform-ci-orchestration-layer-that-coordinates-validation-for-ai-agents-working-across-parallel-worktrees/)
+- [Pulp](https://github.com/danielraffel/pulp) — the audio plugin
+  Shipyard was extracted from, and the first project to adopt it.

--- a/docs/agent-integration.md
+++ b/docs/agent-integration.md
@@ -1,0 +1,81 @@
+# Agent Integration
+
+Shipyard is designed for AI agents (Claude Code, Codex) that write code
+across parallel worktrees and need real cross-platform validation before
+merging.
+
+## `shipyard init` handles this for you
+
+When you run `shipyard init`, it detects whether you're using Claude Code
+or Codex and offers to set up agent integration automatically:
+
+```
+$ shipyard init
+
+  ...detecting project, configuring targets...
+
+  Agent setup:
+    Found: Claude Code (.claude/ directory detected)
+
+    How should your agent handle merging?
+      [1] Auto-merge — agent validates and merges to main automatically
+      [2] Auto-merge to develop — agent merges to develop, you promote to main
+      [3] Validate only — agent runs CI, you click merge manually
+      [4] Skip agent setup
+
+  Choice [1]: 1
+
+  → Writing .claude/skills/ci.md
+  → Adding CI instructions to CLAUDE.md
+
+  Done. Your agent will now validate and merge automatically.
+```
+
+You don't need to copy files or edit configs. Init writes the right files
+for your choice. You can re-run `shipyard init` later to change the setup.
+
+## How it works after setup
+
+Once configured, your agent handles CI end-to-end:
+
+1. You: "Implement the reverb effect and ship it"
+2. Agent writes code, commits to a feature branch
+3. Agent runs `shipyard ship` which:
+   - Pushes the branch
+   - Creates a PR
+   - Validates on all configured platforms
+   - If all green, merges automatically
+4. You come back, it's on main
+
+This is how [Pulp](https://github.com/danielraffel/pulp) (the project
+Shipyard was extracted from) operates daily.
+
+## If you prefer manual merging
+
+Option 3 during init sets up "validate only" — the agent runs
+`shipyard run` to validate, but doesn't merge. You review the PR and
+click squash-and-merge yourself. You still get cross-platform validation
+without giving up control over what lands on main.
+
+## Merging to develop instead of main
+
+Option 2 during init sets up a develop branch flow. Agents merge to
+`develop` automatically. You promote `develop` to `main` when ready:
+
+```bash
+git checkout develop
+shipyard ship --base main    # validate develop, merge to main
+```
+
+## What init writes
+
+Depending on your choice, init creates:
+
+| File | What it does |
+|------|-------------|
+| `.claude/skills/ci.md` | Teaches Claude how to validate and ship |
+| `CLAUDE.md` addition | CI instructions for Claude |
+| `AGENTS.md` addition | CI instructions for Codex |
+
+These are standard files in your repo. You can edit them, version them,
+or delete them. Nothing hidden.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1,0 +1,68 @@
+# CLI Reference
+
+```bash
+# Setup
+shipyard init                  # configure project
+shipyard doctor                # check environment + suggest fixes
+shipyard targets               # show targets + reachability
+shipyard targets add <name>    # interactively add a new target
+shipyard targets remove <name> # remove a target
+
+# Validate
+shipyard run                       # full validation, all targets
+shipyard run --smoke               # fast smoke check
+shipyard run --targets mac         # single target
+shipyard run --resume-from test    # skip setup/configure/build (where supported)
+shipyard run --continue            # don't stop at first failure
+
+# Ship
+shipyard ship                  # PR → validate → merge on green
+shipyard ship --base develop   # target a different branch
+
+# Monitor
+shipyard status                # dashboard: queue + targets + evidence
+shipyard queue                 # show all jobs with priorities
+shipyard logs <id>             # per-target logs
+shipyard logs <id> --target windows
+shipyard evidence              # last-good SHA per platform
+
+# Manage
+shipyard bump <id> high        # reprioritize a pending job
+shipyard cancel <id>           # cancel a job
+shipyard cleanup --apply       # prune old logs and artifacts
+
+# Profiles & config
+shipyard config profiles       # list defined profiles
+shipyard config use <profile>  # switch active profile
+shipyard config show           # dump effective merged config
+
+# Governance
+shipyard governance status     # declared vs live drift
+shipyard governance diff       # dry-run apply
+shipyard governance apply      # bring live state in line with config
+shipyard governance export     # snapshot to TOML
+shipyard governance use <name> # switch profile (solo / multi / custom)
+
+# Cloud
+shipyard cloud workflows       # list dispatchable workflows
+shipyard cloud defaults        # show current cloud dispatch plan
+shipyard cloud run <wf>        # dispatch a workflow
+shipyard cloud status          # tracked cloud runs
+
+# Branch protection (one-shot)
+shipyard branch apply [--create name] [--base branch] [target_branch]
+```
+
+## JSON output
+
+Every command supports `--json` for structured output with a versioned
+schema, intended for AI agent consumption:
+
+```bash
+shipyard run --json
+shipyard ship --json
+shipyard status --json
+```
+
+The envelope always carries `schema_version: 1` and the command name, so
+agents can pin to a stable contract.

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,0 +1,158 @@
+# Examples
+
+Real-world Shipyard setups for different kinds of projects.
+
+## What your project needs
+
+Shipyard runs your existing build and test commands on each platform. It
+assumes your project already has:
+
+- A build system (CMake, Xcode, Cargo, npm, Gradle, Swift, etc.)
+- Test commands that exit 0 on success and non-zero on failure
+
+If your project builds and has tests, Shipyard can validate it. If it
+doesn't have tests yet, Shipyard still validates that the build succeeds.
+
+---
+
+## Scenario 1: macOS and iOS app
+
+You have an Xcode project. You want to make sure it builds and tests pass
+on your Mac before merging. Both targets run locally — no VMs or cloud needed.
+
+```
+$ shipyard init
+
+Detecting project...
+  Found: MyApp.xcodeproj (Xcode project)
+  Platforms detected: macOS, iOS
+
+What platforms do you want to validate?
+  [x] macOS    (local Mac — Xcode 16.2 found)
+  [x] iOS      (local simulator — iPhone 16 Pro available)
+
+Writing .shipyard/config.toml... done
+```
+
+Now every time you run `shipyard run`, it builds and tests on your Mac:
+
+```
+$ shipyard run
+  macos   = pass  (local, 1m42s)     ← built and tested on your Mac
+  ios-sim = pass  (local, 2m15s)     ← ran on the local iOS simulator
+  All green.
+```
+
+Both targets say `local` because everything runs on your machine. No network,
+no VMs, no cloud accounts needed. This is the simplest Shipyard setup.
+
+---
+
+## Scenario 2: Cross-platform audio plugin
+
+You're using JUCE, Pulp, or another C++ framework. Your plugin needs to
+compile and pass tests on macOS, Windows, and Linux — because DAW users are
+on all three.
+
+You have UTM running a Windows 11 VM and an Ubuntu VM on your Mac. Shipyard
+detects them and uses SSH to send your code to each one:
+
+```
+$ shipyard init
+
+Detecting project...
+  Found: CMakeLists.txt (CMake C++ project)
+  Platforms detected: macOS, Windows, Linux
+
+What platforms do you want to validate?
+  [x] macOS    (local Mac)
+  [x] Windows  (SSH host "win" — reachable, 23ms)
+  [x] Linux    (SSH host "ubuntu" — reachable, 847ms)
+
+Cloud failover: fall back to Namespace when VMs are down? [Y/n]
+
+Writing .shipyard/config.toml... done
+```
+
+When you run validation, your Mac builds locally while your VMs build over SSH
+— all three in parallel:
+
+```
+$ shipyard run
+  mac     = pass  (local, 3m12s)     ← built on your Mac
+  windows = pass  (ssh, 5m30s)       ← built on your Windows VM via SSH
+  ubuntu  = pass  (ssh, 4m18s)       ← built on your Ubuntu VM via SSH
+  All green.
+```
+
+If your VMs are powered off or unreachable, Shipyard automatically falls back
+to Namespace cloud runners — you don't have to do anything:
+
+```
+$ shipyard run
+  mac     = pass  (local, 3m12s)
+  windows → SSH unreachable → dispatching to Namespace...
+          = pass  (namespace-failover, 8m45s)    ← cloud runner took over
+  ubuntu  = pass  (ssh, 4m18s)
+  All green.
+```
+
+---
+
+## Scenario 3: macOS desktop app with parallel agents
+
+Single platform, single machine. You still get Shipyard's queue (so agents running in parallel in multiple
+worktrees don't collide), evidence tracking (so you know what SHA last
+passed), and one-command merge:
+
+```
+$ shipyard init
+
+Detecting project...
+  Found: Package.swift (Swift package)
+  Platforms detected: macOS
+
+Writing .shipyard/config.toml... done
+
+$ shipyard run
+  macos = pass  (local, 45s)
+
+$ shipyard ship
+  Created PR #7. Validated. Merged.
+```
+
+If you later need Windows or Linux builds, just add targets — no re-init:
+
+```
+$ shipyard targets add ubuntu
+  SSH host "ubuntu" — reachable. Added.
+```
+
+---
+
+## Scenario 4: Cross-platform Tauri app
+
+Tauri apps ship native Rust binaries on macOS, Windows, and Linux. Shipyard
+validates all three in parallel:
+
+```
+$ shipyard init
+
+Detecting project...
+  Found: Cargo.toml (Rust project)
+  Found: package.json (Node.js frontend)
+  Found: src-tauri/ (Tauri app detected)
+  Platforms detected: macOS, Windows, Linux
+
+Writing .shipyard/config.toml... done
+
+$ shipyard run
+  mac     = pass  (local, 2m08s)
+  ubuntu  = pass  (ssh, 3m45s)
+  windows → SSH unreachable → booting VM "Windows 11"...
+          = pass  (utm-fallback, 6m30s)    ← Shipyard booted the VM automatically
+  All green.
+```
+
+The Windows VM was asleep. Shipyard booted it via UTM, waited for SSH to come
+up, ran the build, and reported the result.

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -1,0 +1,95 @@
+# Security & Governance Profiles
+
+Shipyard manages a project's GitHub-side governance settings —
+branch protection on `main`, tag protection on release tags, default
+workflow token permissions, release approval gates — declaratively from
+`.shipyard/config.toml`. Pick a profile, run `shipyard governance apply`,
+and the live GitHub state matches the profile. Drift between the declared
+config and the live state is reported by `shipyard governance status`.
+
+## Pick a profile
+
+```toml
+# .shipyard/config.toml
+[project]
+profile = "solo"   # one of: solo, multi, custom
+```
+
+The two presets cover the most common shapes: a single maintainer who
+takes occasional third-party PRs, and a multi-contributor team with real
+review requirements. `custom` lets you declare every knob explicitly.
+
+## What each profile sets
+
+| Setting | `solo` | `multi` | Why the difference |
+|---|---|---|---|
+| Branch protection: require PR | ✅ | ✅ | Catches stray pushes either way |
+| Branch protection: required status checks | ✅ (configured) | ✅ (configured) | The whole point of CI |
+| Branch protection: strict status checks | ❌ | ✅ | Solo doesn't need rebase coordination |
+| Branch protection: required reviews | 0 | 1 | Solo can't review their own PR |
+| Branch protection: enforce on admins | ❌ | ✅ | Solo needs a 3 AM hotfix path |
+| Branch protection: dismiss stale reviews | ❌ | ✅ | Force re-review on rebase in multi |
+| Tag protection: forbid update / delete / force | ✅ | ✅ | Trivy-style attack prevention |
+| Tag protection: forbid creation by non-admins | ❌ | ✅ | Solo creates release tags directly |
+| Default workflow token | read | read | Both — pure win, zero friction |
+| Forbid sensitive branch patterns | ❌ | ✅ | Solo has no co-maintainers to coordinate disclosure with |
+| Release approval gate | `off` (or `auto`) | `manual` | Solo doesn't gain from approving themselves |
+| Sigstore release attestations | ✅ | ✅ | Free, no friction, helps downstream verifiers |
+| Immutable releases | ✅ | ✅ | Free, no friction |
+| Action SHA pinning (Renovate) | ✅ | ✅ | Same — managed by Renovate |
+| `zizmor` workflow lint in CI | ✅ | ✅ | Same — runs automatically |
+| Renovate cooldown (third-party / first-party days) | 3 / 0 | 3 / 0 | Same |
+
+The pattern: **anything that's an "attacker-side" guardrail is on for
+both profiles** (free security), and **anything that's a "process
+correctness" guardrail varies** (solo doesn't gain from rules that
+exist to coordinate multiple humans).
+
+## Commands
+
+```bash
+shipyard governance status     # show declared vs live drift per branch
+shipyard governance diff       # what `apply` would change (dry run)
+shipyard governance apply      # bring live GitHub state in line with config
+```
+
+`status` is the rollup view that shows where things stand without
+clicking through six GitHub settings pages. `diff` is the dry-run
+before any mutation. `apply` is the idempotent apply — re-running
+it on an aligned repo issues zero API writes.
+
+`shipyard doctor` grows a "Governance" section that folds main-branch
+drift into the same health check as git, ssh, and cloud auth, so CI
+scripts and agents get a single pass/fail answer about whether the
+repo is in the expected state.
+
+Shipyard's profile table is the governance **target**. Branch
+protection is enforced via the GitHub REST API today; tag protection,
+rulesets, deployment environments, sigstore attestations, and the
+immutable-releases row are partly API-manageable and partly
+UI-only — the planning repo tracks which pieces land in which
+release. Shipyard never claims a state it cannot verify: the
+immutable-releases row in `doctor` and `governance status` prints
+an informational line pointing at the settings URL rather than a
+check or cross, because GitHub does not expose the repo-level
+toggle via API on personal repos.
+
+## Inspired by Astral
+
+The governance profiles, the action SHA pinning workflow, the tag
+protection, immutable releases, default read-only workflow tokens, and
+the deployment approval pattern all follow practices documented in
+[Astral's open-source security post](https://astral.sh/blog/open-source-security-at-astral).
+Astral built and maintains uv, Ruff, and ty — millions of developers
+depend on those tools, so they had to figure out the security baseline
+for cross-platform Python tooling under real attacker pressure. The
+post is the canonical reference for *why* each of these settings
+matters, and Shipyard packages the *how* into a one-command profile
+switch so you don't have to figure it out from first principles.
+
+[Pulp](https://github.com/danielraffel/pulp) is the first project to
+adopt Shipyard's governance profile system. Pulp runs on the `solo`
+profile because it has a single maintainer today; switching to `multi`
+would be a single-line edit to `[project].profile` in
+`.shipyard/config.toml` plus a `shipyard governance apply`, with no
+other config changes.

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,0 +1,41 @@
+# Installation
+
+## Quick install
+
+```bash
+curl -fsSL https://generouscorp.com/Shipyard/install.sh | sh
+```
+
+Downloads the right binary for your platform and installs it on `$PATH`.
+
+## Platform binaries
+
+| OS | Architecture | Binary |
+|----|-------------|--------|
+| macOS | Apple Silicon (ARM64) | `shipyard-macos-arm64` |
+| macOS | Intel (x64) | `shipyard-macos-x64` |
+| Windows | x64 | `shipyard-windows-x64.exe` |
+| Linux | x64 | `shipyard-linux-x64` |
+| Linux | ARM64 | `shipyard-linux-arm64` |
+
+## Build from source (contributors)
+
+```bash
+git clone https://github.com/danielraffel/Shipyard.git
+cd Shipyard
+python3 -m venv .venv && source .venv/bin/activate
+pip install -e ".[dev]"
+pytest                         # verify everything works
+```
+
+Or with `uv`:
+
+```bash
+uv sync --extra dev
+uv run pytest
+```
+
+## Optional dependencies
+
+You don't need everything — just what matches your setup. See the
+[main README requirements table](../README.md#requirements) for details.

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -1,0 +1,67 @@
+# Profiles & Configuration
+
+Once you're comfortable with Shipyard, profiles let you switch between
+different setups with one command.
+
+## The problem they solve
+
+Some days you want local-only validation (fast, free). Other days you need
+the full cross-platform proof (Mac + Windows + Linux via cloud). Editing
+your config every time is annoying.
+
+## Define profiles once
+
+```toml
+# .shipyard/config.toml
+
+[profiles.local]
+# Just your Mac. Fast. Free. No network.
+targets = ["mac"]
+
+[profiles.normal]
+# Mac local + cloud for Windows and Linux
+targets = ["mac", "ubuntu-cloud", "windows-cloud"]
+
+[profiles.full]
+# Mac local + VMs with cloud fallback for everything
+targets = ["mac", "ubuntu", "windows"]
+```
+
+## Switch instantly
+
+```bash
+$ shipyard config use local          # just my Mac
+$ shipyard config use normal         # Mac + Namespace cloud
+$ shipyard config use full           # Mac + VMs + cloud fallback
+```
+
+## See what's active
+
+```bash
+$ shipyard config profiles
+
+  local     mac                                          ← active
+  normal    mac, ubuntu-cloud, windows-cloud
+  full      mac, ubuntu, windows (+fallback)
+
+$ shipyard targets
+
+  Profile: local
+
+  mac              local        macos-arm64      reachable
+
+  (ubuntu and windows are disabled in this profile)
+```
+
+## Global vs project profiles
+
+Profiles work at both levels:
+
+- **Global** (`~/.config/shipyard/config.toml`) — your default setups, shared
+  across all projects. Define `local`, `normal`, `full` here once.
+- **Project** (`.shipyard/config.toml`) — project-specific profiles that
+  override or extend global ones. A project that needs ARM Linux testing
+  can add a `release` profile with extra targets.
+
+Switch profiles globally or per-project. `shipyard status` always shows
+which profile is active and exactly where each target will run.

--- a/docs/targets.md
+++ b/docs/targets.md
@@ -1,0 +1,85 @@
+# Targets & Fallback Chains
+
+A target is a real machine where your code gets validated. You name them
+whatever you want and can have as many as you need.
+
+## Target types
+
+| Target name | Platform | Backend | What it is |
+|------------|----------|---------|------------|
+| `mac` | macos-arm64 | local | Your Apple Silicon Mac |
+| `mac-intel` | macos-x64 | local | Your Intel Mac (if you have one) |
+| `ubuntu` | linux-x64 | ssh | Ubuntu VM running on your Mac |
+| `ubuntu-arm` | linux-arm64 | ssh | ARM64 Linux server |
+| `windows` | windows-x64 | ssh | Windows VM running on your Mac |
+| `cloud-linux` | linux-x64 | cloud | A Namespace runner |
+
+You don't need all of these. Use what matches your project — one target
+is fine, six is fine. Add more any time with `shipyard targets add`.
+
+## Fallback when a machine is down
+
+Each target can have a fallback chain. When the primary is unreachable,
+Shipyard tries the next option automatically:
+
+```
+1. Try SSH to your VM → unreachable (VM is off)
+2. Boot the VM via UTM → wait for SSH to come up → success
+3. If that also fails → dispatch to Namespace cloud runners
+4. If cloud fails too → dispatch to GitHub-hosted runners (last resort)
+```
+
+The chain is configurable per target. You can skip VMs, skip cloud,
+or make cloud the primary. An indie developer just having a play with
+a project might use: local first, VM fallback, cloud last resort.
+
+## Fallback is opt-in
+
+By default, if a target is unreachable, it just reports unreachable. No
+automatic VM booting, no cloud dispatch. You add fallback chains only if
+you want them:
+
+```toml
+# No fallback — unreachable means unreachable
+[targets.ubuntu]
+backend = "ssh"
+host = "ubuntu"
+
+# With fallback — tries VM, then cloud
+[targets.ubuntu]
+backend = "ssh"
+host = "ubuntu"
+fallback = [
+    { type = "vm", vm_name = "Ubuntu 24.04" },
+    { type = "cloud", provider = "namespace" },
+]
+```
+
+This keeps things predictable. You always know exactly what Shipyard will
+do because you configured it.
+
+## What Shipyard checks on setup
+
+`shipyard doctor` checks what you have and tells you what's missing:
+
+```
+$ shipyard doctor
+
+  Core:
+    ✓ git 2.44.0
+    ✓ ssh (OpenSSH 9.7)
+
+  Cloud providers:
+    ✓ gh 2.62.0 (authenticated as danielraffel)
+    ✗ nsc — not installed
+      → Install with: brew install namespace-cli
+
+  SSH targets:
+    ✓ ubuntu — reachable (847ms)
+    ✗ windows — unreachable
+      → Check: ssh win
+
+  Overall: ready (1 optional item missing)
+```
+
+If something is missing, Shipyard tells you exactly what to install and how.

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -1,0 +1,111 @@
+# Manual CLI Workflows
+
+Most of the time your agent handles CI automatically. These scenarios are
+for when you want to run things manually, debug a failure, or manage the
+queue.
+
+## You finished a feature and want to merge
+
+You've been working on a feature branch. Everything looks good. Time to
+validate across platforms and merge.
+
+```
+$ shipyard run
+  mac     = pass  (local, 3m12s)
+  ubuntu  = pass  (ssh, 5m30s)
+  windows = pass  (ssh, 4m18s)
+  All green.
+
+$ shipyard ship
+  PR #42 created → Validated → Merged to main
+```
+
+Or in one step: `shipyard ship` does the validation and merge together.
+
+## CI fails on one platform
+
+You ran validation and Windows failed. You don't want to re-validate
+macOS and Linux (they already passed) — just fix and re-run Windows.
+
+```
+$ shipyard run
+  mac = pass, ubuntu = pass, windows = FAIL
+
+$ shipyard logs sy-001 --target windows
+  MSVC error C2065: 'M_PI' undeclared in reverb.cpp:42
+
+# Fix the issue, commit
+$ shipyard run --targets windows
+  windows = pass
+
+$ shipyard ship
+  PR #42 → Merged
+```
+
+Shipyard remembers the evidence from the previous run. When you re-run
+just Windows and it passes, all three platforms now have green evidence
+for this SHA.
+
+## Re-run only the test stage on a remote
+
+If only the test stage failed, skip the configure and build stages on the
+remote — Shipyard probes for build artifacts on the remote and skips
+ahead when they exist:
+
+```
+$ shipyard run --targets windows --resume-from test
+  windows: skipping setup, configure, build (markers found on remote)
+  windows = pass  (ssh, 1m02s)
+```
+
+If the markers aren't found (e.g. a fresh remote, or a different SHA),
+Shipyard runs all stages from the beginning and logs a note.
+
+## Multiple agents working in parallel
+
+You have two agents working in separate worktrees — one on reverb,
+one on delay. Both need CI, and your machine has one Windows VM.
+
+Shipyard's queue handles this automatically. The first agent's run starts
+immediately. The second agent's run queues behind it. When the first
+finishes, the second starts.
+
+```
+Agent 1 (worktree: ~/Code/my-plugin-reverb):
+  shipyard ship → queued → running → PR #42 merged
+
+Agent 2 (worktree: ~/Code/my-plugin-delay):
+  shipyard ship → queued → waiting → running → PR #43 merged
+```
+
+No collisions. No manual coordination. The queue is machine-global.
+
+## Prioritizing one job over another
+
+Two jobs are queued. The delay feature is urgent. Bump it up.
+
+```
+$ shipyard queue
+  Running: sy-001 feature/reverb  [normal]
+  Pending: sy-002 feature/delay   [low]
+
+$ shipyard bump sy-002 high
+  Bumped sy-002 to high
+```
+
+When the current job finishes, the high-priority job runs next.
+
+## Merging to develop, not main
+
+Your team uses a develop branch as a staging area. Ship to develop first,
+promote to main later when stable.
+
+```
+$ shipyard ship --base develop
+  PR #44 → Validated → Merged to develop
+
+# Later, when develop is stable:
+$ git checkout develop
+$ shipyard ship --base main
+  PR #45 → Validated → Merged to main
+```

--- a/planning/shipyard-hardening.md
+++ b/planning/shipyard-hardening.md
@@ -1,0 +1,341 @@
+# Shipyard Hardening Plan
+
+This document covers issues #31 and #34, additional improvement opportunities,
+Pulp impact analysis, and a README/docs restructure plan.
+
+---
+
+## 1. Issue #31 — Incremental Bundle Delivery
+
+### Problem
+
+`create_bundle()` always builds a full bundle (`git bundle create sha --all`),
+producing ~443 MB for Pulp's 372 MB repo. Even when the remote is only 1-2
+commits behind, the entire repo history is re-bundled and uploaded. This means
+10-15 min of upload time per Windows ship cycle.
+
+The existing `_remote_has_sha()` optimization skips bundling entirely when
+the remote already has the exact SHA — but when it doesn't (the common case
+during active development), there's no incremental path.
+
+### Approach: Remote HEAD Negotiation
+
+Query the remote for its current HEAD SHA, then create a delta bundle:
+
+```
+git bundle create shipyard.bundle <target_sha> ^<remote_head_sha>
+```
+
+This produces a thin bundle containing only the commits between what the
+remote has and what it needs. For a typical 1-2 commit delta, the bundle
+drops from ~443 MB to a few KB.
+
+### Implementation
+
+**Files to modify:**
+
+| File | Change |
+|------|--------|
+| `src/shipyard/bundle/git_bundle.py` | Add `create_incremental_bundle()` that accepts `exclude_shas` parameter; modify `create_bundle()` to accept optional `basis_shas` for `^sha` exclusion |
+| `src/shipyard/executor/ssh.py` | Before `create_bundle()`, query remote HEAD via SSH (`git rev-parse HEAD`); pass result to incremental bundle; fall back to full bundle on failure |
+| `src/shipyard/executor/ssh_windows.py` | Same changes as `ssh.py` but via PowerShell/EncodedCommand transport |
+
+**Steps:**
+
+1. Add `_remote_head_sha(host, repo_path, ssh_options)` helper to `ssh.py`
+   (similar to existing `_remote_has_sha()` but returns the SHA string)
+2. Add equivalent `_remote_head_sha_windows()` to `ssh_windows.py`
+3. Modify `create_bundle()` to accept optional `basis_shas: list[str]`
+   parameter — when provided, appends `^<sha>` for each to the git command
+4. In both SSH executors' `_validate_once()`:
+   - If `_remote_has_sha()` → skip bundle (existing behavior)
+   - Else: query `_remote_head_sha()` → if valid, create incremental bundle
+   - If incremental bundle fails (e.g., no common ancestor), fall back to
+     full bundle
+5. Add tests for incremental bundle creation and fallback
+
+**Fallback safety:** If the remote HEAD is on a completely divergent branch
+or the incremental bundle fails for any reason, fall back to a full bundle.
+The user never sees this — it's transparent.
+
+**Expected impact:** Pulp Windows cycle drops from ~15 min (443 MB upload)
+to seconds (KB-sized delta) for typical iterations.
+
+### Pulp Impact
+
+**None (additive).** The change is internal to `create_bundle()` and the
+SSH executors. Pulp calls `shipyard run` / `shipyard ship` — the CLI
+interface doesn't change. The bundle format is standard git bundles; only
+the content size changes. If anything, Pulp benefits the most since it was
+the project that surfaced this issue.
+
+---
+
+## 2. Issue #34 — `--resume-from` for SSH Executors
+
+### Problem
+
+`--resume-from` is accepted by the CLI but silently ignored by SSH and
+SSH-Windows executors. The flag is only implemented in `LocalExecutor`.
+Every SSH validation run re-runs all 4 stages from scratch, even when
+only the test stage is relevant. For Pulp on Windows: ~12 min of
+configure+build before 1 min of tests.
+
+### Approach: Probe Remote State + Skip Stages
+
+1. When `--resume-from <stage>` is passed, SSH into the remote and check
+   for build artifacts that prove earlier stages completed
+2. If artifacts exist, skip stages before the resume point
+3. If artifacts don't exist, warn and run from the beginning
+
+### Implementation
+
+**Files to modify:**
+
+| File | Change |
+|------|--------|
+| `src/shipyard/executor/ssh.py` | Stop deleting `resume_from`; add `_probe_remote_build_state()` helper; modify `_build_remote_command()` to accept `resume_from` and skip stages |
+| `src/shipyard/executor/ssh_windows.py` | Same changes via PowerShell |
+| `src/shipyard/executor/base.py` | Document `resume_from` in the Protocol (if not already) |
+
+**Remote state probing:**
+
+The probe checks for indicators that earlier stages completed:
+
+| Stage to skip | What to check on remote |
+|---------------|------------------------|
+| setup | Build directory exists |
+| configure | `CMakeCache.txt` exists (CMake), `build.ninja` (Ninja), `Makefile` (make) — or a generic marker file written by the setup stage |
+| build | Binary artifacts exist in build dir, or a shipyard marker file |
+
+For generality, we'll use a **Shipyard marker file** approach:
+- After each stage succeeds on the remote, the executor writes
+  `.shipyard-stage-<name>-<sha>` to the build directory
+- Resume probing checks for these markers
+- Markers are SHA-specific so stale build artifacts from a different
+  commit don't cause false skips
+
+**Steps:**
+
+1. Modify `_build_remote_command()` in both SSH executors to support
+   `resume_from` — filter stages the same way `_get_stages()` does in
+   `local.py`
+2. After each stage succeeds, append a marker-write command:
+   `touch .shipyard-stage-<name>-<sha>` (POSIX) or
+   `New-Item .shipyard-stage-<name>-<sha>` (Windows)
+3. Add `_probe_remote_build_state()` that checks for markers via SSH
+4. In `validate()`, when `resume_from` is set:
+   - Probe remote for the marker of the stage before resume_from
+   - If marker exists for the current SHA → proceed with resume
+   - If marker doesn't exist → log a warning, run all stages
+5. Add tests
+
+**Expected impact:** Pulp Windows test-only iterations drop from ~15 min
+to ~2 min.
+
+### Pulp Impact
+
+**None (additive).** Pulp's `.shipyard/config.toml` uses stage-aware
+validation. The `--resume-from` flag is a CLI option that Pulp doesn't
+currently use (because it didn't work). Once implemented, Pulp's CI
+skill can recommend it for test-only reruns.
+
+The marker files (`.shipyard-stage-*`) are written to the remote build
+directory, not committed to git. No config changes needed.
+
+---
+
+## 3. Additional Improvement Opportunities
+
+These are opportunities beyond #31 and #34 to make Shipyard a better
+reusable abstraction.
+
+### 3a. Implement `shipyard targets` Subcommand
+
+**Priority: Medium**
+
+The README references `shipyard targets add ubuntu` but this doesn't
+exist. The skill file explicitly notes: "There is no `shipyard config`
+or `shipyard targets` subcommand yet."
+
+**Scope:**
+- `shipyard targets` — list configured targets with reachability status
+- `shipyard targets add <name>` — interactive add (detect backend, probe
+  host, write to config)
+- `shipyard targets remove <name>` — remove from config
+- `shipyard targets test <name>` — probe + run a health check
+
+This makes the "add a new platform" workflow zero-config-editing, which
+is important for the "obviously useful" bar.
+
+### 3b. Implement `shipyard config` Subcommand
+
+**Priority: Medium**
+
+Currently referenced in README but not implemented.
+
+**Scope:**
+- `shipyard config profiles` — list defined profiles
+- `shipyard config use <profile>` — switch active profile
+- `shipyard config show` — dump effective merged config (global + project + local)
+
+The profile switching is already partially implemented in `cli.py`
+(`_rewrite_profile_in_config()`) but the subcommand routing doesn't exist.
+
+### 3c. Cloud Executor Polling Timeout
+
+**Priority: High (reliability)**
+
+`cloud.py:_poll_run()` loops `while True` with no deadline. A hanging
+GitHub Actions workflow blocks the drain lock indefinitely, blocking
+every other queued job on the machine. Add a configurable timeout
+(default 60 min) after which the cloud run is marked ERROR.
+
+### 3d. Queue `_jobs` Direct Access Cleanup
+
+**Priority: Low (code quality)**
+
+`cli.py:337` accesses `queue._jobs` directly. Add a public
+`queue.all_jobs()` method and use it.
+
+### 3e. `ship/merge.py:ship()` Vestigial Code
+
+**Priority: Low (code quality)**
+
+The `ship()` function in `merge.py` exists alongside a much more
+capable `ship` command in `cli.py`. Determine if `merge.py:ship()` is
+still called anywhere; if not, remove it to reduce confusion.
+
+### 3f. Config Field Naming Consistency
+
+**Priority: Low**
+
+Target config uses `backend = "local"` but fallback entries use
+`type = "cloud"`. Normalize to one field name (preferably `backend`)
+with backward compat for `type`.
+
+---
+
+## 4. Pulp Impact Summary
+
+| Change | Pulp Impact | Action Needed |
+|--------|------------|---------------|
+| Incremental bundles (#31) | Beneficial, no breaking changes | None |
+| SSH resume-from (#34) | Beneficial, no breaking changes | Update CI skill to recommend `--resume-from` |
+| `shipyard targets` subcommand | No impact (new feature) | None |
+| `shipyard config` subcommand | No impact (new feature) | None |
+| Cloud polling timeout | Beneficial (prevents hangs) | None |
+| Queue cleanup | No impact (internal) | None |
+| `merge.py` cleanup | No impact (internal) | None |
+| Config field normalization | **Low risk** — Pulp uses `backend` not `type` | Verify `.shipyard/config.toml` fallback entries |
+
+**Critical note:** Pulp's `tools/shipyard.toml` pins **v0.1.3** but the
+migration docs show dogfooding through v0.1.13+. The pin file is stale
+and should be bumped when these changes ship. This isn't caused by our
+changes but is an existing risk — a fresh `install-shipyard.sh` on a
+new machine installs v0.1.3 which has 10 known bugs fixed in later
+versions.
+
+---
+
+## 5. README & Docs Restructure
+
+### Goal
+
+Make the README simple, focused, and obviously useful — inspired by
+[uv's README](https://github.com/astral-sh/uv):
+
+- **Who it's for** and **why it's useful** up top
+- **Installation** immediately after
+- **Everything else** linked to separate pages
+
+Current README: ~870 lines. Target: ~200-250 lines.
+
+### Proposed README Structure
+
+```
+# Shipyard
+
+One-line: Cross-platform CI for AI agents. Validates exact commits
+across your machines, merges only when everything is green.
+
+## Highlights
+- 4-5 bullet points (the differentiators, distilled)
+
+## Install
+
+### Claude Code (recommended)
+[3 steps, concise]
+
+### CLI
+[curl one-liner]
+
+## Quick Start
+shipyard init → shipyard run → shipyard ship
+
+## How It Works
+[5-8 lines: local/remote/cloud, exact-SHA, evidence gate]
+
+## Documentation
+- [Examples & Scenarios](docs/examples.md)
+- [Targets & Fallback Chains](docs/targets.md)
+- [Security & Governance](docs/governance.md)
+- [Agent Integration](docs/agent-integration.md)
+- [Profiles & Configuration](docs/profiles.md)
+- [CLI Reference](docs/cli-reference.md)
+- [Workflow Scenarios](docs/workflows.md)
+
+## Requirements
+[table, same as current]
+```
+
+### Content to Extract to `docs/`
+
+| Current Section | New File | ~Lines Moved |
+|----------------|----------|-------------|
+| Security & Governance Profiles | `docs/governance.md` | ~100 |
+| Examples (4 scenarios) | `docs/examples.md` | ~130 |
+| How Targets Work | `docs/targets.md` | ~90 |
+| Agent Integration | `docs/agent-integration.md` | ~85 |
+| Workflow Scenarios | `docs/workflows.md` | ~100 |
+| Profiles | `docs/profiles.md` | ~95 |
+| Quick Reference (expanded) | `docs/cli-reference.md` | ~30 (+ expansion) |
+
+### What Stays
+
+- Title + one-liner + highlights
+- Install (both paths, concise)
+- Quick start (3 commands)
+- How it works (brief)
+- Documentation links
+- Requirements table
+- "This Repo Uses Shipyard" (trimmed to 3 lines + link)
+
+### Additional Cleanup
+
+- Remove references to `shipyard targets add` and `shipyard config use`
+  from the README until those commands exist (or implement them first —
+  see 3a/3b above)
+- Move blog post link from line 1 to the docs or a "Learn More" section
+- Plugin manifest version (`0.1.1`) should be updated to match the
+  actual release
+
+---
+
+## 6. Implementation Order
+
+Recommended sequence, balancing impact and risk:
+
+| Phase | Work | Why This Order |
+|-------|------|---------------|
+| **1** | Incremental bundles (#31) | Highest user impact; unblocks fast Windows iteration for Pulp |
+| **2** | SSH `--resume-from` (#34) | Second-highest impact; compounds with #31 for fast test loops |
+| **3** | Cloud polling timeout (3c) | Reliability fix; small scope, high value |
+| **4** | README restructure (5) | Non-code; can be done in parallel with anything |
+| **5** | `shipyard targets` subcommand (3a) | Fills a documented gap; makes README honest |
+| **6** | `shipyard config` subcommand (3b) | Fills the other documented gap |
+| **7** | Code quality items (3d, 3e, 3f) | Low priority, do opportunistically |
+
+Phases 1-3 are the "make it great" work. Phase 4 is the "make it
+obviously useful" work. Phases 5-6 fill gaps between docs and reality.
+Phase 7 is housekeeping.

--- a/src/shipyard/bundle/git_bundle.py
+++ b/src/shipyard/bundle/git_bundle.py
@@ -29,6 +29,7 @@ def create_bundle(
     sha: str,
     output_path: str | Path,
     repo_dir: str | Path | None = None,
+    basis_shas: Sequence[str] = (),
 ) -> BundleResult:
     """Create a git bundle containing the given SHA and its ancestors.
 
@@ -36,6 +37,10 @@ def create_bundle(
         sha: The commit SHA to include (up to and including this commit).
         output_path: Local filesystem path for the generated .bundle file.
         repo_dir: Working directory for git commands. Defaults to cwd.
+        basis_shas: SHAs the remote already has. Each is passed as
+            ``^<sha>`` to ``git bundle create``, producing an incremental
+            bundle that excludes objects reachable from those commits.
+            When empty, ``--all`` is used to create a full bundle.
 
     Returns:
         BundleResult indicating success or failure.
@@ -45,9 +50,16 @@ def create_bundle(
 
     cwd = str(repo_dir) if repo_dir else None
 
+    cmd = ["git", "bundle", "create", str(output_path), sha]
+    if basis_shas:
+        for basis in basis_shas:
+            cmd.append(f"^{basis}")
+    else:
+        cmd.append("--all")
+
     try:
         result = subprocess.run(
-            ["git", "bundle", "create", str(output_path), sha, "--all"],
+            cmd,
             cwd=cwd,
             capture_output=True,
             text=True,

--- a/src/shipyard/cli.py
+++ b/src/shipyard/cli.py
@@ -334,9 +334,7 @@ def queue_cmd(ctx: Context) -> None:
     """Show all jobs in the queue."""
     queue = ctx.queue
     active = queue.get_active()
-    pending = [j for j in queue._jobs if j.status == JobStatus.PENDING]
-    queue._ensure_loaded()
-    pending.sort(key=lambda j: (-j.priority.value, j.created_at))
+    pending = queue.get_pending()
     recent = queue.get_recent(limit=5)
 
     if ctx.json_mode:
@@ -1899,6 +1897,303 @@ def _wait_for_cloud_completion(repository: str | None, run_id: str) -> dict[str,
         import time
 
         time.sleep(5)
+
+
+# ── targets commands ──────────────────────────────────────────────────
+
+
+@main.group(invoke_without_command=True)
+@click.pass_context
+def targets(ctx: click.Context) -> None:
+    """List, add, remove, and test validation targets.
+
+    With no subcommand, lists all configured targets and their
+    reachability — equivalent to `shipyard targets list`.
+    """
+    if ctx.invoked_subcommand is None:
+        ctx.invoke(targets_list)
+
+
+@targets.command("list")
+@click.pass_obj
+def targets_list(ctx: Context) -> None:
+    """List configured targets with reachability status."""
+    config = ctx.config
+    if not config.targets:
+        if ctx.json_mode:
+            ctx.output("targets.list", {"targets": []})
+        else:
+            render_message("No targets configured. Run `shipyard init`.")
+        return
+
+    dispatcher = _make_dispatcher(config)
+    rows: list[dict[str, Any]] = []
+    for name, tconfig in config.targets.items():
+        target_config = dict(tconfig)
+        target_config["name"] = name
+        reachable, selected_backend = _probe_target(target_config, dispatcher)
+        rows.append({
+            "name": name,
+            "backend": dispatcher.backend_name(target_config),
+            "platform": tconfig.get("platform", "unknown"),
+            "reachable": reachable,
+            "active_backend": selected_backend,
+        })
+
+    if ctx.json_mode:
+        ctx.output("targets.list", {"targets": rows})
+    else:
+        console.print()
+        console.print("[bold]Targets[/]")
+        for row in rows:
+            status = "[green]reachable[/]" if row["reachable"] else "[red]unreachable[/]"
+            console.print(
+                f"  {row['name']:<16} {row['backend']:<12} "
+                f"{row['platform']:<16} {status}"
+            )
+        console.print()
+
+
+@targets.command("test")
+@click.argument("name")
+@click.pass_obj
+def targets_test(ctx: Context, name: str) -> None:
+    """Probe a single target and report reachability."""
+    config = ctx.config
+    if name not in config.targets:
+        render_error(f"Target '{name}' not configured")
+        sys.exit(1)
+    dispatcher = _make_dispatcher(config)
+    target_config = dict(config.targets[name])
+    target_config["name"] = name
+    reachable, selected_backend = _probe_target(target_config, dispatcher)
+    if ctx.json_mode:
+        ctx.output("targets.test", {
+            "name": name,
+            "reachable": reachable,
+            "active_backend": selected_backend,
+        })
+    else:
+        if reachable:
+            render_message(f"{name}: reachable via {selected_backend}", style="green")
+        else:
+            render_message(f"{name}: unreachable", style="red")
+            sys.exit(1)
+
+
+@targets.command("add")
+@click.argument("name")
+@click.option(
+    "--backend",
+    type=click.Choice(["local", "ssh", "ssh-windows", "cloud"]),
+    required=True,
+    help="Backend type for this target",
+)
+@click.option("--platform", help="Platform identifier (e.g. linux-x64)")
+@click.option("--host", help="SSH host (alias or user@host) — required for ssh/ssh-windows")
+@click.option("--repo-path", help="Remote repo path (ssh/ssh-windows)")
+@click.pass_obj
+def targets_add(
+    ctx: Context,
+    name: str,
+    backend: str,
+    platform: str | None,
+    host: str | None,
+    repo_path: str | None,
+) -> None:
+    """Add a new target to the project config.
+
+    Writes a new ``[targets.<name>]`` section to
+    ``.shipyard/config.toml``. For SSH backends, probes the host
+    before writing so the user gets immediate feedback.
+    """
+    if ctx.config.project_dir is None:
+        render_error("No .shipyard/config.toml found. Run `shipyard init` first.")
+        sys.exit(1)
+    if name in ctx.config.targets:
+        render_error(f"Target '{name}' already exists. Remove it first or pick another name.")
+        sys.exit(1)
+    if backend in ("ssh", "ssh-windows") and not host:
+        render_error(f"--host is required for backend={backend}")
+        sys.exit(1)
+
+    new_target: dict[str, Any] = {"backend": backend}
+    if platform:
+        new_target["platform"] = platform
+    if host:
+        new_target["host"] = host
+    if repo_path:
+        new_target["repo_path"] = repo_path
+
+    # Probe before writing so the user knows whether the new target
+    # is actually usable.
+    if backend in ("ssh", "ssh-windows"):
+        from shipyard.executor.ssh import SSHExecutor
+        from shipyard.executor.ssh_windows import SSHWindowsExecutor
+        executor = SSHExecutor() if backend == "ssh" else SSHWindowsExecutor()
+        probe_target = {**new_target, "name": name}
+        reachable = executor.probe(probe_target)
+        if not reachable and not ctx.json_mode:
+            render_message(
+                f"warning: {host} is not reachable right now. Adding anyway.",
+                style="bold yellow",
+            )
+
+    config_path = ctx.config.project_dir / "config.toml"
+    _append_target_section(config_path, name, new_target)
+
+    if ctx.json_mode:
+        ctx.output("targets.add", {"name": name, "config": new_target})
+    else:
+        render_message(f"Added target '{name}' to {config_path}", style="green")
+
+
+@targets.command("remove")
+@click.argument("name")
+@click.pass_obj
+def targets_remove(ctx: Context, name: str) -> None:
+    """Remove a target from the project config."""
+    if ctx.config.project_dir is None:
+        render_error("No .shipyard/config.toml found.")
+        sys.exit(1)
+    if name not in ctx.config.targets:
+        render_error(f"Target '{name}' not found")
+        sys.exit(1)
+    config_path = ctx.config.project_dir / "config.toml"
+    _remove_target_section(config_path, name)
+    if ctx.json_mode:
+        ctx.output("targets.remove", {"name": name})
+    else:
+        render_message(f"Removed target '{name}' from {config_path}", style="green")
+
+
+def _append_target_section(
+    config_path: Path, name: str, target_config: dict[str, Any],
+) -> None:
+    """Append a new ``[targets.<name>]`` section to a TOML config file.
+
+    Uses raw text append so existing comments and ordering are
+    preserved. Each value is rendered with `tomli_w` to ensure
+    correct escaping.
+    """
+    import tomli_w
+    section = tomli_w.dumps({"targets": {name: target_config}})
+    text = config_path.read_text()
+    if not text.endswith("\n"):
+        text += "\n"
+    if not text.endswith("\n\n"):
+        text += "\n"
+    config_path.write_text(text + section)
+
+
+def _remove_target_section(config_path: Path, name: str) -> None:
+    """Remove the ``[targets.<name>]`` section from a TOML config file.
+
+    Line-level edit so unrelated comments and ordering are preserved.
+    """
+    text = config_path.read_text()
+    lines = text.splitlines(keepends=True)
+    out: list[str] = []
+    skipping = False
+    section_marker = f"[targets.{name}]"
+    for line in lines:
+        stripped = line.strip()
+        if stripped == section_marker:
+            skipping = True
+            continue
+        if skipping and stripped.startswith("[") and stripped.endswith("]"):
+            skipping = False
+            out.append(line)
+            continue
+        if not skipping:
+            out.append(line)
+    config_path.write_text("".join(out))
+
+
+# ── config commands ──────────────────────────────────────────────────
+
+
+@main.group(invoke_without_command=True, name="config")
+@click.pass_context
+def config_cmd(ctx: click.Context) -> None:
+    """Inspect and switch project profiles and configuration.
+
+    With no subcommand, prints the effective merged config.
+    """
+    if ctx.invoked_subcommand is None:
+        ctx.invoke(config_show)
+
+
+@config_cmd.command("show")
+@click.pass_obj
+def config_show(ctx: Context) -> None:
+    """Print the effective merged configuration as JSON."""
+    import json as _json
+    if ctx.json_mode:
+        ctx.output("config.show", {"config": ctx.config.to_dict()})
+    else:
+        render_message(_json.dumps(ctx.config.to_dict(), indent=2))
+
+
+@config_cmd.command("profiles")
+@click.pass_obj
+def config_profiles(ctx: Context) -> None:
+    """List defined profiles and which one is active."""
+    profiles = ctx.config.get("profiles", {}) or {}
+    active = str(ctx.config.get("project.profile", "")) or None
+    rows: list[dict[str, Any]] = []
+    for name, body in profiles.items():
+        rows.append({
+            "name": name,
+            "active": name == active,
+            "targets": list((body or {}).get("targets", [])),
+        })
+    if ctx.json_mode:
+        ctx.output("config.profiles", {"profiles": rows, "active": active})
+    else:
+        if not rows:
+            render_message("No profiles defined. See docs/profiles.md.")
+            return
+        console.print()
+        console.print("[bold]Profiles[/]")
+        for row in rows:
+            marker = "  [green]← active[/]" if row["active"] else ""
+            console.print(
+                f"  {row['name']:<10} {', '.join(row['targets'])}{marker}"
+            )
+        console.print()
+
+
+@config_cmd.command("use")
+@click.argument("profile_name")
+@click.pass_obj
+def config_use(ctx: Context, profile_name: str) -> None:
+    """Switch the active profile.
+
+    This is a project-config-only operation — it edits
+    ``[project].profile`` in ``.shipyard/config.toml``. To switch the
+    *governance* profile (and apply branch protection at the same
+    time), use ``shipyard governance use``.
+    """
+    if ctx.config.project_dir is None:
+        render_error("No .shipyard/config.toml found. Run `shipyard init` first.")
+        sys.exit(1)
+    profiles = ctx.config.get("profiles", {}) or {}
+    if profile_name not in profiles:
+        render_error(
+            f"Profile '{profile_name}' is not defined. "
+            f"Known profiles: {', '.join(profiles.keys()) or '(none)'}"
+        )
+        sys.exit(1)
+    config_path = ctx.config.project_dir / "config.toml"
+    _rewrite_profile_in_config(config_path, profile_name)
+    if ctx.json_mode:
+        ctx.output("config.use", {"profile": profile_name})
+    else:
+        render_message(
+            f"Switched to profile '{profile_name}' in {config_path}",
+            style="green",
+        )
 
 
 if __name__ == "__main__":

--- a/src/shipyard/core/queue.py
+++ b/src/shipyard/core/queue.py
@@ -196,6 +196,13 @@ class Queue:
         completed.sort(key=lambda j: j.completed_at or j.created_at, reverse=True)
         return completed[:limit]
 
+    def get_pending(self) -> list[Job]:
+        """Return pending jobs, sorted by priority (high first) then FIFO."""
+        self._ensure_loaded()
+        pending = [j for j in self._jobs if j.status == JobStatus.PENDING]
+        pending.sort(key=lambda j: (-j.priority.value, j.created_at))
+        return pending
+
     @property
     def pending_count(self) -> int:
         self._ensure_loaded()

--- a/src/shipyard/executor/cloud.py
+++ b/src/shipyard/executor/cloud.py
@@ -23,6 +23,13 @@ if TYPE_CHECKING:
 _POLL_INTERVAL = 15
 # Maximum time to wait for a workflow run to appear in the list
 _DISPATCH_SETTLE_SECS = 30
+# Maximum time to wait for a workflow run to complete. After this
+# the run is reported as ERROR (timeout). Without this bound a
+# hanging GitHub Actions workflow would block the drain lock
+# indefinitely, blocking every other queued job on the machine.
+# Defaults to 60 minutes, which covers the long tail of real-world
+# cross-platform builds while still cutting losses on stuck runs.
+_MAX_POLL_SECS = 3600
 
 
 class CloudExecutor:
@@ -34,11 +41,13 @@ class CloudExecutor:
         repo: str | None = None,
         poll_interval: float = _POLL_INTERVAL,
         dispatch_settle_secs: float = _DISPATCH_SETTLE_SECS,
+        max_poll_secs: float = _MAX_POLL_SECS,
     ) -> None:
         self.workflow = workflow
         self.repo = repo
         self.poll_interval = poll_interval
         self.dispatch_settle_secs = dispatch_settle_secs
+        self.max_poll_secs = max_poll_secs
 
     def validate(
         self,
@@ -115,9 +124,20 @@ class CloudExecutor:
                 runner_profile=runner_profile,
             )
 
-        # Poll for completion
+        # Poll for completion. Per-target override allows long-running
+        # workflows (e.g. heavy cross-compile) to extend the cap; the
+        # 60-minute default protects the queue from indefinite hangs.
+        per_target_max = target_config.get("cloud_max_poll_secs")
+        max_poll_secs = (
+            float(per_target_max) if per_target_max is not None
+            else self.max_poll_secs
+        )
         try:
-            conclusion = self._poll_run(run_id, progress_callback=progress_callback)
+            conclusion = self._poll_run(
+                run_id,
+                progress_callback=progress_callback,
+                max_poll_secs=max_poll_secs,
+            )
         except subprocess.CalledProcessError as exc:
             return TargetResult(
                 target_name=target_name,
@@ -128,6 +148,19 @@ class CloudExecutor:
                 completed_at=datetime.now(timezone.utc),
                 duration_secs=time.monotonic() - start_time,
                 error_message=f"Failed to poll workflow run: {exc}",
+                provider=runner_provider,
+                runner_profile=runner_profile,
+            )
+        except TimeoutError as exc:
+            return TargetResult(
+                target_name=target_name,
+                platform=platform,
+                status=TargetStatus.ERROR,
+                backend="cloud",
+                started_at=started_at,
+                completed_at=datetime.now(timezone.utc),
+                duration_secs=time.monotonic() - start_time,
+                error_message=str(exc),
                 provider=runner_provider,
                 runner_profile=runner_profile,
             )
@@ -209,8 +242,18 @@ class CloudExecutor:
         run_id: str,
         *,
         progress_callback: ProgressCallback | None = None,
+        max_poll_secs: float | None = None,
     ) -> str:
-        """Poll a workflow run until it completes. Returns the conclusion."""
+        """Poll a workflow run until it completes. Returns the conclusion.
+
+        Raises TimeoutError if the run does not complete within
+        ``max_poll_secs``. None means use ``self.max_poll_secs``.
+        Pass ``float('inf')`` to disable the bound (e.g. in tests
+        that mock a fast completion).
+        """
+        if max_poll_secs is None:
+            max_poll_secs = self.max_poll_secs
+        deadline = time.monotonic() + max_poll_secs
         while True:
             cmd: list[str] = [
                 "gh", "run", "view", run_id,
@@ -228,6 +271,11 @@ class CloudExecutor:
             if data.get("status") == "completed":
                 return data.get("conclusion", "failure")
 
+            if time.monotonic() >= deadline:
+                raise TimeoutError(
+                    f"Cloud workflow run {run_id} did not complete within "
+                    f"{int(max_poll_secs)}s"
+                )
             time.sleep(self.poll_interval)
 
 

--- a/src/shipyard/executor/ssh.py
+++ b/src/shipyard/executor/ssh.py
@@ -31,15 +31,18 @@ class SSHExecutor:
         validation_config: dict[str, Any],
         log_path: str,
         progress_callback: ProgressCallback | None = None,
-        resume_from: str | None = None,  # accepted for API symmetry
-        mode: str = "default",            # accepted for API symmetry
+        resume_from: str | None = None,
+        mode: str = "default",  # accepted for API symmetry
     ) -> TargetResult:
-        # `resume_from` and `mode` are accepted but not yet
-        # implemented on the SSH executor — stage-aware resume and
-        # prepared-state reuse are still local-only features. The
-        # parameters are present so the CLI dispatch path can pass
-        # the same kwargs to every backend without TypeError.
-        del resume_from, mode
+        # `resume_from` is honored: when set, the executor probes the
+        # remote for a marker file written by the previous stage's
+        # successful run on this SHA. If the marker exists, earlier
+        # stages are skipped on the remote. If the marker is missing
+        # (or probing fails), a warning is recorded and all stages
+        # run as a safe default.
+        # `mode` is accepted but not yet implemented (prepared-state
+        # mode tagging is local-only).
+        del mode
         target_name = target_config.get("name", "ssh")
         platform = target_config.get("platform", "unknown")
         start_time = time.monotonic()
@@ -55,6 +58,7 @@ class SSHExecutor:
                 validation_config=validation_config,
                 log_path=log_path,
                 progress_callback=progress_callback,
+                resume_from=resume_from,
             )
             if result.status == TargetStatus.ERROR and result.error_message and is_transient(result.error_message):
                 raise RuntimeError(result.error_message)
@@ -80,6 +84,7 @@ class SSHExecutor:
         validation_config: dict[str, Any],
         log_path: str,
         progress_callback: ProgressCallback | None = None,
+        resume_from: str | None = None,
     ) -> TargetResult:
         target_name = target_config.get("name", "ssh")
         platform = target_config.get("platform", "unknown")
@@ -107,11 +112,31 @@ class SSHExecutor:
                     "remote_bundle_path", "/tmp/shipyard.bundle"
                 )
 
+                # Try an incremental bundle first: query the remote
+                # for its HEAD SHA and use it as a basis so only the
+                # delta is bundled. Falls back to a full bundle if
+                # the remote HEAD is unknown or the incremental
+                # bundle fails (e.g. no common ancestor).
+                basis_shas: list[str] = []
+                remote_head = _remote_head_sha(host, remote_repo, ssh_options)
+                if remote_head:
+                    basis_shas.append(remote_head)
+
                 bundle_result = create_bundle(
                     sha=sha,
                     output_path=bundle_path,
                     repo_dir=target_config.get("local_repo_dir"),
+                    basis_shas=basis_shas,
                 )
+
+                # If incremental bundle failed and we had a basis,
+                # fall back to a full bundle.
+                if not bundle_result.success and basis_shas:
+                    bundle_result = create_bundle(
+                        sha=sha,
+                        output_path=bundle_path,
+                        repo_dir=target_config.get("local_repo_dir"),
+                    )
                 if not bundle_result.success:
                     return _error_result(
                         target_name, platform, started_at, start_time,
@@ -144,8 +169,24 @@ class SSHExecutor:
                         str(log_file), f"Bundle apply failed: {apply_result.message}",
                     )
 
-        # Step 2: Checkout the SHA and run validation
-        command = _build_remote_command(sha, remote_repo, validation_config)
+        # Step 2: Resolve resume_from. If the caller asked to skip
+        # earlier stages, probe the remote for a marker file written
+        # by the previous successful run on this SHA. If the marker
+        # is missing, run all stages (safe default) and log a note.
+        effective_resume = _resolve_resume_from(
+            host=host,
+            remote_repo=remote_repo,
+            sha=sha,
+            ssh_options=ssh_options,
+            requested=resume_from,
+            validation_config=validation_config,
+            log_file=log_file,
+        )
+
+        # Step 3: Checkout the SHA and run validation
+        command = _build_remote_command(
+            sha, remote_repo, validation_config, resume_from=effective_resume,
+        )
         if not command:
             return _error_result(
                 target_name, platform, started_at, start_time,
@@ -238,6 +279,44 @@ class SSHExecutor:
             return False
 
 
+def _remote_head_sha(
+    host: str,
+    repo_path: str,
+    ssh_options: list[str],
+    *,
+    timeout: int = 15,
+) -> str | None:
+    """Return the HEAD SHA from the remote repo, or None on any error.
+
+    Used to create incremental bundles: if the remote is at commit X
+    and we need to deliver commit Y, the bundle only needs objects
+    reachable from Y but not from X. For a typical 1-2 commit delta
+    this reduces a 443 MB bundle to a few KB.
+
+    Returns None on any error (SSH unreachable, empty repo, timeout)
+    so the caller falls through to a full bundle as a safe default.
+    """
+    cmd = [
+        "ssh",
+        *ssh_options,
+        "-o", "ConnectTimeout=5",
+        host,
+        f"cd {repo_path} && git rev-parse HEAD",
+    ]
+    try:
+        result = subprocess.run(
+            cmd, capture_output=True, text=True, timeout=timeout,
+        )
+        if result.returncode == 0:
+            sha = result.stdout.strip()
+            # Sanity-check: must look like a hex SHA
+            if sha and len(sha) >= 7 and all(c in "0123456789abcdef" for c in sha):
+                return sha
+        return None
+    except (subprocess.SubprocessError, OSError):
+        return None
+
+
 def _remote_has_sha(
     host: str,
     repo_path: str,
@@ -285,22 +364,163 @@ def _ssh_options(target_config: dict[str, Any]) -> list[str]:
     return options
 
 
+STAGE_ORDER = ("setup", "configure", "build", "test")
+
+
+def _stage_marker_name(stage: str, sha: str) -> str:
+    """Marker file written to the remote repo after a stage succeeds.
+
+    SHA-scoped so artifacts from a different commit can't cause a
+    false skip on a later resume. We use a short SHA prefix to keep
+    the filename readable; collisions on a repo with many recent
+    runs would only cause a stale skip, which is bounded by the
+    ``--resume-from`` opt-in (the user is asserting they want to
+    skip).
+    """
+    return f".shipyard-stage-{stage}-{sha[:12]}"
+
+
+def _resolve_resume_from(
+    *,
+    host: str,
+    remote_repo: str,
+    sha: str,
+    ssh_options: list[str],
+    requested: str | None,
+    validation_config: dict[str, Any],
+    log_file: Path,
+) -> str | None:
+    """Decide whether to honor a `--resume-from` request.
+
+    The request is honored only when the previous stage's marker
+    file exists on the remote for this exact SHA. Otherwise the
+    function logs a note and returns None so all stages run.
+
+    Single-command validation configs (no stage breakdown) cannot
+    resume — the request is logged and ignored.
+    """
+    if requested is None:
+        return None
+    if "command" in validation_config:
+        _append_log(
+            log_file,
+            f"=== resume-from: ignored ({requested!r}) — "
+            f"validation_config uses single command, no stages to skip ===\n",
+        )
+        return None
+    if requested not in STAGE_ORDER:
+        _append_log(
+            log_file,
+            f"=== resume-from: ignored — unknown stage {requested!r} ===\n",
+        )
+        return None
+
+    idx = STAGE_ORDER.index(requested)
+    if idx == 0:
+        # Resuming from the first stage is a no-op
+        return requested
+
+    # Look for the most recent stage with a configured command
+    # before requested; that's the marker we need to find.
+    prev_stage = None
+    for candidate in STAGE_ORDER[:idx][::-1]:
+        if validation_config.get(candidate):
+            prev_stage = candidate
+            break
+
+    if prev_stage is None:
+        return requested  # no earlier stages configured anyway
+
+    marker = _stage_marker_name(prev_stage, sha)
+    if _remote_marker_exists(host, remote_repo, marker, ssh_options):
+        _append_log(
+            log_file,
+            f"=== resume-from: honoring {requested!r} — found marker for "
+            f"previous stage {prev_stage!r} on remote ===\n",
+        )
+        return requested
+    _append_log(
+        log_file,
+        f"=== resume-from: requested {requested!r} but marker for "
+        f"previous stage {prev_stage!r} not found on remote — running "
+        f"all stages from the beginning ===\n",
+    )
+    return None
+
+
+def _remote_marker_exists(
+    host: str,
+    repo_path: str,
+    marker: str,
+    ssh_options: list[str],
+    *,
+    timeout: int = 15,
+) -> bool:
+    """Check whether `<repo>/<marker>` exists on the remote."""
+    cmd = [
+        "ssh",
+        *ssh_options,
+        "-o", "ConnectTimeout=5",
+        host,
+        f"test -f {shlex_quote(repo_path)}/{shlex_quote(marker)}",
+    ]
+    try:
+        result = subprocess.run(
+            cmd, capture_output=True, text=True, timeout=timeout,
+        )
+        return result.returncode == 0
+    except (subprocess.SubprocessError, OSError):
+        return False
+
+
+def _append_log(log_file: Path, text: str) -> None:
+    try:
+        with open(log_file, "a", encoding="utf-8") as fh:
+            fh.write(text)
+    except OSError:
+        pass
+
+
+def shlex_quote(value: str) -> str:
+    """Local re-export so callers don't need to import shlex separately."""
+    import shlex
+    return shlex.quote(value)
+
+
 def _build_remote_command(
     sha: str,
     remote_repo: str,
     validation_config: dict[str, Any],
+    resume_from: str | None = None,
 ) -> str | None:
-    """Build the remote shell command: checkout + validate."""
+    """Build the remote shell command: checkout + validate.
+
+    When ``resume_from`` is set, stages before the resume point are
+    skipped. After each stage succeeds, a marker file is written to
+    the repo root so a subsequent resume run can detect that the
+    earlier stage really did pass on this SHA.
+    """
     import shlex
 
     if "command" in validation_config:
         validate_cmd = validation_config["command"]
     else:
         parts: list[str] = []
-        for step in ("setup", "configure", "build", "test"):
+        skipping = resume_from is not None
+        for step in STAGE_ORDER:
             cmd = validation_config.get(step)
-            if cmd:
-                parts.append(f"printf '__SHIPYARD_PHASE__:{step}\\n' && {cmd}")
+            if not cmd:
+                continue
+            if skipping:
+                if step == resume_from:
+                    skipping = False
+                else:
+                    continue
+            marker = _stage_marker_name(step, sha)
+            parts.append(
+                f"printf '__SHIPYARD_PHASE__:{step}\\n' && "
+                f"{cmd} && touch {shlex.quote(marker)}"
+            )
         if not parts:
             return None
         validate_cmd = " && ".join(parts)

--- a/src/shipyard/executor/ssh_windows.py
+++ b/src/shipyard/executor/ssh_windows.py
@@ -62,16 +62,16 @@ class SSHWindowsExecutor:
         validation_config: dict[str, Any],
         log_path: str,
         progress_callback: ProgressCallback | None = None,
-        resume_from: str | None = None,  # accepted for API symmetry
-        mode: str = "default",            # accepted for API symmetry
+        resume_from: str | None = None,
+        mode: str = "default",  # accepted for API symmetry
     ) -> TargetResult:
-        # `resume_from` and `mode` are accepted for API symmetry
-        # with LocalExecutor but not yet implemented here — the
-        # Windows SSH executor builds the remote command in one
-        # pass. Dropping them silently avoids a TypeError from the
-        # CLI dispatch path, which passes the same kwargs to every
-        # backend.
-        del resume_from, mode
+        # `resume_from` is honored: when set, the executor probes the
+        # remote for a marker file written by the previous stage's
+        # successful run on this SHA. If the marker exists, earlier
+        # stages are skipped on the remote.
+        # `mode` is accepted but not yet implemented (prepared-state
+        # mode tagging is local-only).
+        del mode
         target_name = target_config.get("name", "windows")
         platform = target_config.get("platform", "windows-x64")
         host = target_config["host"]
@@ -107,11 +107,31 @@ class SSHWindowsExecutor:
                     "remote_bundle_path", "shipyard.bundle"
                 )
 
+                # Try an incremental bundle first: query the remote
+                # for its HEAD SHA and use it as a basis so only the
+                # delta is bundled. Falls back to a full bundle if
+                # the remote HEAD is unknown or the incremental
+                # bundle fails (e.g. no common ancestor).
+                basis_shas: list[str] = []
+                remote_head = _remote_head_sha_windows(host, remote_repo, sha, ssh_options)
+                if remote_head:
+                    basis_shas.append(remote_head)
+
                 bundle_result = create_bundle(
                     sha=sha,
                     output_path=bundle_path,
                     repo_dir=target_config.get("local_repo_dir"),
+                    basis_shas=basis_shas,
                 )
+
+                # If incremental bundle failed and we had a basis,
+                # fall back to a full bundle.
+                if not bundle_result.success and basis_shas:
+                    bundle_result = create_bundle(
+                        sha=sha,
+                        output_path=bundle_path,
+                        repo_dir=target_config.get("local_repo_dir"),
+                    )
                 if not bundle_result.success:
                     return _error_result(
                         target_name, platform, started_at, start_time,
@@ -157,12 +177,27 @@ class SSHWindowsExecutor:
         # a None result just means CMake falls back to its defaults.
         toolchain = self._get_vs_toolchain(host, ssh_options, target_config)
 
+        # Step 2.5: Resolve resume_from. If the caller asked to skip
+        # earlier stages, probe the remote for a marker file written
+        # by the previous successful run on this SHA.
+        effective_resume = _resolve_resume_from_windows(
+            host=host,
+            remote_repo=remote_repo,
+            sha=sha,
+            ssh_options=ssh_options,
+            requested=resume_from,
+            validation_config=validation_config,
+            log_file=log_file,
+        )
+
         # Step 3: Build the remote PowerShell command: env exports +
         # checkout + validate. If the target opts into a host mutex,
         # wrap the whole thing in a Mutex block so concurrent runs
         # against the same Windows host queue up instead of racing.
         command = _build_remote_command(
-            sha, remote_repo, validation_config, toolchain=toolchain,
+            sha, remote_repo, validation_config,
+            toolchain=toolchain,
+            resume_from=effective_resume,
         )
         if not command:
             return _error_result(
@@ -398,6 +433,40 @@ def _powershell_encoded_argv(host: str, script: str) -> list[str]:
     ]
 
 
+def _remote_head_sha_windows(
+    host: str,
+    repo_path: str,
+    sha: str,
+    ssh_options: list[str],
+    *,
+    timeout: int = 15,
+) -> str | None:
+    """Return the HEAD SHA from the remote Windows repo, or None on error.
+
+    Used to create incremental bundles: if the remote is at commit X
+    and we need to deliver commit Y, the bundle only needs objects
+    reachable from Y but not from X. For a typical 1-2 commit delta
+    this reduces a 443 MB bundle to a few KB.
+
+    Returns None on any error so the caller falls through to a full
+    bundle as a safe default.
+    """
+    safe_repo = _ps_single_quote(repo_path)
+    script = f"cd '{safe_repo}'; git rev-parse HEAD"
+    cmd = ["ssh"] + list(ssh_options) + _powershell_encoded_argv(host, script)
+    try:
+        result = subprocess.run(
+            cmd, capture_output=True, text=True, timeout=timeout,
+        )
+        if result.returncode == 0:
+            head = result.stdout.strip()
+            if head and len(head) >= 7 and all(c in "0123456789abcdef" for c in head):
+                return head
+        return None
+    except (subprocess.SubprocessError, OSError):
+        return None
+
+
 def _remote_has_sha_windows(
     host: str,
     repo_path: str,
@@ -512,27 +581,147 @@ def _ssh_options(target_config: dict[str, Any]) -> list[str]:
     return options
 
 
+STAGE_ORDER = ("setup", "configure", "build", "test")
+
+
+def _stage_marker_name(stage: str, sha: str) -> str:
+    """Marker file written to the remote repo after a stage succeeds."""
+    return f".shipyard-stage-{stage}-{sha[:12]}"
+
+
+def _resolve_resume_from_windows(
+    *,
+    host: str,
+    remote_repo: str,
+    sha: str,
+    ssh_options: list[str],
+    requested: str | None,
+    validation_config: dict[str, Any],
+    log_file: Path,
+) -> str | None:
+    """Decide whether to honor a `--resume-from` request on Windows.
+
+    Mirrors the POSIX behavior: only honor when the previous stage's
+    marker file exists on the remote for this exact SHA.
+    """
+    if requested is None:
+        return None
+    if "command" in validation_config:
+        _append_log(
+            log_file,
+            f"=== resume-from: ignored ({requested!r}) — "
+            f"validation_config uses single command ===\n",
+        )
+        return None
+    if requested not in STAGE_ORDER:
+        _append_log(
+            log_file,
+            f"=== resume-from: ignored — unknown stage {requested!r} ===\n",
+        )
+        return None
+
+    idx = STAGE_ORDER.index(requested)
+    if idx == 0:
+        return requested
+    prev_stage = None
+    for candidate in STAGE_ORDER[:idx][::-1]:
+        if validation_config.get(candidate):
+            prev_stage = candidate
+            break
+    if prev_stage is None:
+        return requested
+
+    marker = _stage_marker_name(prev_stage, sha)
+    if _remote_marker_exists_windows(
+        host, remote_repo, marker, ssh_options,
+    ):
+        _append_log(
+            log_file,
+            f"=== resume-from: honoring {requested!r} — found marker for "
+            f"previous stage {prev_stage!r} on remote ===\n",
+        )
+        return requested
+    _append_log(
+        log_file,
+        f"=== resume-from: requested {requested!r} but marker for "
+        f"previous stage {prev_stage!r} not found on remote — running "
+        f"all stages from the beginning ===\n",
+    )
+    return None
+
+
+def _remote_marker_exists_windows(
+    host: str,
+    repo_path: str,
+    marker: str,
+    ssh_options: list[str],
+    *,
+    timeout: int = 15,
+) -> bool:
+    """Check whether `<repo>\\<marker>` exists on the remote Windows host."""
+    safe_repo = _ps_single_quote(repo_path)
+    safe_marker = _ps_single_quote(marker)
+    script = (
+        f"if (Test-Path (Join-Path '{safe_repo}' '{safe_marker}')) "
+        f"{{ exit 0 }} else {{ exit 1 }}"
+    )
+    cmd = ["ssh"] + list(ssh_options) + _powershell_encoded_argv(host, script)
+    try:
+        result = subprocess.run(
+            cmd, capture_output=True, text=True, timeout=timeout,
+        )
+        return result.returncode == 0
+    except (subprocess.SubprocessError, OSError):
+        return False
+
+
+def _append_log(log_file: Path, text: str) -> None:
+    try:
+        with open(log_file, "a", encoding="utf-8") as fh:
+            fh.write(text)
+    except OSError:
+        pass
+
+
 def _build_remote_command(
     sha: str,
     remote_repo: str,
     validation_config: dict[str, Any],
     *,
     toolchain: VsToolchain | None = None,
+    resume_from: str | None = None,
 ) -> str | None:
     """Build the remote PowerShell command: cd + checkout + validate.
 
     Uses semicolons for PowerShell command chaining with $LASTEXITCODE checks.
     When `toolchain` is provided, the resolved CMake platform and generator
     instance are exported as env vars so stages can reference them.
+
+    When ``resume_from`` is set, stages before the resume point are
+    skipped. After each stage succeeds, a marker file is written so
+    a subsequent resume run can detect the earlier stage's success.
     """
     if "command" in validation_config:
         validate_cmd = validation_config["command"]
     else:
         parts: list[str] = []
-        for step in ("setup", "configure", "build", "test"):
+        skipping = resume_from is not None
+        for step in STAGE_ORDER:
             cmd = validation_config.get(step)
-            if cmd:
-                parts.append(f"Write-Output '__SHIPYARD_PHASE__:{step}'; {cmd}")
+            if not cmd:
+                continue
+            if skipping:
+                if step == resume_from:
+                    skipping = False
+                else:
+                    continue
+            marker = _stage_marker_name(step, sha)
+            safe_marker = _ps_single_quote(marker)
+            parts.append(
+                f"Write-Output '__SHIPYARD_PHASE__:{step}'; {cmd}; "
+                f"if ($LASTEXITCODE -ne 0) {{ exit 1 }}; "
+                f"New-Item -ItemType File -Force -Path '{safe_marker}' | Out-Null"
+            )
         if not parts:
             return None
         # Chain with PowerShell error checking

--- a/src/shipyard/ship/merge.py
+++ b/src/shipyard/ship/merge.py
@@ -114,6 +114,16 @@ def ship(
 ) -> ShipResult:
     """Full ship flow: push, PR, validate, merge on green.
 
+    .. note::
+       This function is **not** the implementation behind the
+       ``shipyard ship`` CLI command. ``cli.py:ship`` is the
+       authoritative ship orchestrator and supports more options
+       (``--base``, ``--allow-root-mismatch``, ``--auto-create-base``,
+       ``--resume-from``, JSON output, etc.). This function is kept
+       as a programmatic API surface for callers that import
+       ``shipyard.ship.merge`` directly; it intentionally does the
+       same logical thing in a simpler shape.
+
     Steps:
     1. Get current branch and SHA
     2. Push to remote

--- a/tests/bundle/test_git_bundle.py
+++ b/tests/bundle/test_git_bundle.py
@@ -74,6 +74,45 @@ class TestCreateBundle:
         assert result.success
         assert (tmp_path / "deep" / "nested").is_dir()
 
+    def test_create_incremental_with_basis(self, tmp_path: Path) -> None:
+        output = tmp_path / "test.bundle"
+        mock_result = MagicMock(returncode=0, stderr="")
+        with patch("subprocess.run", return_value=mock_result) as mock_run:
+            result = create_bundle(
+                sha="abc123", output_path=output, basis_shas=["def456"],
+            )
+
+        assert result.success
+        cmd = mock_run.call_args[0][0]
+        assert "abc123" in cmd
+        assert "^def456" in cmd
+        assert "--all" not in cmd
+
+    def test_create_incremental_multiple_bases(self, tmp_path: Path) -> None:
+        output = tmp_path / "test.bundle"
+        mock_result = MagicMock(returncode=0, stderr="")
+        with patch("subprocess.run", return_value=mock_result) as mock_run:
+            result = create_bundle(
+                sha="abc123", output_path=output,
+                basis_shas=["def456", "789aaa"],
+            )
+
+        assert result.success
+        cmd = mock_run.call_args[0][0]
+        assert "^def456" in cmd
+        assert "^789aaa" in cmd
+        assert "--all" not in cmd
+
+    def test_create_full_bundle_when_no_basis(self, tmp_path: Path) -> None:
+        output = tmp_path / "test.bundle"
+        mock_result = MagicMock(returncode=0, stderr="")
+        with patch("subprocess.run", return_value=mock_result) as mock_run:
+            result = create_bundle(sha="abc123", output_path=output)
+
+        assert result.success
+        cmd = mock_run.call_args[0][0]
+        assert "--all" in cmd
+
 
 class TestUploadBundle:
     def test_upload_success(self, tmp_path: Path) -> None:

--- a/tests/executor/test_cloud.py
+++ b/tests/executor/test_cloud.py
@@ -242,3 +242,107 @@ class TestCloudExecutorValidate:
                 payload = json.loads(cmd[i + 1].split("=", 1)[1])
                 assert payload["linux-x64"] == "nscloud-ubuntu-22.04-amd64-4x16"
         assert found_override, "runner_overrides input not found in dispatch command"
+
+
+class TestCloudPollTimeout:
+    """Tests for the max_poll_secs deadline that prevents indefinite hangs."""
+
+    def test_poll_run_raises_timeout_when_never_completes(self) -> None:
+        """A run that stays in_progress past the deadline raises TimeoutError."""
+        executor = CloudExecutor(
+            workflow="build.yml",
+            repo="owner/repo",
+            poll_interval=0.01,
+            max_poll_secs=0.05,  # 50ms deadline
+        )
+
+        # Always return in_progress — never completes
+        in_progress = MagicMock(
+            returncode=0,
+            stdout=json.dumps({"status": "in_progress", "conclusion": None}),
+        )
+        with patch("subprocess.run", return_value=in_progress):
+            with pytest.raises(TimeoutError, match="did not complete within"):
+                executor._poll_run("12345")
+
+    def test_poll_run_completes_before_deadline(self) -> None:
+        """A run that completes before the deadline returns the conclusion."""
+        executor = CloudExecutor(
+            workflow="build.yml",
+            repo="owner/repo",
+            poll_interval=0.01,
+            max_poll_secs=10,  # generous
+        )
+        completed = MagicMock(
+            returncode=0,
+            stdout=json.dumps({"status": "completed", "conclusion": "success"}),
+        )
+        with patch("subprocess.run", return_value=completed):
+            assert executor._poll_run("12345") == "success"
+
+    def test_validate_returns_error_on_timeout(
+        self, target_config: dict, validation_config: dict, tmp_path,
+    ) -> None:
+        """When _poll_run times out, validate() returns ERROR with the timeout message."""
+        executor = CloudExecutor(
+            workflow="build.yml",
+            repo="owner/repo",
+            poll_interval=0.01,
+            dispatch_settle_secs=0.5,
+            max_poll_secs=0.05,
+        )
+        log_path = str(tmp_path / "log.txt")
+
+        # Patch dispatch + run lookup to succeed, then make _poll_run hang
+        with patch.object(
+            executor, "_dispatch_workflow", return_value=None,
+        ), patch.object(
+            executor, "_wait_for_run", return_value="12345",
+        ), patch.object(
+            executor, "_poll_run",
+            side_effect=TimeoutError("Cloud workflow run 12345 did not complete within 60s"),
+        ):
+            result = executor.validate(
+                sha="abc123",
+                branch="main",
+                target_config=target_config,
+                validation_config=validation_config,
+                log_path=log_path,
+            )
+
+        assert result.status == TargetStatus.ERROR
+        assert "did not complete" in (result.error_message or "")
+
+    def test_per_target_max_poll_overrides_executor_default(
+        self, target_config: dict, validation_config: dict, tmp_path,
+    ) -> None:
+        """target_config['cloud_max_poll_secs'] overrides the executor default."""
+        executor = CloudExecutor(
+            workflow="build.yml",
+            repo="owner/repo",
+            poll_interval=0.01,
+            max_poll_secs=10,  # default
+        )
+        log_path = str(tmp_path / "log.txt")
+        target = {**target_config, "cloud_max_poll_secs": 999}
+
+        captured = {}
+
+        def fake_poll(run_id, *, progress_callback=None, max_poll_secs=None):
+            captured["max_poll_secs"] = max_poll_secs
+            return "success"
+
+        with patch.object(
+            executor, "_dispatch_workflow", return_value=None,
+        ), patch.object(
+            executor, "_wait_for_run", return_value="12345",
+        ), patch.object(executor, "_poll_run", side_effect=fake_poll):
+            executor.validate(
+                sha="abc123",
+                branch="main",
+                target_config=target,
+                validation_config=validation_config,
+                log_path=log_path,
+            )
+
+        assert captured["max_poll_secs"] == 999.0

--- a/tests/executor/test_ssh.py
+++ b/tests/executor/test_ssh.py
@@ -272,6 +272,276 @@ class TestSSHExecutorValidate:
             assert "make test" in remote_cmd
 
 
+class TestSSHRemoteHeadSha:
+    """Tests for _remote_head_sha used in incremental bundle negotiation."""
+
+    def test_returns_sha_on_success(self) -> None:
+        from shipyard.executor.ssh import _remote_head_sha
+        mock_result = MagicMock(returncode=0, stdout="abc123def456\n", stderr="")
+        with patch("subprocess.run", return_value=mock_result):
+            sha = _remote_head_sha("ubuntu", "~/repo", [])
+        assert sha == "abc123def456"
+
+    def test_returns_none_on_failure(self) -> None:
+        from shipyard.executor.ssh import _remote_head_sha
+        mock_result = MagicMock(returncode=128, stdout="", stderr="not a repo")
+        with patch("subprocess.run", return_value=mock_result):
+            sha = _remote_head_sha("ubuntu", "~/repo", [])
+        assert sha is None
+
+    def test_returns_none_on_timeout(self) -> None:
+        from shipyard.executor.ssh import _remote_head_sha
+        with patch("subprocess.run", side_effect=subprocess.TimeoutExpired("ssh", 15)):
+            sha = _remote_head_sha("ubuntu", "~/repo", [])
+        assert sha is None
+
+    def test_returns_none_on_non_hex_output(self) -> None:
+        from shipyard.executor.ssh import _remote_head_sha
+        mock_result = MagicMock(returncode=0, stdout="not-a-sha\n", stderr="")
+        with patch("subprocess.run", return_value=mock_result):
+            sha = _remote_head_sha("ubuntu", "~/repo", [])
+        assert sha is None
+
+    def test_returns_none_on_empty_output(self) -> None:
+        from shipyard.executor.ssh import _remote_head_sha
+        mock_result = MagicMock(returncode=0, stdout="", stderr="")
+        with patch("subprocess.run", return_value=mock_result):
+            sha = _remote_head_sha("ubuntu", "~/repo", [])
+        assert sha is None
+
+
+class TestSSHIncrementalBundle:
+    """Tests for incremental bundle negotiation in SSH executor."""
+
+    def test_uses_basis_sha_when_remote_has_head(self, tmp_path) -> None:
+        from shipyard.bundle.git_bundle import BundleResult
+
+        executor = SSHExecutor()
+        log_path = str(tmp_path / "log.txt")
+
+        with patch(
+            "shipyard.executor.ssh._remote_has_sha", return_value=False,
+        ), patch(
+            "shipyard.executor.ssh._remote_head_sha", return_value="aabbcc",
+        ), patch(
+            "shipyard.executor.ssh.create_bundle",
+            return_value=BundleResult(success=True, message="ok", path="/tmp/b"),
+        ) as mock_create, patch(
+            "shipyard.executor.ssh.upload_bundle",
+            return_value=BundleResult(success=True, message="ok", path="/tmp/b"),
+        ), patch(
+            "shipyard.executor.ssh.apply_bundle",
+            return_value=BundleResult(success=True, message="ok", path="/tmp/b"),
+        ), patch(
+            "shipyard.executor.ssh.run_streaming_command",
+            return_value=_streaming_result(0, "ok"),
+        ):
+            executor.validate(
+                sha="abc123", branch="main",
+                target_config=_target_config(),
+                validation_config=_validation_config(),
+                log_path=log_path,
+            )
+
+        # First call should use basis_shas
+        first_call = mock_create.call_args_list[0]
+        assert first_call[1].get("basis_shas") == ["aabbcc"]
+
+    def test_falls_back_to_full_bundle_on_incremental_failure(self, tmp_path) -> None:
+        from shipyard.bundle.git_bundle import BundleResult
+
+        executor = SSHExecutor()
+        log_path = str(tmp_path / "log.txt")
+
+        create_results = [
+            BundleResult(success=False, message="bad basis"),  # incremental fails
+            BundleResult(success=True, message="ok", path="/tmp/b"),  # full succeeds
+        ]
+
+        with patch(
+            "shipyard.executor.ssh._remote_has_sha", return_value=False,
+        ), patch(
+            "shipyard.executor.ssh._remote_head_sha", return_value="aabbcc",
+        ), patch(
+            "shipyard.executor.ssh.create_bundle",
+            side_effect=create_results,
+        ) as mock_create, patch(
+            "shipyard.executor.ssh.upload_bundle",
+            return_value=BundleResult(success=True, message="ok", path="/tmp/b"),
+        ), patch(
+            "shipyard.executor.ssh.apply_bundle",
+            return_value=BundleResult(success=True, message="ok", path="/tmp/b"),
+        ), patch(
+            "shipyard.executor.ssh.run_streaming_command",
+            return_value=_streaming_result(0, "ok"),
+        ):
+            result = executor.validate(
+                sha="abc123", branch="main",
+                target_config=_target_config(),
+                validation_config=_validation_config(),
+                log_path=log_path,
+            )
+
+        assert result.status == TargetStatus.PASS
+        assert mock_create.call_count == 2
+        # Second call should NOT have basis_shas (full bundle)
+        second_call = mock_create.call_args_list[1]
+        assert not second_call[1].get("basis_shas")
+
+    def test_skips_negotiation_when_remote_head_unknown(self, tmp_path) -> None:
+        from shipyard.bundle.git_bundle import BundleResult
+
+        executor = SSHExecutor()
+        log_path = str(tmp_path / "log.txt")
+
+        with patch(
+            "shipyard.executor.ssh._remote_has_sha", return_value=False,
+        ), patch(
+            "shipyard.executor.ssh._remote_head_sha", return_value=None,
+        ), patch(
+            "shipyard.executor.ssh.create_bundle",
+            return_value=BundleResult(success=True, message="ok", path="/tmp/b"),
+        ) as mock_create, patch(
+            "shipyard.executor.ssh.upload_bundle",
+            return_value=BundleResult(success=True, message="ok", path="/tmp/b"),
+        ), patch(
+            "shipyard.executor.ssh.apply_bundle",
+            return_value=BundleResult(success=True, message="ok", path="/tmp/b"),
+        ), patch(
+            "shipyard.executor.ssh.run_streaming_command",
+            return_value=_streaming_result(0, "ok"),
+        ):
+            executor.validate(
+                sha="abc123", branch="main",
+                target_config=_target_config(),
+                validation_config=_validation_config(),
+                log_path=log_path,
+            )
+
+        # Should create a full bundle (no basis)
+        assert mock_create.call_count == 1
+        first_call = mock_create.call_args_list[0]
+        assert not first_call[1].get("basis_shas")
+
+
+class TestSSHResumeFrom:
+    """Tests for --resume-from support in SSH executor."""
+
+    def _stage_validation_config(self) -> dict:
+        return {
+            "setup": "echo setup",
+            "configure": "cmake .",
+            "build": "cmake --build .",
+            "test": "ctest",
+        }
+
+    def test_build_command_includes_markers_per_stage(self) -> None:
+        from shipyard.executor.ssh import _build_remote_command
+        cfg = self._stage_validation_config()
+        cmd = _build_remote_command("abc123def456", "/repo", cfg)
+        assert cmd is not None
+        # Each stage should write its own marker
+        assert ".shipyard-stage-setup-abc123def456" in cmd
+        assert ".shipyard-stage-configure-abc123def456" in cmd
+        assert ".shipyard-stage-build-abc123def456" in cmd
+        assert ".shipyard-stage-test-abc123def456" in cmd
+
+    def test_build_command_respects_resume_from(self) -> None:
+        from shipyard.executor.ssh import _build_remote_command
+        cfg = self._stage_validation_config()
+        cmd = _build_remote_command(
+            "abc123def456", "/repo", cfg, resume_from="test",
+        )
+        assert cmd is not None
+        # Earlier stages should be skipped
+        assert "echo setup" not in cmd
+        assert "cmake ." not in cmd
+        assert "cmake --build" not in cmd
+        # test stage and its marker should be present
+        assert "ctest" in cmd
+        assert ".shipyard-stage-test-" in cmd
+
+    def test_resume_from_honored_when_marker_exists(self, tmp_path) -> None:
+        from shipyard.executor.ssh import _resolve_resume_from
+        log = tmp_path / "log.txt"
+        with patch(
+            "shipyard.executor.ssh._remote_marker_exists", return_value=True,
+        ):
+            result = _resolve_resume_from(
+                host="ubuntu", remote_repo="/repo", sha="abc123",
+                ssh_options=[], requested="test",
+                validation_config=self._stage_validation_config(),
+                log_file=log,
+            )
+        assert result == "test"
+
+    def test_resume_from_falls_back_when_marker_missing(self, tmp_path) -> None:
+        from shipyard.executor.ssh import _resolve_resume_from
+        log = tmp_path / "log.txt"
+        with patch(
+            "shipyard.executor.ssh._remote_marker_exists", return_value=False,
+        ):
+            result = _resolve_resume_from(
+                host="ubuntu", remote_repo="/repo", sha="abc123",
+                ssh_options=[], requested="test",
+                validation_config=self._stage_validation_config(),
+                log_file=log,
+            )
+        assert result is None
+        assert "marker for previous stage" in log.read_text()
+
+    def test_resume_from_ignored_for_single_command(self, tmp_path) -> None:
+        from shipyard.executor.ssh import _resolve_resume_from
+        log = tmp_path / "log.txt"
+        result = _resolve_resume_from(
+            host="ubuntu", remote_repo="/repo", sha="abc123",
+            ssh_options=[], requested="test",
+            validation_config={"command": "make test"},
+            log_file=log,
+        )
+        assert result is None
+        assert "single command" in log.read_text()
+
+    def test_resume_from_none_returns_none(self, tmp_path) -> None:
+        from shipyard.executor.ssh import _resolve_resume_from
+        log = tmp_path / "log.txt"
+        result = _resolve_resume_from(
+            host="ubuntu", remote_repo="/repo", sha="abc123",
+            ssh_options=[], requested=None,
+            validation_config=self._stage_validation_config(),
+            log_file=log,
+        )
+        assert result is None
+
+    def test_validate_passes_resume_from_through(self, tmp_path) -> None:
+        from shipyard.bundle.git_bundle import BundleResult
+
+        executor = SSHExecutor()
+        log_path = str(tmp_path / "log.txt")
+        cfg = self._stage_validation_config()
+
+        with patch(
+            "shipyard.executor.ssh._remote_has_sha", return_value=True,
+        ), patch(
+            "shipyard.executor.ssh._remote_marker_exists", return_value=True,
+        ), patch(
+            "shipyard.executor.ssh.run_streaming_command",
+            return_value=_streaming_result(0, "ok"),
+        ) as mock_run:
+            executor.validate(
+                sha="abc123def456", branch="main",
+                target_config=_target_config(),
+                validation_config=cfg,
+                log_path=log_path,
+                resume_from="test",
+            )
+
+        ssh_cmd = mock_run.call_args[0][0]
+        remote_cmd = ssh_cmd[-1]
+        assert "ctest" in remote_cmd
+        assert "echo setup" not in remote_cmd
+
+
 # ---------------------------------------------------------------------------
 # SSHWindowsExecutor tests
 # ---------------------------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -455,7 +455,7 @@ wheels = [
 
 [[package]]
 name = "shipyard"
-version = "0.1.0"
+version = "0.1.16"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Closes #31, closes #34. Plus several adjacent hardening and DX improvements.

### Issues fixed

- **#31 — Incremental bundle delivery.** SSH executors now query the remote HEAD and create a delta bundle (`git bundle create sha ^remote_head`) instead of bundling the full history every cycle. Drops Pulp's Windows uploads from ~443 MB to KB for typical 1-2 commit deltas. Falls back transparently to a full bundle on any failure.
- **#34 — `--resume-from` for SSH executors.** Both SSH/SSH-Windows executors now honor the flag instead of silently dropping it. Marker files (`.shipyard-stage-<name>-<short_sha>`) are written on the remote after each successful stage; the resume request is honored only when the previous stage's marker exists for the current SHA, and falls back safely (run all stages + log warning) when missing.

### Adjacent hardening

- **Cloud polling timeout.** `CloudExecutor` gains `max_poll_secs` (default 60 min) so a hanging GitHub Actions workflow can no longer block the machine-global drain lock indefinitely. Per-target override via `cloud_max_poll_secs`.

### New CLI subcommands

- `shipyard targets list / test / add / remove` — fills the documented gap; SSH backends probe before writing config.
- `shipyard config show / profiles / use` — reuses existing `_rewrite_profile_in_config()` for safe edits.

### Code quality

- `Queue.get_pending()` public method replaces `cli.py` poking `queue._jobs` directly.
- Clarifying docstring on `ship/merge.py:ship()` noting it is not the CLI implementation.

### Docs

- README slimmed from ~870 → ~140 lines, inspired by uv's structure.
- Content extracted to `docs/`: examples, targets, governance, agent-integration, profiles, workflows, cli-reference, install.
- `planning/shipyard-hardening.md` captures the full plan, Pulp impact analysis, and rationale.

### Pulp impact

**Zero breaking changes.** All work is additive or internal. Pulp uses only the CLI; bundle format is standard git bundles with smaller content; SSH executor signatures are unchanged. Pulp's `tools/shipyard.toml` should be bumped from v0.1.3 — that's a pre-existing gap, not caused by this PR.

## Test plan

- [x] Added 21 new tests (8 bundle, 9 SSH resume, 4 cloud timeout)
- [x] Full test suite: 494 passed, 0 failed
- [x] `ruff check src/` — all checks passed
- [x] `shipyard --help` — new `targets` and `config` subcommands appear