### PR TITLE
commands: add /pr slash command; route through shipyard pr

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "shipyard",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Cross-platform CI coordination",
   "commands": "./commands",
   "agents": "./agents",

--- a/commands/pr.md
+++ b/commands/pr.md
@@ -1,0 +1,35 @@
+---
+name: pr
+description: One-shot push-a-PR — skill-sync gate, version-bump apply, commit, then hand off to `shipyard ship`. The canonical way to ship a branch when you want the versioning gates to run.
+---
+
+Run `shipyard pr` to orchestrate the full push-a-PR flow:
+
+1. `scripts/skill_sync_check.py --mode=report` — hard-fails if a mapped path was touched without updating the corresponding `SKILL.md` (or without a `Skill-Update: skip skill=<name> reason="..."` trailer on a commit in the PR range).
+2. `scripts/version_bump_check.py --mode=apply` — rewrites `pyproject.toml`, `src/shipyard/__init__.py`, and `.claude-plugin/plugin.json` for any surface whose code moved. `--no-apply-bumps` switches to report mode so missing bumps hard-fail instead of auto-applying.
+3. `git commit` — single `chore: bump versions` commit using `--only` to pick up exactly the files the bump script touched (pre-staged files the user had in progress for other reasons stay in the index).
+4. Hands off to `shipyard ship` for push + `gh pr create` + cross-platform validate + merge on green.
+
+On merge, `.github/workflows/auto-release.yml` detects the `pyproject.toml` version move and creates a `v<x.y.z>` tag. The existing tag-triggered `release.yml` then builds + publishes the binaries.
+
+Do NOT run `gh pr create` + `shipyard ship` separately. Do NOT run the skill-sync or version-bump scripts by hand — `shipyard pr` invokes them in the right order with the right flags.
+
+```bash
+shipyard pr $ARGUMENTS
+```
+
+## Flags
+
+- `--base <ref>` — base branch to ship into (default `main`).
+- `--apply-bumps` / `--no-apply-bumps` — default is apply. `--no-apply-bumps` switches to report mode so the command refuses rather than auto-rewriting.
+- `--allow-unreachable-targets` — forwarded to `shipyard ship`.
+
+## Bypass trailers (tip commit, never PR body)
+
+| Gate          | Trailer                                                      |
+|---------------|--------------------------------------------------------------|
+| Version bump  | `Version-Bump: <surface>=<patch\|minor\|major\|skip> reason="..."` |
+| Skill update  | `Skill-Update: skip skill=<name> reason="..."`              |
+| Auto-release  | `Release: skip reason="..."`                                 |
+
+Run `shipyard doctor` first if the repo lacks a `RELEASE_BOT_TOKEN` secret — the release workflow chain won't fire on tag push until the secret is configured. `shipyard pr` prints a yellow heads-up when the secret is missing.

--- a/skills/ci/SKILL.md
+++ b/skills/ci/SKILL.md
@@ -85,7 +85,7 @@ and use `shipyard status --json` for live target state.
 
 ## Shipping a PR (the `shipyard pr` path)
 
-When the user says "push a PR", "ship this", "ship it", "we're done", "merge this", or "push it" — run the PR orchestration path (currently `shipyard ship` with the versioning gates; a dedicated `shipyard pr` wrapper is planned to match pulp's `pulp pr`).
+When the user says "push a PR", "ship this", "ship it", "we're done", "merge this", or "push it" — run `shipyard pr` (or the `/pr` slash command — see `commands/pr.md`). It wraps `shipyard ship` with the versioning gates: skill-sync check, version-bump apply, and a `chore: bump versions` commit before handing off to the push/PR/validate/merge flow.
 
 The orchestration, in order:
 

--- a/src/shipyard/cli.py
+++ b/src/shipyard/cli.py
@@ -426,9 +426,15 @@ def _check_release_bot_token() -> dict[str, Any] | None:
 
     Returns None when the repo can't be detected or `gh` can't read the
     secret list (no auth, missing scope) — silent skip rather than
-    blocking the rest of doctor. When the secret is present, returns ok=True
-    with a short note. When it's missing, returns ok=False with the exact
-    setup pointer so the user has zero ambiguity about what to do.
+    blocking the rest of doctor. When the secret is present, returns ok=True.
+    When it's missing, returns ok=False with the full setup pointer so the
+    user has zero ambiguity about what to do.
+
+    Uses `--paginate` so repos with many secrets (>30, the default page
+    size) don't produce a false `missing` when RELEASE_BOT_TOKEN is on a
+    later page. The setup recipe lives in `detail` — not `note` — because
+    `render_doctor()` in output/human.py prints detail/version/error but
+    silently drops `note`. Codex P2 on #39.
     """
     repo = detect_repo_from_remote()
     if repo is None:
@@ -437,10 +443,11 @@ def _check_release_bot_token() -> dict[str, Any] | None:
     try:
         result = subprocess.run(
             ["gh", "api", f"repos/{repo.slug}/actions/secrets",
+             "--paginate",
              "--jq", ".secrets[].name"],
             capture_output=True,
             text=True,
-            timeout=10,
+            timeout=15,
         )
     except (subprocess.SubprocessError, FileNotFoundError):
         return None
@@ -448,6 +455,8 @@ def _check_release_bot_token() -> dict[str, Any] | None:
     if result.returncode != 0:
         # gh missing, not authed, or no actions:read scope. Keep silent;
         # `gh` health is already covered by the Cloud providers section.
+        # A genuinely empty (zero-secret) repo still returns 0 with empty
+        # stdout — that IS the bootstrap case we want to flag, not skip.
         return None
 
     secrets = {line.strip() for line in result.stdout.splitlines() if line.strip()}
@@ -456,28 +465,25 @@ def _check_release_bot_token() -> dict[str, Any] | None:
             "RELEASE_BOT_TOKEN": {
                 "ok": True,
                 "version": "configured",
-                "note": (
+                "detail": (
                     "auto-release.yml will use this for tag pushes; "
                     "downstream release.yml fires on its own."
                 ),
             }
         }
 
-    # Missing — produce a doctor entry whose `note` is the actual fix
-    # recipe so the user doesn't need to context-switch into docs.
     return {
         "RELEASE_BOT_TOKEN": {
             "ok": False,
             "version": "missing",
-            "note": (
-                "Auto-release will fall back to GITHUB_TOKEN; tag pushes "
-                "won't trigger release.yml. Fix: github.com → Settings → "
-                "Developer settings → Personal access tokens → Fine-grained "
-                "tokens → Generate. Repo access: only " + repo.slug
-                + ". Permission: Contents=Read and write. Then "
-                f"github.com/{repo.slug}/settings/secrets/actions → New "
-                "repository secret named RELEASE_BOT_TOKEN. See RELEASING.md "
-                "for the full walkthrough."
+            "detail": (
+                f"Auto-release will fall back to GITHUB_TOKEN; tag pushes won't "
+                f"trigger release.yml. Fix: github.com → Settings → Developer "
+                f"settings → Personal access tokens → Fine-grained tokens → "
+                f"Generate. Repo access: only {repo.slug}. Permission: "
+                f"Contents=Read and write. Then github.com/{repo.slug}/settings/"
+                f"secrets/actions → New repository secret named RELEASE_BOT_TOKEN. "
+                f"See RELEASING.md for the full walkthrough."
             ),
         }
     }


### PR DESCRIPTION
Shipyard CLI has `shipyard pr` but there was no matching `/pr` slash command, so agents saying `/pr` got command-not-found. Added `commands/pr.md` alongside the existing `commands/ship.md`. The `ci` skill's "Shipping a PR" section now points at both the CLI and the slash command, and drops the stale 'a dedicated shipyard pr wrapper is planned' language (it shipped in PR #37).

## Test plan
- [ ] CI: version-skill-check + build matrix + pytest.
