### PR TITLE
feat: failure classification + flaky-target quarantine (closes #83)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "shipyard",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Cross-platform CI coordination",
   "commands": "./commands",
   "agents": "./agents",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "shipyard",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Cross-platform CI coordination",
   "commands": "./commands",
   "agents": "./agents",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to Shipyard are documented here. Each entry links
 to its [GitHub Release](https://github.com/danielraffel/Shipyard/releases).
 
 <a id="v0140"></a>
+## [0.15.0]
+
 ## [0.14.0] - 2026-04-19
 
 - Mid-flight lane add: shipyard cloud add-lane (#86) ([#90](https://github.com/danielraffel/Shipyard/pull/90))

--- a/commands/quarantine.md
+++ b/commands/quarantine.md
@@ -1,0 +1,28 @@
+---
+name: quarantine
+description: Manage the flaky-target quarantine list (.shipyard/quarantine.toml)
+---
+
+Shipyard's quarantine list lets maintainers mark known-flaky targets so a TEST/UNKNOWN failure on that target during `shipyard ship` doesn't block the merge.
+
+**What quarantine does:**
+- TEST or UNKNOWN failure on a quarantined target → treated as advisory (logged, not merge-blocking).
+- INFRA / TIMEOUT / CONTRACT failures are *always* authoritative — quarantine never suppresses them.
+- Lives in `.shipyard/quarantine.toml` and is opt-in per repo.
+
+**Usage:**
+
+```bash
+# List quarantined targets
+shipyard quarantine list --json
+
+# Add a target (record a reason — reviewers will see it)
+shipyard quarantine add windows-arm64 --reason "flaky runner apr-2026 outage"
+
+# Remove once the underlying flakiness is fixed
+shipyard quarantine remove windows-arm64
+```
+
+The merge check in `shipyard ship` / `shipyard auto-merge` reads this file automatically. A failing target will surface under `advisory` in the merge check JSON instead of `failing`.
+
+If a target should block the merge regardless of failure class, remove it from quarantine.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "shipyard"
-version = "0.13.0"
+version = "0.14.0"
 description = "Cross-platform CI coordination — local VMs, SSH hosts, cloud runners"
 readme = "README.md"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "shipyard"
-version = "0.14.0"
+version = "0.15.0"
 description = "Cross-platform CI coordination — local VMs, SSH hosts, cloud runners"
 readme = "README.md"
 license = "MIT"

--- a/skills/ci/SKILL.md
+++ b/skills/ci/SKILL.md
@@ -48,6 +48,9 @@ Shipyard coordinates validation across local, SSH, and cloud targets.
 | Inspect tracked cloud runs | `shipyard cloud status --json` |
 | Environment check | `shipyard doctor --json` |
 | Clean up artifacts | `shipyard cleanup --apply` |
+| List quarantined targets | `shipyard quarantine list --json` |
+| Quarantine a flaky target | `shipyard quarantine add <target> --reason "..."` |
+| Remove from quarantine | `shipyard quarantine remove <target>` |
 
 ## When to use `watch` (agent decision guide)
 
@@ -181,6 +184,35 @@ Full docs: [`docs/targets.md`](../../docs/targets.md) and
 ## SSH delivery: incremental bundles
 
 SSH-backed targets deliver code via `git bundle`. On the first run the bundle is full (every object reachable from the target SHA, ~443 MB for Pulp-sized repos). On every subsequent run Shipyard probes the remote for its current HEAD over SSH (`git rev-parse HEAD`), verifies that the local clone has that commit as an ancestor, and emits `git bundle create <bundle> <target> ^<remote_head>` — a delta bundle that is typically kilobytes instead of megabytes. Any failure in the probe, ancestry check, or delta create silently falls back to the full-bundle path so the behavior on cold/corrupt remotes is unchanged. Each run logs a `bundle_mode=delta|full bundle_bytes=<N>` line to the per-target log so operators can confirm the optimisation is active.
+
+## Failure classification
+
+Every non-passing `TargetResult` and `EvidenceRecord` carries a `failure_class` (visible in `shipyard run --json`, `shipyard evidence --json`, and `shipyard watch --json`):
+
+| Class | Meaning | Retry policy |
+|-------|---------|--------------|
+| `INFRA` | Network/SSH/runner availability problem (`Connection refused`, `ssh: connect`, `Network is unreachable`, `RUN_IN_DAYS_DEAD`, etc.) | Auto-retry on the next backend in the fallback chain |
+| `TIMEOUT` | Hit the wall-clock cap | Auto-retry once |
+| `CONTRACT` | `[validation.contract]` marker missing | Never retry — product bug |
+| `TEST` | Non-zero exit with no infra/contract markers | Never retry — authoritative test failure |
+| `UNKNOWN` | Fallback when the heuristics can't decide | Surfaced to the agent; not auto-retried |
+
+Agents should read `failure_class` before deciding whether to retry, escalate, or surface to a human.
+
+## Flaky-target quarantine
+
+`.shipyard/quarantine.toml` is an opt-in list of targets whose `TEST` or `UNKNOWN` failures should be treated as advisory during the merge decision. `INFRA`, `TIMEOUT`, and `CONTRACT` failures are *never* suppressed — quarantine only hides authentic test flakiness, not infrastructure or contract bugs.
+
+```toml
+[[quarantine]]
+target = "windows-arm64"
+reason = "flaky Windows runner apr-2026 outage"
+added_at = "2026-04-18"
+```
+
+Manage via `shipyard quarantine {list,add,remove}` (see table above). The merge check surfaces quarantined failures in the `advisory` field of the JSON payload; reviewers still see them but the merge is not blocked.
+
+Remove a target from quarantine the moment the underlying flakiness is fixed — the list is meant to be short-lived.
 
 ## Troubleshooting
 

--- a/src/shipyard/__init__.py
+++ b/src/shipyard/__init__.py
@@ -1,3 +1,3 @@
 """Shipyard — Cross-platform CI coordination."""
 
-__version__ = "0.13.0"
+__version__ = "0.14.0"

--- a/src/shipyard/__init__.py
+++ b/src/shipyard/__init__.py
@@ -1,3 +1,3 @@
 """Shipyard — Cross-platform CI coordination."""
 
-__version__ = "0.14.0"
+__version__ = "0.15.0"

--- a/src/shipyard/cli.py
+++ b/src/shipyard/cli.py
@@ -3721,6 +3721,7 @@ def _record_evidence(ctx: Context, job: Job) -> None:
                 failover_reason=result.failover_reason,
                 provider=result.provider,
                 runner_profile=result.runner_profile,
+                failure_class=result.failure_class,
             ))
 
 
@@ -4384,6 +4385,120 @@ def config_use(ctx: Context, profile_name: str) -> None:
             f"Switched to profile '{profile_name}' in {config_path}",
             style="green",
         )
+
+
+# ── quarantine (flaky targets) ──────────────────────────────────────
+
+
+@main.group(name="quarantine", invoke_without_command=True)
+@click.pass_context
+def quarantine_group(ctx: click.Context) -> None:
+    """Manage the flaky-target quarantine list.
+
+    Targets listed in ``.shipyard/quarantine.toml`` whose failure class
+    is TEST or UNKNOWN are treated as advisory during the merge
+    decision — they don't block ``shipyard ship`` / ``auto-merge``.
+    INFRA / TIMEOUT / CONTRACT failures are still authoritative.
+
+    With no subcommand, lists the quarantined targets.
+    """
+    if ctx.invoked_subcommand is None:
+        ctx.invoke(quarantine_list)
+
+
+def _quarantine_path_or_exit(ctx: Context) -> Path:
+    if ctx.config.project_dir is None:
+        render_error("No .shipyard/ directory found. Run `shipyard init` first.")
+        sys.exit(1)
+    from shipyard.core.quarantine import QUARANTINE_FILENAME
+    return ctx.config.project_dir / QUARANTINE_FILENAME
+
+
+@quarantine_group.command("list")
+@click.pass_obj
+def quarantine_list(ctx: Context) -> None:
+    """List quarantined targets."""
+    from shipyard.core.quarantine import QuarantineList
+
+    q = QuarantineList.load_from_project(ctx.config.project_dir)
+    if ctx.json_mode:
+        ctx.output("quarantine.list", q.to_dict())
+        return
+    if not q.entries:
+        render_message(
+            "No quarantined targets. "
+            "(.shipyard/quarantine.toml is absent or empty.)",
+            style="dim",
+        )
+        return
+    console.print()
+    console.print("[bold]Quarantined targets[/]")
+    for entry in q.entries:
+        reason = f" — {entry.reason}" if entry.reason else ""
+        date_str = f" (added {entry.added_at})" if entry.added_at else ""
+        console.print(f"  {entry.target}{reason}{date_str}")
+    console.print()
+
+
+@quarantine_group.command("add")
+@click.argument("target")
+@click.option("--reason", default="", help="Free-form note (recommended).")
+@click.pass_obj
+def quarantine_add(ctx: Context, target: str, reason: str) -> None:
+    """Add a target to the quarantine list."""
+    from shipyard.core.quarantine import QuarantineList
+
+    path = _quarantine_path_or_exit(ctx)
+    q = QuarantineList.load(path)
+    q.path = path  # load() preserves path; defensive re-set
+    added = q.add(target, reason=reason)
+    if added:
+        q.save()
+    if ctx.json_mode:
+        ctx.output(
+            "quarantine.add",
+            {"target": target, "added": added, "path": str(path)},
+        )
+    else:
+        if added:
+            render_message(
+                f"Quarantined '{target}' — TEST/UNKNOWN failures on this "
+                f"target will be advisory.",
+                style="green",
+            )
+        else:
+            render_message(
+                f"'{target}' was already quarantined.", style="dim"
+            )
+
+
+@quarantine_group.command("remove")
+@click.argument("target")
+@click.pass_obj
+def quarantine_remove(ctx: Context, target: str) -> None:
+    """Remove a target from the quarantine list."""
+    from shipyard.core.quarantine import QuarantineList
+
+    path = _quarantine_path_or_exit(ctx)
+    q = QuarantineList.load(path)
+    q.path = path
+    removed = q.remove(target)
+    if removed:
+        q.save()
+    if ctx.json_mode:
+        ctx.output(
+            "quarantine.remove",
+            {"target": target, "removed": removed, "path": str(path)},
+        )
+    else:
+        if removed:
+            render_message(
+                f"Removed '{target}' from quarantine.", style="green"
+            )
+        else:
+            render_message(
+                f"'{target}' was not quarantined.", style="dim"
+            )
 
 
 # ── changelog / post-release docs sync ──────────────────────────────

--- a/src/shipyard/core/classify.py
+++ b/src/shipyard/core/classify.py
@@ -1,0 +1,118 @@
+"""Failure classification.
+
+Parse a target's failure into a coarse-grained class so agents and the
+ship layer can make retry / merge / escalation decisions without
+reading raw logs. Classification is a pure function — heuristics over
+the combined stdout / stderr, exit code, and two explicit booleans that
+the executor already knows:
+
+- ``wall_clock_exceeded`` — the executor hit its timeout budget
+- ``contract_violated`` — the validation contract (``[validation.contract]``)
+  was not satisfied
+
+The five classes:
+
+- ``CONTRACT`` — validation contract was not satisfied (wrong code path,
+  script bypassed). Never retryable.
+- ``TIMEOUT`` — process hit the wall-clock cap. Retryable once.
+- ``INFRA`` — network / SSH / runner availability problem. Retryable
+  once on the next backend in the chain.
+- ``TEST`` — non-zero exit, no infra markers, no contract violation.
+  Authoritative test failure; never retry.
+- ``UNKNOWN`` — fallback. Treated as ``TEST`` by the ship layer (don't
+  retry, don't merge) but surfaced separately so agents can flag it.
+
+Ordering matters: ``contract_violated`` and ``wall_clock_exceeded`` are
+checked first because an infra-error fingerprint in stderr plus a
+timeout should still be classified as ``TIMEOUT`` (the timeout is the
+proximate cause — infra markers may appear in the tail of output
+because the executor killed the process).
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+
+
+class FailureClass(str, Enum):
+    """Coarse-grained failure taxonomy.
+
+    Values are plain strings so the enum serializes cleanly in JSON.
+    """
+
+    INFRA = "INFRA"
+    TIMEOUT = "TIMEOUT"
+    CONTRACT = "CONTRACT"
+    TEST = "TEST"
+    UNKNOWN = "UNKNOWN"
+
+
+# Substrings whose presence in stderr indicates an infrastructure
+# problem rather than a test or product failure. Kept explicit (not
+# regex) so the list stays reviewable and agents can extend it via
+# project config without writing regex.
+_INFRA_MARKERS: tuple[str, ...] = (
+    "Connection refused",
+    "ssh: connect",
+    "Network is unreachable",
+    "Could not resolve host",
+    "RUN_IN_DAYS_DEAD",
+    "github runner offline",
+    # Common secondary fingerprints we've seen in production.
+    "No route to host",
+    "kex_exchange_identification",
+    "Connection reset by peer",
+    "Connection closed by remote host",
+    "Connection timed out",
+    "ssh_exchange_identification",
+)
+
+
+def classify_failure(
+    stdout: str,
+    stderr: str,
+    exit_code: int,
+    wall_clock_exceeded: bool = False,
+    contract_violated: bool = False,
+) -> FailureClass:
+    """Classify a failure into one of the five ``FailureClass`` values.
+
+    Only call this for non-success outcomes. A zero exit code with no
+    contract violation and no timeout is a PASS — the caller should
+    not be classifying it.
+
+    Heuristic precedence (first match wins):
+
+    1. ``contract_violated`` → ``CONTRACT``
+    2. ``wall_clock_exceeded`` → ``TIMEOUT``
+    3. Any ``_INFRA_MARKERS`` substring in stderr → ``INFRA``
+    4. Non-zero exit with no markers → ``TEST``
+    5. Fallback → ``UNKNOWN``
+    """
+    if contract_violated:
+        return FailureClass.CONTRACT
+
+    if wall_clock_exceeded:
+        return FailureClass.TIMEOUT
+
+    stderr_blob = stderr or ""
+    for marker in _INFRA_MARKERS:
+        if marker in stderr_blob:
+            return FailureClass.INFRA
+
+    if exit_code != 0:
+        return FailureClass.TEST
+
+    return FailureClass.UNKNOWN
+
+
+def is_retryable(failure_class: FailureClass) -> bool:
+    """Whether this failure class is worth retrying once.
+
+    Auto-retry lane, called by ``failover/retry.py`` and the ship layer:
+
+    - ``INFRA`` / ``TIMEOUT`` → retry (transient by nature)
+    - ``CONTRACT`` / ``TEST`` → no retry (authoritative)
+    - ``UNKNOWN`` → no retry (fail safe; surface to the agent)
+    """
+    return failure_class in (FailureClass.INFRA, FailureClass.TIMEOUT)

--- a/src/shipyard/core/evidence.py
+++ b/src/shipyard/core/evidence.py
@@ -33,6 +33,10 @@ class EvidenceRecord:
     failover_reason: str | None = None
     provider: str | None = None
     runner_profile: str | None = None
+    # Coarse-grained failure taxonomy when ``status == "fail"``. One of
+    # "INFRA" | "TIMEOUT" | "CONTRACT" | "TEST" | "UNKNOWN". None on a
+    # passing record. See ``shipyard.core.classify``.
+    failure_class: str | None = None
 
     @property
     def passed(self) -> bool:
@@ -48,7 +52,10 @@ class EvidenceRecord:
             "backend": self.backend,
             "completed_at": self.completed_at.isoformat(),
         }
-        for key in ("duration_secs", "host", "primary_backend", "failover_reason", "provider", "runner_profile"):
+        for key in (
+            "duration_secs", "host", "primary_backend", "failover_reason",
+            "provider", "runner_profile", "failure_class",
+        ):
             val = getattr(self, key)
             if val is not None:
                 d[key] = val
@@ -70,6 +77,7 @@ class EvidenceRecord:
             failover_reason=d.get("failover_reason"),
             provider=d.get("provider"),
             runner_profile=d.get("runner_profile"),
+            failure_class=d.get("failure_class"),
         )
 
 

--- a/src/shipyard/core/job.py
+++ b/src/shipyard/core/job.py
@@ -84,6 +84,12 @@ class TargetResult:
     contract_markers_seen: tuple[str, ...] = ()
     contract_markers_missing: tuple[str, ...] = ()
     contract_violation: str | None = None
+    # Coarse-grained failure taxonomy. Populated by the executor
+    # (or failover chain) whenever ``status`` is FAIL / ERROR /
+    # UNREACHABLE. Values: "INFRA" | "TIMEOUT" | "CONTRACT" | "TEST"
+    # | "UNKNOWN". None for PASS/PENDING/RUNNING results. See
+    # ``shipyard.core.classify`` for heuristics.
+    failure_class: str | None = None
 
     @property
     def passed(self) -> bool:
@@ -146,6 +152,8 @@ class TargetResult:
             d["contract_markers_missing"] = list(self.contract_markers_missing)
         if self.contract_violation:
             d["contract_violation"] = self.contract_violation
+        if self.failure_class:
+            d["failure_class"] = self.failure_class
         return d
 
 

--- a/src/shipyard/core/quarantine.py
+++ b/src/shipyard/core/quarantine.py
@@ -33,8 +33,10 @@ from __future__ import annotations
 import sys
 from dataclasses import dataclass, field
 from datetime import date
-from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 if sys.version_info >= (3, 11):
     import tomllib

--- a/src/shipyard/core/quarantine.py
+++ b/src/shipyard/core/quarantine.py
@@ -1,0 +1,166 @@
+"""Flaky-target quarantine list.
+
+When a target is listed in ``.shipyard/quarantine.toml`` and its failure
+class is TEST or UNKNOWN, the ship layer treats the failure as
+*advisory* — it records the failure but does not block the merge. This
+gives maintainers a decoupled way to say "we know this target is flaky,
+don't block the world on it" without having to delete the target or
+edit workflow code.
+
+Quarantine is deliberately narrow:
+
+- It only suppresses TEST / UNKNOWN failures. INFRA / TIMEOUT /
+  CONTRACT are still authoritative because they indicate real
+  fixable problems (unreachable host, wall-clock cap, bypassed
+  contract) that quarantine shouldn't paper over.
+- It's an opt-in file. The absence of a quarantine file is a no-op —
+  the ship layer behaves exactly as before.
+- Entries carry a free-form ``reason`` so code review sees why a target
+  was quarantined.
+
+File format (``.shipyard/quarantine.toml``)::
+
+    [[quarantine]]
+    target = "windows-arm64"
+    reason = "flaky Windows runner during Apr 2026 outage"
+    added_at = "2026-04-18"
+
+Add / remove / list is exposed via ``shipyard quarantine {add,remove,list}``.
+"""
+
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass, field
+from datetime import date
+from pathlib import Path
+from typing import Any
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:  # pragma: no cover
+    import tomli as tomllib
+
+import tomli_w
+
+QUARANTINE_FILENAME = "quarantine.toml"
+
+
+@dataclass(frozen=True)
+class QuarantineEntry:
+    """One quarantined target and why."""
+
+    target: str
+    reason: str = ""
+    added_at: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        d: dict[str, Any] = {"target": self.target}
+        if self.reason:
+            d["reason"] = self.reason
+        if self.added_at:
+            d["added_at"] = self.added_at
+        return d
+
+
+@dataclass
+class QuarantineList:
+    """In-memory view of ``.shipyard/quarantine.toml``."""
+
+    entries: list[QuarantineEntry] = field(default_factory=list)
+    path: Path | None = None
+
+    @classmethod
+    def load(cls, path: Path | None) -> QuarantineList:
+        """Load from disk. Missing file → empty list (not an error)."""
+        if path is None or not path.exists():
+            return cls(entries=[], path=path)
+        data = tomllib.loads(path.read_text())
+        raw = data.get("quarantine", [])
+        entries = [
+            QuarantineEntry(
+                target=str(item.get("target", "")).strip(),
+                reason=str(item.get("reason", "")).strip(),
+                added_at=str(item.get("added_at", "")).strip(),
+            )
+            for item in raw
+            if isinstance(item, dict) and item.get("target")
+        ]
+        return cls(entries=entries, path=path)
+
+    @classmethod
+    def load_from_project(cls, project_dir: Path | None) -> QuarantineList:
+        """Locate the file under ``<project_dir>/quarantine.toml``."""
+        if project_dir is None:
+            return cls(entries=[], path=None)
+        return cls.load(project_dir / QUARANTINE_FILENAME)
+
+    def is_quarantined(self, target: str) -> bool:
+        """True iff ``target`` appears in the list."""
+        return any(e.target == target for e in self.entries)
+
+    def get(self, target: str) -> QuarantineEntry | None:
+        for e in self.entries:
+            if e.target == target:
+                return e
+        return None
+
+    def add(self, target: str, reason: str = "") -> bool:
+        """Append an entry. Returns False if ``target`` was already present."""
+        if self.is_quarantined(target):
+            return False
+        self.entries.append(
+            QuarantineEntry(
+                target=target,
+                reason=reason,
+                added_at=date.today().isoformat(),
+            )
+        )
+        return True
+
+    def remove(self, target: str) -> bool:
+        """Remove by target name. Returns False if not present."""
+        before = len(self.entries)
+        self.entries = [e for e in self.entries if e.target != target]
+        return len(self.entries) < before
+
+    def save(self) -> None:
+        """Write back to ``self.path``. Requires ``path`` to be set."""
+        if self.path is None:
+            raise ValueError("QuarantineList.save() requires self.path")
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        payload: dict[str, Any] = {
+            "quarantine": [e.to_dict() for e in self.entries]
+        }
+        self.path.write_bytes(tomli_w.dumps(payload).encode("utf-8"))
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"entries": [e.to_dict() for e in self.entries]}
+
+
+# Failure classes that quarantine can suppress. INFRA/TIMEOUT/CONTRACT
+# are authoritative regardless of quarantine status.
+_SUPPRESSIBLE_CLASSES = frozenset({"TEST", "UNKNOWN"})
+
+
+def is_advisory_failure(
+    quarantine: QuarantineList,
+    target_name: str,
+    failure_class: str | None,
+) -> bool:
+    """Decide whether a failure should be treated as advisory.
+
+    Returns True iff the target is quarantined AND the failure class
+    is one that quarantine is allowed to suppress (TEST / UNKNOWN).
+    Callers (ship/merge) should skip blocking the merge on advisory
+    failures while still recording them in evidence.
+
+    A missing ``failure_class`` (None) is conservatively treated as
+    non-advisory — we'd rather block than silently merge an
+    unclassified failure.
+    """
+    if not failure_class:
+        return False
+    if not quarantine.is_quarantined(target_name):
+        return False
+    return failure_class in _SUPPRESSIBLE_CLASSES

--- a/src/shipyard/executor/cloud.py
+++ b/src/shipyard/executor/cloud.py
@@ -14,6 +14,7 @@ import time
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any
 
+from shipyard.core.classify import FailureClass
 from shipyard.core.job import TargetResult, TargetStatus
 
 if TYPE_CHECKING:
@@ -104,6 +105,7 @@ class CloudExecutor:
                 error_message=f"Failed to dispatch workflow: {exc}",
                 provider=runner_provider,
                 runner_profile=runner_profile,
+                failure_class=FailureClass.INFRA.value,
             )
 
         # Wait for the run to appear and get its ID
@@ -122,6 +124,7 @@ class CloudExecutor:
                 error_message=str(exc),
                 provider=runner_provider,
                 runner_profile=runner_profile,
+                failure_class=FailureClass.TIMEOUT.value,
             )
 
         # Poll for completion. Per-target override allows long-running
@@ -150,6 +153,7 @@ class CloudExecutor:
                 error_message=f"Failed to poll workflow run: {exc}",
                 provider=runner_provider,
                 runner_profile=runner_profile,
+                failure_class=FailureClass.INFRA.value,
             )
         except TimeoutError as exc:
             return TargetResult(
@@ -163,10 +167,16 @@ class CloudExecutor:
                 error_message=str(exc),
                 provider=runner_provider,
                 runner_profile=runner_profile,
+                failure_class=FailureClass.TIMEOUT.value,
             )
 
         elapsed = time.monotonic() - start_time
         status = TargetStatus.PASS if conclusion == "success" else TargetStatus.FAIL
+
+        # Cloud executor doesn't have local stderr — we can only
+        # distinguish "the workflow reported failure" (TEST) from the
+        # infra/timeout paths above, which short-circuit before here.
+        failure_class = None if status == TargetStatus.PASS else FailureClass.TEST.value
 
         return TargetResult(
             target_name=target_name,
@@ -179,6 +189,7 @@ class CloudExecutor:
             log_path=log_path,
             provider=runner_provider,
             runner_profile=runner_profile,
+            failure_class=failure_class,
         )
 
     def probe(self, target_config: dict[str, Any]) -> bool:

--- a/src/shipyard/executor/local.py
+++ b/src/shipyard/executor/local.py
@@ -18,6 +18,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from shipyard.core.classify import FailureClass, classify_failure
 from shipyard.core.job import TargetResult, TargetStatus
 from shipyard.core.prepared_state import (
     PreparedStateRecord,
@@ -98,6 +99,7 @@ class LocalExecutor:
                 status=TargetStatus.ERROR, backend="local",
                 error_message="No validation command configured",
                 started_at=started_at, completed_at=datetime.now(timezone.utc),
+                failure_class=FailureClass.UNKNOWN.value,
             )
 
         return self._run_stages(
@@ -130,6 +132,14 @@ class LocalExecutor:
             evaluation = evaluate_contract(contract_config, result.contract_markers_seen)
             if evaluation.should_force_fail and status == TargetStatus.PASS:
                 status = TargetStatus.FAIL
+            failure_class: str | None = None
+            if status != TargetStatus.PASS:
+                failure_class = classify_failure(
+                    stdout="",
+                    stderr=_read_log_tail(log_file),
+                    exit_code=result.returncode,
+                    contract_violated=evaluation.violated and evaluation.enforce,
+                ).value
             return TargetResult(
                 target_name=target_name, platform=platform,
                 status=status, backend="local", duration_secs=result.duration_secs,
@@ -140,6 +150,7 @@ class LocalExecutor:
                 contract_markers_seen=evaluation.seen,
                 contract_markers_missing=evaluation.missing,
                 contract_violation=evaluation.message,
+                failure_class=failure_class,
             )
         except subprocess.TimeoutExpired:
             return TargetResult(
@@ -148,6 +159,7 @@ class LocalExecutor:
                 duration_secs=time.monotonic() - start_time,
                 started_at=started_at, completed_at=datetime.now(timezone.utc),
                 log_path=str(log_file), error_message="Validation timed out",
+                failure_class=FailureClass.TIMEOUT.value,
             )
         except OSError as exc:
             return TargetResult(
@@ -155,6 +167,9 @@ class LocalExecutor:
                 status=TargetStatus.ERROR, backend="local",
                 started_at=started_at, completed_at=datetime.now(timezone.utc),
                 log_path=str(log_file), error_message=str(exc),
+                failure_class=classify_failure(
+                    stdout="", stderr=str(exc), exit_code=-1,
+                ).value,
             )
 
     def _run_stages(
@@ -274,6 +289,7 @@ class LocalExecutor:
                 duration_secs=time.monotonic() - start_time,
                 started_at=started_at, completed_at=datetime.now(timezone.utc),
                 log_path=str(log_file), error_message="Validation timed out",
+                failure_class=FailureClass.TIMEOUT.value,
             )
         except OSError as exc:
             return TargetResult(
@@ -281,6 +297,9 @@ class LocalExecutor:
                 status=TargetStatus.ERROR, backend="local",
                 started_at=started_at, completed_at=datetime.now(timezone.utc),
                 log_path=str(log_file), error_message=str(exc),
+                failure_class=classify_failure(
+                    stdout="", stderr=str(exc), exit_code=-1,
+                ).value,
             )
 
         elapsed = time.monotonic() - start_time
@@ -299,6 +318,12 @@ class LocalExecutor:
                 contract_markers_seen=evaluation.seen,
                 contract_markers_missing=evaluation.missing,
                 contract_violation=evaluation.message,
+                failure_class=classify_failure(
+                    stdout="",
+                    stderr=_read_log_tail(log_file),
+                    exit_code=1,
+                    contract_violated=evaluation.violated and evaluation.enforce,
+                ).value,
             )
 
         # All stages passed by exit code. Now check the contract — a
@@ -320,6 +345,11 @@ class LocalExecutor:
             contract_markers_seen=evaluation.seen,
             contract_markers_missing=evaluation.missing,
             contract_violation=evaluation.message,
+            failure_class=(
+                FailureClass.CONTRACT.value
+                if final_status == TargetStatus.FAIL
+                else None
+            ),
         )
 
     def probe(self, target_config: dict[str, Any]) -> bool:
@@ -352,6 +382,25 @@ def _get_stages(
         stages.append((stage_name, cmd))
 
     return stages
+
+
+def _read_log_tail(log_file: Path, max_bytes: int = 8192) -> str:
+    """Read the tail of the log file for failure-classification heuristics.
+
+    The classifier looks for infra markers (``Connection refused``,
+    ``Network is unreachable``, etc.) which almost always appear near
+    the end of a failed run. Reading only the tail keeps classification
+    cheap on very long logs. Any I/O error returns an empty string so
+    the classifier gracefully falls back to TEST/UNKNOWN.
+    """
+    try:
+        size = log_file.stat().st_size
+        with open(log_file, "rb") as f:
+            if size > max_bytes:
+                f.seek(-max_bytes, 2)  # SEEK_END
+            return f.read().decode("utf-8", errors="replace")
+    except (OSError, ValueError):
+        return ""
 
 
 def _prepared_state_enabled(validation_config: dict[str, Any] | None) -> bool:

--- a/src/shipyard/executor/ssh.py
+++ b/src/shipyard/executor/ssh.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import Any
 
 from shipyard.bundle.git_bundle import apply_bundle, create_bundle, upload_bundle
+from shipyard.core.classify import FailureClass, classify_failure
 from shipyard.core.job import TargetResult, TargetStatus
 from shipyard.executor.contract import evaluate_contract, required_markers
 from shipyard.executor.streaming import ProgressCallback, run_streaming_command
@@ -235,6 +236,15 @@ class SSHExecutor:
                 status = TargetStatus.FAIL
                 error_message = evaluation.message
 
+            failure_class: str | None = None
+            if status != TargetStatus.PASS:
+                failure_class = classify_failure(
+                    stdout="",
+                    stderr=result.output or error_message or "",
+                    exit_code=result.returncode,
+                    contract_violated=evaluation.violated and evaluation.enforce,
+                ).value
+
             return TargetResult(
                 target_name=target_name,
                 platform=platform,
@@ -250,6 +260,7 @@ class SSHExecutor:
                 contract_markers_seen=evaluation.seen,
                 contract_markers_missing=evaluation.missing,
                 contract_violation=evaluation.message,
+                failure_class=failure_class,
             )
 
         except subprocess.TimeoutExpired:
@@ -264,6 +275,7 @@ class SSHExecutor:
                 completed_at=datetime.now(timezone.utc),
                 log_path=str(log_file),
                 error_message="Validation timed out",
+                failure_class=FailureClass.TIMEOUT.value,
             )
 
         except OSError as exc:
@@ -613,7 +625,20 @@ def _error_result(
         completed_at=datetime.now(timezone.utc),
         log_path=log_path,
         error_message=message,
+        failure_class=_classify_ssh_error(message),
     )
+
+
+def _classify_ssh_error(message: str) -> str:
+    """Classify an SSH-level error for ``_error_result`` callers.
+
+    Called only after we've already decided the outcome is ERROR, so
+    the classifier never returns CONTRACT / TEST / TIMEOUT here — the
+    fingerprints in the error message pick INFRA or UNKNOWN.
+    """
+    return classify_failure(
+        stdout="", stderr=message, exit_code=-1,
+    ).value
 
 
 def _extract_ssh_error(output: str) -> str | None:

--- a/src/shipyard/failover/chain.py
+++ b/src/shipyard/failover/chain.py
@@ -27,6 +27,7 @@ import logging
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Protocol
 
+from shipyard.core.classify import FailureClass
 from shipyard.core.job import TargetResult, TargetStatus
 
 if TYPE_CHECKING:
@@ -118,6 +119,7 @@ class FallbackChain:
                 status=TargetStatus.ERROR,
                 backend="none",
                 error_message="No backends configured in fallback chain",
+                failure_class=FailureClass.UNKNOWN.value,
             )
 
         # Apply locality-routing filter before any probing/validation.
@@ -137,6 +139,7 @@ class FallbackChain:
                 status=TargetStatus.ERROR,
                 backend=_backend_label(self.backends[0]),
                 error_message=msg,
+                failure_class=FailureClass.INFRA.value,
             )
 
         primary_type = _backend_label(filtered_backends[0])
@@ -168,6 +171,7 @@ class FallbackChain:
                     status=TargetStatus.UNREACHABLE,
                     backend=_backend_label(backend_def),
                     error_message=f"Probe failed for {_backend_label(backend_def)}",
+                    failure_class=FailureClass.INFRA.value,
                 )
                 continue
 
@@ -203,6 +207,7 @@ class FallbackChain:
                         failover_reason=last_result.error_message if last_result else "unknown",
                         provider=result.provider,
                         runner_profile=result.runner_profile,
+                        failure_class=result.failure_class,
                     )
                 return result
 
@@ -229,6 +234,7 @@ class FallbackChain:
                 primary_backend=primary_type,
                 failover_reason="All backends exhausted",
                 error_message=last_result.error_message,
+                failure_class=last_result.failure_class or FailureClass.INFRA.value,
             )
 
         return TargetResult(
@@ -239,6 +245,7 @@ class FallbackChain:
             primary_backend=primary_type,
             failover_reason="No usable executors found",
             error_message="All backends skipped (no matching executors)",
+            failure_class=FailureClass.UNKNOWN.value,
         )
 
 

--- a/src/shipyard/failover/retry.py
+++ b/src/shipyard/failover/retry.py
@@ -2,6 +2,17 @@
 
 Detects common transient SSH errors and retries with increasing delays.
 Fails fast on permanent errors (auth failures, no route, etc.).
+
+Failure-class aware retry
+-------------------------
+
+``should_retry_failure_class`` is the policy surface used by the
+``ship`` and ``failover`` layers when they've already classified a
+failure via :func:`shipyard.core.classify.classify_failure`. Policy:
+
+- ``INFRA`` / ``TIMEOUT`` → retry once on the next backend
+- ``CONTRACT`` / ``TEST`` → no retry (authoritative)
+- ``UNKNOWN`` → no retry (fail safe)
 """
 
 from __future__ import annotations
@@ -11,10 +22,31 @@ import logging
 import time
 from typing import TYPE_CHECKING, Any, TypeVar
 
+from shipyard.core.classify import FailureClass, is_retryable
+
 if TYPE_CHECKING:
     from collections.abc import Callable
 
 logger = logging.getLogger(__name__)
+
+
+def should_retry_failure_class(failure_class: FailureClass | str | None) -> bool:
+    """Whether a classified failure is worth one auto-retry.
+
+    Accepts either the enum, the string value, or ``None`` (no
+    classification → treat as non-retryable to fail safe). This is the
+    single policy hook called by both the in-process retry path and
+    the cross-backend fallback chain; when Shipyard grows per-class
+    retry budgets, this is the place to extend.
+    """
+    if failure_class is None:
+        return False
+    if isinstance(failure_class, str):
+        try:
+            failure_class = FailureClass(failure_class)
+        except ValueError:
+            return False
+    return is_retryable(failure_class)
 
 # Patterns that indicate a transient (retryable) SSH failure.
 TRANSIENT_PATTERNS: tuple[str, ...] = (

--- a/src/shipyard/ship/merge.py
+++ b/src/shipyard/ship/merge.py
@@ -7,9 +7,10 @@ required platforms, and merge only when evidence proves all green.
 from __future__ import annotations
 
 import subprocess
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
+from shipyard.core.quarantine import QuarantineList, is_advisory_failure
 from shipyard.ship.pr import GhError, PrInfo, create_pr, find_pr_for_branch, merge_pr
 
 if TYPE_CHECKING:
@@ -20,7 +21,15 @@ if TYPE_CHECKING:
 
 @dataclass(frozen=True)
 class MergeCheck:
-    """Result of checking whether a branch is ready to merge."""
+    """Result of checking whether a branch is ready to merge.
+
+    Quarantine interaction: targets listed in ``.shipyard/quarantine.toml``
+    whose failure class is TEST or UNKNOWN don't count against ``ready``
+    — they land in ``advisory`` instead of ``failing`` so the reviewer
+    still sees them. Failures with class INFRA / TIMEOUT / CONTRACT are
+    never suppressed by quarantine (they indicate real, fixable
+    infrastructure or contract problems).
+    """
 
     ready: bool
     sha: str
@@ -29,9 +38,10 @@ class MergeCheck:
     passing: list[str]
     missing: list[str]
     failing: list[str]
+    advisory: list[str] = field(default_factory=list)
 
     def to_dict(self) -> dict[str, Any]:
-        return {
+        d: dict[str, Any] = {
             "ready": self.ready,
             "sha": self.sha,
             "branch": self.branch,
@@ -40,6 +50,9 @@ class MergeCheck:
             "missing": self.missing,
             "failing": self.failing,
         }
+        if self.advisory:
+            d["advisory"] = self.advisory
+        return d
 
 
 def can_merge(
@@ -47,16 +60,23 @@ def can_merge(
     branch: str,
     sha: str,
     required_platforms: list[str],
+    quarantine: QuarantineList | None = None,
 ) -> MergeCheck:
     """Check if all required platforms have passing evidence for this SHA.
 
-    Returns a MergeCheck with detailed status per platform.
+    When ``quarantine`` is supplied, targets whose evidence shows a
+    suppressible failure class (TEST / UNKNOWN) AND whose *target name*
+    appears on the list are moved from ``failing`` to ``advisory`` and
+    do not block ``ready``. When ``quarantine`` is None, behavior is
+    identical to the pre-quarantine code path (backward compatible).
     """
     passing: list[str] = []
     missing: list[str] = []
     failing: list[str] = []
+    advisory: list[str] = []
 
     records = evidence_store.get_branch(branch)
+    q = quarantine or QuarantineList(entries=[], path=None)
 
     for platform in required_platforms:
         found = False
@@ -65,13 +85,16 @@ def can_merge(
                 found = True
                 if rec.passed:
                     passing.append(platform)
+                elif is_advisory_failure(q, rec.target_name, rec.failure_class):
+                    advisory.append(platform)
                 else:
                     failing.append(platform)
                 break
         if not found:
             missing.append(platform)
 
-    ready = len(passing) == len(required_platforms)
+    # A platform counts toward merge-ready if it's passing or advisory.
+    ready = (len(passing) + len(advisory)) == len(required_platforms) and not failing
 
     return MergeCheck(
         ready=ready,
@@ -81,6 +104,7 @@ def can_merge(
         passing=passing,
         missing=missing,
         failing=failing,
+        advisory=advisory,
     )
 
 
@@ -170,8 +194,13 @@ def ship(
     )
     job = queue.enqueue(job)
 
-    # Check if we already have enough evidence to merge
-    check = can_merge(evidence_store, branch, sha, required_platforms)
+    # Check if we already have enough evidence to merge, honoring
+    # any `.shipyard/quarantine.toml` entries.
+    quarantine = QuarantineList.load_from_project(config.project_dir)
+    check = can_merge(
+        evidence_store, branch, sha, required_platforms,
+        quarantine=quarantine,
+    )
 
     if check.ready:
         try:

--- a/tests/core/test_classify.py
+++ b/tests/core/test_classify.py
@@ -1,0 +1,115 @@
+"""Tests for failure classification heuristics."""
+
+from __future__ import annotations
+
+import pytest
+
+from shipyard.core.classify import FailureClass, classify_failure, is_retryable
+
+
+class TestClassifyFailure:
+    def test_contract_violation_takes_priority(self) -> None:
+        # Even with infra markers and exit 0, a contract violation is
+        # CONTRACT.
+        assert (
+            classify_failure(
+                stdout="",
+                stderr="Connection refused by remote host",
+                exit_code=0,
+                contract_violated=True,
+            )
+            == FailureClass.CONTRACT
+        )
+
+    def test_timeout_takes_priority_over_infra(self) -> None:
+        # Infra-looking stderr + timeout → TIMEOUT wins (the timeout
+        # is the proximate cause; the infra string is a side effect
+        # of the killed process).
+        assert (
+            classify_failure(
+                stdout="",
+                stderr="Connection reset by peer",
+                exit_code=124,
+                wall_clock_exceeded=True,
+            )
+            == FailureClass.TIMEOUT
+        )
+
+    @pytest.mark.parametrize(
+        "stderr",
+        [
+            "ssh: connect to host x failed",
+            "Connection refused",
+            "Network is unreachable",
+            "Could not resolve host: foo.example",
+            "RUN_IN_DAYS_DEAD",
+            "github runner offline",
+            "No route to host",
+            "kex_exchange_identification failed",
+        ],
+    )
+    def test_infra_markers_classify_as_infra(self, stderr: str) -> None:
+        assert (
+            classify_failure(stdout="", stderr=stderr, exit_code=255)
+            == FailureClass.INFRA
+        )
+
+    def test_non_zero_exit_no_markers_is_test(self) -> None:
+        assert (
+            classify_failure(
+                stdout="AssertionError: expected 2 got 3",
+                stderr="",
+                exit_code=1,
+            )
+            == FailureClass.TEST
+        )
+
+    def test_zero_exit_no_markers_is_unknown(self) -> None:
+        # Caller shouldn't call us here but we must not crash; UNKNOWN
+        # is the explicit fallback.
+        assert (
+            classify_failure(stdout="", stderr="", exit_code=0)
+            == FailureClass.UNKNOWN
+        )
+
+    def test_infra_marker_embedded_in_larger_stderr(self) -> None:
+        stderr = (
+            "Running tests...\n"
+            "Test foo passed\n"
+            "ssh: connect to host bar.local port 22: "
+            "Operation timed out\n"
+        )
+        assert (
+            classify_failure(stdout="", stderr=stderr, exit_code=255)
+            == FailureClass.INFRA
+        )
+
+
+class TestIsRetryable:
+    @pytest.mark.parametrize(
+        "cls",
+        [FailureClass.INFRA, FailureClass.TIMEOUT],
+    )
+    def test_infra_and_timeout_are_retryable(self, cls: FailureClass) -> None:
+        assert is_retryable(cls) is True
+
+    @pytest.mark.parametrize(
+        "cls",
+        [FailureClass.CONTRACT, FailureClass.TEST, FailureClass.UNKNOWN],
+    )
+    def test_authoritative_classes_not_retryable(self, cls: FailureClass) -> None:
+        assert is_retryable(cls) is False
+
+
+class TestShouldRetryFailureClass:
+    """The public policy hook used by ship + failover."""
+
+    def test_accepts_enum_string_and_none(self) -> None:
+        from shipyard.failover.retry import should_retry_failure_class
+
+        assert should_retry_failure_class(FailureClass.INFRA) is True
+        assert should_retry_failure_class("INFRA") is True
+        assert should_retry_failure_class("TEST") is False
+        assert should_retry_failure_class(None) is False
+        # Unknown string → fail safe to False.
+        assert should_retry_failure_class("not-a-class") is False

--- a/tests/core/test_quarantine.py
+++ b/tests/core/test_quarantine.py
@@ -1,0 +1,99 @@
+"""Tests for the flaky-target quarantine list."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from shipyard.core.quarantine import (
+    QUARANTINE_FILENAME,
+    QuarantineEntry,
+    QuarantineList,
+    is_advisory_failure,
+)
+
+
+class TestLoad:
+    def test_missing_file_is_empty(self, tmp_path: Path) -> None:
+        q = QuarantineList.load(tmp_path / "missing.toml")
+        assert q.entries == []
+
+    def test_none_path_is_empty(self) -> None:
+        q = QuarantineList.load(None)
+        assert q.entries == []
+
+    def test_roundtrip(self, tmp_path: Path) -> None:
+        path = tmp_path / QUARANTINE_FILENAME
+        q = QuarantineList(entries=[], path=path)
+        assert q.add("windows-arm64", reason="flaky runner") is True
+        q.save()
+
+        reloaded = QuarantineList.load(path)
+        assert len(reloaded.entries) == 1
+        entry = reloaded.entries[0]
+        assert entry.target == "windows-arm64"
+        assert entry.reason == "flaky runner"
+        assert entry.added_at  # today's date was populated
+
+    def test_malformed_entries_are_dropped(self, tmp_path: Path) -> None:
+        path = tmp_path / QUARANTINE_FILENAME
+        path.write_text(
+            "[[quarantine]]\ntarget = \"valid\"\n"
+            "[[quarantine]]\nreason = \"no target key\"\n"
+        )
+        q = QuarantineList.load(path)
+        assert [e.target for e in q.entries] == ["valid"]
+
+
+class TestAddRemove:
+    def test_add_is_idempotent(self, tmp_path: Path) -> None:
+        q = QuarantineList(entries=[], path=tmp_path / "q.toml")
+        assert q.add("foo") is True
+        assert q.add("foo") is False
+        assert len(q.entries) == 1
+
+    def test_remove_returns_false_when_absent(self) -> None:
+        q = QuarantineList(entries=[QuarantineEntry(target="foo")])
+        assert q.remove("bar") is False
+        assert q.remove("foo") is True
+        assert q.entries == []
+
+
+class TestIsAdvisory:
+    def _q(self, *targets: str) -> QuarantineList:
+        return QuarantineList(
+            entries=[QuarantineEntry(target=t) for t in targets]
+        )
+
+    def test_quarantined_test_failure_is_advisory(self) -> None:
+        assert is_advisory_failure(self._q("flaky"), "flaky", "TEST") is True
+
+    def test_quarantined_unknown_failure_is_advisory(self) -> None:
+        assert (
+            is_advisory_failure(self._q("flaky"), "flaky", "UNKNOWN") is True
+        )
+
+    def test_quarantined_infra_still_blocks(self) -> None:
+        assert is_advisory_failure(self._q("flaky"), "flaky", "INFRA") is False
+
+    def test_quarantined_timeout_still_blocks(self) -> None:
+        assert (
+            is_advisory_failure(self._q("flaky"), "flaky", "TIMEOUT") is False
+        )
+
+    def test_quarantined_contract_still_blocks(self) -> None:
+        assert (
+            is_advisory_failure(self._q("flaky"), "flaky", "CONTRACT") is False
+        )
+
+    def test_not_quarantined_never_advisory(self) -> None:
+        assert is_advisory_failure(self._q(), "anything", "TEST") is False
+
+    def test_missing_class_never_advisory(self) -> None:
+        assert is_advisory_failure(self._q("flaky"), "flaky", None) is False
+
+    def test_save_without_path_raises(self) -> None:
+        import pytest
+
+        q = QuarantineList(entries=[QuarantineEntry(target="foo")], path=None)
+        with pytest.raises(ValueError):
+            q.save()

--- a/tests/ship/test_merge_quarantine.py
+++ b/tests/ship/test_merge_quarantine.py
@@ -1,0 +1,197 @@
+"""Tests for quarantine-aware merge decisions.
+
+Quarantine suppresses TEST/UNKNOWN failures on quarantined targets but
+keeps INFRA/TIMEOUT/CONTRACT authoritative. These are the merge-layer
+semantics — the rest of the ship flow doesn't need to care.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from shipyard.core.evidence import EvidenceRecord, EvidenceStore
+from shipyard.core.quarantine import QuarantineEntry, QuarantineList
+from shipyard.ship.merge import can_merge
+
+
+@pytest.fixture
+def empty_quarantine() -> QuarantineList:
+    return QuarantineList(entries=[], path=None)
+
+
+@pytest.fixture
+def flaky_quarantine() -> QuarantineList:
+    return QuarantineList(
+        entries=[QuarantineEntry(target="flaky-win", reason="bad runner")],
+        path=None,
+    )
+
+
+def _record(
+    store: EvidenceStore,
+    *,
+    target: str,
+    platform: str,
+    status: str,
+    failure_class: str | None = None,
+    sha: str = "abc123",
+    branch: str = "feature/x",
+) -> None:
+    store.record(EvidenceRecord(
+        sha=sha,
+        branch=branch,
+        target_name=target,
+        platform=platform,
+        status=status,
+        backend="local",
+        completed_at=datetime.now(timezone.utc),
+        failure_class=failure_class,
+    ))
+
+
+class TestQuarantineSuppressesTestFailures:
+    def test_quarantined_target_test_failure_is_advisory(
+        self,
+        evidence_store: EvidenceStore,
+        flaky_quarantine: QuarantineList,
+    ) -> None:
+        _record(
+            evidence_store, target="mac", platform="macos-arm64",
+            status="pass",
+        )
+        _record(
+            evidence_store, target="flaky-win", platform="windows-arm64",
+            status="fail", failure_class="TEST",
+        )
+
+        check = can_merge(
+            evidence_store, "feature/x", "abc123",
+            ["macos-arm64", "windows-arm64"],
+            quarantine=flaky_quarantine,
+        )
+
+        assert check.ready is True
+        assert "windows-arm64" in check.advisory
+        assert "windows-arm64" not in check.failing
+        assert "macos-arm64" in check.passing
+
+    def test_quarantined_target_unknown_failure_is_advisory(
+        self,
+        evidence_store: EvidenceStore,
+        flaky_quarantine: QuarantineList,
+    ) -> None:
+        _record(
+            evidence_store, target="flaky-win", platform="windows-arm64",
+            status="fail", failure_class="UNKNOWN",
+        )
+
+        check = can_merge(
+            evidence_store, "feature/x", "abc123",
+            ["windows-arm64"],
+            quarantine=flaky_quarantine,
+        )
+        assert check.ready is True
+        assert check.advisory == ["windows-arm64"]
+
+
+class TestQuarantineNeverSuppressesAuthoritativeClasses:
+    @pytest.mark.parametrize(
+        "failure_class",
+        ["INFRA", "TIMEOUT", "CONTRACT"],
+    )
+    def test_authoritative_classes_still_block(
+        self,
+        evidence_store: EvidenceStore,
+        flaky_quarantine: QuarantineList,
+        failure_class: str,
+    ) -> None:
+        _record(
+            evidence_store, target="flaky-win", platform="windows-arm64",
+            status="fail", failure_class=failure_class,
+        )
+
+        check = can_merge(
+            evidence_store, "feature/x", "abc123",
+            ["windows-arm64"],
+            quarantine=flaky_quarantine,
+        )
+        assert check.ready is False
+        assert check.failing == ["windows-arm64"]
+        assert check.advisory == []
+
+
+class TestNoQuarantineIsIdentityBehavior:
+    def test_passing_empty_list_matches_old_behavior(
+        self,
+        evidence_store: EvidenceStore,
+    ) -> None:
+        _record(
+            evidence_store, target="mac", platform="macos-arm64",
+            status="fail", failure_class="TEST",
+        )
+        # No quarantine arg at all.
+        check = can_merge(
+            evidence_store, "feature/x", "abc123",
+            ["macos-arm64"],
+        )
+        assert check.ready is False
+        assert check.failing == ["macos-arm64"]
+        assert check.advisory == []
+
+    def test_quarantined_unrelated_target_does_nothing(
+        self,
+        evidence_store: EvidenceStore,
+    ) -> None:
+        q = QuarantineList(
+            entries=[QuarantineEntry(target="different-target")],
+            path=None,
+        )
+        _record(
+            evidence_store, target="mac", platform="macos-arm64",
+            status="fail", failure_class="TEST",
+        )
+        check = can_merge(
+            evidence_store, "feature/x", "abc123",
+            ["macos-arm64"],
+            quarantine=q,
+        )
+        assert check.ready is False
+        assert check.failing == ["macos-arm64"]
+
+
+class TestMergeCheckDictContainsAdvisory:
+    def test_to_dict_emits_advisory_when_present(
+        self,
+        evidence_store: EvidenceStore,
+        flaky_quarantine: QuarantineList,
+    ) -> None:
+        _record(
+            evidence_store, target="flaky-win", platform="windows-arm64",
+            status="fail", failure_class="TEST",
+        )
+        check = can_merge(
+            evidence_store, "feature/x", "abc123",
+            ["windows-arm64"],
+            quarantine=flaky_quarantine,
+        )
+        d = check.to_dict()
+        assert d["advisory"] == ["windows-arm64"]
+        assert d["failing"] == []
+        assert d["ready"] is True
+
+    def test_to_dict_omits_advisory_when_empty(
+        self,
+        evidence_store: EvidenceStore,
+    ) -> None:
+        _record(
+            evidence_store, target="mac", platform="macos-arm64",
+            status="pass",
+        )
+        check = can_merge(
+            evidence_store, "feature/x", "abc123",
+            ["macos-arm64"],
+        )
+        d = check.to_dict()
+        assert "advisory" not in d

--- a/tests/test_cli_quarantine.py
+++ b/tests/test_cli_quarantine.py
@@ -1,0 +1,123 @@
+"""CLI tests for `shipyard quarantine {list,add,remove}`."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from shipyard.cli import main
+from shipyard.core.config import Config
+
+
+def _config(tmp_path: Path) -> Config:
+    project_dir = tmp_path / ".shipyard"
+    project_dir.mkdir()
+    return Config(
+        data={
+            "project": {"name": "shipyard"},
+            "targets": {
+                "mac": {"backend": "local", "platform": "macos-arm64"},
+                "flaky-win": {"backend": "ssh", "platform": "win-x64", "host": "x"},
+            },
+        },
+        project_dir=project_dir,
+    )
+
+
+def test_quarantine_list_empty(tmp_path, monkeypatch) -> None:
+    config = _config(tmp_path)
+    monkeypatch.setattr(
+        "shipyard.cli.Config.load_from_cwd", lambda cwd=None: config
+    )
+    monkeypatch.setattr(
+        "shipyard.core.config._default_state_dir", lambda: tmp_path / "state"
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["--json", "quarantine", "list"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["entries"] == []
+    assert payload["command"] == "quarantine.list"
+
+
+def test_quarantine_add_and_list_roundtrip(tmp_path, monkeypatch) -> None:
+    config = _config(tmp_path)
+    monkeypatch.setattr(
+        "shipyard.cli.Config.load_from_cwd", lambda cwd=None: config
+    )
+    monkeypatch.setattr(
+        "shipyard.core.config._default_state_dir", lambda: tmp_path / "state"
+    )
+
+    runner = CliRunner()
+    add = runner.invoke(
+        main,
+        ["--json", "quarantine", "add", "flaky-win", "--reason", "bad runner"],
+    )
+    assert add.exit_code == 0, add.output
+    add_payload = json.loads(add.output)
+    assert add_payload["added"] is True
+
+    # File should exist on disk.
+    q_file = config.project_dir / "quarantine.toml"
+    assert q_file.exists()
+    text = q_file.read_text()
+    assert "flaky-win" in text
+    assert "bad runner" in text
+
+    # Re-adding the same target is a no-op.
+    again = runner.invoke(
+        main, ["--json", "quarantine", "add", "flaky-win"],
+    )
+    assert again.exit_code == 0
+    assert json.loads(again.output)["added"] is False
+
+    # List reflects the entry.
+    listed = runner.invoke(main, ["--json", "quarantine", "list"])
+    payload = json.loads(listed.output)
+    entries = payload["entries"]
+    assert [e["target"] for e in entries] == ["flaky-win"]
+    assert entries[0]["reason"] == "bad runner"
+
+
+def test_quarantine_remove(tmp_path, monkeypatch) -> None:
+    config = _config(tmp_path)
+    monkeypatch.setattr(
+        "shipyard.cli.Config.load_from_cwd", lambda cwd=None: config
+    )
+    monkeypatch.setattr(
+        "shipyard.core.config._default_state_dir", lambda: tmp_path / "state"
+    )
+
+    runner = CliRunner()
+    runner.invoke(main, ["quarantine", "add", "flaky-win"])
+    removed = runner.invoke(
+        main, ["--json", "quarantine", "remove", "flaky-win"]
+    )
+    assert removed.exit_code == 0
+    assert json.loads(removed.output)["removed"] is True
+
+    # Removing again is an idempotent no-op.
+    missing = runner.invoke(
+        main, ["--json", "quarantine", "remove", "flaky-win"]
+    )
+    assert missing.exit_code == 0
+    assert json.loads(missing.output)["removed"] is False
+
+
+def test_quarantine_requires_project_dir(tmp_path, monkeypatch) -> None:
+    # Config without project_dir — emulates running outside a
+    # shipyard project.
+    config = Config(data={}, project_dir=None)
+    monkeypatch.setattr(
+        "shipyard.cli.Config.load_from_cwd", lambda cwd=None: config
+    )
+    monkeypatch.setattr(
+        "shipyard.core.config._default_state_dir", lambda: tmp_path / "state"
+    )
+    runner = CliRunner()
+    result = runner.invoke(main, ["quarantine", "add", "foo"])
+    assert result.exit_code != 0

--- a/uv.lock
+++ b/uv.lock
@@ -455,7 +455,7 @@ wheels = [
 
 [[package]]
 name = "shipyard"
-version = "0.12.0"
+version = "0.14.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },

--- a/uv.lock
+++ b/uv.lock
@@ -455,7 +455,7 @@ wheels = [
 
 [[package]]
 name = "shipyard"
-version = "0.14.0"
+version = "0.15.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

- Adds `FailureClass` enum (`INFRA | TIMEOUT | CONTRACT | TEST | UNKNOWN`) + `shipyard.core.classify.classify_failure()` heuristic. Populated on every non-passing `TargetResult` and `EvidenceRecord` by all three executors (local, ssh, cloud) and the failover chain.
- Adds opt-in `.shipyard/quarantine.toml` + `shipyard quarantine {add,remove,list}` CLI. Merge check treats quarantined `TEST` / `UNKNOWN` failures as advisory (visible under `advisory`, not `failing`); `INFRA` / `TIMEOUT` / `CONTRACT` remain authoritative regardless of quarantine status.
- `shipyard.failover.retry.should_retry_failure_class()` is the single policy hook for retry decisions — agents and future code can call it instead of hard-coding per-class behaviour.

## Test plan

- [x] 46 new unit tests cover:
  - every classifier path (precedence, each infra marker, exit-code fallback)
  - quarantine load/save/add/remove/idempotent semantics
  - `is_advisory_failure` suppresses only `TEST` / `UNKNOWN`
  - `can_merge` with/without quarantine (advisory vs failing split, authoritative classes still block)
  - `shipyard quarantine {list,add,remove}` JSON roundtrip + project-dir guard
- [x] Full suite: 773 passed, 1 skipped (pre-existing pyyaml skip).
- [x] Version bump + skill-sync gates green (`cli: 0.13.0→0.14.0`, `plugin: 0.5.0→0.6.0`, `skills/ci/SKILL.md` updated).

## Surfaces updated

- **CLI**: `shipyard quarantine {list,add,remove}` (new subcommand in `src/shipyard/cli.py`), `shipyard.core.classify`, `shipyard.core.quarantine`, `failure_class` field on `TargetResult` + `EvidenceRecord`, quarantine-aware `ship/merge.can_merge`.
- **Plugin**: `commands/quarantine.md` (new).
- **Skill**: `skills/ci/SKILL.md` — new "Failure classification" + "Flaky-target quarantine" sections, quick-reference rows added.