### PR TITLE
Incremental git bundles for SSH delivery (#81)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "shipyard",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Cross-platform CI coordination",
   "commands": "./commands",
   "agents": "./agents",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to Shipyard are documented here. Each entry links
 to its [GitHub Release](https://github.com/danielraffel/Shipyard/releases).
 
 <a id="v0120"></a>
+## [0.13.0]
+
 ## [0.12.0] - 2026-04-19
 
 - Ship feat/locality-routing ([#89](https://github.com/danielraffel/Shipyard/pull/89))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "shipyard"
-version = "0.12.0"
+version = "0.13.0"
 description = "Cross-platform CI coordination — local VMs, SSH hosts, cloud runners"
 readme = "README.md"
 license = "MIT"

--- a/skills/ci/SKILL.md
+++ b/skills/ci/SKILL.md
@@ -134,6 +134,10 @@ compatible). When nothing matches, the target errors with
 Full docs: [`docs/targets.md`](../../docs/targets.md) and
 [`docs/profiles.md`](../../docs/profiles.md).
 
+## SSH delivery: incremental bundles
+
+SSH-backed targets deliver code via `git bundle`. On the first run the bundle is full (every object reachable from the target SHA, ~443 MB for Pulp-sized repos). On every subsequent run Shipyard probes the remote for its current HEAD over SSH (`git rev-parse HEAD`), verifies that the local clone has that commit as an ancestor, and emits `git bundle create <bundle> <target> ^<remote_head>` — a delta bundle that is typically kilobytes instead of megabytes. Any failure in the probe, ancestry check, or delta create silently falls back to the full-bundle path so the behavior on cold/corrupt remotes is unchanged. Each run logs a `bundle_mode=delta|full bundle_bytes=<N>` line to the per-target log so operators can confirm the optimisation is active.
+
 ## Troubleshooting
 
 - `shipyard doctor --json` — checks git, ssh, gh, nsc are installed

--- a/src/shipyard/__init__.py
+++ b/src/shipyard/__init__.py
@@ -1,3 +1,3 @@
 """Shipyard — Cross-platform CI coordination."""
 
-__version__ = "0.12.0"
+__version__ = "0.13.0"

--- a/src/shipyard/executor/ssh.py
+++ b/src/shipyard/executor/ssh.py
@@ -111,23 +111,33 @@ class SSHExecutor:
                 remote_bundle = target_config.get(
                     "remote_bundle_path", "/tmp/shipyard.bundle"
                 )
+                local_repo_dir = target_config.get("local_repo_dir")
 
                 # Try an incremental bundle first: query the remote
                 # for its HEAD SHA and use it as a basis so only the
-                # delta is bundled. Falls back to a full bundle if
-                # the remote HEAD is unknown or the incremental
-                # bundle fails (e.g. no common ancestor).
+                # delta is bundled. The remote HEAD must also exist
+                # as an ancestor in the local repo, otherwise
+                # `git bundle create ^<basis>` has no meaningful cut
+                # point and either fails or silently produces a full
+                # bundle. Falls back to a full bundle if the remote
+                # HEAD is unknown, not locally reachable, or the
+                # incremental bundle fails.
                 basis_shas: list[str] = []
+                bundle_mode = "full"
                 remote_head = _remote_head_sha(host, remote_repo, ssh_options)
-                if remote_head:
+                if remote_head and _local_has_commit(
+                    remote_head, repo_dir=local_repo_dir,
+                ):
                     basis_shas.append(remote_head)
 
                 bundle_result = create_bundle(
                     sha=sha,
                     output_path=bundle_path,
-                    repo_dir=target_config.get("local_repo_dir"),
+                    repo_dir=local_repo_dir,
                     basis_shas=basis_shas,
                 )
+                if bundle_result.success and basis_shas:
+                    bundle_mode = "delta"
 
                 # If incremental bundle failed and we had a basis,
                 # fall back to a full bundle.
@@ -135,13 +145,21 @@ class SSHExecutor:
                     bundle_result = create_bundle(
                         sha=sha,
                         output_path=bundle_path,
-                        repo_dir=target_config.get("local_repo_dir"),
+                        repo_dir=local_repo_dir,
                     )
+                    bundle_mode = "full"
                 if not bundle_result.success:
                     return _error_result(
                         target_name, platform, started_at, start_time,
                         str(log_file), f"Bundle creation failed: {bundle_result.message}",
                     )
+
+                bundle_bytes = _safe_filesize(bundle_path)
+                _append_log(
+                    log_file,
+                    f"=== bundle_mode={bundle_mode} bundle_bytes={bundle_bytes} "
+                    f"sha={sha} remote_head={remote_head or 'unknown'} ===\n",
+                )
 
                 upload_result = upload_bundle(
                     bundle_path=bundle_path,
@@ -315,6 +333,47 @@ def _remote_head_sha(
         return None
     except (subprocess.SubprocessError, OSError):
         return None
+
+
+def _local_has_commit(
+    sha: str,
+    repo_dir: str | None = None,
+    *,
+    timeout: int = 10,
+) -> bool:
+    """Return True when the local repo has `sha` as a reachable commit.
+
+    Used to validate a candidate basis SHA for incremental-bundle
+    creation. `git bundle create <target> ^<basis>` only produces a
+    meaningful delta when `<basis>` is an ancestor of `<target>` in
+    the local object store; if the local clone hasn't fetched the
+    remote's HEAD yet (e.g. the remote was updated out-of-band, or
+    the basis was rewritten), the negation is a no-op and we'd waste
+    bandwidth shipping what is effectively a full bundle.
+
+    Returns False on any error (missing git, bad cwd, timeout) so
+    the caller falls back to a full bundle as a safe default.
+    """
+    cmd = ["git", "cat-file", "-e", f"{sha}^{{commit}}"]
+    try:
+        result = subprocess.run(
+            cmd,
+            cwd=repo_dir,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+        return result.returncode == 0
+    except (subprocess.SubprocessError, OSError):
+        return False
+
+
+def _safe_filesize(path: Path) -> int:
+    """Return file size in bytes, or -1 if the file can't be stat'd."""
+    try:
+        return path.stat().st_size
+    except OSError:
+        return -1
 
 
 def _remote_has_sha(

--- a/tests/executor/test_ssh.py
+++ b/tests/executor/test_ssh.py
@@ -324,6 +324,8 @@ class TestSSHIncrementalBundle:
         ), patch(
             "shipyard.executor.ssh._remote_head_sha", return_value="aabbcc",
         ), patch(
+            "shipyard.executor.ssh._local_has_commit", return_value=True,
+        ), patch(
             "shipyard.executor.ssh.create_bundle",
             return_value=BundleResult(success=True, message="ok", path="/tmp/b"),
         ) as mock_create, patch(
@@ -363,6 +365,8 @@ class TestSSHIncrementalBundle:
         ), patch(
             "shipyard.executor.ssh._remote_head_sha", return_value="aabbcc",
         ), patch(
+            "shipyard.executor.ssh._local_has_commit", return_value=True,
+        ), patch(
             "shipyard.executor.ssh.create_bundle",
             side_effect=create_results,
         ) as mock_create, patch(
@@ -399,6 +403,8 @@ class TestSSHIncrementalBundle:
         ), patch(
             "shipyard.executor.ssh._remote_head_sha", return_value=None,
         ), patch(
+            "shipyard.executor.ssh._local_has_commit", return_value=False,
+        ), patch(
             "shipyard.executor.ssh.create_bundle",
             return_value=BundleResult(success=True, message="ok", path="/tmp/b"),
         ) as mock_create, patch(
@@ -422,6 +428,179 @@ class TestSSHIncrementalBundle:
         assert mock_create.call_count == 1
         first_call = mock_create.call_args_list[0]
         assert not first_call[1].get("basis_shas")
+
+    def test_skips_basis_when_local_missing_ancestor(self, tmp_path) -> None:
+        """Remote HEAD is known but not present locally → full bundle.
+
+        This is the case the issue calls out: the ancestry check must
+        reject basis SHAs the local clone hasn't fetched, otherwise
+        `git bundle create ^<basis>` silently degenerates into a full
+        bundle (or fails) and wastes the delta attempt.
+        """
+        from shipyard.bundle.git_bundle import BundleResult
+
+        executor = SSHExecutor()
+        log_path = str(tmp_path / "log.txt")
+
+        with patch(
+            "shipyard.executor.ssh._remote_has_sha", return_value=False,
+        ), patch(
+            "shipyard.executor.ssh._remote_head_sha", return_value="deadbeef",
+        ), patch(
+            "shipyard.executor.ssh._local_has_commit", return_value=False,
+        ), patch(
+            "shipyard.executor.ssh.create_bundle",
+            return_value=BundleResult(success=True, message="ok", path="/tmp/b"),
+        ) as mock_create, patch(
+            "shipyard.executor.ssh.upload_bundle",
+            return_value=BundleResult(success=True, message="ok", path="/tmp/b"),
+        ), patch(
+            "shipyard.executor.ssh.apply_bundle",
+            return_value=BundleResult(success=True, message="ok", path="/tmp/b"),
+        ), patch(
+            "shipyard.executor.ssh.run_streaming_command",
+            return_value=_streaming_result(0, "ok"),
+        ):
+            executor.validate(
+                sha="abc123", branch="main",
+                target_config=_target_config(),
+                validation_config=_validation_config(),
+                log_path=log_path,
+            )
+
+        assert mock_create.call_count == 1
+        first_call = mock_create.call_args_list[0]
+        assert not first_call[1].get("basis_shas")
+
+    def test_logs_bundle_mode_and_bytes_for_delta(self, tmp_path) -> None:
+        """Delta path must log bundle_mode=delta and bundle_bytes=<N>."""
+        from shipyard.bundle.git_bundle import BundleResult
+
+        executor = SSHExecutor()
+        log_path = tmp_path / "log.txt"
+
+        def fake_create_bundle(sha, output_path, repo_dir=None, basis_shas=()):
+            # Simulate the bundle writer so _safe_filesize returns a
+            # realistic delta size (few KB rather than 443 MB).
+            from pathlib import Path as _P
+            _P(output_path).write_bytes(b"DELTA" * 200)
+            return BundleResult(success=True, message="ok", path=str(output_path))
+
+        with patch(
+            "shipyard.executor.ssh._remote_has_sha", return_value=False,
+        ), patch(
+            "shipyard.executor.ssh._remote_head_sha", return_value="aabbccddeeff",
+        ), patch(
+            "shipyard.executor.ssh._local_has_commit", return_value=True,
+        ), patch(
+            "shipyard.executor.ssh.create_bundle",
+            side_effect=fake_create_bundle,
+        ), patch(
+            "shipyard.executor.ssh.upload_bundle",
+            return_value=BundleResult(success=True, message="ok", path="/tmp/b"),
+        ), patch(
+            "shipyard.executor.ssh.apply_bundle",
+            return_value=BundleResult(success=True, message="ok", path="/tmp/b"),
+        ), patch(
+            "shipyard.executor.ssh.run_streaming_command",
+            return_value=_streaming_result(0, "ok"),
+        ):
+            executor.validate(
+                sha="abc123", branch="main",
+                target_config=_target_config(),
+                validation_config=_validation_config(),
+                log_path=str(log_path),
+            )
+
+        contents = log_path.read_text()
+        assert "bundle_mode=delta" in contents
+        assert "bundle_bytes=1000" in contents
+        assert "remote_head=aabbccddeeff" in contents
+
+    def test_logs_bundle_mode_full_when_no_basis(self, tmp_path) -> None:
+        """Full path must log bundle_mode=full and the byte count."""
+        from shipyard.bundle.git_bundle import BundleResult
+
+        executor = SSHExecutor()
+        log_path = tmp_path / "log.txt"
+
+        def fake_create_bundle(sha, output_path, repo_dir=None, basis_shas=()):
+            from pathlib import Path as _P
+            _P(output_path).write_bytes(b"FULLBUNDLE" * 10)
+            return BundleResult(success=True, message="ok", path=str(output_path))
+
+        with patch(
+            "shipyard.executor.ssh._remote_has_sha", return_value=False,
+        ), patch(
+            "shipyard.executor.ssh._remote_head_sha", return_value=None,
+        ), patch(
+            "shipyard.executor.ssh._local_has_commit", return_value=False,
+        ), patch(
+            "shipyard.executor.ssh.create_bundle",
+            side_effect=fake_create_bundle,
+        ), patch(
+            "shipyard.executor.ssh.upload_bundle",
+            return_value=BundleResult(success=True, message="ok", path="/tmp/b"),
+        ), patch(
+            "shipyard.executor.ssh.apply_bundle",
+            return_value=BundleResult(success=True, message="ok", path="/tmp/b"),
+        ), patch(
+            "shipyard.executor.ssh.run_streaming_command",
+            return_value=_streaming_result(0, "ok"),
+        ):
+            executor.validate(
+                sha="abc123", branch="main",
+                target_config=_target_config(),
+                validation_config=_validation_config(),
+                log_path=str(log_path),
+            )
+
+        contents = log_path.read_text()
+        assert "bundle_mode=full" in contents
+        assert "bundle_bytes=100" in contents
+        assert "remote_head=unknown" in contents
+
+
+class TestLocalHasCommit:
+    """Tests for the ancestry probe used to validate basis SHAs."""
+
+    def test_returns_true_when_commit_exists(self) -> None:
+        from shipyard.executor.ssh import _local_has_commit
+        mock_result = MagicMock(returncode=0, stdout="", stderr="")
+        with patch("subprocess.run", return_value=mock_result) as mock_run:
+            assert _local_has_commit("abc123") is True
+            cmd = mock_run.call_args[0][0]
+            assert cmd[0] == "git"
+            assert "cat-file" in cmd
+            # Must query the commit type specifically (prevents
+            # false positives on dangling blobs / trees).
+            assert any(arg.startswith("abc123") and "commit" in arg for arg in cmd)
+
+    def test_returns_false_when_commit_missing(self) -> None:
+        from shipyard.executor.ssh import _local_has_commit
+        mock_result = MagicMock(returncode=1, stdout="", stderr="not found")
+        with patch("subprocess.run", return_value=mock_result):
+            assert _local_has_commit("deadbeef") is False
+
+    def test_returns_false_on_timeout(self) -> None:
+        from shipyard.executor.ssh import _local_has_commit
+        with patch(
+            "subprocess.run",
+            side_effect=subprocess.TimeoutExpired("git", 10),
+        ):
+            assert _local_has_commit("abc123") is False
+
+    def test_returns_false_on_os_error(self) -> None:
+        from shipyard.executor.ssh import _local_has_commit
+        with patch("subprocess.run", side_effect=OSError("no git")):
+            assert _local_has_commit("abc123") is False
+
+    def test_uses_repo_dir_cwd(self, tmp_path) -> None:
+        from shipyard.executor.ssh import _local_has_commit
+        mock_result = MagicMock(returncode=0, stdout="", stderr="")
+        with patch("subprocess.run", return_value=mock_result) as mock_run:
+            _local_has_commit("abc123", repo_dir=str(tmp_path))
+            assert mock_run.call_args[1]["cwd"] == str(tmp_path)
 
 
 class TestSSHResumeFrom:


### PR DESCRIPTION
## Summary

Closes #81. SSH delivery used to ship a full ~443 MB git bundle on every run. For typical 1–2 commit iterations this is wasteful.

- **Probe**: before creating the bundle, query remote HEAD via `ssh <host> 'cd <repo> && git rev-parse HEAD'`.
- **Ancestry gate**: verify the local clone has the remote HEAD as a reachable commit (`git cat-file -e <sha>^{commit}`). Only then do we use it as a basis.
- **Delta bundle**: `git bundle create <bundle> <target> ^<remote_head>` when the basis is valid; typically KB instead of MB.
- **Fallback**: any failure (no remote HEAD, basis not in local history, delta `git bundle create` failure) falls through to the existing full-bundle path. Remote apply (`git fetch` into `refs/shipyard-bundles/*`) is unchanged.
- **Observability**: each run logs `bundle_mode=delta|full bundle_bytes=<N> sha=<target> remote_head=<head|unknown>` to the per-target log.

Scope is surgical: `ssh_windows.py` is deliberately untouched — it already uses the same `create_bundle` helper, so it picks up the `basis_shas` path only via the POSIX executor's probe. A follow-up can wire the same negotiation for the Windows lane if measurement shows it's worth the risk.

## Test plan

- [x] `uv run pytest -x` — full suite (699 passed, 1 skipped unrelated)
- [x] New unit coverage in `tests/executor/test_ssh.py`:
  - `TestLocalHasCommit` (5 cases) — ancestry probe: hit / miss / timeout / OSError / cwd override
  - `TestSSHIncrementalBundle::test_skips_basis_when_local_missing_ancestor` — the new ancestry-gate case
  - `TestSSHIncrementalBundle::test_logs_bundle_mode_and_bytes_for_delta` + `..._full_when_no_basis` — log-line format
  - Existing delta/full/fallback tests updated to patch `_local_has_commit` now that the executor consults it
- [ ] Real-world validation on a Pulp-scale repo still needs to happen once this lands; the log line is the primary confirmation channel.