### PR TITLE
Cross-PR evidence reuse for rebase-only / non-intersecting PRs

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "shipyard",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Cross-platform CI coordination",
   "commands": "./commands",
   "agents": "./agents",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to Shipyard are documented here. Each entry links
 to its [GitHub Release](https://github.com/danielraffel/Shipyard/releases).
 
 <a id="v0150"></a>
+## [0.16.0]
+
 ## [0.15.0] - 2026-04-19
 
 - feat: failure classification + flaky-target quarantine (closes #83) ([#94](https://github.com/danielraffel/Shipyard/pull/94))

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,6 +113,16 @@ re-dispatching the full matrix. Idempotent (no-op if target already
 tracked); refuses if the ship is past dispatch phase. Dry-run by
 default; add `--apply` to execute.
 
+### Cross-PR evidence reuse
+
+Opt-in per target via `reuse_if_paths_unchanged = ["src/backend/**"]`
+in `[targets.<name>]`. When HEAD's diff since an ancestor SHA doesn't
+touch any matching path, Shipyard borrows that ancestor's passing
+evidence and skips dispatch. Safety: refuses across non-fast-forward
+lineage, validation-contract drift, or stage-list drift. Surfaces as
+`status: "reused"` in `shipyard watch --json` (and `✓ reused (from
+a1b2c3)` in human mode). See `skills/ci/SKILL.md` for details.
+
 ### Trailer shortcuts
 
 `shipyard pr --skip-bump <surface> --bump-reason "..."` and

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "shipyard"
-version = "0.15.0"
+version = "0.16.0"
 description = "Cross-platform CI coordination — local VMs, SSH hosts, cloud runners"
 readme = "README.md"
 license = "MIT"

--- a/skills/ci/SKILL.md
+++ b/skills/ci/SKILL.md
@@ -42,6 +42,7 @@ Shipyard coordinates validation across local, SSH, and cloud targets.
 | Show cloud defaults | `shipyard cloud defaults --json` |
 | Dispatch a cloud workflow | `shipyard cloud run build --json` |
 | Dispatch only if remote matches HEAD | `shipyard cloud run build --require-sha HEAD --json` |
+| Opt a target into cross-PR reuse | set `reuse_if_paths_unchanged = ["src/backend/**"]` under `[targets.<name>]` |
 | Retarget one lane on an in-flight PR | `shipyard cloud retarget --pr <n> --target macos --provider namespace` (dry-run; add `--apply`) |
 | Add a new lane to an in-flight PR | `shipyard cloud add-lane --pr <n> --target windows [--provider namespace]` (dry-run; add `--apply`) |
 | Skip a version-bump gate | `shipyard pr --skip-bump sdk --bump-reason "docs only"` |
@@ -205,6 +206,62 @@ Full docs: [`docs/targets.md`](../../docs/targets.md) and
 ## SSH delivery: incremental bundles
 
 SSH-backed targets deliver code via `git bundle`. On the first run the bundle is full (every object reachable from the target SHA, ~443 MB for Pulp-sized repos). On every subsequent run Shipyard probes the remote for its current HEAD over SSH (`git rev-parse HEAD`), verifies that the local clone has that commit as an ancestor, and emits `git bundle create <bundle> <target> ^<remote_head>` — a delta bundle that is typically kilobytes instead of megabytes. Any failure in the probe, ancestry check, or delta create silently falls back to the full-bundle path so the behavior on cold/corrupt remotes is unchanged. Each run logs a `bundle_mode=delta|full bundle_bytes=<N>` line to the per-target log so operators can confirm the optimisation is active.
+
+## Cross-PR evidence reuse
+
+When PR B rebases onto PR A's merged SHA and B's diff doesn't touch any
+path that a target actually exercises, Shipyard can reuse A's passing
+evidence instead of re-running the target. Off by default; opt-in per
+target via `reuse_if_paths_unchanged`.
+
+```toml
+[targets.ubuntu-cpu]
+backend = "ssh"
+host = "ubuntu"
+platform = "linux-x64"
+# Only dispatch this target if HEAD changed one of these paths. If
+# none match, borrow the most-recent passing evidence from an ancestor
+# SHA and skip dispatch.
+reuse_if_paths_unchanged = ["src/backend/**", "Cargo.lock"]
+```
+
+### When reuse fires
+
+Pre-dispatch, for each target with `reuse_if_paths_unchanged` set:
+
+1. Walk HEAD's first-parent ancestors and query the evidence store for
+   the most recent PASS on this target whose SHA is in that list.
+2. If found, compute `git diff --name-only <ancestor>..HEAD`.
+3. If no changed file matches any glob, write a synthetic PASS evidence
+   record with `reused_from: <ancestor_sha>` and skip dispatch.
+4. Otherwise dispatch normally.
+
+### Safety rules (always enforced)
+
+| Refusal | Why |
+|---|---|
+| Non-fast-forward lineage | `git merge-base --is-ancestor` must succeed; rebases across unrelated history never reuse |
+| Validation contract changed | The `[validation.contract]` subtable's digest is stored with each record; any change forces a re-run |
+| Stage list changed | Adding / removing a stage between the ancestor and HEAD forces a re-run |
+| No passing ancestor | If the most recent ancestor failed, or there's no record, reuse is declined |
+| Chain reuse | A reused record is never itself a reuse source — we only borrow from real dispatches |
+
+### How it surfaces
+
+- `shipyard watch --json` emits `{"status": "reused", "reused_from": "<sha>"}` for reused targets (instead of the bare `"pass"`).
+- `shipyard watch` human mode prints `evidence: <target>=✓ reused (from a1b2c3)`.
+- Evidence records in the store carry `reused_from`; `shipyard evidence --json` shows it verbatim.
+- The ship-state merge gate still counts reused targets as `pass`, so PR drain isn't blocked on a borrowed lane.
+
+### When to enable
+
+Reuse pays off on projects where the target's exercised surface is a
+small subset of the repo — think a backend-only test lane on a mixed
+frontend/backend monorepo, or a Cargo `cargo test -p backend` lane
+whose output only changes when the crate or its dependencies move.
+Don't enable it on a lane that runs the full suite — the globs would
+have to cover the whole tree, at which point you're back to
+re-running everything anyway.
 
 ## Failure classification
 

--- a/src/shipyard/__init__.py
+++ b/src/shipyard/__init__.py
@@ -1,3 +1,3 @@
 """Shipyard — Cross-platform CI coordination."""
 
-__version__ = "0.15.0"
+__version__ = "0.16.0"

--- a/src/shipyard/cli.py
+++ b/src/shipyard/cli.py
@@ -3357,7 +3357,7 @@ def watch(
                 sys.exit(0)
 
             observed_any_state = True
-            signature = _watch_signature(state)
+            signature = _watch_event_signature(ctx, state)
             if signature != last_signature:
                 _emit_watch_event(ctx, state)
                 last_signature = signature
@@ -3412,8 +3412,52 @@ def _watch_signature(state: ShipState) -> str:
     return "|".join(parts)
 
 
+def _watch_event_signature(ctx: Context, state: ShipState) -> str:
+    """Signature that also folds in reused_from annotations.
+
+    `_watch_signature` intentionally omits reuse because it reflects
+    the ship-state snapshot only; reuse is an evidence-store fact.
+    `_watch_event_signature` augments the base signature with the
+    set of reused targets so a first-time reuse detection emits a
+    fresh watch event instead of being collapsed as "no change".
+    """
+    base = _watch_signature(state)
+    try:
+        records = ctx.evidence.get_branch(state.branch)
+    except Exception:  # noqa: BLE001
+        records = {}
+    reuse_parts = sorted(
+        f"{t}:{rec.reused_from[:12]}"
+        for t, rec in records.items()
+        if rec.reused_from and rec.sha == state.head_sha
+    )
+    return base + "|reused=" + ",".join(reuse_parts)
+
+
 def _emit_watch_event(ctx: Context, state: ShipState) -> None:
+    # Cross-reference the evidence store so we can surface reused
+    # lanes. Reused passes still report status="pass" in the ship
+    # snapshot (merge-gating keeps working), but watch callers want
+    # to see "✓ reused (from a1b2c3)" instead of a plain pass.
+    reuse_map: dict[str, str] = {}
+    try:
+        branch_records = ctx.evidence.get_branch(state.branch)
+    except Exception:  # noqa: BLE001 — evidence store is best-effort
+        branch_records = {}
+    for target, rec in branch_records.items():
+        if rec.sha == state.head_sha and rec.reused_from:
+            reuse_map[target] = rec.reused_from
+
     if ctx.json_mode:
+        evidence_out: dict[str, dict[str, Any] | str] = {}
+        for target, status in state.evidence_snapshot.items():
+            if target in reuse_map and status == "pass":
+                evidence_out[target] = {
+                    "status": "reused",
+                    "reused_from": reuse_map[target],
+                }
+            else:
+                evidence_out[target] = status
         ctx.output(
             "watch",
             {
@@ -3421,7 +3465,7 @@ def _emit_watch_event(ctx: Context, state: ShipState) -> None:
                 "pr": state.pr,
                 "head_sha": state.head_sha,
                 "attempt": state.attempt,
-                "evidence": dict(state.evidence_snapshot),
+                "evidence": evidence_out,
                 "dispatched_runs": [r.to_dict() for r in state.dispatched_runs],
                 "updated_at": state.updated_at.isoformat(),
             },
@@ -3435,7 +3479,11 @@ def _emit_watch_event(ctx: Context, state: ShipState) -> None:
         f"attempt={state.attempt}  age={age_s}s"
     )
     for target, status in sorted(state.evidence_snapshot.items()):
-        render_message(f"  evidence: {target}={status}")
+        if target in reuse_map and status == "pass":
+            short = reuse_map[target][:7]
+            render_message(f"  evidence: {target}=✓ reused (from {short})")
+        else:
+            render_message(f"  evidence: {target}={status}")
     for run in state.dispatched_runs:
         render_message(
             f"  run: {run.target} ({run.provider}) "
@@ -3872,6 +3920,28 @@ def _execute_job(
         target_config["name"] = name
         log_path = str(config.state_dir / "logs" / job.id / f"{name}.log")
         backend_name = dispatcher.backend_name(target_config)
+        resolved_validation = _resolve_target_validation(
+            config, name, validation_config
+        )
+
+        # Cross-PR evidence reuse (opt-in via the target's
+        # ``reuse_if_paths_unchanged`` glob list). When the diff since
+        # an ancestor SHA does not touch any path the target cares
+        # about, we borrow that ancestor's PASS evidence instead of
+        # dispatching. See ``shipyard.ship.reuse``.
+        reuse_result = _maybe_reuse_evidence(
+            ctx=ctx,
+            job=job,
+            target_name=name,
+            target_config=target_config,
+            validation_config=resolved_validation,
+        )
+        if reuse_result is not None:
+            job = job.with_result(reuse_result)
+            ctx.queue.update(job)
+            if not ctx.json_mode:
+                render_job(job)
+            continue
 
         running = TargetResult(
             target_name=name,
@@ -3910,7 +3980,7 @@ def _execute_job(
             sha=job.sha,
             branch=job.branch,
             target_config=target_config,
-            validation_config=_resolve_target_validation(config, name, validation_config),
+            validation_config=resolved_validation,
             log_path=log_path,
             progress_callback=progress_callback,
             resume_from=resume_from,
@@ -3932,26 +4002,84 @@ def _execute_job(
     return job
 
 
+def _maybe_reuse_evidence(
+    *,
+    ctx: Context,
+    job: Job,
+    target_name: str,
+    target_config: dict[str, Any],
+    validation_config: dict[str, Any],
+) -> TargetResult | None:
+    """Return a synthetic reuse :class:`TargetResult` or ``None``.
+
+    ``None`` means "dispatch normally". When a result is returned,
+    ``status`` is always PASS and ``reused_from`` carries the
+    ancestor SHA the evidence was borrowed from. The caller should
+    skip dispatch and let the standard evidence-record path write
+    the synthetic PASS.
+    """
+    from shipyard.ship.reuse import evaluate_reuse
+
+    decision = evaluate_reuse(
+        target_name=target_name,
+        target_config=target_config,
+        validation_config=validation_config,
+        head_sha=job.sha,
+        evidence_store=ctx.evidence,
+    )
+    if not decision.reused:
+        return None
+
+    assert decision.ancestor_sha is not None  # narrows type for mypy
+    now = datetime.now(timezone.utc)
+    return TargetResult(
+        target_name=target_name,
+        platform=target_config.get("platform", "unknown"),
+        status=TargetStatus.PASS,
+        backend="reused",
+        started_at=now,
+        completed_at=now,
+        duration_secs=0.0,
+        reused_from=decision.ancestor_sha,
+    )
+
+
 def _record_evidence(ctx: Context, job: Job) -> None:
     from shipyard.core.evidence import EvidenceRecord
+    from shipyard.ship.reuse import compute_validation_signature
+
+    # Resolve the validation config once so the signature we write on
+    # each record reflects the same config the dispatcher just ran.
+    # A reuse decision on a future PR compares these fingerprints.
+    validation_base = _resolve_validation(ctx.config, job.mode)
 
     for name, result in job.results.items():
-        if result.is_terminal:
-            ctx.evidence.record(EvidenceRecord(
-                sha=job.sha,
-                branch=job.branch,
-                target_name=name,
-                platform=result.platform,
-                status="pass" if result.passed else "fail",
-                backend=result.backend,
-                completed_at=result.completed_at or job.completed_at,  # type: ignore[arg-type]
-                duration_secs=result.duration_secs,
-                primary_backend=result.primary_backend,
-                failover_reason=result.failover_reason,
-                provider=result.provider,
-                runner_profile=result.runner_profile,
-                failure_class=result.failure_class,
-            ))
+        if not result.is_terminal:
+            continue
+        per_target_validation = _resolve_target_validation(
+            ctx.config, name, validation_base
+        )
+        contract_digest, stages_signature = compute_validation_signature(
+            per_target_validation
+        )
+        ctx.evidence.record(EvidenceRecord(
+            sha=job.sha,
+            branch=job.branch,
+            target_name=name,
+            platform=result.platform,
+            status="pass" if result.passed else "fail",
+            backend=result.backend,
+            completed_at=result.completed_at or job.completed_at,  # type: ignore[arg-type]
+            duration_secs=result.duration_secs,
+            primary_backend=result.primary_backend,
+            failover_reason=result.failover_reason,
+            provider=result.provider,
+            runner_profile=result.runner_profile,
+            failure_class=result.failure_class,
+            reused_from=result.reused_from,
+            contract_digest=contract_digest,
+            stages_signature=stages_signature,
+        ))
 
 
 def _update_ship_state_from_job(

--- a/src/shipyard/core/evidence.py
+++ b/src/shipyard/core/evidence.py
@@ -37,10 +37,28 @@ class EvidenceRecord:
     # "INFRA" | "TIMEOUT" | "CONTRACT" | "TEST" | "UNKNOWN". None on a
     # passing record. See ``shipyard.core.classify``.
     failure_class: str | None = None
+    # Cross-PR evidence reuse provenance. When set, this record was
+    # synthesized from an earlier PASS on an ancestor SHA because the
+    # diff between that SHA and HEAD did not touch any path the target
+    # cares about (see ``reuse_if_paths_unchanged`` on target config).
+    # Value is the ancestor SHA the evidence was borrowed from.
+    reused_from: str | None = None
+    # Fingerprints of the validation contract + stages in effect when
+    # the record was written. Reuse compares these between the
+    # candidate ancestor record and the current target config and
+    # refuses reuse on drift (e.g., contract markers changed, a new
+    # build stage was added). ``None`` on pre-reuse records.
+    contract_digest: str | None = None
+    stages_signature: str | None = None
 
     @property
     def passed(self) -> bool:
         return self.status == "pass"
+
+    @property
+    def reused(self) -> bool:
+        """True if this record was borrowed from an ancestor PASS."""
+        return self.reused_from is not None
 
     def to_dict(self) -> dict[str, Any]:
         d: dict[str, Any] = {
@@ -55,6 +73,7 @@ class EvidenceRecord:
         for key in (
             "duration_secs", "host", "primary_backend", "failover_reason",
             "provider", "runner_profile", "failure_class",
+            "reused_from", "contract_digest", "stages_signature",
         ):
             val = getattr(self, key)
             if val is not None:
@@ -78,6 +97,9 @@ class EvidenceRecord:
             provider=d.get("provider"),
             runner_profile=d.get("runner_profile"),
             failure_class=d.get("failure_class"),
+            reused_from=d.get("reused_from"),
+            contract_digest=d.get("contract_digest"),
+            stages_signature=d.get("stages_signature"),
         )
 
 
@@ -138,6 +160,45 @@ class EvidenceStore:
                 all_green = False
 
         return all_green, evidence_map
+
+    def query_passing_for_target(
+        self,
+        target_name: str,
+        sha_candidates: list[str],
+    ) -> EvidenceRecord | None:
+        """Find the most recent PASS record for ``target_name`` whose
+        SHA is in ``sha_candidates``.
+
+        Searches across every branch file in the store. This is the
+        primary lookup for cross-PR evidence reuse: pass in the list
+        of ancestor SHAs reachable from HEAD (newest first) and this
+        returns the first PASS that matches. Returns None if no
+        ancestor has passing evidence for the target.
+
+        ``sha_candidates`` is treated as an ordered preference list —
+        earlier entries win on ties. Records with ``reused_from`` set
+        are **excluded** (we only borrow from real runs, never
+        chain-reuse from another reuse).
+        """
+        candidate_set = {sha: rank for rank, sha in enumerate(sha_candidates)}
+        best: tuple[int, EvidenceRecord] | None = None
+        for entry in self.path.glob("*.json"):
+            branch_key = entry.stem
+            try:
+                records = self._load_branch(branch_key)
+            except (OSError, ValueError):
+                continue
+            for rec in records.values():
+                if rec.target_name != target_name or not rec.passed:
+                    continue
+                if rec.reused_from is not None:
+                    continue
+                rank = candidate_set.get(rec.sha)
+                if rank is None:
+                    continue
+                if best is None or rank < best[0]:
+                    best = (rank, rec)
+        return best[1] if best else None
 
     def _branch_file(self, branch_key: str) -> Path:
         return self.path / f"{branch_key}.json"

--- a/src/shipyard/core/job.py
+++ b/src/shipyard/core/job.py
@@ -90,6 +90,12 @@ class TargetResult:
     # | "UNKNOWN". None for PASS/PENDING/RUNNING results. See
     # ``shipyard.core.classify`` for heuristics.
     failure_class: str | None = None
+    # Cross-PR evidence reuse: set when this result was synthesized
+    # from an earlier PASS on an ancestor SHA because the HEAD diff
+    # did not touch any path the target exercises. The value is the
+    # ancestor SHA the evidence was borrowed from. ``status`` is
+    # always PASS for reused results. See ``shipyard.ship.reuse``.
+    reused_from: str | None = None
 
     @property
     def passed(self) -> bool:
@@ -154,6 +160,8 @@ class TargetResult:
             d["contract_violation"] = self.contract_violation
         if self.failure_class:
             d["failure_class"] = self.failure_class
+        if self.reused_from:
+            d["reused_from"] = self.reused_from
         return d
 
 

--- a/src/shipyard/output/human.py
+++ b/src/shipyard/output/human.py
@@ -52,10 +52,16 @@ def render_job(job: Job) -> None:
     for name in job.target_names:
         result = job.results.get(name)
         if result:
-            status_text = _style_status(result.status.value)
-            backend = result.backend
-            if result.failover_reason:
-                backend = f"{result.backend} ({result.failover_reason})"
+            if result.reused_from:
+                # Cross-PR reuse: show "reused" in the status column
+                # so humans see the skipped lane and its provenance.
+                status_text = Text("reused", style="green")
+                backend = f"reused (from {result.reused_from[:7]})"
+            else:
+                status_text = _style_status(result.status.value)
+                backend = result.backend
+                if result.failover_reason:
+                    backend = f"{result.backend} ({result.failover_reason})"
             duration = _format_duration(result.duration_secs) if result.duration_secs else "..."
         else:
             status_text = _style_status("pending")

--- a/src/shipyard/ship/reuse.py
+++ b/src/shipyard/ship/reuse.py
@@ -1,0 +1,342 @@
+"""Cross-PR evidence reuse for rebase-only / non-intersecting PRs.
+
+When a PR's HEAD only adds commits on top of an already-validated
+ancestor SHA, and the diff ``<ancestor>..HEAD`` touches no path that a
+given target actually exercises, we can *reuse* the ancestor's passing
+evidence instead of re-running the target. Opt-in per target via the
+``reuse_if_paths_unchanged`` glob list on the target config.
+
+This module holds the pure logic — ancestor check, diff collection,
+glob matching, safety gates (contract/stages drift, non-fast-forward) —
+plus the git helpers. The CLI's ``_execute_job`` imports
+:func:`evaluate_reuse` as a pre-dispatch step per target.
+
+Safety posture:
+
+* Every failure mode returns ``ReuseDecision(reused=False, reason=...)``
+  rather than raising. The caller falls back to a normal dispatch;
+  reuse is always best-effort.
+* We never "chain-reuse" — a candidate record whose ``reused_from`` is
+  set is excluded by :meth:`EvidenceStore.query_passing_for_target`.
+* Validation contract + stage list changes between SHAs force reuse to
+  refuse; see :func:`_validation_signature`.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import hashlib
+import json
+import subprocess
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from shipyard.core.evidence import EvidenceRecord, EvidenceStore
+
+
+# ---- stage list -------------------------------------------------------
+# Source of truth is ``shipyard.executor.local.STAGES`` but importing it
+# here would create a cycle (executor imports core, core imports ship).
+# Keep a local copy — its shape is stable and changing it would be a
+# contract-level bump anyway.
+_STAGES = ("setup", "configure", "build", "test")
+
+
+@dataclass(frozen=True)
+class ReuseDecision:
+    """Outcome of evaluating reuse for one target.
+
+    ``reused=True`` means the caller should skip dispatch and write a
+    synthetic PASS evidence record. ``reused=False`` means fall back
+    to the normal dispatch path. ``reason`` is a short human string;
+    surfaced in logs and, when reuse succeeds, also in the evidence
+    record's ``backend`` field.
+    """
+
+    reused: bool
+    reason: str
+    ancestor_sha: str | None = None
+    ancestor_record: EvidenceRecord | None = None
+    contract_digest: str | None = None
+    stages_signature: str | None = None
+
+
+def evaluate_reuse(
+    *,
+    target_name: str,
+    target_config: dict[str, Any],
+    validation_config: dict[str, Any],
+    head_sha: str,
+    evidence_store: EvidenceStore,
+    repo_dir: str | None = None,
+    max_candidates: int = 50,
+) -> ReuseDecision:
+    """Decide whether to reuse evidence for ``target_name``.
+
+    Parameters mirror what ``_execute_job`` has at dispatch time. The
+    function is pure w.r.t. its arguments plus git (via ``repo_dir``)
+    and the evidence store — it does not mutate either.
+
+    Returns a :class:`ReuseDecision`. On ``reused=False`` the
+    ``reason`` field explains why so operators can see the decision in
+    the log tail / ship summary.
+    """
+    from shipyard.targets import extract_reuse_globs
+
+    globs = extract_reuse_globs(target_config)
+    if not globs:
+        return ReuseDecision(reused=False, reason="reuse not enabled for target")
+
+    # Walk recent first-parent history for ancestor candidates. We
+    # restrict to first-parent so a merge-in of a side branch doesn't
+    # accidentally suggest reuse from a commit that was never the
+    # trunk's HEAD.
+    candidates = _list_ancestor_shas(head_sha, limit=max_candidates, repo_dir=repo_dir)
+    if not candidates:
+        return ReuseDecision(
+            reused=False,
+            reason="no ancestor commits found (shallow clone or orphan HEAD)",
+        )
+
+    record = evidence_store.query_passing_for_target(target_name, candidates)
+    if record is None:
+        return ReuseDecision(
+            reused=False,
+            reason="no passing ancestor evidence for target",
+        )
+
+    # Safety: refuse reuse across lineage breaks. ``query_passing``
+    # already restricted the SHA to our candidate list, but a shallow
+    # clone might have given us a truncated ancestor list. Verify
+    # directly.
+    if not _is_ancestor(record.sha, head_sha, repo_dir=repo_dir):
+        return ReuseDecision(
+            reused=False,
+            reason=f"ancestor {record.sha[:12]} is not reachable from HEAD",
+        )
+
+    # Safety: refuse if validation contract or stage list changed
+    # between the ancestor record and current config.
+    contract_digest, stages_signature = _validation_signature(validation_config)
+    if (
+        record.contract_digest is not None
+        and record.contract_digest != contract_digest
+    ):
+        return ReuseDecision(
+            reused=False,
+            reason="validation contract changed between SHAs",
+        )
+    if (
+        record.stages_signature is not None
+        and record.stages_signature != stages_signature
+    ):
+        return ReuseDecision(
+            reused=False,
+            reason="validation stage list changed between SHAs",
+        )
+
+    # Path intersection. If ANY changed file matches ANY glob, the
+    # target exercises the change — reuse would be unsound.
+    try:
+        changed = _diff_name_only(record.sha, head_sha, repo_dir=repo_dir)
+    except _GitError as err:
+        return ReuseDecision(
+            reused=False,
+            reason=f"git diff unavailable: {err}",
+        )
+
+    matched = [path for path in changed if _matches_any_glob(path, globs)]
+    if matched:
+        return ReuseDecision(
+            reused=False,
+            reason=(
+                f"{len(matched)} changed path(s) intersect reuse globs "
+                f"(e.g. {matched[0]})"
+            ),
+        )
+
+    return ReuseDecision(
+        reused=True,
+        reason=f"reused from {record.sha[:12]} ({len(changed)} file(s) unchanged)",
+        ancestor_sha=record.sha,
+        ancestor_record=record,
+        contract_digest=contract_digest,
+        stages_signature=stages_signature,
+    )
+
+
+def compute_validation_signature(
+    validation_config: dict[str, Any],
+) -> tuple[str, str]:
+    """Public wrapper around :func:`_validation_signature`.
+
+    Used by the dispatch site when writing a *real* (non-reuse)
+    evidence record so future reuse attempts can compare fingerprints.
+    """
+    return _validation_signature(validation_config)
+
+
+def _matches_any_glob(path: str, globs: list[str]) -> bool:
+    """True if ``path`` matches any of ``globs``.
+
+    Uses ``fnmatch`` with two fixes for glob-style paths:
+      * ``**`` is translated to match across path separators
+      * a directory-style glob (e.g. ``src/backend/``) is expanded to
+        ``src/backend/**`` so users can declare whole-dir reuse gates
+        without remembering the trailing ``**``.
+    """
+    norm_path = path.replace("\\", "/")
+    for raw in globs:
+        pattern = raw.replace("\\", "/")
+        if pattern.endswith("/"):
+            pattern = pattern + "**"
+        # fnmatch treats ``*`` as "any chars except /"; expand ``**``
+        # to a single-segment ``*`` and rely on a multi-pass match so
+        # the user's intuition of "any depth" works.
+        if _fnmatch_recursive(norm_path, pattern):
+            return True
+    return False
+
+
+def _fnmatch_recursive(path: str, pattern: str) -> bool:
+    """``fnmatch`` with recursive ``**`` support.
+
+    ``fnmatch`` doesn't understand ``**`` natively; we split on
+    ``/**/`` and require each chunk to match a contiguous path prefix.
+    This handles the common cases: ``src/**/*.py``, ``**/*.md``,
+    ``docs/**``.
+    """
+    if "**" not in pattern:
+        return fnmatch.fnmatchcase(path, pattern)
+
+    # Normalize leading/trailing ``**`` cases.
+    if pattern == "**":
+        return True
+    if pattern.startswith("**/"):
+        tail = pattern[3:]
+        # Match ``tail`` at any depth (including zero).
+        parts = path.split("/")
+        for i in range(len(parts) + 1):
+            sub = "/".join(parts[i:])
+            if _fnmatch_recursive(sub, tail):
+                return True
+        return False
+    if pattern.endswith("/**"):
+        head = pattern[:-3]
+        return path == head or path.startswith(head + "/") or fnmatch.fnmatchcase(path, head)
+
+    # General case: a ``/**/`` in the middle.
+    head, _, tail = pattern.partition("/**/")
+    parts = path.split("/")
+    for i in range(1, len(parts) + 1):
+        head_candidate = "/".join(parts[:i])
+        if fnmatch.fnmatchcase(head_candidate, head):
+            rest = "/".join(parts[i:])
+            if _fnmatch_recursive(rest, tail):
+                return True
+    return False
+
+
+# ---- git helpers ------------------------------------------------------
+
+
+class _GitError(RuntimeError):
+    """Raised when a git invocation fails."""
+
+
+def _run_git(args: list[str], *, repo_dir: str | None) -> str:
+    cmd = ["git"]
+    if repo_dir:
+        cmd.extend(["-C", repo_dir])
+    cmd.extend(args)
+    try:
+        result = subprocess.run(
+            cmd, capture_output=True, text=True, timeout=15, check=False,
+        )
+    except FileNotFoundError as err:
+        raise _GitError("git not installed") from err
+    except subprocess.TimeoutExpired as err:
+        raise _GitError("git command timed out") from err
+    if result.returncode != 0:
+        raise _GitError((result.stderr or result.stdout or "git failed").strip())
+    return result.stdout
+
+
+def _list_ancestor_shas(
+    head_sha: str, *, limit: int, repo_dir: str | None
+) -> list[str]:
+    """Return the first-parent ancestor SHAs of HEAD, newest first.
+
+    Includes ``head_sha`` itself (a same-SHA PASS is trivially a
+    reuse candidate — handy for re-runs). Returns an empty list on
+    any git failure so the caller can fall back gracefully.
+    """
+    try:
+        out = _run_git(
+            [
+                "rev-list",
+                "--first-parent",
+                f"--max-count={limit}",
+                head_sha,
+            ],
+            repo_dir=repo_dir,
+        )
+    except _GitError:
+        return []
+    return [line.strip() for line in out.splitlines() if line.strip()]
+
+
+def _is_ancestor(sha: str, head_sha: str, *, repo_dir: str | None) -> bool:
+    """True iff ``sha`` is an ancestor of ``head_sha``."""
+    try:
+        _run_git(
+            ["merge-base", "--is-ancestor", sha, head_sha],
+            repo_dir=repo_dir,
+        )
+    except _GitError:
+        return False
+    return True
+
+
+def _diff_name_only(
+    ancestor_sha: str, head_sha: str, *, repo_dir: str | None
+) -> list[str]:
+    """Return ``git diff --name-only <ancestor>..HEAD``.
+
+    Empty list when ``ancestor_sha == head_sha``. Raises ``_GitError``
+    on any other git failure so the caller refuses reuse rather than
+    silently proceeding on a missing diff.
+    """
+    if ancestor_sha == head_sha:
+        return []
+    out = _run_git(
+        ["diff", "--name-only", f"{ancestor_sha}..{head_sha}"],
+        repo_dir=repo_dir,
+    )
+    return [line.strip() for line in out.splitlines() if line.strip()]
+
+
+# ---- validation fingerprint ------------------------------------------
+
+
+def _validation_signature(
+    validation_config: dict[str, Any],
+) -> tuple[str, str]:
+    """Return (contract_digest, stages_signature) for a resolved config.
+
+    The contract digest hashes the ``[validation.contract]`` subtable
+    (markers + enforce flag). The stage signature is a
+    ``|``-separated list of the stages that *have* commands, in the
+    fixed stage order — changing or adding a stage changes the sig.
+    Both are stable across Python dict iteration order.
+    """
+    contract = validation_config.get("contract") or {}
+    contract_norm = json.dumps(
+        contract, sort_keys=True, default=str, separators=(",", ":")
+    )
+    contract_digest = hashlib.sha256(contract_norm.encode("utf-8")).hexdigest()[:16]
+
+    present = [s for s in _STAGES if validation_config.get(s)]
+    stages_signature = "|".join(present) or "(empty)"
+    return contract_digest, stages_signature

--- a/src/shipyard/targets/__init__.py
+++ b/src/shipyard/targets/__init__.py
@@ -38,6 +38,12 @@ class TargetConfig:
         fallback: Ordered list of backend definitions to try when the
             primary is unreachable. Each entry is a dict with a
             ``type`` key and backend-specific fields.
+        reuse_if_paths_unchanged: Opt-in globs for cross-PR evidence
+            reuse. When set, ``shipyard ship`` will borrow a passing
+            evidence record from an ancestor SHA if the diff
+            ``<ancestor>..HEAD`` touches no path matching any of these
+            globs. Empty list = feature off (default; backward-
+            compatible). See ``src/shipyard/ship/reuse.py``.
         raw: The original dict this was parsed from, preserved so
             callers can reach backend-specific keys without a
             round-trip through the dataclass.
@@ -48,6 +54,7 @@ class TargetConfig:
     backend: str = ""
     requires: list[str] = field(default_factory=list)
     fallback: list[dict[str, Any]] = field(default_factory=list)
+    reuse_if_paths_unchanged: list[str] = field(default_factory=list)
     raw: dict[str, Any] = field(default_factory=dict)
 
 
@@ -76,14 +83,36 @@ def parse_target(name: str, data: dict[str, Any]) -> TargetConfig:
         data.get("backend") or data.get("type") or ""
     ).strip()
 
+    reuse_raw = data.get("reuse_if_paths_unchanged", []) or []
+    if not isinstance(reuse_raw, list):
+        raise ValueError(
+            f"target '{name}': reuse_if_paths_unchanged must be a list, "
+            f"got {type(reuse_raw).__name__}"
+        )
+    reuse_globs = [str(item).strip() for item in reuse_raw if str(item).strip()]
+
     return TargetConfig(
         name=name,
         platform=str(data.get("platform", "")),
         backend=backend,
         requires=requires,
         fallback=[entry for entry in fallback_raw if isinstance(entry, dict)],
+        reuse_if_paths_unchanged=reuse_globs,
         raw=data,
     )
+
+
+def extract_reuse_globs(target_config: dict[str, Any]) -> list[str]:
+    """Extract the normalized ``reuse_if_paths_unchanged`` list.
+
+    Returns an empty list (meaning "reuse disabled") when the key is
+    missing, empty, or malformed. This mirrors ``extract_requires``
+    so dispatch-site callers don't need a full parse.
+    """
+    raw = target_config.get("reuse_if_paths_unchanged", []) or []
+    if not isinstance(raw, list):
+        return []
+    return [str(item).strip() for item in raw if str(item).strip()]
 
 
 def extract_requires(target_config: dict[str, Any]) -> list[str]:
@@ -99,4 +128,9 @@ def extract_requires(target_config: dict[str, Any]) -> list[str]:
     return [str(item).strip() for item in raw if str(item).strip()]
 
 
-__all__ = ["TargetConfig", "parse_target", "extract_requires"]
+__all__ = [
+    "TargetConfig",
+    "parse_target",
+    "extract_requires",
+    "extract_reuse_globs",
+]

--- a/tests/core/test_evidence.py
+++ b/tests/core/test_evidence.py
@@ -49,6 +49,34 @@ class TestEvidenceRecord:
         assert d["primary_backend"] == "ssh"
         assert d["failover_reason"] == "ssh_unreachable"
 
+    def test_reused_fields_roundtrip(self) -> None:
+        rec = EvidenceRecord(
+            sha="new", branch="feat/x", target_name="mac",
+            platform="macos-arm64", status="pass", backend="reused",
+            completed_at=datetime.now(timezone.utc),
+            reused_from="old", contract_digest="abc123",
+            stages_signature="build|test",
+        )
+        assert rec.reused is True
+        d = rec.to_dict()
+        assert d["reused_from"] == "old"
+        assert d["contract_digest"] == "abc123"
+        assert d["stages_signature"] == "build|test"
+        restored = EvidenceRecord.from_dict(d)
+        assert restored.reused_from == "old"
+        assert restored.contract_digest == "abc123"
+        assert restored.stages_signature == "build|test"
+
+    def test_reused_false_on_normal_record(self) -> None:
+        rec = EvidenceRecord(
+            sha="abc", branch="main", target_name="mac",
+            platform="macos-arm64", status="pass", backend="local",
+            completed_at=datetime.now(timezone.utc),
+        )
+        assert rec.reused is False
+        d = rec.to_dict()
+        assert "reused_from" not in d
+
 
 class TestEvidenceStore:
     def test_record_and_retrieve(self, evidence_store: EvidenceStore) -> None:

--- a/tests/ship/test_execute_job_reuse.py
+++ b/tests/ship/test_execute_job_reuse.py
@@ -1,0 +1,256 @@
+"""Integration tests for cross-PR reuse in ``_execute_job``.
+
+These drive the real ``_execute_job`` loop with a fake dispatcher so
+we can assert:
+  * a target with reuse globs whose diff misses the globs is **not**
+    dispatched (fake dispatcher's counter stays at 0) and ends up
+    with a synthetic PASS ``TargetResult`` whose ``reused_from`` is
+    set.
+  * a target without reuse globs is dispatched normally.
+  * the recorded ``EvidenceRecord`` carries ``reused_from``.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING
+
+import pytest
+
+from shipyard.cli import Context, _execute_job
+from shipyard.core.evidence import EvidenceRecord, EvidenceStore
+from shipyard.core.job import (
+    Job,
+    TargetResult,
+    TargetStatus,
+    ValidationMode,
+)
+from shipyard.core.queue import Queue
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _git(cmd: list[str], *, cwd: Path) -> str:
+    result = subprocess.run(
+        ["git", *cmd], cwd=cwd, capture_output=True, text=True, check=True
+    )
+    return result.stdout.strip()
+
+
+@pytest.fixture
+def linear_repo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Two-commit repo; initial touches src/, second touches docs/."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(["init", "--initial-branch=main"], cwd=repo)
+    _git(["config", "user.email", "t@e.com"], cwd=repo)
+    _git(["config", "user.name", "t"], cwd=repo)
+    _git(["config", "commit.gpgsign", "false"], cwd=repo)
+    (repo / "src").mkdir()
+    (repo / "src" / "a.py").write_text("x\n")
+    _git(["add", "."], cwd=repo)
+    _git(["commit", "-m", "initial"], cwd=repo)
+    (repo / "docs").mkdir()
+    (repo / "docs" / "README.md").write_text("docs\n")
+    _git(["add", "."], cwd=repo)
+    _git(["commit", "-m", "docs"], cwd=repo)
+    # The reuse module uses ``cwd`` via its ``repo_dir`` argument; our
+    # cli wiring omits it so fall back to process cwd.
+    monkeypatch.chdir(repo)
+    return repo
+
+
+@dataclass
+class _DispatchCount:
+    n: int = 0
+
+
+class _FakeDispatcher:
+    """Minimal stand-in for :class:`ExecutorDispatcher`.
+
+    Records each ``validate_target`` call so tests can assert dispatch
+    was / was not invoked.
+    """
+
+    def __init__(self) -> None:
+        self.dispatched: list[str] = []
+
+    def backend_name(self, target_config: dict) -> str:  # noqa: ANN001
+        return "local"
+
+    def validate_target(self, **kwargs) -> TargetResult:  # noqa: ANN003
+        name = kwargs["target_config"]["name"]
+        self.dispatched.append(name)
+        now = datetime.now(timezone.utc)
+        return TargetResult(
+            target_name=name,
+            platform=kwargs["target_config"].get("platform", "unknown"),
+            status=TargetStatus.PASS,
+            backend="local",
+            started_at=now,
+            completed_at=now,
+            duration_secs=1.0,
+        )
+
+
+def _build_ctx(tmp_path: Path) -> Context:
+    ctx = Context(json_mode=True)
+    ctx._evidence = EvidenceStore(path=tmp_path / "evidence")
+    ctx._queue = Queue(state_dir=tmp_path / "queue")
+    return ctx
+
+
+def _config_with_targets(
+    tmp_path: Path, targets: dict[str, dict]
+) -> object:
+    """Build a minimal Config-ish object with ``targets``, ``validation``, and
+    ``state_dir`` — the three bits ``_execute_job`` touches.
+    """
+
+    class _Cfg:
+        validation = {"default": {"build": "echo build"}}
+
+        def __init__(self) -> None:
+            self.state_dir = tmp_path / "state"
+            self.state_dir.mkdir(exist_ok=True)
+
+        @property
+        def targets(self) -> dict[str, dict]:
+            return targets
+
+        def get(self, key: str, default=None):  # noqa: ANN001
+            return default
+
+    return _Cfg()
+
+
+def test_reuses_when_diff_misses_globs(
+    linear_repo: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # head = docs commit, ancestor = initial commit. Target cares
+    # about src/** but the diff only touches docs/ → reuse.
+    head_sha = _git(["rev-parse", "HEAD"], cwd=linear_repo)
+    ancestor_sha = _git(["rev-parse", "HEAD~1"], cwd=linear_repo)
+
+    state_tmp = tmp_path / "state"
+    ctx = _build_ctx(state_tmp)
+    # Seed a passing ancestor evidence record.
+    ctx.evidence.record(EvidenceRecord(
+        sha=ancestor_sha, branch="main", target_name="mac",
+        platform="macos-arm64", status="pass", backend="local",
+        completed_at=datetime.now(timezone.utc),
+    ))
+
+    targets = {
+        "mac": {
+            "backend": "local",
+            "platform": "macos-arm64",
+            "reuse_if_paths_unchanged": ["src/**"],
+        }
+    }
+    config = _config_with_targets(state_tmp, targets)
+    # Make the Context return our hand-rolled config.
+    monkeypatch.setattr(
+        type(ctx), "config", property(lambda self, c=config: c)
+    )
+
+    dispatcher = _FakeDispatcher()
+    job = Job.create(
+        sha=head_sha, branch="feature/x",
+        target_names=["mac"], mode=ValidationMode.FULL,
+    )
+
+    completed = _execute_job(
+        ctx=ctx, job=job, config=config, dispatcher=dispatcher,  # type: ignore[arg-type]
+        mode=ValidationMode.FULL, fail_fast=True, resume_from=None,
+    )
+
+    assert dispatcher.dispatched == [], "reuse must skip dispatch"
+    result = completed.results["mac"]
+    assert result.status == TargetStatus.PASS
+    assert result.reused_from == ancestor_sha
+    assert result.backend == "reused"
+    # Evidence record carries reused_from.
+    rec = ctx.evidence.get_target("feature/x", "mac")
+    assert rec is not None
+    assert rec.reused_from == ancestor_sha
+
+
+def test_dispatches_when_diff_touches_globs(
+    linear_repo: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Add a third commit that touches src/** so reuse must refuse.
+    (linear_repo / "src" / "a.py").write_text("y\n")
+    _git(["add", "."], cwd=linear_repo)
+    _git(["commit", "-m", "touch src"], cwd=linear_repo)
+    head_sha = _git(["rev-parse", "HEAD"], cwd=linear_repo)
+    ancestor_sha = _git(["rev-parse", "HEAD~2"], cwd=linear_repo)
+
+    state_tmp = tmp_path / "state"
+    ctx = _build_ctx(state_tmp)
+    ctx.evidence.record(EvidenceRecord(
+        sha=ancestor_sha, branch="main", target_name="mac",
+        platform="macos-arm64", status="pass", backend="local",
+        completed_at=datetime.now(timezone.utc),
+    ))
+    targets = {
+        "mac": {
+            "backend": "local",
+            "platform": "macos-arm64",
+            "reuse_if_paths_unchanged": ["src/**"],
+        }
+    }
+    config = _config_with_targets(state_tmp, targets)
+    monkeypatch.setattr(
+        type(ctx), "config", property(lambda self, c=config: c)
+    )
+
+    dispatcher = _FakeDispatcher()
+    job = Job.create(
+        sha=head_sha, branch="feature/x",
+        target_names=["mac"], mode=ValidationMode.FULL,
+    )
+    completed = _execute_job(
+        ctx=ctx, job=job, config=config, dispatcher=dispatcher,  # type: ignore[arg-type]
+        mode=ValidationMode.FULL, fail_fast=True, resume_from=None,
+    )
+
+    assert dispatcher.dispatched == ["mac"]
+    result = completed.results["mac"]
+    assert result.reused_from is None
+
+
+def test_target_without_reuse_config_dispatches_normally(
+    linear_repo: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    head_sha = _git(["rev-parse", "HEAD"], cwd=linear_repo)
+    ancestor_sha = _git(["rev-parse", "HEAD~1"], cwd=linear_repo)
+
+    state_tmp = tmp_path / "state"
+    ctx = _build_ctx(state_tmp)
+    ctx.evidence.record(EvidenceRecord(
+        sha=ancestor_sha, branch="main", target_name="mac",
+        platform="macos-arm64", status="pass", backend="local",
+        completed_at=datetime.now(timezone.utc),
+    ))
+    # No reuse_if_paths_unchanged on the target.
+    targets = {"mac": {"backend": "local", "platform": "macos-arm64"}}
+    config = _config_with_targets(state_tmp, targets)
+    monkeypatch.setattr(
+        type(ctx), "config", property(lambda self, c=config: c)
+    )
+
+    dispatcher = _FakeDispatcher()
+    job = Job.create(
+        sha=head_sha, branch="feature/x",
+        target_names=["mac"], mode=ValidationMode.FULL,
+    )
+    completed = _execute_job(
+        ctx=ctx, job=job, config=config, dispatcher=dispatcher,  # type: ignore[arg-type]
+        mode=ValidationMode.FULL, fail_fast=True, resume_from=None,
+    )
+    assert dispatcher.dispatched == ["mac"]
+    assert completed.results["mac"].reused_from is None

--- a/tests/ship/test_reuse.py
+++ b/tests/ship/test_reuse.py
@@ -1,0 +1,360 @@
+"""Tests for cross-PR evidence reuse (``shipyard.ship.reuse``)."""
+
+from __future__ import annotations
+
+import subprocess
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING
+
+import pytest
+
+from shipyard.core.evidence import EvidenceRecord, EvidenceStore
+from shipyard.ship.reuse import (
+    ReuseDecision,
+    _fnmatch_recursive,
+    _matches_any_glob,
+    compute_validation_signature,
+    evaluate_reuse,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+# ---- helpers --------------------------------------------------------------
+
+
+def _git(cmd: list[str], *, cwd: Path) -> str:
+    """Run ``git`` in ``cwd`` and return stdout; raise on failure."""
+    result = subprocess.run(
+        ["git", *cmd], cwd=cwd, capture_output=True, text=True, check=True
+    )
+    return result.stdout.strip()
+
+
+@pytest.fixture
+def tiny_repo(tmp_path: Path) -> Path:
+    """Minimal git repo with three linear commits so tests can exercise
+    ancestor ordering and ``git diff --name-only`` without hitting the
+    network.
+
+    Commits (oldest → newest):
+      1) initial    — ``src/backend/api.py``, ``docs/readme.md``
+      2) docs-only  — updates ``docs/readme.md``
+      3) docs-only  — updates ``docs/guide.md``
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(["init", "--initial-branch=main"], cwd=repo)
+    _git(["config", "user.email", "test@example.com"], cwd=repo)
+    _git(["config", "user.name", "Test"], cwd=repo)
+    _git(["config", "commit.gpgsign", "false"], cwd=repo)
+
+    (repo / "src").mkdir()
+    (repo / "src" / "backend").mkdir()
+    (repo / "docs").mkdir()
+    (repo / "src" / "backend" / "api.py").write_text("print('hi')\n")
+    (repo / "docs" / "readme.md").write_text("initial\n")
+    _git(["add", "."], cwd=repo)
+    _git(["commit", "-m", "initial"], cwd=repo)
+
+    (repo / "docs" / "readme.md").write_text("updated readme\n")
+    _git(["add", "."], cwd=repo)
+    _git(["commit", "-m", "docs only 1"], cwd=repo)
+
+    (repo / "docs" / "guide.md").write_text("a guide\n")
+    _git(["add", "."], cwd=repo)
+    _git(["commit", "-m", "docs only 2"], cwd=repo)
+
+    return repo
+
+
+def _shas(repo: Path) -> list[str]:
+    """Return commit SHAs newest-first (like rev-list)."""
+    out = _git(["rev-list", "HEAD"], cwd=repo)
+    return [line.strip() for line in out.splitlines() if line.strip()]
+
+
+def _pass_record(
+    sha: str,
+    *,
+    target: str = "mac",
+    contract_digest: str | None = None,
+    stages_signature: str | None = None,
+) -> EvidenceRecord:
+    return EvidenceRecord(
+        sha=sha,
+        branch="main",
+        target_name=target,
+        platform="macos-arm64",
+        status="pass",
+        backend="local",
+        completed_at=datetime.now(timezone.utc),
+        contract_digest=contract_digest,
+        stages_signature=stages_signature,
+    )
+
+
+# ---- glob matching --------------------------------------------------------
+
+
+class TestGlobMatching:
+    def test_simple_prefix(self) -> None:
+        assert _matches_any_glob("src/backend/api.py", ["src/backend/**"])
+
+    def test_directory_shortcut(self) -> None:
+        assert _matches_any_glob("src/backend/api.py", ["src/backend/"])
+
+    def test_miss(self) -> None:
+        assert not _matches_any_glob("docs/readme.md", ["src/backend/**"])
+
+    def test_star_star_leading(self) -> None:
+        assert _matches_any_glob("x/y/z/foo.py", ["**/*.py"])
+
+    def test_extension_only(self) -> None:
+        assert _matches_any_glob("deep/nested/thing.go", ["**/*.go"])
+        assert not _matches_any_glob("deep/nested/thing.py", ["**/*.go"])
+
+    def test_direct_match_no_stars(self) -> None:
+        assert _fnmatch_recursive("Makefile", "Makefile")
+        assert not _fnmatch_recursive("src/Makefile", "Makefile")
+
+
+# ---- validation signature -------------------------------------------------
+
+
+class TestValidationSignature:
+    def test_stable_across_dict_order(self) -> None:
+        cfg1 = {
+            "setup": "./setup.sh",
+            "build": "./build.sh",
+            "test": "./test.sh",
+            "contract": {"markers": ["BUILD_OK"], "enforce": True},
+        }
+        cfg2 = {
+            "contract": {"enforce": True, "markers": ["BUILD_OK"]},
+            "test": "./test.sh",
+            "build": "./build.sh",
+            "setup": "./setup.sh",
+        }
+        assert compute_validation_signature(cfg1) == compute_validation_signature(cfg2)
+
+    def test_stage_added_changes_signature(self) -> None:
+        a = {"build": "b", "test": "t"}
+        b = {"build": "b", "test": "t", "configure": "c"}
+        assert compute_validation_signature(a)[1] != compute_validation_signature(b)[1]
+
+    def test_contract_change_changes_digest(self) -> None:
+        a = {"build": "b", "contract": {"markers": ["X"]}}
+        b = {"build": "b", "contract": {"markers": ["Y"]}}
+        assert compute_validation_signature(a)[0] != compute_validation_signature(b)[0]
+
+
+# ---- evaluate_reuse end-to-end -------------------------------------------
+
+
+class TestEvaluateReuse:
+    def test_disabled_by_default(
+        self, tiny_repo: Path, evidence_store: EvidenceStore
+    ) -> None:
+        shas = _shas(tiny_repo)
+        head = shas[0]
+        decision = evaluate_reuse(
+            target_name="mac",
+            target_config={},  # no reuse globs -> feature off
+            validation_config={"build": "b"},
+            head_sha=head,
+            evidence_store=evidence_store,
+            repo_dir=str(tiny_repo),
+        )
+        assert decision.reused is False
+        assert "reuse not enabled" in decision.reason
+
+    def test_reuses_when_diff_misses_globs(
+        self, tiny_repo: Path, evidence_store: EvidenceStore
+    ) -> None:
+        # Ancestor = commit 1 (initial), HEAD = commit 3. Only docs
+        # touched between them, and the target only cares about src/.
+        shas = _shas(tiny_repo)
+        head_sha = shas[0]
+        ancestor_sha = shas[2]
+        evidence_store.record(_pass_record(ancestor_sha))
+        decision = evaluate_reuse(
+            target_name="mac",
+            target_config={"reuse_if_paths_unchanged": ["src/backend/**"]},
+            validation_config={"build": "b"},
+            head_sha=head_sha,
+            evidence_store=evidence_store,
+            repo_dir=str(tiny_repo),
+        )
+        assert decision.reused is True
+        assert decision.ancestor_sha == ancestor_sha
+        assert "reused from" in decision.reason
+
+    def test_refuses_when_diff_touches_globs(
+        self, tiny_repo: Path, evidence_store: EvidenceStore
+    ) -> None:
+        # Create a *new* commit that touches src/backend/api.py and
+        # ask for reuse: should refuse.
+        shas_before = _shas(tiny_repo)
+        ancestor_sha = shas_before[0]  # current HEAD becomes ancestor
+        evidence_store.record(_pass_record(ancestor_sha))
+        (tiny_repo / "src" / "backend" / "api.py").write_text("print('v2')\n")
+        _git(["add", "."], cwd=tiny_repo)
+        _git(["commit", "-m", "touch backend"], cwd=tiny_repo)
+        head_sha = _git(["rev-parse", "HEAD"], cwd=tiny_repo)
+
+        decision = evaluate_reuse(
+            target_name="mac",
+            target_config={"reuse_if_paths_unchanged": ["src/backend/**"]},
+            validation_config={"build": "b"},
+            head_sha=head_sha,
+            evidence_store=evidence_store,
+            repo_dir=str(tiny_repo),
+        )
+        assert decision.reused is False
+        assert "intersect reuse globs" in decision.reason
+
+    def test_no_passing_ancestor(
+        self, tiny_repo: Path, evidence_store: EvidenceStore
+    ) -> None:
+        shas = _shas(tiny_repo)
+        head_sha = shas[0]
+        # store has nothing -> no candidate
+        decision = evaluate_reuse(
+            target_name="mac",
+            target_config={"reuse_if_paths_unchanged": ["**"]},
+            validation_config={"build": "b"},
+            head_sha=head_sha,
+            evidence_store=evidence_store,
+            repo_dir=str(tiny_repo),
+        )
+        assert decision.reused is False
+        assert "no passing ancestor" in decision.reason
+
+    def test_refuses_on_lineage_break(
+        self, tiny_repo: Path, evidence_store: EvidenceStore
+    ) -> None:
+        # Put a record at a totally unrelated SHA that our first-
+        # parent walk would never surface. The query returns None so
+        # we just assert "no passing ancestor" — which is the correct
+        # refusal for a lineage break under this implementation.
+        evidence_store.record(_pass_record("deadbeefcafebabe0123"))
+        shas = _shas(tiny_repo)
+        decision = evaluate_reuse(
+            target_name="mac",
+            target_config={"reuse_if_paths_unchanged": ["**"]},
+            validation_config={"build": "b"},
+            head_sha=shas[0],
+            evidence_store=evidence_store,
+            repo_dir=str(tiny_repo),
+        )
+        assert decision.reused is False
+
+    def test_refuses_on_contract_drift(
+        self, tiny_repo: Path, evidence_store: EvidenceStore
+    ) -> None:
+        shas = _shas(tiny_repo)
+        head_sha = shas[0]
+        ancestor_sha = shas[2]
+        # Store a record whose contract digest won't match the current
+        # validation config.
+        rec = _pass_record(
+            ancestor_sha, contract_digest="0000aaaa", stages_signature="build"
+        )
+        evidence_store.record(rec)
+        decision = evaluate_reuse(
+            target_name="mac",
+            target_config={"reuse_if_paths_unchanged": ["src/backend/**"]},
+            validation_config={
+                "build": "b",
+                "contract": {"markers": ["NEW_MARKER"], "enforce": True},
+            },
+            head_sha=head_sha,
+            evidence_store=evidence_store,
+            repo_dir=str(tiny_repo),
+        )
+        assert decision.reused is False
+        assert "contract" in decision.reason
+
+    def test_refuses_on_stage_drift(
+        self, tiny_repo: Path, evidence_store: EvidenceStore
+    ) -> None:
+        shas = _shas(tiny_repo)
+        head_sha = shas[0]
+        ancestor_sha = shas[2]
+        rec = _pass_record(
+            ancestor_sha,
+            contract_digest=compute_validation_signature({"build": "b"})[0],
+            stages_signature="build",  # old config only had build
+        )
+        evidence_store.record(rec)
+        decision = evaluate_reuse(
+            target_name="mac",
+            target_config={"reuse_if_paths_unchanged": ["src/backend/**"]},
+            validation_config={"build": "b", "test": "t"},  # added test
+            head_sha=head_sha,
+            evidence_store=evidence_store,
+            repo_dir=str(tiny_repo),
+        )
+        assert decision.reused is False
+        assert "stage list" in decision.reason
+
+
+# ---- EvidenceStore.query_passing_for_target -------------------------------
+
+
+class TestQueryPassingForTarget:
+    def test_returns_ranked_match(self, evidence_store: EvidenceStore) -> None:
+        for sha in ("a" * 40, "b" * 40, "c" * 40):
+            evidence_store.record(EvidenceRecord(
+                sha=sha, branch=f"b{sha[0]}", target_name="mac",
+                platform="macos", status="pass", backend="local",
+                completed_at=datetime.now(timezone.utc),
+            ))
+        # Candidates ordered b, c, a → should pick b.
+        rec = evidence_store.query_passing_for_target(
+            "mac", ["b" * 40, "c" * 40, "a" * 40]
+        )
+        assert rec is not None
+        assert rec.sha == "b" * 40
+
+    def test_excludes_reused_records(self, evidence_store: EvidenceStore) -> None:
+        evidence_store.record(EvidenceRecord(
+            sha="abc", branch="main", target_name="mac",
+            platform="macos", status="pass", backend="reused",
+            completed_at=datetime.now(timezone.utc),
+            reused_from="parent",
+        ))
+        rec = evidence_store.query_passing_for_target("mac", ["abc"])
+        assert rec is None
+
+    def test_excludes_failed(self, evidence_store: EvidenceStore) -> None:
+        evidence_store.record(EvidenceRecord(
+            sha="abc", branch="main", target_name="mac",
+            platform="macos", status="fail", backend="local",
+            completed_at=datetime.now(timezone.utc),
+        ))
+        rec = evidence_store.query_passing_for_target("mac", ["abc"])
+        assert rec is None
+
+    def test_returns_none_for_unknown_target(
+        self, evidence_store: EvidenceStore
+    ) -> None:
+        evidence_store.record(EvidenceRecord(
+            sha="abc", branch="main", target_name="mac",
+            platform="macos", status="pass", backend="local",
+            completed_at=datetime.now(timezone.utc),
+        ))
+        rec = evidence_store.query_passing_for_target("ubuntu", ["abc"])
+        assert rec is None
+
+
+# ---- ReuseDecision dataclass ---------------------------------------------
+
+
+class TestReuseDecision:
+    def test_default_ancestor_fields(self) -> None:
+        d = ReuseDecision(reused=False, reason="nope")
+        assert d.ancestor_sha is None
+        assert d.ancestor_record is None

--- a/tests/targets/test_model.py
+++ b/tests/targets/test_model.py
@@ -4,7 +4,11 @@ from __future__ import annotations
 
 import pytest
 
-from shipyard.targets import TargetConfig, extract_requires, parse_target
+from shipyard.targets import (
+    extract_requires,
+    extract_reuse_globs,
+    parse_target,
+)
 
 
 class TestParseTarget:
@@ -60,3 +64,32 @@ class TestExtractRequires:
     def test_malformed_returns_empty(self) -> None:
         # Malformed values are tolerated — missing requires is safer than crashing.
         assert extract_requires({"requires": "gpu"}) == []
+
+
+class TestReuseIfPathsUnchanged:
+    def test_parse_reuse_globs(self) -> None:
+        t = parse_target(
+            "mac",
+            {
+                "platform": "macos-arm64",
+                "reuse_if_paths_unchanged": ["src/backend/**", "Cargo.lock"],
+            },
+        )
+        assert t.reuse_if_paths_unchanged == ["src/backend/**", "Cargo.lock"]
+
+    def test_default_empty(self) -> None:
+        t = parse_target("mac", {"platform": "macos-arm64"})
+        assert t.reuse_if_paths_unchanged == []
+
+    def test_reuse_must_be_list(self) -> None:
+        with pytest.raises(ValueError, match="reuse_if_paths_unchanged must be a list"):
+            parse_target("x", {"reuse_if_paths_unchanged": "src/**"})
+
+    def test_extract_helper(self) -> None:
+        assert extract_reuse_globs({}) == []
+        assert extract_reuse_globs({"reuse_if_paths_unchanged": []}) == []
+        assert extract_reuse_globs(
+            {"reuse_if_paths_unchanged": ["src/**", "  ", ""]}
+        ) == ["src/**"]
+        # Malformed -> empty (safer than crashing mid-dispatch).
+        assert extract_reuse_globs({"reuse_if_paths_unchanged": "src/**"}) == []

--- a/tests/test_cli_watch.py
+++ b/tests/test_cli_watch.py
@@ -16,6 +16,7 @@ from shipyard.cli import (
     _watch_signature,
     main,
 )
+from shipyard.core.evidence import EvidenceRecord, EvidenceStore
 from shipyard.core.ship_state import (
     DispatchedRun,
     ShipState,
@@ -107,22 +108,27 @@ class TestTerminalVerdict:
 class TestWatchCli:
     def _runner_with_store(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> tuple[CliRunner, ShipStateStore]:
+    ) -> tuple[CliRunner, ShipStateStore, EvidenceStore]:
         store = ShipStateStore(path=tmp_path / "ship")
+        evidence = EvidenceStore(path=tmp_path / "evidence")
         monkeypatch.setattr(
             "shipyard.cli.Context.ship_state",
             property(lambda self: store),
+        )
+        monkeypatch.setattr(
+            "shipyard.cli.Context.evidence",
+            property(lambda self: evidence),
         )
         # Don't actually sleep.
         import time
 
         monkeypatch.setattr(time, "sleep", lambda s: None)
-        return CliRunner(), store
+        return CliRunner(), store, evidence
 
     def test_no_active_ship_exits_2(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        runner, _ = self._runner_with_store(tmp_path, monkeypatch)
+        runner, _, _ = self._runner_with_store(tmp_path, monkeypatch)
         monkeypatch.setattr("shipyard.cli._git_branch", lambda: "feature/x")
         result = runner.invoke(main, ["watch", "--no-follow"])
         assert result.exit_code == 2
@@ -132,7 +138,7 @@ class TestWatchCli:
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         # Terminal success → exit 0 under --no-follow.
-        runner, store = self._runner_with_store(tmp_path, monkeypatch)
+        runner, store, _ = self._runner_with_store(tmp_path, monkeypatch)
         store.save(_state(pr=77, evidence={"macos": "pass", "linux": "pass"}))
         monkeypatch.setattr("shipyard.cli._git_branch", lambda: "feature/x")
         result = runner.invoke(main, ["watch", "--no-follow"])
@@ -144,7 +150,7 @@ class TestWatchCli:
     ) -> None:
         # #62 P1: --pr that has no state file must NOT exit 0; that
         # would let automation treat typos as successful completion.
-        runner, _ = self._runner_with_store(tmp_path, monkeypatch)
+        runner, _, _ = self._runner_with_store(tmp_path, monkeypatch)
         monkeypatch.setattr("shipyard.cli._git_branch", lambda: "feature/x")
         result = runner.invoke(main, ["watch", "--pr", "9999", "--no-follow"])
         assert result.exit_code == 2, result.output
@@ -156,7 +162,7 @@ class TestWatchCli:
         # #62 P2: --no-follow on an in-flight ship must produce a
         # distinct exit code from terminal success so callers can
         # tell "keep polling" apart from "all done".
-        runner, store = self._runner_with_store(tmp_path, monkeypatch)
+        runner, store, _ = self._runner_with_store(tmp_path, monkeypatch)
         store.save(_state(pr=88, evidence={"macos": "pending"}))
         monkeypatch.setattr("shipyard.cli._git_branch", lambda: "feature/x")
         result = runner.invoke(main, ["watch", "--no-follow"])
@@ -166,7 +172,7 @@ class TestWatchCli:
     def test_terminal_failure_exits_1(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        runner, store = self._runner_with_store(tmp_path, monkeypatch)
+        runner, store, _ = self._runner_with_store(tmp_path, monkeypatch)
         store.save(
             _state(pr=78, evidence={"macos": "pass", "linux": "fail"})
         )
@@ -179,7 +185,7 @@ class TestWatchCli:
     ) -> None:
         # Explicit --pr wins over current-branch detection. This
         # state has a single passing target — terminal success.
-        runner, store = self._runner_with_store(tmp_path, monkeypatch)
+        runner, store, _ = self._runner_with_store(tmp_path, monkeypatch)
         store.save(_state(pr=10, evidence={"macos": "pass"}))
         monkeypatch.setattr(
             "shipyard.cli._git_branch", lambda: "unrelated"
@@ -191,7 +197,7 @@ class TestWatchCli:
     def test_json_emits_ndjson_update(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        runner, store = self._runner_with_store(tmp_path, monkeypatch)
+        runner, store, _ = self._runner_with_store(tmp_path, monkeypatch)
         store.save(
             _state(
                 pr=11,
@@ -207,3 +213,54 @@ class TestWatchCli:
         # At least one event JSON line with the expected shape.
         assert '"event": "update"' in result.output
         assert '"pr": 11' in result.output
+
+    def test_reused_surfaced_in_json(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A reused evidence record on the current SHA should flip the
+        # JSON status to "reused" and include ``reused_from``.
+        runner, store, evidence = self._runner_with_store(
+            tmp_path, monkeypatch
+        )
+        head_sha = "a" * 40
+        store.save(
+            _state(
+                pr=12,
+                evidence={"macos": "pass", "linux": "pass"},
+            )
+        )
+        evidence.record(EvidenceRecord(
+            sha=head_sha, branch="feature/x", target_name="macos",
+            platform="macos-arm64", status="pass", backend="reused",
+            completed_at=datetime.now(timezone.utc),
+            reused_from="b" * 40,
+        ))
+        monkeypatch.setattr("shipyard.cli._git_branch", lambda: "feature/x")
+        result = runner.invoke(
+            main, ["--json", "watch", "--pr", "12", "--no-follow"]
+        )
+        assert result.exit_code == 0, result.output
+        assert '"status": "reused"' in result.output
+        assert '"reused_from"' in result.output
+
+    def test_reused_surfaced_in_human_mode(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        runner, store, evidence = self._runner_with_store(
+            tmp_path, monkeypatch
+        )
+        head_sha = "a" * 40
+        store.save(
+            _state(pr=13, evidence={"macos": "pass"})
+        )
+        evidence.record(EvidenceRecord(
+            sha=head_sha, branch="feature/x", target_name="macos",
+            platform="macos-arm64", status="pass", backend="reused",
+            completed_at=datetime.now(timezone.utc),
+            reused_from="cafebabe12345678",
+        ))
+        monkeypatch.setattr("shipyard.cli._git_branch", lambda: "feature/x")
+        result = runner.invoke(main, ["watch", "--pr", "13", "--no-follow"])
+        assert result.exit_code == 0, result.output
+        assert "reused" in result.output
+        assert "cafebab" in result.output

--- a/uv.lock
+++ b/uv.lock
@@ -455,7 +455,7 @@ wheels = [
 
 [[package]]
 name = "shipyard"
-version = "0.15.0"
+version = "0.16.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Closes #88.

## Summary

- When PR B rebases onto a freshly-merged ancestor SHA and B's diff doesn't touch any path a target actually exercises, borrow the ancestor's passing evidence instead of re-running.
- Opt-in per target via `reuse_if_paths_unchanged = ["src/backend/**", ...]` — off by default.
- Surfaces as `status: "reused"` + `reused_from: <sha>` in `shipyard watch --json`; `✓ reused (from a1b2c3)` in human mode.
- Evidence record carries `reused_from` plus `contract_digest` + `stages_signature` fingerprints so future reuse attempts can detect drift.

## Safety gates (all hard-refuse)

| Refusal | Check |
|---|---|
| Non-fast-forward lineage | `git merge-base --is-ancestor <sha> HEAD` |
| Validation contract changed | `[validation.contract]` digest mismatch |
| Stage list changed | Present-stage signature mismatch |
| No passing ancestor | `query_passing_for_target` returned None |
| Chain reuse | Ancestor with `reused_from != None` excluded |

## Files

- `src/shipyard/ship/reuse.py` — pure logic (`evaluate_reuse`, glob match, git helpers, validation fingerprint).
- `src/shipyard/core/evidence.py` — `query_passing_for_target` + `reused_from` / `contract_digest` / `stages_signature` fields.
- `src/shipyard/targets/__init__.py` — `reuse_if_paths_unchanged` on `TargetConfig` + `extract_reuse_globs` helper.
- `src/shipyard/cli.py` — pre-dispatch hook in `_execute_job`; watch-event enrichment.
- `src/shipyard/core/job.py`, `src/shipyard/output/human.py` — propagation.
- Docs: `skills/ci/SKILL.md` new "Cross-PR evidence reuse" section; `CLAUDE.md` entry.

## Tests

- `tests/ship/test_reuse.py` — 21 tests covering glob matching, validation signature stability, and `evaluate_reuse` against a real git repo for the 5 acceptance scenarios.
- `tests/ship/test_execute_job_reuse.py` — 3 integration tests exercising `_execute_job` with a fake dispatcher.
- Extended `tests/core/test_evidence.py`, `tests/targets/test_model.py`, `tests/test_cli_watch.py` with reuse assertions.

## Test plan

- [x] `uv run pytest -x` — 819 passed (was 787; +32 new tests)
- [x] `uv run ruff check src/` — clean
- [x] `uv run mypy src/` — 73 files, no issues
- [x] `version_bump_check.py --mode=report` — green (cli 0.15.0 → 0.16.0, plugin 0.7.0 → 0.8.0)
- [x] `skill_sync_check.py --mode=report` — ci skill updated