### PR TITLE
Port versioning & skill-sync gates to Shipyard + shipyard pr wrapper

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Shipyard pre-push hook (agent-agnostic).
+#
+# Runs the versioning + skill-sync gates against origin/main before pushing.
+# Advisory by default — warnings print but don't block. Set
+# SHIPYARD_ENFORCE_PREPUSH=1 to upgrade warnings to hard errors (CI does this).
+#
+# Install once via scripts/install-githooks.sh:
+#   git config core.hooksPath .githooks
+#
+# Single-push emergency bypass:
+#   SHIPYARD_SKIP_PREPUSH=1 git push
+
+set -u
+
+ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || exit 0
+cd "$ROOT" || exit 0
+
+if [ "${SHIPYARD_SKIP_PREPUSH:-0}" = "1" ]; then
+    echo "[pre-push] SHIPYARD_SKIP_PREPUSH=1 — skipping gates." >&2
+    exit 0
+fi
+
+PYTHON="${PYTHON:-python3}"
+VBC="$ROOT/scripts/version_bump_check.py"
+SSC="$ROOT/scripts/skill_sync_check.py"
+CFG="$ROOT/scripts/versioning.json"
+
+if [ ! -f "$VBC" ] || [ ! -f "$SSC" ] || [ ! -f "$CFG" ]; then
+    exit 0  # pre-versioning checkout; no-op
+fi
+
+BASE="${SHIPYARD_PREPUSH_BASE:-origin/main}"
+fail=0
+
+"$PYTHON" "$SSC" --base "$BASE" --config "$CFG" --mode=report
+case $? in
+    0) ;;
+    1) fail=1 ;;
+    *) echo "[pre-push] skill_sync_check: internal error" >&2 ;;
+esac
+
+"$PYTHON" "$VBC" --base "$BASE" --config "$CFG" --mode=report
+case $? in
+    0) ;;
+    1) fail=1 ;;
+    *) echo "[pre-push] version_bump_check: internal error" >&2 ;;
+esac
+
+if [ "$fail" = "0" ]; then
+    echo "[pre-push] gates clean." >&2
+    exit 0
+fi
+
+if [ "${SHIPYARD_ENFORCE_PREPUSH:-0}" = "1" ]; then
+    echo "[pre-push] SHIPYARD_ENFORCE_PREPUSH=1 — blocking push due to gate failures above." >&2
+    exit 1
+fi
+
+echo "[pre-push] warnings above are advisory (export SHIPYARD_ENFORCE_PREPUSH=1 to block)." >&2
+exit 0

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,0 +1,118 @@
+name: Auto-Release on CLI Version Bump
+
+# Shipyard mirror of pulp's auto-release workflow. On every push to main,
+# diff pyproject.toml's project.version against the previous push range.
+# If it moved, create the matching v<x.y.z> tag; the existing tag-triggered
+# release.yml workflow then builds + publishes the 5-platform binaries.
+#
+# Plugin-version bumps (.claude-plugin/plugin.json) are intentionally NOT
+# tagged: per RELEASING.md, plugin files are delivered from git, not from
+# the binary, so there is no binary release to cut for plugin-only
+# changes. See planning/ralph-prompt-shipyard-versioning.md § Open
+# Question 4 for the decision.
+#
+# Safety properties match pulp's workflow: concurrency group, idempotent-
+# strict tagging (fails loudly on mismatched existing tags), Release: skip
+# trailer suppression, revert detection.
+
+on:
+  push:
+    branches: [main]
+
+concurrency:
+  group: auto-release
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    name: Tag CLI version bumps
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_BOT_TOKEN || secrets.GITHUB_TOKEN }}
+
+      - name: Skip on trailer or revert
+        id: guard
+        shell: bash
+        run: |
+          subject=$(git log -1 --format=%s HEAD)
+          body=$(git log -1 --format=%B HEAD)
+          if echo "$body" | git interpret-trailers --parse | grep -iq '^release: skip'; then
+              echo "skip=1" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          if [[ "$subject" =~ ^[Rr]evert ]]; then
+              echo "skip=1" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          if echo "$body" | git interpret-trailers --parse | grep -iq '^revert-of:'; then
+              echo "skip=1" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          echo "skip=0" >> "$GITHUB_OUTPUT"
+
+      - name: Read pyproject version at before/after
+        id: versions
+        if: steps.guard.outputs.skip == '0'
+        shell: bash
+        run: |
+          set -euo pipefail
+          before='${{ github.event.before }}'
+          if [ -z "$before" ] || [ "$before" = "0000000000000000000000000000000000000000" ]; then
+              before="HEAD~1"
+          fi
+
+          extract_pyproject_version() {
+              local ref="$1"
+              git show "${ref}:pyproject.toml" 2>/dev/null \
+                | python3 -c 'import sys, re; m = re.search(r"^\s*version\s*=\s*\"([^\"]+)\"", sys.stdin.read(), re.M); print(m.group(1) if m else "")'
+          }
+
+          v_before=$(extract_pyproject_version "$before" || true)
+          v_after=$(extract_pyproject_version HEAD || true)
+
+          echo "before=$v_before" >> "$GITHUB_OUTPUT"
+          echo "after=$v_after"   >> "$GITHUB_OUTPUT"
+          echo "pyproject version: $v_before -> $v_after"
+
+      - name: Create tag if CLI version moved
+        if: steps.guard.outputs.skip == '0'
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_BOT_TOKEN || secrets.GITHUB_TOKEN }}
+          V_BEFORE: ${{ steps.versions.outputs.before }}
+          V_AFTER: ${{ steps.versions.outputs.after }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "$V_AFTER" ] || [ "$V_BEFORE" = "$V_AFTER" ]; then
+              echo "CLI version unchanged — no tagging."
+              exit 0
+          fi
+
+          # The tag-triggered release.yml expects tags of the form v<x.y.z>.
+          tag="v${V_AFTER}"
+
+          git config user.name  "shipyard-release-bot"
+          git config user.email "shipyard-release-bot@users.noreply.github.com"
+
+          # Idempotent-strict: if tag already exists at HEAD, no-op; at a
+          # different SHA, fail loudly. Never overwrite.
+          if git ls-remote --tags origin "$tag" | grep -q .; then
+              remote_sha=$(git ls-remote --tags origin "$tag" | awk '{print $1}')
+              local_sha=$(git rev-parse HEAD)
+              if [ "$remote_sha" = "$local_sha" ]; then
+                  echo "tag $tag already at $local_sha — no-op"
+                  exit 0
+              fi
+              echo "ERROR: tag $tag exists at $remote_sha but HEAD is $local_sha" >&2
+              echo "Manual reconciliation required." >&2
+              exit 1
+          fi
+
+          git tag -a "$tag" -m "Release $tag (automated by auto-release.yml)"
+          git push origin "$tag"
+          echo "created $tag"

--- a/.github/workflows/version-skill-check.yml
+++ b/.github/workflows/version-skill-check.yml
@@ -1,0 +1,55 @@
+name: Versioning & Skill-Sync
+
+# Authoritative gate for Shipyard's versioning/skill-sync policy.
+# Mirrors the pulp-side workflow — same scripts, Shipyard-specific config.
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: version-skill-check-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  version-skill-check:
+    runs-on: ubuntu-latest
+    name: Enforce version & skill sync
+
+    env:
+      SHIPYARD_ENFORCE_PREPUSH: "1"
+
+    steps:
+      - name: Checkout PR head with full history
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Resolve diff base
+        id: base
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "ref=origin/${{ github.base_ref }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "ref=origin/main" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Skill-sync check
+        run: |
+          python3 scripts/skill_sync_check.py \
+              --base "${{ steps.base.outputs.ref }}" \
+              --config scripts/versioning.json \
+              --mode=report
+
+      - name: Version-bump check
+        run: |
+          python3 scripts/version_bump_check.py \
+              --base "${{ steps.base.outputs.ref }}" \
+              --config scripts/versioning.json \
+              --mode=report

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,4 @@
+# AGENTS.md
+
+
+Read `CLAUDE.md` before making any changes.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,64 @@
+# CLAUDE.md
+
+Guidance for Claude Code (and Codex via `AGENTS.md → CLAUDE.md`) when working in this repository.
+
+## What is Shipyard
+
+Shipyard is a cross-platform CI controller: local VMs, SSH hosts, and cloud runners (Namespace / GitHub-hosted) coordinated under one queue-and-evidence model. It is designed so agents, not humans, are the primary users.
+
+The project is Python-packaged (`pyproject.toml`, `src/shipyard/`) and ships a Claude Code plugin (`.claude-plugin/`, `commands/`, `skills/`, `agents/`, `hooks/`) delivered directly from this git repo.
+
+## Two independently-versioned surfaces
+
+| Surface        | Where                                            | When it moves                                  |
+|----------------|--------------------------------------------------|------------------------------------------------|
+| CLI binary     | `pyproject.toml` `project.version`, `src/shipyard/__init__.py` `__version__` | `src/shipyard/` changes that affect behavior   |
+| Claude plugin  | `.claude-plugin/plugin.json` `version`           | `commands/`, `skills/`, `agents/`, `hooks/`, or `.claude-plugin/` changes |
+
+These are **decoupled by policy** (`RELEASING.md`) — plugin files are delivered from git, not the binary, so a plugin-only change is not a binary release. The gate just ensures each surface's version moves when its own code moves.
+
+## Versioning & Skill-Sync Policy
+
+Enforcement runs in three layers, all calling the same two scripts.
+
+| Layer | Where | Mode |
+|---|---|---|
+| 1 (agent hook) | `hooks/hooks.json` PostToolUse | `--mode=hint` — advisory text only |
+| 2 (pre-push)   | `.githooks/pre-push` (install via `scripts/install-githooks.sh`) | `--mode=report` advisory by default; `SHIPYARD_ENFORCE_PREPUSH=1` upgrades to hard fail |
+| 3 (CI)         | `.github/workflows/version-skill-check.yml` | `--mode=report` with `SHIPYARD_ENFORCE_PREPUSH=1` — blocks merge |
+
+Scripts:
+
+- `scripts/version_bump_check.py` — detects which surfaces need a bump. Heuristic (public-API vs internal paths) + conventional-commit signals + explicit `Version-Bump:` trailer override. `--mode=apply` rewrites version files in place.
+- `scripts/skill_sync_check.py` — hard-fails when a mapped path is touched without the corresponding `SKILL.md` update. The map is `scripts/skill_path_map.json`; every dir under `skills/` must appear in it.
+
+Full design: borrowed from `pulp` (upstream) — the schema and scripts are shared. See the pulp repo's `docs/guides/versioning.md` for the source of truth on the design.
+
+### Shipping a PR
+
+When the user says "push a PR", "ship this", "ship it", "we're done", "merge this", or similar, invoke `shipyard pr` (or `shipyard ship` if that name is reserved for release today — check `skills/ci/SKILL.md`). It orchestrates:
+
+1. `skill_sync_check.py --mode=report` — hard-fails on missing SKILL.md updates.
+2. `version_bump_check.py --mode=apply` — applies the right bump per surface.
+3. `git commit` + `gh pr create` + CI validate + merge on green.
+4. `.github/workflows/auto-release.yml` tags the moved CLI version on merge; the existing tag-triggered `release.yml` publishes binaries.
+
+Never invoke `gh pr create` + release separately. Never run the version-bump or skill-sync scripts by hand.
+
+### Bypass trailers (tip commit, never PR body)
+
+| Gate          | Trailer                                                      |
+|---------------|--------------------------------------------------------------|
+| Version bump  | `Version-Bump: <surface>=<patch\|minor\|major\|skip> reason="..."` |
+| Skill update  | `Skill-Update: skip skill=<name> reason="..."`              |
+| Auto-release  | `Release: skip reason="..."`                                 |
+
+## Manual fallback release
+
+`./scripts/release.sh` remains as a break-glass manual path. The default is the automatic path above (auto-release workflow on merge). Do not call `release.sh` directly unless the automatic path is genuinely blocked.
+
+## Development
+
+- `uv sync` to install.
+- `pytest -x` for the test suite.
+- Never push directly to `main` — always PR → CI → merge.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,20 +1,24 @@
 # Releasing Shipyard
 
-## When to release
+## Default path: automatic on merge
 
-Release a new version when `src/shipyard/` changes (new commands, bug fixes,
-behavior changes). You don't need a release for:
+Normal releases are automatic. You don't call any script.
 
-- README edits
-- Plugin file changes (commands/, skills/, agents/, hooks/)
-- Config file changes (.shipyard/)
-- Planning docs
+1. Open a PR via `shipyard pr` (or `shipyard ship`).
+2. CI runs `.github/workflows/version-skill-check.yml`, which confirms the right bump(s) are present via `scripts/version_bump_check.py` + `scripts/skill_sync_check.py`. Merge on green.
+3. On push to `main`, `.github/workflows/auto-release.yml` diffs `pyproject.toml`'s version against the previous push. If it moved, the workflow creates a `v<x.y.z>` tag.
+4. The existing tag-triggered `release.yml` builds binaries on 5 platforms and publishes the GitHub Release.
 
-Plugin files are delivered from the Git repo, not from the binary.
+Plugin-version bumps (`.claude-plugin/plugin.json`) are intentionally **not** tagged — plugin files are delivered from git, not from the binary. Bumping the plugin version still requires a PR and goes through the same gate, but it doesn't cut a binary release.
 
-## How to release
+## When to go manual
 
-One command:
+Only when the automatic flow is genuinely unavailable:
+
+- The auto-release workflow is disabled or broken.
+- An emergency hotfix needs direct tag control (rare — prefer a PR even for hotfixes).
+
+### Manual fallback
 
 ```bash
 ./scripts/release.sh patch    # 0.1.0 → 0.1.1 (bug fixes)
@@ -25,6 +29,7 @@ One command:
 
 The script:
 
+0. Runs `scripts/version_bump_check.py --mode=report` and refuses to tag if the required bumps aren't present. `RELEASE_SKIP_VERSION_CHECK=1` bypasses this for emergencies; log a reason in the commit trailer.
 1. Bumps the version in `pyproject.toml`, `__init__.py`, and plugin manifests
 2. Commits the version bump
 3. Tags the commit (`v0.1.1`)

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -10,5 +10,17 @@
         }
       ]
     }
+  ],
+  "PostToolUse": [
+    {
+      "matcher": "Edit|Write",
+      "hooks": [
+        {
+          "type": "command",
+          "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/version-skill-hint.sh",
+          "timeout": 3000
+        }
+      ]
+    }
   ]
 }

--- a/hooks/version-skill-hint.sh
+++ b/hooks/version-skill-hint.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Layer-1 agent hook: run the versioning + skill-sync gates in --mode=hint
+# after every Edit|Write so drift is surfaced while iterating rather than
+# at pr-push time. Advisory only — never blocks. Does not interfere with
+# the SessionStart CLI-install hook.
+
+FILE=$(echo "$TOOL_INPUT" | python3 -c "
+import sys, json
+try:
+    data = json.load(sys.stdin)
+    print(data.get('file_path', ''))
+except Exception:
+    pass
+" 2>/dev/null)
+
+if [ -z "$FILE" ]; then
+    exit 0
+fi
+
+# Locate repo root by walking up from the edited file.
+REPO_ROOT=""
+candidate="$(dirname "$FILE")"
+while [ -n "$candidate" ] && [ "$candidate" != "/" ]; do
+    if [ -f "$candidate/scripts/versioning.json" ]; then
+        REPO_ROOT="$candidate"
+        break
+    fi
+    candidate="$(dirname "$candidate")"
+done
+
+if [ -z "$REPO_ROOT" ]; then
+    exit 0
+fi
+
+VBC="$REPO_ROOT/scripts/version_bump_check.py"
+SSC="$REPO_ROOT/scripts/skill_sync_check.py"
+CFG="$REPO_ROOT/scripts/versioning.json"
+
+if [ -x "$VBC" ]; then
+    "$VBC" --base origin/main --config "$CFG" --mode=hint 2>/dev/null || true
+fi
+if [ -x "$SSC" ]; then
+    "$SSC" --base origin/main --config "$CFG" --mode=hint 2>/dev/null || true
+fi

--- a/planning/shipyard-versioning-acceptance.md
+++ b/planning/shipyard-versioning-acceptance.md
@@ -1,0 +1,83 @@
+# shipyard versioning-sync — acceptance transcript
+
+Captured on branch `versioning-sync` ahead of the merge PR to `main`.
+
+---
+
+## 1. Both gate scripts exist and work against Shipyard's layout
+
+Config-driven — the same scripts pulp ships work unchanged against Shipyard's `pyproject.toml` + `src/shipyard/__init__.py` (CLI surface) and `.claude-plugin/plugin.json` (plugin surface).
+
+```
+$ python3 scripts/skill_sync_check.py --base origin/main --config scripts/versioning.json --mode=report
+[ci] ✓ SKILL.md updated
+exit=0
+
+$ python3 scripts/version_bump_check.py --base origin/main --config scripts/versioning.json --mode=report
+[cli] Shipyard CLI: no bump needed
+[plugin] Shipyard Claude plugin: heuristic=patch final=patch current=0.1.1 ? bump suggested (patch)
+exit=0
+```
+
+The plugin surface shows `? bump suggested (patch)` — advisory only, not a hard fail (patch-level verdicts don't block merge). The touched paths are `commands/`, `hooks/`, `skills/` additions that are internal-only per Shipyard's `internal_only_paths` config (`hooks/*.sh`); the rest of the change adds new plugin policy material that could reasonably be called either patch or minor. Left at "suggested" so the human author (or the PR reviewer) can bump if they want; not required.
+
+## 2. Manual shipyard pr exercise
+
+`shipyard pr --help` renders the full synopsis and passes the flags through to `shipyard ship`:
+
+```
+$ uv run shipyard pr --help
+Usage: shipyard pr [OPTIONS]
+
+  One-shot push-a-PR: skill-sync + version-bump + ship.
+
+  Mirrors pulp's `pulp pr` for parity with the ci skill's natural- language
+  triggers ("push a PR", "ship this"). Internally:
+
+      1. scripts/skill_sync_check.py --mode=report
+      2. scripts/version_bump_check.py --mode=(apply|report)
+      3. git commit of any bumps
+      4. invokes `shipyard ship` for push + PR + validate + merge
+
+Options:
+  --base TEXT                     Base branch to ship into (default: main)
+  --apply-bumps / --no-apply-bumps
+                                  Run scripts/version_bump_check.py
+                                  --mode=apply to auto-rewrite version files
+                                  when a surface moved. On by default (mirrors
+                                  pulp's pulp pr). --no-apply-bumps switches
+                                  to --mode=report so missing bumps hard-fail.
+```
+
+## 3. pytest green
+
+```
+$ uv run pytest -x
+...
+tests/test_cli.py ....                                                   [ 91%]
+tests/test_cli_codex_regressions.py ......                               [ 92%]
+tests/test_cli_governance_diff.py .                                      [ 92%]
+tests/test_codex_review_p1_batch.py ..........                           [ 94%]
+tests/test_governance_use_rewrite.py .....                               [ 95%]
+tests/test_preflight.py .....                                            [ 96%]
+tests/test_ship_auto_create_base.py .........                            [ 98%]
+tests/test_windows_false_green.py ........                               [100%]
+
+======================= 494 passed in 275.07s (0:04:35) ========================
+```
+
+All 494 tests pass. The new `shipyard pr` command didn't introduce any regression — it's additive and delegates to the existing `ship` command for push/PR/validate/merge.
+
+## 4. No existing drift to fix
+
+`git diff --name-only v0.2.0..origin/main` is empty — Shipyard's main is exactly at the v0.2.0 release tag, so there's no prior-work drift to reconcile. Any new bumps originate with this PR (the plugin-surface patch-suggested above).
+
+## 5. End-to-end auto-release — deferred until after merge
+
+Same rationale as the pulp acceptance doc: the full loop (PR → merge → auto-release.yml fires → tag → release.yml builds + publishes) only proves itself once the PR lands on `main`. That evidence is captured in a follow-up commit (or the release page) after this PR merges.
+
+## Known follow-ups (not blockers for merge)
+
+- Plugin-version patch-suggested: reviewer decides whether to bump `plugin.json` from 0.1.1 → 0.1.2 in this PR or leave it for a follow-up. Gate is advisory at patch-level; not blocking.
+- `shipyard pr` currently always delegates to `ship` with the default ctx.invoke — when Shipyard adds per-stage JSON output flags to `ship`, `pr` should forward those through too.
+- `scripts/install-githooks.sh`, `scripts/skill_sync_check.py`, and `scripts/version_bump_check.py` are copied verbatim from pulp. When pulp updates the scripts, re-vendor here (or revisit Open Question 1 by publishing to PyPI / adding a submodule).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,3 +60,8 @@ addopts = "-ra --strict-markers"
 markers = [
     "integration: marks tests requiring real git repos or SSH",
 ]
+
+[dependency-groups]
+dev = [
+    "pytest>=9.0.3",
+]

--- a/scripts/install-githooks.sh
+++ b/scripts/install-githooks.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# install-githooks.sh — point this checkout's git at .githooks/.
+#
+# Idempotent. Safe to run repeatedly. Called by setup.sh during bootstrap
+# and available standalone when developers want to enable the hooks in a
+# pre-existing checkout.
+
+set -euo pipefail
+
+# Walk up from this script's directory until we find a .git entry (handles
+# both `tools/scripts/` and `scripts/` layouts so the same script ports
+# cleanly across repos).
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+candidate="$script_dir"
+ROOT=""
+while [ "$candidate" != "/" ] && [ -n "$candidate" ]; do
+    if [ -e "$candidate/.git" ]; then
+        ROOT="$candidate"
+        break
+    fi
+    candidate="$(dirname "$candidate")"
+done
+if [ -z "$ROOT" ]; then
+    echo "install-githooks: could not find git repo root above $script_dir" >&2
+    exit 1
+fi
+cd "$ROOT"
+
+if [ ! -d ".githooks" ]; then
+    echo "install-githooks: .githooks/ not found at $ROOT" >&2
+    exit 1
+fi
+
+current="$(git config --get core.hooksPath || true)"
+if [ "$current" = ".githooks" ]; then
+    echo "install-githooks: already configured (core.hooksPath=.githooks)."
+    exit 0
+fi
+
+git config core.hooksPath .githooks
+chmod +x .githooks/* 2>/dev/null || true
+echo "install-githooks: set core.hooksPath=.githooks"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,7 +1,16 @@
 #!/bin/bash
 set -euo pipefail
 
-# Release a new version of Shipyard.
+# Release a new version of Shipyard — MANUAL FALLBACK PATH.
+#
+# The default release flow is: open a PR via `shipyard pr` (or
+# `shipyard ship`), let CI validate + merge, and let
+# .github/workflows/auto-release.yml create the tag on push to main. The
+# existing tag-triggered release.yml then builds and publishes.
+#
+# This script is the break-glass path when the automatic flow is
+# unavailable (e.g. the auto-release workflow is disabled, or an
+# emergency hotfix needs direct tag control).
 #
 # Usage:
 #   ./scripts/release.sh patch    # 0.1.0 → 0.1.1
@@ -9,20 +18,36 @@ set -euo pipefail
 #   ./scripts/release.sh major    # 0.1.0 → 1.0.0
 #   ./scripts/release.sh 0.3.0    # explicit version
 #
-# This script:
-#   1. Bumps the version in pyproject.toml and __init__.py
-#   2. Commits the version bump
-#   3. Tags the commit
-#   4. Pushes the tag (which triggers the release workflow)
-#
-# The release workflow builds binaries on 5 platforms and publishes
-# a GitHub Release automatically.
+# Steps:
+#   0. Pre-release version-bump gate (fails fast if bumps are missing)
+#   1. Bump pyproject.toml and __init__.py
+#   2. Commit the bump
+#   3. Tag and push — triggers release.yml binary build
 
 BUMP="${1:-}"
 
 if [ -z "$BUMP" ]; then
   echo "Usage: ./scripts/release.sh <patch|minor|major|X.Y.Z>"
   exit 1
+fi
+
+# ── Pre-release version-bump gate ───────────────────────────────────────
+# Refuse to release when version_bump_check would fail against
+# origin/main. Set RELEASE_SKIP_VERSION_CHECK=1 with a logged reason to
+# bypass (rare — only when this script is being used precisely because
+# the automatic path refused to tag).
+if [ "${RELEASE_SKIP_VERSION_CHECK:-0}" != "1" ]; then
+  if [ -x "scripts/version_bump_check.py" ] && [ -f "scripts/versioning.json" ]; then
+    echo "▸ Pre-release version-bump gate..."
+    if ! python3 scripts/version_bump_check.py \
+           --base origin/main \
+           --config scripts/versioning.json \
+           --mode=report; then
+      echo "release.sh: version_bump_check failed — fix the bump or rerun with" >&2
+      echo "            RELEASE_SKIP_VERSION_CHECK=1 and a commit trailer reason." >&2
+      exit 1
+    fi
+  fi
 fi
 
 # Get current version from pyproject.toml

--- a/scripts/skill_path_map.json
+++ b/scripts/skill_path_map.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "../../pulp-versioning-v2/tools/scripts/versioning.schema.json",
+  "schema_version": 1,
+  "_comment": "Shipyard skill → path-glob map. Only one skill today (ci). Paired with scripts/versioning.json. Every subdir under skills/ MUST have an entry here; skill_sync_check.py fails if one is missing.",
+
+  "skills": {
+    "ci": {
+      "paths": [
+        "src/shipyard/cli/**",
+        "src/shipyard/runners/**",
+        "src/shipyard/config/**",
+        "src/shipyard/queue/**",
+        "commands/**",
+        "agents/**",
+        "hooks/**",
+        ".claude-plugin/**",
+        ".github/workflows/**",
+        "scripts/release.sh"
+      ]
+    }
+  }
+}

--- a/scripts/skill_sync_check.py
+++ b/scripts/skill_sync_check.py
@@ -1,0 +1,354 @@
+#!/usr/bin/env python3
+"""Skill-sync gate.
+
+Given a diff range (base..head), check that every skill whose mapped paths
+were touched also has its SKILL.md updated in the same range — or has a
+`Skill-Update: skip skill=<name> reason="..."` trailer on the tip commit.
+
+Authoritative gate for CI; also runs as a local pre-push hook (advisory)
+and from agent hooks in hint mode. Source of truth for the whole family.
+See tools/scripts/versioning.json and tools/scripts/skill_path_map.json.
+
+Uses JSON (not YAML) for zero-dependency execution on PEP-668 Python.
+"""
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import json
+import os
+import re
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable
+
+
+# ── Types ───────────────────────────────────────────────────────────────
+
+
+@dataclass
+class Config:
+    skills_dir: Path
+    path_map_file: Path
+    generated_globs: list[str] = field(default_factory=list)
+    trailer_skill_update: str = "Skill-Update"
+
+
+@dataclass
+class SkillMap:
+    skills: dict[str, list[str]]
+
+
+@dataclass
+class Finding:
+    skill: str
+    touched_paths: list[str]
+    skill_md_modified: bool
+    bypass_reason: str | None
+
+
+# ── Git helpers ─────────────────────────────────────────────────────────
+
+
+def repo_root() -> Path:
+    out = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        check=True, capture_output=True, text=True,
+    )
+    return Path(out.stdout.strip())
+
+
+def git_diff_names(base: str, head: str) -> list[str]:
+    out = subprocess.run(
+        ["git", "diff", "--name-only", f"{base}..{head}"],
+        check=True, capture_output=True, text=True,
+    )
+    return [line for line in out.stdout.splitlines() if line.strip()]
+
+
+def git_commit_trailers(ref: str) -> dict[str, list[str]]:
+    try:
+        body = subprocess.run(
+            ["git", "log", "-1", "--format=%B", ref],
+            check=True, capture_output=True, text=True,
+        ).stdout
+    except subprocess.CalledProcessError:
+        return {}
+
+    trailers = subprocess.run(
+        ["git", "interpret-trailers", "--parse"],
+        input=body, capture_output=True, text=True,
+    )
+    result: dict[str, list[str]] = {}
+    for line in trailers.stdout.splitlines():
+        if ":" not in line:
+            continue
+        key, _, value = line.partition(":")
+        result.setdefault(key.strip().lower(), []).append(value.strip())
+    return result
+
+
+# ── Config loading ──────────────────────────────────────────────────────
+
+
+def _strip_comments(data: dict) -> dict:
+    # Drop top-level `_comment` and `$schema` keys to keep in-memory data tidy.
+    if isinstance(data, dict):
+        return {k: v for k, v in data.items() if not k.startswith("_") and k != "$schema"}
+    return data
+
+
+def load_config(path: Path, repo: Path) -> Config:
+    data = _strip_comments(json.loads(path.read_text()))
+    skills_section = data.get("skills", {})
+    trailers = data.get("trailers", {})
+
+    skills_dir = Path(skills_section["skills_dir"])
+    if not skills_dir.is_absolute():
+        skills_dir = repo / skills_dir
+
+    path_map_file = Path(skills_section["path_map"])
+    if not path_map_file.is_absolute():
+        path_map_file = repo / path_map_file
+
+    return Config(
+        skills_dir=skills_dir,
+        path_map_file=path_map_file,
+        generated_globs=data.get("generated_globs", []) or [],
+        trailer_skill_update=trailers.get("skill_update", "Skill-Update"),
+    )
+
+
+def load_skill_map(path: Path) -> SkillMap:
+    data = _strip_comments(json.loads(path.read_text()))
+    raw = data.get("skills", {}) or {}
+    skills: dict[str, list[str]] = {}
+    for name, entry in raw.items():
+        paths = entry.get("paths", []) if isinstance(entry, dict) else []
+        skills[name] = list(paths)
+    return SkillMap(skills=skills)
+
+
+# ── Matching ────────────────────────────────────────────────────────────
+
+
+def _glob_match(path: str, pattern: str) -> bool:
+    """fnmatch-with-`**` support.
+
+    fnmatch treats `*` as matching `/`, which is already what we want for
+    `**` semantics — but we also need `**/X` to match `X` at the repo root.
+    Normalize the pattern so that `**` expands to allow any segment count,
+    including zero.
+    """
+    # Normalize `**/` at the start to match both `foo/X` and `X`.
+    if pattern.startswith("**/"):
+        tail = pattern[3:]
+        return fnmatch.fnmatchcase(path, tail) or fnmatch.fnmatchcase(path, pattern)
+    return fnmatch.fnmatchcase(path, pattern)
+
+
+def _matches_any(path: str, patterns: Iterable[str]) -> bool:
+    p = path.replace(os.sep, "/")
+    for pat in patterns:
+        if _glob_match(p, pat):
+            return True
+    return False
+
+
+def filter_generated(changed: list[str], globs: Iterable[str]) -> list[str]:
+    gs = list(globs)
+    return [f for f in changed if not _matches_any(f, gs)]
+
+
+def parse_skill_update_trailer(trailers: dict[str, list[str]], key: str) -> dict[str, str]:
+    bypasses: dict[str, str] = {}
+    for v in trailers.get(key.lower(), []):
+        if not v.lower().startswith("skip"):
+            continue
+        m = re.search(r"skill\s*=\s*([A-Za-z0-9_.-]+)", v)
+        if not m:
+            continue
+        skill = m.group(1)
+        reason_m = (
+            re.search(r'reason\s*=\s*"([^"]*)"', v)
+            or re.search(r"reason\s*=\s*(\S+)", v)
+        )
+        reason = reason_m.group(1) if reason_m else "(no reason given)"
+        bypasses[skill] = reason
+    return bypasses
+
+
+# ── Core check ──────────────────────────────────────────────────────────
+
+
+def self_check(skill_map: SkillMap, skills_dir: Path) -> list[str]:
+    errors: list[str] = []
+    if not skills_dir.exists():
+        return errors
+    for entry in sorted(skills_dir.iterdir()):
+        if not entry.is_dir():
+            continue
+        if entry.name not in skill_map.skills:
+            errors.append(
+                f"self-check: skill directory '{entry.name}' has no entry in skill_path_map.json"
+            )
+    for name in skill_map.skills:
+        if not (skills_dir / name).exists():
+            errors.append(
+                f"self-check: skill_path_map.json references missing skill '{name}'"
+            )
+    return errors
+
+
+def compute_findings(
+    changed: list[str],
+    skill_map: SkillMap,
+    skills_dir: Path,
+    repo: Path,
+    bypasses: dict[str, str],
+) -> list[Finding]:
+    findings: list[Finding] = []
+    try:
+        rel = skills_dir.relative_to(repo)
+    except ValueError:
+        rel = skills_dir
+    # str.lstrip removes *characters* not a prefix, which would eat the
+    # leading '.' in '.agents/skills'. Normalize manually instead.
+    rel_skills_dir = str(rel).replace(os.sep, "/")
+    if rel_skills_dir.startswith("./"):
+        rel_skills_dir = rel_skills_dir[2:]
+
+    for skill, patterns in skill_map.skills.items():
+        touched = [p for p in changed if _matches_any(p, patterns)]
+        if not touched:
+            continue
+        skill_md_prefix = f"{rel_skills_dir}/{skill}/"
+        skill_md_modified = any(p.startswith(skill_md_prefix) for p in changed)
+        findings.append(
+            Finding(
+                skill=skill,
+                touched_paths=sorted(touched),
+                skill_md_modified=skill_md_modified,
+                bypass_reason=bypasses.get(skill),
+            )
+        )
+    return findings
+
+
+# ── Reporting ───────────────────────────────────────────────────────────
+
+
+def render_report(
+    findings: list[Finding],
+    trailer_key: str,
+    mode: str,
+) -> tuple[str, int]:
+    lines: list[str] = []
+    hard_failures: list[Finding] = []
+
+    for f in findings:
+        if f.skill_md_modified:
+            status = "✓ SKILL.md updated"
+        elif f.bypass_reason is not None:
+            status = f'✓ bypassed ({f.bypass_reason})'
+        else:
+            status = "✗ SKILL.md NOT updated"
+            hard_failures.append(f)
+        lines.append(f"[{f.skill}] {status}")
+        if mode != "report" or not f.skill_md_modified:
+            for tp in f.touched_paths[:8]:
+                lines.append(f"    {tp}")
+            if len(f.touched_paths) > 8:
+                lines.append(f"    … {len(f.touched_paths) - 8} more")
+
+    if hard_failures and mode in ("report", "apply"):
+        lines.append("")
+        lines.append("Skill-sync check FAILED.")
+        lines.append("For each skill above marked ✗:")
+        lines.append("  1. Add a gotcha / note to the skill's SKILL.md in this branch, OR")
+        lines.append("  2. Add a commit trailer on the tip commit with the exact form:")
+        for f in hard_failures:
+            lines.append(
+                f'     {trailer_key}: skip skill={f.skill} reason="..."'
+            )
+        return "\n".join(lines), 1
+
+    if not findings:
+        lines.append("skill-sync: no mapped paths touched — nothing to verify.")
+    return "\n".join(lines), 0
+
+
+# ── Main ────────────────────────────────────────────────────────────────
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description="Skill-sync gate")
+    parser.add_argument("--base", default="origin/main",
+                        help="Diff base (default: origin/main)")
+    parser.add_argument("--head", default="HEAD",
+                        help="Diff head (default: HEAD)")
+    parser.add_argument(
+        "--config",
+        default=None,
+        help="Path to versioning.json (default: tools/scripts/versioning.json at repo root)",
+    )
+    parser.add_argument(
+        "--mode",
+        choices=("report", "hint", "apply"),
+        default="report",
+        help="report: fail on issues (CI); hint: advisory text only; apply: same as report (skill content cannot be auto-generated)",
+    )
+    parser.add_argument(
+        "--repo-root",
+        default=None,
+        help="Override repo root (default: git rev-parse --show-toplevel)",
+    )
+    args = parser.parse_args(argv)
+
+    root = Path(args.repo_root) if args.repo_root else repo_root()
+    cfg_path = (
+        Path(args.config) if args.config
+        else root / "tools" / "scripts" / "versioning.json"
+    )
+    if not cfg_path.exists():
+        sys.stderr.write(f"skill_sync_check: config not found: {cfg_path}\n")
+        return 2
+
+    cfg = load_config(cfg_path, root)
+
+    skill_map = load_skill_map(cfg.path_map_file)
+
+    self_errors = self_check(skill_map, cfg.skills_dir)
+    if self_errors:
+        print("\n".join(self_errors), file=sys.stderr)
+        if args.mode in ("report", "apply"):
+            return 1
+
+    changed = git_diff_names(args.base, args.head)
+    changed = filter_generated(changed, cfg.generated_globs)
+
+    trailers = git_commit_trailers(args.head)
+    bypasses = parse_skill_update_trailer(trailers, cfg.trailer_skill_update)
+
+    findings = compute_findings(
+        changed=changed,
+        skill_map=skill_map,
+        skills_dir=cfg.skills_dir,
+        repo=root,
+        bypasses=bypasses,
+    )
+
+    text, code = render_report(findings, cfg.trailer_skill_update, args.mode)
+    if text:
+        print(text)
+
+    if args.mode == "hint":
+        return 0
+    return code
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/version_bump_check.py
+++ b/scripts/version_bump_check.py
@@ -1,0 +1,627 @@
+#!/usr/bin/env python3
+"""Version-bump gate.
+
+Given a diff range (base..head), decide whether each configured surface
+needs a version bump (patch/minor/major). Three modes:
+
+    report  exit 0 if every surface that moved has a bumped version,
+            exit 1 otherwise. Authoritative gate for CI.
+    apply   same as report, but for every surface missing a bump, rewrite
+            the version file(s) in place and stage them for commit.
+            Used by `pulp pr` to make bumps automatic.
+    hint    advisory text only; always exits 0. Used by agent hooks.
+
+Heuristics (per surface, deliberately conservative):
+    - If only internal_only_paths changed       → patch-suggested
+    - If any public_api_paths changed (non-comment/whitespace diff)
+                                                → minor-required
+    - If a Version-Bump: <surface>=<level>      → that level wins (after
+      path filtering — a plugin-only `BREAKING` does not bump the SDK)
+    - Conventional-commit subjects (`feat:`, `fix:`, `BREAKING:` or `!:`
+      in subjects) may RAISE the heuristic verdict on a surface whose
+      trigger_paths were actually touched. Cannot lower it.
+    - Revert commits (subject starts with `Revert` or `Revert-Of:` trailer)
+      suppress signals from the reverted work.
+
+Uses JSON configs (zero-dep).
+"""
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import json
+import os
+import re
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable
+
+
+# ── Types ───────────────────────────────────────────────────────────────
+
+# Ordered least → most impactful.
+LEVELS = ("none", "patch", "minor", "major")
+
+
+@dataclass
+class VersionFile:
+    path: str
+    kind: str
+    field: str | None = None
+    pattern: str | None = None
+
+
+@dataclass
+class Surface:
+    name: str
+    label: str
+    version_files: list[VersionFile]
+    trigger_paths: list[str]
+    public_api_paths: list[str] = field(default_factory=list)
+    internal_only_paths: list[str] = field(default_factory=list)
+    changelog: str | None = None
+
+
+@dataclass
+class Config:
+    surfaces: list[Surface]
+    generated_globs: list[str]
+    trailer_version_bump: str
+
+
+@dataclass
+class Verdict:
+    surface: Surface
+    heuristic: str       # "none"|"patch"|"minor"|"major"
+    trailer_override: str | None  # set / skip / None
+    current_version: str | None
+    final_level: str     # what level is actually needed after overrides
+
+
+# ── Git helpers ─────────────────────────────────────────────────────────
+
+
+def repo_root() -> Path:
+    out = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        check=True, capture_output=True, text=True,
+    )
+    return Path(out.stdout.strip())
+
+
+def git_diff_names(base: str, head: str) -> list[str]:
+    out = subprocess.run(
+        ["git", "diff", "--name-only", f"{base}..{head}"],
+        check=True, capture_output=True, text=True,
+    )
+    return [line for line in out.stdout.splitlines() if line.strip()]
+
+
+def git_diff_ignore_whitespace_nonempty(base: str, head: str, path: str) -> bool:
+    """True iff there is a meaningful (non-whitespace, non-comment) diff for `path`.
+
+    First tries --ignore-all-space; if that leaves any hunks, checks whether
+    every hunk line is a C/C++/Python comment. Useful for collapsing comment
+    reflows down to patch-suggested instead of minor-required.
+    """
+    out = subprocess.run(
+        ["git", "diff", "--ignore-all-space", f"{base}..{head}", "--", path],
+        check=True, capture_output=True, text=True,
+    )
+    if not out.stdout.strip():
+        return False
+
+    has_real = False
+    for line in out.stdout.splitlines():
+        if not (line.startswith("+") or line.startswith("-")):
+            continue
+        if line.startswith(("+++", "---")):
+            continue
+        body = line[1:].strip()
+        if not body:
+            continue
+        if body.startswith(("//", "#", "/*", "*/", "*")):
+            continue
+        has_real = True
+        break
+    return has_real
+
+
+def git_log_subjects_and_bodies(base: str, head: str) -> list[tuple[str, str]]:
+    out = subprocess.run(
+        ["git", "log", "--format=%H%x00%s%x00%B%x01", f"{base}..{head}"],
+        check=True, capture_output=True, text=True,
+    )
+    commits: list[tuple[str, str]] = []
+    for chunk in out.stdout.split("\x01"):
+        chunk = chunk.strip()
+        if not chunk:
+            continue
+        parts = chunk.split("\x00", 2)
+        if len(parts) < 3:
+            continue
+        _sha, subject, body = parts
+        commits.append((subject, body))
+    return commits
+
+
+def git_commit_trailers(ref: str) -> dict[str, list[str]]:
+    try:
+        body = subprocess.run(
+            ["git", "log", "-1", "--format=%B", ref],
+            check=True, capture_output=True, text=True,
+        ).stdout
+    except subprocess.CalledProcessError:
+        return {}
+    trailers = subprocess.run(
+        ["git", "interpret-trailers", "--parse"],
+        input=body, capture_output=True, text=True,
+    )
+    result: dict[str, list[str]] = {}
+    for line in trailers.stdout.splitlines():
+        if ":" not in line:
+            continue
+        key, _, value = line.partition(":")
+        result.setdefault(key.strip().lower(), []).append(value.strip())
+    return result
+
+
+# ── Config loading ──────────────────────────────────────────────────────
+
+
+def _strip_meta(data: dict) -> dict:
+    return {k: v for k, v in data.items() if not k.startswith("_") and k != "$schema"}
+
+
+def load_config(path: Path) -> Config:
+    data = _strip_meta(json.loads(path.read_text()))
+    surfaces: list[Surface] = []
+    for name, entry in (data.get("surfaces") or {}).items():
+        vfs = [VersionFile(**_strip_meta(vf) if isinstance(vf, dict) else vf)
+               for vf in entry.get("version_files", [])]
+        surfaces.append(Surface(
+            name=name,
+            label=entry.get("label", name),
+            version_files=vfs,
+            trigger_paths=entry.get("trigger_paths", []),
+            public_api_paths=entry.get("public_api_paths", []),
+            internal_only_paths=entry.get("internal_only_paths", []),
+            changelog=entry.get("changelog"),
+        ))
+    trailers = data.get("trailers") or {}
+    return Config(
+        surfaces=surfaces,
+        generated_globs=data.get("generated_globs", []) or [],
+        trailer_version_bump=trailers.get("version_bump", "Version-Bump"),
+    )
+
+
+# ── Version-file I/O ────────────────────────────────────────────────────
+
+_CMAKE_PROJECT_VERSION_RE = re.compile(
+    r"(project\s*\(\s*[A-Za-z_][\w]*\s+VERSION\s+)(\d+\.\d+\.\d+)",
+    re.MULTILINE,
+)
+
+
+def read_version(repo: Path, vf: VersionFile) -> str | None:
+    p = repo / vf.path
+    if not p.exists():
+        return None
+    text = p.read_text()
+    if vf.kind == "cmake_project_version":
+        m = _CMAKE_PROJECT_VERSION_RE.search(text)
+        return m.group(2) if m else None
+    if vf.kind == "json_field":
+        try:
+            data = json.loads(text)
+        except json.JSONDecodeError:
+            return None
+        return data.get(vf.field)
+    if vf.kind == "pyproject_version":
+        m = re.search(r'^\s*version\s*=\s*"([^"]+)"', text, re.MULTILINE)
+        return m.group(1) if m else None
+    if vf.kind == "python_dunder_version":
+        m = re.search(r'^\s*__version__\s*=\s*"([^"]+)"', text, re.MULTILINE)
+        return m.group(1) if m else None
+    if vf.kind == "regex" and vf.pattern:
+        m = re.search(vf.pattern, text)
+        return m.group(1) if m else None
+    return None
+
+
+def write_version(repo: Path, vf: VersionFile, new: str) -> bool:
+    p = repo / vf.path
+    if not p.exists():
+        return False
+    text = p.read_text()
+    new_text = text
+    if vf.kind == "cmake_project_version":
+        new_text = _CMAKE_PROJECT_VERSION_RE.sub(
+            lambda m: f"{m.group(1)}{new}", text, count=1
+        )
+    elif vf.kind == "json_field":
+        try:
+            data = json.loads(text)
+        except json.JSONDecodeError:
+            return False
+        data[vf.field] = new
+        # Preserve trailing newline if original had one.
+        end = "\n" if text.endswith("\n") else ""
+        new_text = json.dumps(data, indent=2) + end
+    elif vf.kind == "pyproject_version":
+        new_text = re.sub(
+            r'(^\s*version\s*=\s*")([^"]+)(")',
+            lambda m: f"{m.group(1)}{new}{m.group(3)}", text,
+            count=1, flags=re.MULTILINE,
+        )
+    elif vf.kind == "python_dunder_version":
+        new_text = re.sub(
+            r'(^\s*__version__\s*=\s*")([^"]+)(")',
+            lambda m: f"{m.group(1)}{new}{m.group(3)}", text,
+            count=1, flags=re.MULTILINE,
+        )
+    elif vf.kind == "regex" and vf.pattern:
+        # A capture-group-1 version string is required.
+        new_text = re.sub(vf.pattern, lambda m: m.group(0).replace(m.group(1), new), text, count=1)
+    else:
+        return False
+    if new_text == text:
+        return False
+    p.write_text(new_text)
+    return True
+
+
+# ── Matching / heuristics ───────────────────────────────────────────────
+
+
+def _glob_match(path: str, pattern: str) -> bool:
+    if pattern.startswith("**/"):
+        tail = pattern[3:]
+        return fnmatch.fnmatchcase(path, tail) or fnmatch.fnmatchcase(path, pattern)
+    return fnmatch.fnmatchcase(path, pattern)
+
+
+def _matches_any(path: str, patterns: Iterable[str]) -> bool:
+    p = path.replace(os.sep, "/")
+    for pat in patterns:
+        if _glob_match(p, pat):
+            return True
+    return False
+
+
+def filter_generated(changed: list[str], globs: Iterable[str]) -> list[str]:
+    gs = list(globs)
+    return [f for f in changed if not _matches_any(f, gs)]
+
+
+def is_revert_commit(subject: str, trailers: dict[str, list[str]]) -> bool:
+    if subject.lower().startswith("revert"):
+        return True
+    if "revert-of" in trailers:
+        return True
+    return False
+
+
+def classify_conventional(subject: str) -> str:
+    """Map a commit subject to a bump level it would *suggest*.
+
+    `BREAKING:` anywhere in subject or `!:` after the type → major.
+    `feat:` → minor. `fix:` or `perf:` → patch. Otherwise none.
+    """
+    s = subject.strip()
+    if re.search(r"\bBREAKING\b", s):
+        return "major"
+    # `type!:` or `type(scope)!:` signals breaking change.
+    if re.match(r"^[a-zA-Z]+(\([^)]*\))?!:", s):
+        return "major"
+    m = re.match(r"^([a-zA-Z]+)(\([^)]*\))?:", s)
+    if not m:
+        return "none"
+    kind = m.group(1).lower()
+    if kind == "feat":
+        return "minor"
+    if kind in ("fix", "perf"):
+        return "patch"
+    return "none"
+
+
+def max_level(*levels: str) -> str:
+    best = "none"
+    for lv in levels:
+        if LEVELS.index(lv) > LEVELS.index(best):
+            best = lv
+    return best
+
+
+def heuristic_for_surface(
+    surface: Surface,
+    changed: list[str],
+    base: str,
+    head: str,
+) -> str:
+    touched = [p for p in changed if _matches_any(p, surface.trigger_paths)]
+    if not touched:
+        return "none"
+
+    # Public-API paths: minor-required if diff has real content (not just
+    # comments/whitespace). Downgrade to patch if the diff is trivial.
+    public_touched = [p for p in touched if _matches_any(p, surface.public_api_paths)]
+    meaningful_public = False
+    for p in public_touched:
+        if git_diff_ignore_whitespace_nonempty(base, head, p):
+            meaningful_public = True
+            break
+
+    if meaningful_public:
+        return "minor"
+
+    # Only internal paths touched → patch-suggested (warning, not hard fail
+    # at the CI level; we still report it so humans can decide).
+    internal_touched = [p for p in touched if _matches_any(p, surface.internal_only_paths)]
+    if internal_touched or touched:
+        return "patch"
+
+    return "none"
+
+
+def surface_trailer_override(
+    trailers: dict[str, list[str]],
+    trailer_key: str,
+    surface_name: str,
+) -> str | None:
+    """Parse `Version-Bump: <surface>=<level> reason="..."` from trailers."""
+    for v in trailers.get(trailer_key.lower(), []):
+        m = re.search(rf"{re.escape(surface_name)}\s*=\s*([A-Za-z]+)", v)
+        if not m:
+            continue
+        level = m.group(1).lower()
+        if level in LEVELS or level == "skip":
+            return level
+    return None
+
+
+# ── Version bumping arithmetic ──────────────────────────────────────────
+
+
+def bump_version(current: str, level: str) -> str:
+    m = re.match(r"^(\d+)\.(\d+)\.(\d+)", current)
+    if not m:
+        return current
+    major, minor, patch = map(int, m.groups())
+    if level == "major":
+        return f"{major + 1}.0.0"
+    if level == "minor":
+        return f"{major}.{minor + 1}.0"
+    if level == "patch":
+        return f"{major}.{minor}.{patch + 1}"
+    return current
+
+
+# ── Reporting / apply ───────────────────────────────────────────────────
+
+
+def already_bumped(base: str, vf: VersionFile, repo: Path) -> bool:
+    """True iff the version file's version at HEAD differs from at base."""
+    p = repo / vf.path
+    if not p.exists():
+        return False
+    try:
+        base_text = subprocess.run(
+            ["git", "show", f"{base}:{vf.path}"],
+            check=True, capture_output=True, text=True,
+        ).stdout
+    except subprocess.CalledProcessError:
+        return False
+
+    def extract(text: str) -> str | None:
+        if vf.kind == "cmake_project_version":
+            m = _CMAKE_PROJECT_VERSION_RE.search(text)
+            return m.group(2) if m else None
+        if vf.kind == "json_field":
+            try:
+                return json.loads(text).get(vf.field)
+            except json.JSONDecodeError:
+                return None
+        if vf.kind == "pyproject_version":
+            m = re.search(r'^\s*version\s*=\s*"([^"]+)"', text, re.MULTILINE)
+            return m.group(1) if m else None
+        if vf.kind == "python_dunder_version":
+            m = re.search(r'^\s*__version__\s*=\s*"([^"]+)"', text, re.MULTILINE)
+            return m.group(1) if m else None
+        return None
+
+    base_ver = extract(base_text)
+    head_ver = extract((repo / vf.path).read_text())
+    if base_ver is None or head_ver is None:
+        return False
+    return base_ver != head_ver
+
+
+def assess_surfaces(
+    cfg: Config,
+    changed: list[str],
+    base: str,
+    head: str,
+    repo: Path,
+) -> list[Verdict]:
+    trailers = git_commit_trailers(head)
+    verdicts: list[Verdict] = []
+    for s in cfg.surfaces:
+        heur = heuristic_for_surface(s, changed, base, head)
+
+        override = surface_trailer_override(trailers, cfg.trailer_version_bump, s.name)
+        final = heur
+        if override == "skip":
+            final = "none"
+        elif override in LEVELS:
+            # Only raise, never lower. And only if the surface was actually touched.
+            if heur != "none" and LEVELS.index(override) > LEVELS.index(heur):
+                final = override
+            elif heur != "none":
+                final = heur
+            else:
+                # Surface not touched; ignore the override to avoid
+                # rubber-stamping unrelated bumps.
+                final = "none"
+
+        # Promote via conventional-commit subjects on commits that touched
+        # this surface — this is a ceiling raise only.
+        if heur != "none":
+            conv_ceiling = "none"
+            for subject, body in git_log_subjects_and_bodies(base, head):
+                if is_revert_commit(subject, {}):
+                    continue
+                conv_ceiling = max_level(conv_ceiling, classify_conventional(subject))
+            if LEVELS.index(conv_ceiling) > LEVELS.index(final):
+                final = conv_ceiling
+
+        # patch-suggested is advisory; never hard-fails.
+        # (Callers map this to a warning in report mode.)
+
+        current = None
+        for vf in s.version_files:
+            current = read_version(repo, vf)
+            if current:
+                break
+
+        verdicts.append(Verdict(
+            surface=s,
+            heuristic=heur,
+            trailer_override=override,
+            current_version=current,
+            final_level=final,
+        ))
+    return verdicts
+
+
+def render_report(
+    verdicts: list[Verdict],
+    mode: str,
+    base: str,
+    repo: Path,
+) -> tuple[str, int]:
+    lines: list[str] = []
+    failures = 0
+    warnings = 0
+    for v in verdicts:
+        if v.final_level == "none":
+            lines.append(f"[{v.surface.name}] {v.surface.label}: no bump needed")
+            continue
+        # Already bumped since base?
+        bumped = any(already_bumped(base, vf, repo) for vf in v.surface.version_files)
+        tag = "✓ bumped" if bumped else "✗ bump required"
+        lines.append(
+            f"[{v.surface.name}] {v.surface.label}: "
+            f"heuristic={v.heuristic}"
+            f"{' override=' + v.trailer_override if v.trailer_override else ''} "
+            f"final={v.final_level} "
+            f"current={v.current_version or '?'} "
+            f"{tag}"
+        )
+        if not bumped:
+            if v.final_level == "patch":
+                warnings += 1
+            else:
+                failures += 1
+
+    if mode == "hint":
+        return "\n".join(lines), 0
+
+    if failures:
+        lines.append("")
+        lines.append("Version-bump check FAILED.")
+        lines.append("Apply the required bump with:")
+        lines.append("  python3 tools/scripts/version_bump_check.py --mode=apply")
+        lines.append("Or record an explicit override on the tip commit:")
+        lines.append('  Version-Bump: <surface>=<patch|minor|major|skip> reason="..."')
+        return "\n".join(lines), 1
+
+    return "\n".join(lines), 0
+
+
+def apply_bumps(
+    verdicts: list[Verdict],
+    base: str,
+    repo: Path,
+) -> list[str]:
+    """Write new versions for surfaces that need a bump and aren't already bumped."""
+    edited: list[str] = []
+    for v in verdicts:
+        if v.final_level in ("none", "patch"):
+            continue
+        bumped = any(already_bumped(base, vf, repo) for vf in v.surface.version_files)
+        if bumped or not v.current_version:
+            continue
+        new_ver = bump_version(v.current_version, v.final_level)
+        for vf in v.surface.version_files:
+            if write_version(repo, vf, new_ver):
+                edited.append(vf.path)
+        # Changelog stub.
+        if v.surface.changelog:
+            cl_path = repo / v.surface.changelog
+            if cl_path.exists():
+                header = f"## [{new_ver}]\n\n"
+                cl_text = cl_path.read_text()
+                pos = cl_text.find("## [")
+                if pos != -1:
+                    cl_text = cl_text[:pos] + header + cl_text[pos:]
+                else:
+                    cl_text = header + cl_text
+                cl_path.write_text(cl_text)
+                edited.append(str(cl_path.relative_to(repo)))
+    # Stage for commit so callers see them in `git status`.
+    if edited:
+        subprocess.run(["git", "-C", str(repo), "add", "--"] + edited, check=False)
+    return edited
+
+
+# ── Main ────────────────────────────────────────────────────────────────
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description="Version-bump gate")
+    parser.add_argument("--base", default="origin/main")
+    parser.add_argument("--head", default="HEAD")
+    parser.add_argument("--config", default=None)
+    parser.add_argument("--mode", choices=("report", "hint", "apply"), default="report")
+    parser.add_argument("--repo-root", default=None)
+    args = parser.parse_args(argv)
+
+    root = Path(args.repo_root) if args.repo_root else repo_root()
+    cfg_path = Path(args.config) if args.config else root / "tools" / "scripts" / "versioning.json"
+    if not cfg_path.exists():
+        sys.stderr.write(f"version_bump_check: config not found: {cfg_path}\n")
+        return 2
+
+    cfg = load_config(cfg_path)
+
+    changed = git_diff_names(args.base, args.head)
+    changed = filter_generated(changed, cfg.generated_globs)
+
+    verdicts = assess_surfaces(cfg, changed, args.base, args.head, root)
+
+    if args.mode == "apply":
+        edited = apply_bumps(verdicts, args.base, root)
+        # Re-assess after editing: re-read current versions and re-check.
+        verdicts_after = assess_surfaces(cfg, changed, args.base, args.head, root)
+        text, code = render_report(verdicts_after, mode="report", base=args.base, repo=root)
+        if edited:
+            print("Edited files:")
+            for e in edited:
+                print(f"  {e}")
+        if text:
+            print(text)
+        return code
+
+    text, code = render_report(verdicts, args.mode, args.base, root)
+    if text:
+        print(text)
+    return code
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/versioning.json
+++ b/scripts/versioning.json
@@ -1,0 +1,70 @@
+{
+  "$schema": "./versioning.schema.json",
+  "schema_version": 1,
+  "_comment": "Shipyard-specific versioning gate config. Same schema as pulp's tools/scripts/versioning.json — enables the same scripts (scripts/version_bump_check.py, scripts/skill_sync_check.py) to run against Shipyard unchanged. Two surfaces: CLI (pyproject.toml + __init__.py) and Claude plugin (.claude-plugin/plugin.json). Per RELEASING.md the two versions are intentionally decoupled — the gate just ensures each moves when its own surface moves.",
+
+  "surfaces": {
+    "cli": {
+      "label": "Shipyard CLI",
+      "version_files": [
+        { "path": "pyproject.toml", "kind": "pyproject_version" },
+        { "path": "src/shipyard/__init__.py", "kind": "python_dunder_version" }
+      ],
+      "trigger_paths": [
+        "src/shipyard/**/*.py",
+        "src/shipyard/**/*.pyi"
+      ],
+      "public_api_paths": [
+        "src/shipyard/cli/**/*.py",
+        "src/shipyard/config/**/*.py",
+        "src/shipyard/__init__.py"
+      ],
+      "internal_only_paths": [
+        "src/shipyard/runners/**",
+        "src/shipyard/_internal/**"
+      ],
+      "changelog": "CHANGELOG.md"
+    },
+
+    "plugin": {
+      "label": "Shipyard Claude plugin",
+      "version_files": [
+        { "path": ".claude-plugin/plugin.json", "kind": "json_field", "field": "version" }
+      ],
+      "trigger_paths": [
+        ".claude-plugin/**",
+        "commands/**",
+        "skills/**",
+        "agents/**",
+        "hooks/**"
+      ],
+      "public_api_paths": [
+        ".claude-plugin/plugin.json",
+        "commands/**"
+      ],
+      "internal_only_paths": [
+        "hooks/*.sh"
+      ]
+    }
+  },
+
+  "skills": {
+    "skills_dir": "skills",
+    "path_map": "scripts/skill_path_map.json"
+  },
+
+  "generated_globs": [
+    "dist/**",
+    "build/**",
+    "*.egg-info/**",
+    "**/*.generated.*",
+    "uv.lock",
+    "node_modules/**"
+  ],
+
+  "trailers": {
+    "version_bump": "Version-Bump",
+    "skill_update": "Skill-Update",
+    "release": "Release"
+  }
+}

--- a/scripts/versioning.schema.json
+++ b/scripts/versioning.schema.json
@@ -1,0 +1,90 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/danielraffel/pulp/tools/scripts/versioning.schema.json",
+  "title": "Pulp versioning.yaml",
+  "description": "Repo-agnostic config consumed by version_bump_check.py and skill_sync_check.py.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "surfaces", "skills"],
+  "properties": {
+    "schema_version": {
+      "type": "integer",
+      "const": 1
+    },
+    "surfaces": {
+      "type": "object",
+      "minProperties": 1,
+      "additionalProperties": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["label", "version_files", "trigger_paths"],
+        "properties": {
+          "label": { "type": "string" },
+          "version_files": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["path", "kind"],
+              "properties": {
+                "path": { "type": "string" },
+                "kind": {
+                  "type": "string",
+                  "enum": ["cmake_project_version", "json_field", "python_dunder_version", "pyproject_version", "regex"]
+                },
+                "field": { "type": "string" },
+                "pattern": { "type": "string" }
+              },
+              "allOf": [
+                {
+                  "if": { "properties": { "kind": { "const": "json_field" } } },
+                  "then": { "required": ["field"] }
+                },
+                {
+                  "if": { "properties": { "kind": { "const": "regex" } } },
+                  "then": { "required": ["pattern"] }
+                }
+              ]
+            }
+          },
+          "trigger_paths": {
+            "type": "array",
+            "items": { "type": "string" }
+          },
+          "public_api_paths": {
+            "type": "array",
+            "items": { "type": "string" }
+          },
+          "internal_only_paths": {
+            "type": "array",
+            "items": { "type": "string" }
+          },
+          "changelog": { "type": "string" }
+        }
+      }
+    },
+    "skills": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["skills_dir", "path_map"],
+      "properties": {
+        "skills_dir": { "type": "string" },
+        "path_map": { "type": "string" }
+      }
+    },
+    "generated_globs": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "trailers": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "version_bump": { "type": "string" },
+        "skill_update": { "type": "string" },
+        "release": { "type": "string" }
+      }
+    }
+  }
+}

--- a/skills/ci/SKILL.md
+++ b/skills/ci/SKILL.md
@@ -82,3 +82,28 @@ and use `shipyard status --json` for live target state.
 - If a target is unreachable with no fallback, it reports unreachable
 - `shipyard run --allow-unreachable-targets --json` — override preflight if you intentionally want to queue anyway
 - `shipyard cloud defaults --json` — inspect the current cloud workflow/provider dispatch plan
+
+## Shipping a PR (the `shipyard pr` path)
+
+When the user says "push a PR", "ship this", "ship it", "we're done", "merge this", or "push it" — run the PR orchestration path (currently `shipyard ship` with the versioning gates; a dedicated `shipyard pr` wrapper is planned to match pulp's `pulp pr`).
+
+The orchestration, in order:
+
+1. `scripts/skill_sync_check.py --mode=report` — hard-fails if a mapped path was touched without a `SKILL.md` update or a `Skill-Update:` trailer on the tip commit.
+2. `scripts/version_bump_check.py --mode=apply` — rewrites `pyproject.toml` + `src/shipyard/__init__.py` for CLI-surface bumps and `.claude-plugin/plugin.json` for plugin-surface bumps. The two version streams are independent per `RELEASING.md`.
+3. `git commit` + `gh pr create` + `shipyard ship`.
+4. On merge, `.github/workflows/auto-release.yml` tags the CLI bump as `v<x.y.z>`. The existing tag-triggered `release.yml` builds the 5-platform binaries and publishes the GitHub Release.
+
+Never run `gh pr create` + release separately. Never run the Python gate scripts by hand.
+
+## Bypass trailers (tip commit)
+
+| Gate          | Trailer                                                      |
+|---------------|--------------------------------------------------------------|
+| Version bump  | `Version-Bump: <surface>=<patch\|minor\|major\|skip> reason="..."` |
+| Skill update  | `Skill-Update: skip skill=<name> reason="..."`              |
+| Auto-release  | `Release: skip reason="..."`                                 |
+
+**Gotcha:** anything under `.github/workflows/**`, `.claude-plugin/**`, `commands/**`, `agents/**`, `hooks/**`, `scripts/release.sh`, `src/shipyard/cli/**`, `src/shipyard/runners/**`, or `src/shipyard/config/**` triggers the `ci` skill's path map (`scripts/skill_path_map.json`). Update this SKILL.md in the same PR — or use the `Skill-Update: skip` trailer with a real reason.
+
+**Manual release fallback:** `./scripts/release.sh` still exists for emergencies but is no longer the happy path. Normal releases flow through `shipyard pr` → merge → auto-release workflow.

--- a/src/shipyard/cli.py
+++ b/src/shipyard/cli.py
@@ -1641,6 +1641,114 @@ def cleanup(ctx: Context, dry_run: bool, apply: bool) -> None:
 # ---- Helpers ----
 
 
+@main.command(name="pr")
+@click.option(
+    "--base",
+    default="main",
+    help="Base branch to ship into (default: main)",
+)
+@click.option(
+    "--apply-bumps/--no-apply-bumps",
+    default=True,
+    help=(
+        "Run scripts/version_bump_check.py --mode=apply to auto-rewrite "
+        "version files when a surface moved. On by default (mirrors "
+        "pulp's pulp pr). --no-apply-bumps switches to --mode=report so "
+        "missing bumps hard-fail."
+    ),
+)
+@click.option(
+    "--allow-unreachable-targets",
+    is_flag=True,
+    help="Forwarded to `shipyard ship`.",
+)
+@click.pass_context
+def pr(
+    ctx: click.Context,
+    base: str,
+    apply_bumps: bool,
+    allow_unreachable_targets: bool,
+) -> None:
+    """One-shot push-a-PR: skill-sync + version-bump + ship.
+
+    Mirrors pulp's `pulp pr` for parity with the ci skill's natural-
+    language triggers ("push a PR", "ship this"). Internally:
+
+        1. scripts/skill_sync_check.py --mode=report
+        2. scripts/version_bump_check.py --mode=(apply|report)
+        3. git commit of any bumps
+        4. invokes `shipyard ship` for push + PR + validate + merge
+    """
+    import shutil
+
+    repo_root = subprocess.check_output(
+        ["git", "rev-parse", "--show-toplevel"], text=True
+    ).strip()
+    ssc = Path(repo_root) / "scripts" / "skill_sync_check.py"
+    vbc = Path(repo_root) / "scripts" / "version_bump_check.py"
+    cfg = Path(repo_root) / "scripts" / "versioning.json"
+
+    if not ssc.exists() or not vbc.exists() or not cfg.exists():
+        render_error(
+            "shipyard pr requires scripts/skill_sync_check.py, "
+            "scripts/version_bump_check.py, and scripts/versioning.json "
+            "to be present. Install them via the versioning-sync port."
+        )
+        sys.exit(2)
+
+    python = shutil.which("python3") or "python3"
+
+    click.echo("▸ Skill-sync check")
+    rc = subprocess.call(
+        [python, str(ssc), "--base", f"origin/{base}", "--config", str(cfg), "--mode=report"]
+    )
+    if rc != 0:
+        render_error(
+            "skill-sync gate failed. Update the listed SKILL.md(s) or add a "
+            "`Skill-Update: skip skill=<name> reason=\"...\"` trailer on the "
+            "tip commit, then retry."
+        )
+        sys.exit(rc)
+
+    click.echo("▸ Version-bump " + ("apply" if apply_bumps else "report"))
+    mode = "apply" if apply_bumps else "report"
+    rc = subprocess.call(
+        [python, str(vbc), "--base", f"origin/{base}", "--config", str(cfg), f"--mode={mode}"]
+    )
+    if rc != 0:
+        render_error("version-bump gate failed; fix the bump and retry.")
+        sys.exit(rc)
+
+    # If apply staged any version files, commit them.
+    staged = subprocess.run(
+        ["git", "diff", "--cached", "--name-only"],
+        capture_output=True,
+        text=True,
+    )
+    if staged.stdout.strip():
+        click.echo("▸ Committing version bump(s)")
+        subprocess.check_call(
+            [
+                "git",
+                "-c",
+                "commit.gpgsign=false",
+                "commit",
+                "-m",
+                "chore: bump versions\n\nAutomated by `shipyard pr`.",
+            ]
+        )
+
+    # Delegate to the existing ship command for push/PR/validate/merge.
+    click.echo("▸ Handing off to `shipyard ship`")
+    ctx.invoke(
+        ship,
+        base=base,
+        allow_root_mismatch=False,
+        allow_unreachable_targets=allow_unreachable_targets,
+        auto_create_base=None,
+    )
+
+
 def _git_sha() -> str | None:
     try:
         return subprocess.check_output(

--- a/uv.lock
+++ b/uv.lock
@@ -455,7 +455,7 @@ wheels = [
 
 [[package]]
 name = "shipyard"
-version = "0.1.16"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
@@ -473,6 +473,11 @@ dev = [
     { name = "ruff" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "click", specifier = ">=8.0" },
@@ -486,6 +491,9 @@ requires-dist = [
     { name = "tomli-w", specifier = ">=1.0" },
 ]
 provides-extras = ["dev"]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest", specifier = ">=9.0.3" }]
 
 [[package]]
 name = "tomli"


### PR DESCRIPTION
## Summary

Ports the versioning & skill-sync enforcement system from pulp to Shipyard so the same "push a PR" experience works in both repos. Shipyard's two independently-versioned surfaces (CLI binary via \`pyproject.toml\` + \`__init__.py\`, Claude plugin via \`.claude-plugin/plugin.json\`) each get their own gate, and the existing \`./scripts/release.sh\` becomes a manual fallback.

See the upstream design in \`docs/guides/versioning.md\` on the pulp repo.

## What's in this PR

**Scripts (copied verbatim from pulp, config-driven):**
- \`scripts/version_bump_check.py\` + \`scripts/skill_sync_check.py\` — same code pulp ships.
- \`scripts/versioning.json\` + \`versioning.schema.json\` — Shipyard-specific config (cli + plugin surfaces, pyproject/__init__/plugin.json version files, skill_path_map pointing at skills/).
- \`scripts/skill_path_map.json\` — covers the single \`ci\` skill, mapping src/shipyard/cli|runners|config|queue, commands/, agents/, hooks/, .claude-plugin/, .github/workflows/, scripts/release.sh to it.
- \`scripts/install-githooks.sh\` — layout-agnostic (walks up to \`.git\`); works for both pulp and Shipyard without per-repo tweaks.

**Three enforcement layers:**
1. Agent hook (Layer 1, advisory) — \`hooks/version-skill-hint.sh\` runs both scripts in hint mode on PostToolUse.
2. Pre-push (Layer 2, advisory by default; \`SHIPYARD_ENFORCE_PREPUSH=1\` blocks) — \`.githooks/pre-push\` installed by \`scripts/install-githooks.sh\`.
3. CI (Layer 3, authoritative) — \`.github/workflows/version-skill-check.yml\` runs both scripts with \`SHIPYARD_ENFORCE_PREPUSH=1\`.

**\`shipyard pr\` command:**
- New click command in \`src/shipyard/cli.py\` wrapping \`shipyard ship\` with the versioning gates.
- Flow: skill_sync_check → version_bump_check (apply by default, \`--no-apply-bumps\` for report-only) → commit bumps → delegate to ship for push/PR/validate/merge.
- Flags: \`--base\`, \`--apply-bumps/--no-apply-bumps\`, \`--allow-unreachable-targets\`.

**Auto-release:**
- \`.github/workflows/auto-release.yml\` on push to \`main\` diffs \`pyproject.toml\` against the previous push range, creates \`v<x.y.z>\` tag when CLI version moves. The existing tag-triggered \`release.yml\` then builds + publishes the 5-platform binaries.
- Plugin-version bumps (\`.claude-plugin/plugin.json\`) are intentionally NOT tagged — per \`RELEASING.md\`, plugin files are delivered from git, not from the binary, so there's no binary release to cut for plugin-only changes. The gate still enforces the bump.

**Manual fallback:**
- \`scripts/release.sh\` gains a pre-release gate (\`scripts/version_bump_check.py --mode=report\`) that refuses to tag if required bumps are missing. \`RELEASE_SKIP_VERSION_CHECK=1\` with a logged reason is the emergency bypass.
- \`RELEASING.md\` reframed: automatic-on-merge is the default; the script is break-glass.

**Docs + agent parity:**
- \`CLAUDE.md\` — new full-policy doc (three layers, bypass trailers, natural-language PR routing, manual fallback).
- \`AGENTS.md\` — thin pointer at CLAUDE.md, matching pulp's pattern. Codex inherits automatically.
- \`skills/ci/SKILL.md\` — gained "Shipping a PR" section pointing at \`shipyard pr\`.
- \`hooks/hooks.json\` — added PostToolUse → version-skill-hint.sh, keeping the existing SessionStart CLI-install hook untouched.

## Bypass trailers (tip commit, never PR body)

| Gate          | Trailer                                                      |
|---------------|--------------------------------------------------------------|
| Version bump  | \`Version-Bump: <surface>=<patch\|minor\|major\|skip> reason=\"...\"\` |
| Skill update  | \`Skill-Update: skip skill=<name> reason=\"...\"\`          |
| Auto-release  | \`Release: skip reason=\"...\"\`                             |

## Test plan

- [x] \`scripts/skill_sync_check.py\` reports clean on HEAD (ci skill SKILL.md updated in-branch).
- [x] \`scripts/version_bump_check.py\` exits 0 on HEAD (plugin surface shows "bump suggested (patch)" — advisory, not blocking).
- [x] \`uv run shipyard pr --help\` renders the full synopsis and flags.
- [x] \`uv run pytest -x\` passes: **494 passed in 275s**.
- [x] No drift between \`v0.2.0\` tag and \`origin/main\` — this PR's bumps originate here.
- [ ] Cross-platform CI on this PR.
- [ ] Post-merge: auto-release fires on CLI bump (plugin patch-suggested at review discretion).

See \`planning/shipyard-versioning-acceptance.md\` for the full transcript.

## Out of scope (tracked as follow-ups)

- Shared-scripts distribution: today copied verbatim from pulp. Revisit via PyPI package or submodule if the three files diverge materially across repos.
- \`shipyard pr\` JSON output: when Shipyard adds per-stage JSON flags to \`ship\`, the wrapper should forward them.