### PR TITLE
Fix Codex P1 + P2 review on PR #37

### DIFF
--- a/scripts/version_bump_check.py
+++ b/scripts/version_bump_check.py
@@ -437,39 +437,46 @@ def bump_version(current: str, level: str) -> str:
 # ── Reporting / apply ───────────────────────────────────────────────────
 
 
-def already_bumped(base: str, vf: VersionFile, repo: Path) -> bool:
-    """True iff the version file's version at HEAD differs from at base."""
-    p = repo / vf.path
-    if not p.exists():
-        return False
+def _extract_version_from_text(text: str, vf: VersionFile) -> str | None:
+    if vf.kind == "cmake_project_version":
+        m = _CMAKE_PROJECT_VERSION_RE.search(text)
+        return m.group(2) if m else None
+    if vf.kind == "json_field":
+        try:
+            return json.loads(text).get(vf.field)
+        except json.JSONDecodeError:
+            return None
+    if vf.kind == "pyproject_version":
+        m = re.search(r'^\s*version\s*=\s*"([^"]+)"', text, re.MULTILINE)
+        return m.group(1) if m else None
+    if vf.kind == "python_dunder_version":
+        m = re.search(r'^\s*__version__\s*=\s*"([^"]+)"', text, re.MULTILINE)
+        return m.group(1) if m else None
+    return None
+
+
+def version_at_base(base: str, vf: VersionFile) -> str | None:
+    """Read the version from a file as it existed at `base`, or None."""
     try:
         base_text = subprocess.run(
             ["git", "show", f"{base}:{vf.path}"],
             check=True, capture_output=True, text=True,
         ).stdout
     except subprocess.CalledProcessError:
-        return False
-
-    def extract(text: str) -> str | None:
-        if vf.kind == "cmake_project_version":
-            m = _CMAKE_PROJECT_VERSION_RE.search(text)
-            return m.group(2) if m else None
-        if vf.kind == "json_field":
-            try:
-                return json.loads(text).get(vf.field)
-            except json.JSONDecodeError:
-                return None
-        if vf.kind == "pyproject_version":
-            m = re.search(r'^\s*version\s*=\s*"([^"]+)"', text, re.MULTILINE)
-            return m.group(1) if m else None
-        if vf.kind == "python_dunder_version":
-            m = re.search(r'^\s*__version__\s*=\s*"([^"]+)"', text, re.MULTILINE)
-            return m.group(1) if m else None
         return None
+    return _extract_version_from_text(base_text, vf)
 
-    base_ver = extract(base_text)
-    head_ver = extract((repo / vf.path).read_text())
-    if base_ver is None or head_ver is None:
+
+def already_bumped(base: str, vf: VersionFile, repo: Path) -> bool:
+    """True iff the version file's version at HEAD differs from at base."""
+    p = repo / vf.path
+    if not p.exists():
+        return False
+    base_ver = version_at_base(base, vf)
+    if base_ver is None:
+        return False
+    head_ver = _extract_version_from_text((repo / vf.path).read_text(), vf)
+    if head_ver is None:
         return False
     return base_ver != head_ver
 
@@ -622,7 +629,18 @@ def apply_bumps(
         all_bumped = all(already_bumped(base, vf, repo) for vf in v.surface.version_files)
         if all_bumped or not v.current_version:
             continue
-        new_ver = bump_version(v.current_version, v.final_level)
+        # Compute the target from the BASE version, not v.current_version.
+        # v.current_version reflects the first readable file at HEAD, which
+        # may already have been bumped by a prior partial run — bumping it
+        # again would double-bump (e.g. 0.1.0 -> 0.2.0 -> 0.3.0). Reading
+        # the base keeps a partial-apply idempotent.
+        base_ver: str | None = None
+        for vf in v.surface.version_files:
+            base_ver = version_at_base(base, vf)
+            if base_ver:
+                break
+        source_ver = base_ver or v.current_version
+        new_ver = bump_version(source_ver, v.final_level)
         for vf in v.surface.version_files:
             if write_version(repo, vf, new_ver):
                 edited.append(vf.path)

--- a/src/shipyard/cli.py
+++ b/src/shipyard/cli.py
@@ -1713,37 +1713,49 @@ def pr(
     click.echo("▸ Version-bump " + ("apply" if apply_bumps else "report"))
     mode = "apply" if apply_bumps else "report"
 
-    # Record the currently-staged set BEFORE running version_bump_check so we
-    # can isolate the files it stages. Otherwise any unrelated staged changes
-    # the user had in progress would sweep into the "chore: bump" commit
-    # (Codex P1 on PR #36).
-    staged_before = subprocess.run(
-        ["git", "diff", "--cached", "--name-only", "-z"],
+    # Ask version_bump_check itself which files it edited. Parsing its
+    # "Edited files:" stdout is robust to files that were ALSO pre-staged
+    # by the user — a simple pre/post index-set diff drops those. Users
+    # with unrelated pre-staged work keep that work in the index; only the
+    # bump-touched files go into the chore: commit, even if the user had
+    # e.g. plugin.json staged for their own reason.
+    vbc_run = subprocess.run(
+        [python, str(vbc), "--base", f"origin/{base}", "--config", str(cfg), f"--mode={mode}"],
         capture_output=True,
         text=True,
     )
-    pre_set = {p for p in staged_before.stdout.split("\x00") if p}
-
-    rc = subprocess.call(
-        [python, str(vbc), "--base", f"origin/{base}", "--config", str(cfg), f"--mode={mode}"]
-    )
-    if rc != 0:
+    # Stream the script's output so the user still sees it.
+    if vbc_run.stdout:
+        click.echo(vbc_run.stdout, nl=False)
+    if vbc_run.stderr:
+        click.echo(vbc_run.stderr, nl=False, err=True)
+    if vbc_run.returncode != 0:
         render_error("version-bump gate failed; fix the bump and retry.")
-        sys.exit(rc)
+        sys.exit(vbc_run.returncode)
 
-    staged_after = subprocess.run(
-        ["git", "diff", "--cached", "--name-only", "-z"],
-        capture_output=True,
-        text=True,
-    )
-    post_set = {p for p in staged_after.stdout.split("\x00") if p}
-    bumped_files = sorted(post_set - pre_set)
+    # Parse the "Edited files:" section. Lines after that header until a
+    # blank line or the next `[` surface report begin with two spaces and
+    # a path.
+    bumped_files: list[str] = []
+    in_edited_block = False
+    for line in vbc_run.stdout.splitlines():
+        if line.startswith("Edited files:"):
+            in_edited_block = True
+            continue
+        if in_edited_block:
+            if line.startswith("  ") and line.strip():
+                bumped_files.append(line.strip())
+            else:
+                break
 
     if bumped_files:
         click.echo(f"▸ Committing version bump(s) — {len(bumped_files)} file(s)")
-        # Commit only the files version_bump_check added. Anything the user
-        # had staged before is left in the index for them to commit (or
-        # reset) separately.
+        # `--only -- <paths>` commits exactly those paths' current working-
+        # tree state. If a file was pre-staged by the user with unrelated
+        # changes, this captures the post-bump content (their changes +
+        # the bump), which is the right semantics: the file's on-disk
+        # state is now "user edit + bump", and committing it together
+        # prevents shipping a split-brain bump.
         subprocess.check_call(
             [
                 "git",


### PR DESCRIPTION
Addresses the two unaddressed Codex review comments on [PR #37](https://github.com/danielraffel/Shipyard/pull/37):

- **P1** — Derive repaired versions from base, not already-bumped file.
  Re-vendors pulp's updated \`version_bump_check.py\` with \`_extract_version_from_text\` + \`version_at_base\` helpers. \`apply_bumps\` now reads the source version from the base commit. A partial-apply retry over a split-brain tree (plugin.json at 0.2.0 but marketplace.json still 0.1.0) no longer double-bumps to 0.3.0.

- **P2** — Include modified pre-staged bump files in the bump commit.
  \`shipyard pr\` was computing \`bumped_files = post_set - pre_set\` over \`git diff --cached --name-only\`. That set difference DROPS any file the user had pre-staged for their own reasons that the bump also modified. Now the command parses \`version_bump_check.py\`'s own \"Edited files:\" stdout — robust to pre-staging. \`--only -- <paths>\` captures the current on-disk state of the bump-touched files while leaving unrelated pre-staged work in the index.

## Test plan

- [x] \`uv run shipyard pr --help\` renders cleanly.
- [x] \`scripts/skill_sync_check.py --base origin/main\` clean.
- [x] \`scripts/version_bump_check.py --base origin/main\` clean.
- [ ] CI: version-skill-check + build matrix + pytest.

## Related
- Pulp mirror: danielraffel/pulp#147 (already merged — P1 fix was included in the squash-merge).