### PR TITLE
doctor + pr: surface missing RELEASE_BOT_TOKEN secret

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,5 +1,32 @@
 # Releasing Shipyard
 
+## One-time setup: `RELEASE_BOT_TOKEN` secret
+
+The auto-release workflow needs a fine-grained PAT to push tags so that downstream `release.yml` actually fires. **Without this secret, auto-release silently degrades**: tags are still created via `GITHUB_TOKEN`, but GitHub Actions deliberately does not chain workflows from `GITHUB_TOKEN`-pushed tags (anti-infinite-loop safety), so `release.yml` never runs and no binaries ship.
+
+Run `shipyard doctor` to check whether the secret is configured. If it shows `RELEASE_BOT_TOKEN: missing`, set it up:
+
+1. **Generate the token.** github.com → top-right avatar → Settings → Developer settings → Personal access tokens → **Fine-grained tokens** → Generate new token.
+2. **Token name:** `shipyard-release-bot` (or any descriptive name).
+3. **Expiration:** 1 year (mark your calendar to renew).
+4. **Resource owner:** the org or user that owns this repo.
+5. **Repository access:** Only select repositories → this repo only.
+6. **Permissions** (Repository permissions section): **Contents: Read and write**. Leave everything else at the default.
+7. **Generate**, copy the token (starts with `github_pat_…`).
+8. **Add to repo secrets:** github.com/<owner>/<repo>/settings/secrets/actions → New repository secret. Name: `RELEASE_BOT_TOKEN`. Value: paste the token.
+
+That's it — no code change needed. The workflow already reads `${{ secrets.RELEASE_BOT_TOKEN || secrets.GITHUB_TOKEN }}`. `shipyard doctor` will then report `RELEASE_BOT_TOKEN: configured`.
+
+### What if you can't or don't want to set the secret?
+
+The chain still works but requires one manual step per release:
+
+```bash
+gh workflow run release.yml --ref v<x.y.z>
+```
+
+Run that after the auto-tag appears. The release workflow will pick up the existing tag and publish the binaries. (Pulp's first auto-released tag, `v0.4.0`, used this fallback before its `RELEASE_BOT_TOKEN` was provisioned.)
+
 ## Default path: automatic on merge
 
 Normal releases are automatic. You don't call any script.

--- a/skills/ci/SKILL.md
+++ b/skills/ci/SKILL.md
@@ -107,3 +107,5 @@ Never run `gh pr create` + release separately. Never run the Python gate scripts
 **Gotcha:** anything under `.github/workflows/**`, `.claude-plugin/**`, `commands/**`, `agents/**`, `hooks/**`, `scripts/release.sh`, `src/shipyard/cli/**`, `src/shipyard/runners/**`, or `src/shipyard/config/**` triggers the `ci` skill's path map (`scripts/skill_path_map.json`). Update this SKILL.md in the same PR — or use the `Skill-Update: skip` trailer with a real reason.
 
 **Manual release fallback:** `./scripts/release.sh` still exists for emergencies but is no longer the happy path. Normal releases flow through `shipyard pr` → merge → auto-release workflow.
+
+**`RELEASE_BOT_TOKEN` is required for the auto-release chain to fire.** Without it, auto-release silently degrades — tags get created via `GITHUB_TOKEN` but GitHub doesn't trigger workflows on `GITHUB_TOKEN`-pushed tags, so `release.yml` never runs and no binaries ship. Run `shipyard doctor` to check; if the secret is missing, follow the "One-time setup" section in `RELEASING.md`. `shipyard pr` will also print a heads-up before pushing the PR if the secret isn't present.

--- a/src/shipyard/cli.py
+++ b/src/shipyard/cli.py
@@ -23,6 +23,7 @@ from shipyard.core.evidence import EvidenceStore
 from shipyard.core.job import Job, JobStatus, TargetResult, TargetStatus, ValidationMode
 from shipyard.core.queue import Queue
 from shipyard.executor.dispatch import ExecutorDispatcher
+from shipyard.governance.github import detect_repo_from_remote
 from shipyard.output.human import (
     console,
     render_doctor,
@@ -392,11 +393,24 @@ def doctor(ctx: Context) -> None:
     if governance_section:
         checks["Governance"] = governance_section
 
+    # Release-bot token check — informational. The auto-release workflow
+    # falls back to GITHUB_TOKEN when RELEASE_BOT_TOKEN isn't set, but
+    # tags pushed by GITHUB_TOKEN don't trigger downstream workflows
+    # (GitHub anti-infinite-loop safety), so the binary release pipeline
+    # silently never fires. Surfacing this in doctor is the cheapest way
+    # to keep new contributors out of that trap.
+    release_token_section = _check_release_bot_token()
+    if release_token_section:
+        checks["Release pipeline"] = release_token_section
+
     # Ready = core tools healthy AND (no governance section declared
     # OR every governance check is ok). Informational entries (the
     # immutable-releases line) set `ok=True` specifically because
     # they can't lie — they report what the API exposes and nothing
     # more — so they're allowed to contribute to the ready rollup.
+    # The release-token section is informational only — a missing
+    # bot token doesn't break shipyard run/ship, it only breaks the
+    # auto-release tag chain — so we DON'T include it in `ready`.
     ready = all(info.get("ok", False) for info in core.values()) and all(
         info.get("ok", False) for info in (governance_section or {}).values()
     )
@@ -405,6 +419,68 @@ def doctor(ctx: Context) -> None:
         ctx.output("doctor", {"ready": ready, "checks": checks})
     else:
         render_doctor(checks, ready)
+
+
+def _check_release_bot_token() -> dict[str, Any] | None:
+    """Probe whether RELEASE_BOT_TOKEN is configured on the active repo.
+
+    Returns None when the repo can't be detected or `gh` can't read the
+    secret list (no auth, missing scope) — silent skip rather than
+    blocking the rest of doctor. When the secret is present, returns ok=True
+    with a short note. When it's missing, returns ok=False with the exact
+    setup pointer so the user has zero ambiguity about what to do.
+    """
+    repo = detect_repo_from_remote()
+    if repo is None:
+        return None
+
+    try:
+        result = subprocess.run(
+            ["gh", "api", f"repos/{repo.slug}/actions/secrets",
+             "--jq", ".secrets[].name"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (subprocess.SubprocessError, FileNotFoundError):
+        return None
+
+    if result.returncode != 0:
+        # gh missing, not authed, or no actions:read scope. Keep silent;
+        # `gh` health is already covered by the Cloud providers section.
+        return None
+
+    secrets = {line.strip() for line in result.stdout.splitlines() if line.strip()}
+    if "RELEASE_BOT_TOKEN" in secrets:
+        return {
+            "RELEASE_BOT_TOKEN": {
+                "ok": True,
+                "version": "configured",
+                "note": (
+                    "auto-release.yml will use this for tag pushes; "
+                    "downstream release.yml fires on its own."
+                ),
+            }
+        }
+
+    # Missing — produce a doctor entry whose `note` is the actual fix
+    # recipe so the user doesn't need to context-switch into docs.
+    return {
+        "RELEASE_BOT_TOKEN": {
+            "ok": False,
+            "version": "missing",
+            "note": (
+                "Auto-release will fall back to GITHUB_TOKEN; tag pushes "
+                "won't trigger release.yml. Fix: github.com → Settings → "
+                "Developer settings → Personal access tokens → Fine-grained "
+                "tokens → Generate. Repo access: only " + repo.slug
+                + ". Permission: Contents=Read and write. Then "
+                f"github.com/{repo.slug}/settings/secrets/actions → New "
+                "repository secret named RELEASE_BOT_TOKEN. See RELEASING.md "
+                "for the full walkthrough."
+            ),
+        }
+    }
 
 
 def _check_governance_drift(config: Config) -> dict[str, Any] | None:
@@ -1697,6 +1773,21 @@ def pr(
         sys.exit(2)
 
     python = shutil.which("python3") or "python3"
+
+    # Best-effort heads-up if the auto-release chain isn't wired up. We
+    # don't block the PR — the gate scripts and the merge are unaffected
+    # — but warning here is the cheapest way to surface the trap *before*
+    # the user wonders why no GitHub Release appeared on merge. Run
+    # `shipyard doctor` for the same check + the fix recipe.
+    token_section = _check_release_bot_token()
+    if token_section and not token_section.get("RELEASE_BOT_TOKEN", {}).get("ok", True):
+        click.secho(
+            "▸ Heads-up: RELEASE_BOT_TOKEN secret is missing on this repo.\n"
+            "         Auto-release will tag but the binary release workflow won't fire.\n"
+            "         See `shipyard doctor` for the one-time setup steps.",
+            fg="yellow",
+            err=True,
+        )
 
     click.echo("▸ Skill-sync check")
     rc = subprocess.call(


### PR DESCRIPTION
## Why

Without \`RELEASE_BOT_TOKEN\`, auto-release degrades silently. Tags get pushed (via fallback to \`GITHUB_TOKEN\`), but GitHub Actions deliberately doesn't trigger workflows on \`GITHUB_TOKEN\`-pushed tags (anti-infinite-loop safety), so \`release.yml\` never fires and no binaries ship. We hit this on pulp's first auto-released tag (\`v0.4.0\`) — ~30 min wasted figuring it out.

## What

Three nudges so the next person doesn't repeat that:

1. **\`shipyard doctor\`** gains a "Release pipeline" section. Probes the active repo's secrets via \`gh api repos/<slug>/actions/secrets\`. Reports \`configured\` or \`missing\` with the exact 8-step fix recipe inline. Skipped silently when the repo can't be detected, \`gh\` isn't authenticated, or \`actions:read\` isn't granted — no false alarms. Informational only — doesn't affect doctor's overall \`ready=true\` rollup.
2. **\`shipyard pr\`** prints a one-line yellow heads-up before the PR opens if the secret is missing. Doesn't block.
3. **\`RELEASING.md\`** gets a dedicated "One-time setup: \`RELEASE_BOT_TOKEN\` secret" section with the same 8-step PAT walkthrough plus the manual fallback (\`gh workflow run release.yml --ref v<x.y.z>\`) for users who can't or don't want to set the secret.
4. **\`skills/ci/SKILL.md\`** points at doctor + RELEASING for the setup.

## Test plan

- [x] \`uv run shipyard doctor\` runs against this repo and shows \`RELEASE_BOT_TOKEN\` row (Shipyard repo doesn't have it set yet, so it'll show "missing" — that's the correct signal).
- [ ] CI: version-skill-check + build matrix + pytest.

## Mirror PR

Same fixes ported to pulp: TBD link.