### PR TITLE
Fix Codex P1 + P2 review on PR #36 (versioning-sync)

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -101,14 +101,23 @@ jobs:
 
           # Idempotent-strict: if tag already exists at HEAD, no-op; at a
           # different SHA, fail loudly. Never overwrite.
+          #
+          # `git ls-remote --tags origin <tag>` returns the TAG OBJECT SHA
+          # for annotated tags (the default created by this workflow via
+          # `git tag -a`), not the referenced commit SHA. Dereference via
+          # `<tag>^{}` before comparing to HEAD; fall back to the raw SHA
+          # for lightweight tags (no ^{} entry).
           if git ls-remote --tags origin "$tag" | grep -q .; then
-              remote_sha=$(git ls-remote --tags origin "$tag" | awk '{print $1}')
+              remote_target=$(git ls-remote --tags origin "${tag}^{}" | awk '{print $1}')
+              if [ -z "$remote_target" ]; then
+                  remote_target=$(git ls-remote --tags origin "$tag" | awk '{print $1}')
+              fi
               local_sha=$(git rev-parse HEAD)
-              if [ "$remote_sha" = "$local_sha" ]; then
+              if [ "$remote_target" = "$local_sha" ]; then
                   echo "tag $tag already at $local_sha — no-op"
                   exit 0
               fi
-              echo "ERROR: tag $tag exists at $remote_sha but HEAD is $local_sha" >&2
+              echo "ERROR: tag $tag exists at $remote_target but HEAD is $local_sha" >&2
               echo "Manual reconciliation required." >&2
               exit 1
           fi

--- a/scripts/skill_sync_check.py
+++ b/scripts/skill_sync_check.py
@@ -225,8 +225,16 @@ def compute_findings(
         touched = [p for p in changed if _matches_any(p, patterns)]
         if not touched:
             continue
-        skill_md_prefix = f"{rel_skills_dir}/{skill}/"
-        skill_md_modified = any(p.startswith(skill_md_prefix) for p in changed)
+        # Require SKILL.md specifically, not side files (fixtures, notes,
+        # logs) that happen to live next to it. A nested SKILL.md inside
+        # a subfolder (rare but allowed) also counts as updating the skill.
+        skill_md_exact = f"{rel_skills_dir}/{skill}/SKILL.md"
+        skill_md_subdir_prefix = f"{rel_skills_dir}/{skill}/"
+        skill_md_modified = any(
+            p == skill_md_exact
+            or (p.startswith(skill_md_subdir_prefix) and p.endswith("/SKILL.md"))
+            for p in changed
+        )
         findings.append(
             Finding(
                 skill=skill,

--- a/scripts/skill_sync_check.py
+++ b/scripts/skill_sync_check.py
@@ -69,6 +69,40 @@ def git_diff_names(base: str, head: str) -> list[str]:
     return [line for line in out.stdout.splitlines() if line.strip()]
 
 
+def git_range_trailers(base: str, head: str) -> dict[str, list[str]]:
+    """Collect trailers from ALL commits in `base..head`, merged.
+
+    CI checks out a synthetic merge commit as HEAD, so a bypass trailer on
+    the branch's tip commit wouldn't be seen if we only looked at HEAD.
+    Walk the whole range instead — any commit in the range carries the
+    bypass.
+    """
+    try:
+        body = subprocess.run(
+            ["git", "log", "--format=%B%x00", f"{base}..{head}"],
+            check=True, capture_output=True, text=True,
+        ).stdout
+    except subprocess.CalledProcessError:
+        return {}
+
+    result: dict[str, list[str]] = {}
+    # Each commit body ends with a NUL byte.
+    for body_chunk in body.split("\x00"):
+        if not body_chunk.strip():
+            continue
+        trailers = subprocess.run(
+            ["git", "interpret-trailers", "--parse"],
+            input=body_chunk, capture_output=True, text=True,
+        )
+        for line in trailers.stdout.splitlines():
+            if ":" not in line:
+                continue
+            key, _, value = line.partition(":")
+            result.setdefault(key.strip().lower(), []).append(value.strip())
+    return result
+
+
+# Back-compat shim for any external callers.
 def git_commit_trailers(ref: str) -> dict[str, list[str]]:
     try:
         body = subprocess.run(
@@ -77,7 +111,6 @@ def git_commit_trailers(ref: str) -> dict[str, list[str]]:
         ).stdout
     except subprocess.CalledProcessError:
         return {}
-
     trailers = subprocess.run(
         ["git", "interpret-trailers", "--parse"],
         input=body, capture_output=True, text=True,
@@ -338,7 +371,7 @@ def main(argv: list[str]) -> int:
     changed = git_diff_names(args.base, args.head)
     changed = filter_generated(changed, cfg.generated_globs)
 
-    trailers = git_commit_trailers(args.head)
+    trailers = git_range_trailers(args.base, args.head)
     bypasses = parse_skill_update_trailer(trailers, cfg.trailer_skill_update)
 
     findings = compute_findings(

--- a/scripts/version_bump_check.py
+++ b/scripts/version_bump_check.py
@@ -159,6 +159,33 @@ def git_commit_files(sha: str) -> list[str]:
     return [line for line in out.stdout.splitlines() if line.strip()]
 
 
+def git_range_trailers(base: str, head: str) -> dict[str, list[str]]:
+    """Collect trailers from every commit in base..head (CI checks out
+    a synthetic merge commit as HEAD, so a bypass on the branch tip
+    wouldn't be visible if we only looked at HEAD)."""
+    try:
+        body = subprocess.run(
+            ["git", "log", "--format=%B%x00", f"{base}..{head}"],
+            check=True, capture_output=True, text=True,
+        ).stdout
+    except subprocess.CalledProcessError:
+        return {}
+    result: dict[str, list[str]] = {}
+    for body_chunk in body.split("\x00"):
+        if not body_chunk.strip():
+            continue
+        trailers = subprocess.run(
+            ["git", "interpret-trailers", "--parse"],
+            input=body_chunk, capture_output=True, text=True,
+        )
+        for line in trailers.stdout.splitlines():
+            if ":" not in line:
+                continue
+            key, _, value = line.partition(":")
+            result.setdefault(key.strip().lower(), []).append(value.strip())
+    return result
+
+
 def git_commit_trailers(ref: str) -> dict[str, list[str]]:
     try:
         body = subprocess.run(
@@ -454,7 +481,7 @@ def assess_surfaces(
     head: str,
     repo: Path,
 ) -> list[Verdict]:
-    trailers = git_commit_trailers(head)
+    trailers = git_range_trailers(base, head)
     verdicts: list[Verdict] = []
     for s in cfg.surfaces:
         heur = heuristic_for_surface(s, changed, base, head)

--- a/scripts/version_bump_check.py
+++ b/scripts/version_bump_check.py
@@ -130,12 +130,13 @@ def git_diff_ignore_whitespace_nonempty(base: str, head: str, path: str) -> bool
     return has_real
 
 
-def git_log_subjects_and_bodies(base: str, head: str) -> list[tuple[str, str]]:
+def git_log_subjects_and_bodies(base: str, head: str) -> list[tuple[str, str, str]]:
+    """Return (sha, subject, body) tuples for each commit in base..head."""
     out = subprocess.run(
         ["git", "log", "--format=%H%x00%s%x00%B%x01", f"{base}..{head}"],
         check=True, capture_output=True, text=True,
     )
-    commits: list[tuple[str, str]] = []
+    commits: list[tuple[str, str, str]] = []
     for chunk in out.stdout.split("\x01"):
         chunk = chunk.strip()
         if not chunk:
@@ -143,9 +144,19 @@ def git_log_subjects_and_bodies(base: str, head: str) -> list[tuple[str, str]]:
         parts = chunk.split("\x00", 2)
         if len(parts) < 3:
             continue
-        _sha, subject, body = parts
-        commits.append((subject, body))
+        sha, subject, body = parts
+        commits.append((sha, subject, body))
     return commits
+
+
+def git_commit_files(sha: str) -> list[str]:
+    """Files touched by a single commit. Used to scope conv-commit signals
+    to surfaces whose trigger_paths the commit actually modified."""
+    out = subprocess.run(
+        ["git", "show", "--name-only", "--format=", sha],
+        check=True, capture_output=True, text=True,
+    )
+    return [line for line in out.stdout.splitlines() if line.strip()]
 
 
 def git_commit_trailers(ref: str) -> dict[str, list[str]]:
@@ -347,25 +358,20 @@ def heuristic_for_surface(
     if not touched:
         return "none"
 
-    # Public-API paths: minor-required if diff has real content (not just
-    # comments/whitespace). Downgrade to patch if the diff is trivial.
-    public_touched = [p for p in touched if _matches_any(p, surface.public_api_paths)]
-    meaningful_public = False
-    for p in public_touched:
-        if git_diff_ignore_whitespace_nonempty(base, head, p):
-            meaningful_public = True
-            break
+    # Filter to touched paths with a meaningful (non-whitespace, non-comment-only)
+    # diff. Paths whose changes are entirely whitespace or comments don't
+    # trigger a version bump — fall through to "none".
+    meaningful = [p for p in touched if git_diff_ignore_whitespace_nonempty(base, head, p)]
+    if not meaningful:
+        return "none"
 
-    if meaningful_public:
+    # Any public-API path with a meaningful diff → minor-required.
+    if any(_matches_any(p, surface.public_api_paths) for p in meaningful):
         return "minor"
 
-    # Only internal paths touched → patch-suggested (warning, not hard fail
-    # at the CI level; we still report it so humans can decide).
-    internal_touched = [p for p in touched if _matches_any(p, surface.internal_only_paths)]
-    if internal_touched or touched:
-        return "patch"
-
-    return "none"
+    # Otherwise internal-only changes → patch-suggested (advisory; report mode
+    # treats this as a warning, never hard fail).
+    return "patch"
 
 
 def surface_trailer_override(
@@ -455,7 +461,9 @@ def assess_surfaces(
 
         override = surface_trailer_override(trailers, cfg.trailer_version_bump, s.name)
         final = heur
-        if override == "skip":
+        skip_requested = (override == "skip")
+
+        if skip_requested:
             final = "none"
         elif override in LEVELS:
             # Only raise, never lower. And only if the surface was actually touched.
@@ -469,11 +477,20 @@ def assess_surfaces(
                 final = "none"
 
         # Promote via conventional-commit subjects on commits that touched
-        # this surface — this is a ceiling raise only.
-        if heur != "none":
+        # THIS surface — never from commits that only touched unrelated
+        # paths. A plugin-only `feat:` cannot raise the SDK ceiling. An
+        # explicit `Version-Bump: <surface>=skip` on the tip commit is
+        # authoritative and is NOT raised back up by conv-commit subjects.
+        if heur != "none" and not skip_requested:
             conv_ceiling = "none"
-            for subject, body in git_log_subjects_and_bodies(base, head):
+            for sha, subject, body in git_log_subjects_and_bodies(base, head):
                 if is_revert_commit(subject, {}):
+                    continue
+                # Scope to commits whose files intersect this surface's
+                # trigger_paths — otherwise a feat: on the plugin can raise
+                # the SDK.
+                files = git_commit_files(sha)
+                if not any(_matches_any(f, s.trigger_paths) for f in files):
                     continue
                 conv_ceiling = max_level(conv_ceiling, classify_conventional(subject))
             if LEVELS.index(conv_ceiling) > LEVELS.index(final):
@@ -511,9 +528,23 @@ def render_report(
         if v.final_level == "none":
             lines.append(f"[{v.surface.name}] {v.surface.label}: no bump needed")
             continue
-        # Already bumped since base?
-        bumped = any(already_bumped(base, vf, repo) for vf in v.surface.version_files)
-        tag = "✓ bumped" if bumped else "✗ bump required"
+        # Every version file in the surface must have moved, not just one.
+        # Otherwise surfaces with multiple files (plugin.json + marketplace.json)
+        # could pass with only one bumped, causing split-brain versions.
+        per_file = [(vf, already_bumped(base, vf, repo)) for vf in v.surface.version_files]
+        all_bumped = all(bumped for _, bumped in per_file)
+        any_bumped = any(bumped for _, bumped in per_file)
+
+        if all_bumped:
+            tag = "✓ bumped"
+        elif any_bumped:
+            unbumped = [vf.path for vf, b in per_file if not b]
+            tag = f"✗ partial bump — not moved: {', '.join(unbumped)}"
+        elif v.final_level == "patch":
+            # Advisory only — not a hard fail.
+            tag = "? bump suggested (patch)"
+        else:
+            tag = "✗ bump required"
         lines.append(
             f"[{v.surface.name}] {v.surface.label}: "
             f"heuristic={v.heuristic}"
@@ -522,8 +553,13 @@ def render_report(
             f"current={v.current_version or '?'} "
             f"{tag}"
         )
-        if not bumped:
-            if v.final_level == "patch":
+        if not all_bumped:
+            # Partial-bump is always a hard fail — split-brain versions are
+            # never acceptable. Patch-suggested stays advisory only when
+            # nothing has been bumped at all.
+            if any_bumped:
+                failures += 1
+            elif v.final_level == "patch":
                 warnings += 1
             else:
                 failures += 1
@@ -553,8 +589,11 @@ def apply_bumps(
     for v in verdicts:
         if v.final_level in ("none", "patch"):
             continue
-        bumped = any(already_bumped(base, vf, repo) for vf in v.surface.version_files)
-        if bumped or not v.current_version:
+        # Skip if ALL version files are already at the target; otherwise
+        # apply to every file (keeps plugin.json and marketplace.json in
+        # lockstep after a partial-bump from a prior run).
+        all_bumped = all(already_bumped(base, vf, repo) for vf in v.surface.version_files)
+        if all_bumped or not v.current_version:
             continue
         new_ver = bump_version(v.current_version, v.final_level)
         for vf in v.surface.version_files:

--- a/src/shipyard/cli.py
+++ b/src/shipyard/cli.py
@@ -1712,6 +1712,18 @@ def pr(
 
     click.echo("▸ Version-bump " + ("apply" if apply_bumps else "report"))
     mode = "apply" if apply_bumps else "report"
+
+    # Record the currently-staged set BEFORE running version_bump_check so we
+    # can isolate the files it stages. Otherwise any unrelated staged changes
+    # the user had in progress would sweep into the "chore: bump" commit
+    # (Codex P1 on PR #36).
+    staged_before = subprocess.run(
+        ["git", "diff", "--cached", "--name-only", "-z"],
+        capture_output=True,
+        text=True,
+    )
+    pre_set = {p for p in staged_before.stdout.split("\x00") if p}
+
     rc = subprocess.call(
         [python, str(vbc), "--base", f"origin/{base}", "--config", str(cfg), f"--mode={mode}"]
     )
@@ -1719,14 +1731,19 @@ def pr(
         render_error("version-bump gate failed; fix the bump and retry.")
         sys.exit(rc)
 
-    # If apply staged any version files, commit them.
-    staged = subprocess.run(
-        ["git", "diff", "--cached", "--name-only"],
+    staged_after = subprocess.run(
+        ["git", "diff", "--cached", "--name-only", "-z"],
         capture_output=True,
         text=True,
     )
-    if staged.stdout.strip():
-        click.echo("▸ Committing version bump(s)")
+    post_set = {p for p in staged_after.stdout.split("\x00") if p}
+    bumped_files = sorted(post_set - pre_set)
+
+    if bumped_files:
+        click.echo(f"▸ Committing version bump(s) — {len(bumped_files)} file(s)")
+        # Commit only the files version_bump_check added. Anything the user
+        # had staged before is left in the index for them to commit (or
+        # reset) separately.
         subprocess.check_call(
             [
                 "git",
@@ -1735,6 +1752,9 @@ def pr(
                 "commit",
                 "-m",
                 "chore: bump versions\n\nAutomated by `shipyard pr`.",
+                "--only",
+                "--",
+                *bumped_files,
             ]
         )
 


### PR DESCRIPTION
Addresses the three Codex review comments on [PR #36](https://github.com/danielraffel/Shipyard/pull/36):

- **P1** — `shipyard pr` committed ALL staged files, not just the version files auto-bumped. Unrelated in-flight staged work was swept into the \"chore: bump\" commit.
  **Fix:** snapshot the staged set before/after \`version_bump_check.py --mode=apply\`, then \`git commit --only -- <bumped>\`. User's unrelated staged changes are left in the index.

- **P2** — Skill-sync gate treated any file under \`skills/<skill>/\` as a SKILL.md update. Side files satisfied the gate spuriously.
  **Fix:** accept exact SKILL.md or nested \`**/SKILL.md\` only. Script re-vendored from pulp's fixed version.

- **P2** — \`auto-release.yml\` compared \`ls-remote --tags\` output (tag object SHA for annotated tags) against \`rev-parse HEAD\` (commit SHA), so the idempotent-strict check would mismatch every time.
  **Fix:** dereference via \`<tag>^{}\`; fall back to raw SHA for lightweight tags.

Version_bump_check.py also picked up the pulp-side P1 (all-files-bumped) and P2 (surface-scoped conv-commits) fixes via re-vendoring.

## Test plan

- [x] \`python3 scripts/skill_sync_check.py --base origin/main --config scripts/versioning.json --mode=report\` clean.
- [x] \`python3 scripts/version_bump_check.py --base origin/main --config scripts/versioning.json --mode=report\` clean.
- [x] \`uv run shipyard pr --help\` renders (no regression).
- [ ] CI: version-skill-check + build matrix + full pytest.

## Related
- Pulp mirror fix: danielraffel/pulp#147