### PR TITLE
feat: warm-pool runner reuse across PRs (closes #82)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "shipyard",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Cross-platform CI coordination",
   "commands": "./commands",
   "agents": "./agents",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to Shipyard are documented here. Each entry links
 to its [GitHub Release](https://github.com/danielraffel/Shipyard/releases).
 
 <a id="v0180"></a>
+## [0.19.0]
+
 ## [0.18.0] - 2026-04-19
 
 - Ship feat/degrade-mode ([#97](https://github.com/danielraffel/Shipyard/pull/97))

--- a/commands/targets.md
+++ b/commands/targets.md
@@ -1,17 +1,42 @@
 ---
 name: targets
-description: Inspect configured targets and live target status
+description: Inspect configured targets, live target status, and the warm-pool of reusable runners
 ---
 
-Shipyard does not have a dedicated `shipyard targets` subcommand yet.
+Shipyard exposes a handful of `shipyard targets` subcommands; the older
+`shipyard status --json` remains the canonical live-state view.
 
-Use these instead:
+| Task | Command |
+|------|---------|
+| List configured targets and reachability | `shipyard targets list --json` |
+| Probe one target | `shipyard targets test <name> --json` |
+| Add a target | `shipyard targets add <name> --backend ssh --host <host> --platform <plat>` |
+| Remove a target | `shipyard targets remove <name>` |
+| Show live target phase / liveness | `shipyard status --json` |
+| Show warm-pool entries (target, host, TTL, SHA) | `shipyard targets warm status --json` |
+| Drain the warm-pool (force cold-start everywhere) | `shipyard targets warm drain --yes` |
 
-- `shipyard status --json` for queue state, live target phase/liveness, and
-  fallback information during active jobs.
-- `.shipyard/config.toml` and `.shipyard.local/config.toml` for the configured
-  targets, backends, hosts, and fallback chains.
-- `shipyard doctor --json` to confirm the local toolchain before running jobs.
+## Warm-pool reuse
+
+A target can opt in to warm-pool reuse by setting
+`warm_keepalive_seconds = <N>` on its config section. On PASS Shipyard
+records `(target, host, workdir, sha, expires_at)`; the next
+`shipyard ship` / `shipyard run` within the TTL and on the same SHA
+re-enters the same workdir and skips the pre-stage (clone / sync /
+deps). Validate always re-runs.
+
+**Three disable levels** (use when reporting / recommending):
+
+1. Per-target: `warm_keepalive_seconds = 0` (default — feature is off).
+2. Global kill switch: `SHIPYARD_NO_WARM_POOL=1` in the environment.
+3. Per-ship flag: `shipyard ship --no-warm` / `shipyard run --no-warm`.
+
+Any failure during a warm reuse evicts the entry, so the pool never
+serves a dirty workdir twice. GitHub-hosted cloud backends are silently
+ineligible (workflow runs are ephemeral); Shipyard warns once per
+invocation when a target opted in on an ineligible backend.
+
+## Configured vs active backend
 
 When reporting target state, distinguish between:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "shipyard"
-version = "0.18.0"
+version = "0.19.0"
 description = "Cross-platform CI coordination — local VMs, SSH hosts, cloud runners"
 readme = "README.md"
 license = "MIT"

--- a/skills/ci/SKILL.md
+++ b/skills/ci/SKILL.md
@@ -43,6 +43,11 @@ Shipyard coordinates validation across local, SSH, and cloud targets.
 | Dispatch a cloud workflow | `shipyard cloud run build --json` |
 | Dispatch only if remote matches HEAD | `shipyard cloud run build --require-sha HEAD --json` |
 | Opt a target into cross-PR reuse | set `reuse_if_paths_unchanged = ["src/backend/**"]` under `[targets.<name>]` |
+| Opt a target into warm-pool reuse | set `warm_keepalive_seconds = 600` under `[targets.<name>]` (see "Warm-pool reuse" below) |
+| Inspect warm-pool entries | `shipyard targets warm status --json` |
+| Drain the warm-pool (force cold-start everywhere) | `shipyard targets warm drain --yes` |
+| Force cold-start for one ship only | `shipyard ship --no-warm` (or `shipyard run --no-warm`) |
+| Global warm-pool kill switch | `SHIPYARD_NO_WARM_POOL=1` in the environment |
 | Retarget one lane on an in-flight PR | `shipyard cloud retarget --pr <n> --target macos --provider namespace` (dry-run; add `--apply`) |
 | Add a new lane to an in-flight PR | `shipyard cloud add-lane --pr <n> --target windows [--provider namespace]` (dry-run; add `--apply`) |
 | Skip a version-bump gate | `shipyard pr --skip-bump sdk --bump-reason "docs only"` |
@@ -280,6 +285,100 @@ whose output only changes when the crate or its dependencies move.
 Don't enable it on a lane that runs the full suite — the globs would
 have to cover the whole tree, at which point you're back to
 re-running everything anyway.
+
+## Warm-pool runner reuse
+
+Cross-PR evidence reuse (above) skips the whole target when nothing
+the target cares about changed. Warm-pool reuse is a narrower
+optimisation: even when the diff *did* touch paths the target runs
+against, the *runner itself* (SSH host, local workdir) doesn't need
+to be re-cloned and re-dep-installed every time. When a PASS landed
+within the last few minutes, the next ship on the same SHA can
+re-enter the already-populated workdir and skip the pre-stage
+(clone / sync / deps install). Validate — configure / build / test —
+re-runs in full, so a code change is never silently masked.
+
+Off by default. Opt in per target:
+
+```toml
+[targets.ubuntu]
+backend = "ssh"
+host = "ubuntu"
+platform = "linux-x64"
+# Hold the workdir open for 10 minutes after a PASS. Same-SHA ships
+# within the window skip clone/sync/deps. Default 0 = feature off.
+warm_keepalive_seconds = 600
+```
+
+### Three disable levels — why all three exist
+
+| Level | Knob | When to reach for it |
+|-------|------|----------------------|
+| Per-target | `warm_keepalive_seconds = 0` (default) | Targets that rely on a pristine env (release validation, flaky build scripts) stay cold-only. |
+| Global kill switch | `SHIPYARD_NO_WARM_POOL=1` env var | A CI that shells out to `shipyard` from inside another workflow — the outer runner is already ephemeral, and warm-pool state on that runner would be per-job noise. One-shot fresh escape hatch. |
+| Per-ship CLI flag | `shipyard ship --no-warm` / `shipyard run --no-warm` | An agent deliberately wants a cold-start for this one ship — typically when debugging a pre-stage regression or confirming a clean-room build. |
+
+The three levels compose: any one of them is enough to force a cold
+start. Why this isn't simply always-on:
+
+1. **Cloud runners cost money per second.** Silent always-on reuse on
+   a paid provider would surprise a monthly bill.
+2. **State drift is real.** Tests leave tmp files, build scripts
+   assume fresh `~/.cache`, background processes upgrade deps.
+   "Cold every time" is a correctness fence some users rely on.
+3. **Sometimes the point IS cold.** Release-validation lanes
+   deliberately want a pristine env to catch "works on my machine"
+   regressions.
+
+### Mechanics (what gets skipped, what still runs)
+
+When a warm-pool hit fires, the dispatcher passes `resume_from=configure`
+to the executor — the same machinery that powers `shipyard run
+--resume-from <stage>`. The remote:
+
+- Keeps the existing workdir at the recorded SHA — no re-clone, no
+  bundle delivery, no `git checkout`.
+- Skips the `setup` stage (the conventional home for deps installs).
+- Runs `configure`, `build`, `test` as normal.
+
+A validation config that uses a single `command` field (no stage
+breakdown) can still benefit — the pre-stage skip still applies, but
+the single command always runs in full.
+
+### Eligibility and eviction
+
+| Condition | Behavior |
+|---|---|
+| Target is on backend `cloud` / `github-hosted` | Silently ineligible. Workflow runs are ephemeral — there's nothing to keep warm. Shipyard warns once per invocation so a misconfigured target surfaces, not silently. |
+| Current job SHA differs from the pool entry's SHA | Miss → cold start. The pool is strictly same-SHA; it is not a cross-SHA workdir cache. |
+| Pool entry past `expires_at` | Pruned on lookup; cold start. |
+| Any non-PASS outcome after a warm reuse was applied | Entry evicted. The pool never serves a dirty workdir twice. |
+| `SHIPYARD_NO_WARM_POOL=1` set | Every lookup short-circuits to miss; no entries are recorded either. |
+
+### How it surfaces
+
+- `shipyard targets warm status --json` lists every live entry with
+  target, host, backend, workdir, SHA, TTL remaining, expires_at,
+  created_at. Expired entries are pruned as a side effect.
+- `shipyard targets warm drain [--yes]` empties the pool — use after a
+  host reboot, runner-image change, or any event that invalidates
+  the tracked workdirs.
+- Pool file lives at `<state_dir>/warm_pool.json`. Safe to delete
+  manually; worst case, the next ship cold-starts.
+
+### When to enable
+
+- SSH lanes against a long-lived host where `apt install` / `npm
+  install` / `cargo fetch` dominates the per-run wall clock.
+- Local lanes with expensive first-run setup (e.g. virtualenv
+  creation, system framework bootstrap).
+
+### When NOT to enable
+
+- Release-validation lanes — you want pristine every time.
+- Flaky targets that sometimes leave lockfiles behind.
+- Cloud / GitHub-hosted lanes — the backend is ineligible; the knob
+  has no effect and Shipyard warns to reconcile the config.
 
 ## Failure classification
 

--- a/src/shipyard/__init__.py
+++ b/src/shipyard/__init__.py
@@ -1,3 +1,3 @@
 """Shipyard — Cross-platform CI coordination."""
 
-__version__ = "0.18.0"
+__version__ = "0.19.0"

--- a/src/shipyard/cli.py
+++ b/src/shipyard/cli.py
@@ -52,6 +52,16 @@ from shipyard.release_bot.setup import (
     set_secret,
     verify_token,
 )
+from shipyard.targets.warm_pool import (
+    PoolEntry,
+    WarmPool,
+    compute_expires_at,
+    default_pool_path,
+    extract_warm_keepalive_seconds,
+    is_backend_eligible,
+    warm_host_key,
+    warm_reuse_disabled_by_env,
+)
 
 if TYPE_CHECKING:
     from shipyard.ship.lane_policy import LanePolicy
@@ -139,6 +149,15 @@ def main(ctx: click.Context, json_mode: bool) -> None:
     is_flag=True,
     help="Queue the run even if no backend is reachable for one or more targets",
 )
+@click.option(
+    "--no-warm",
+    is_flag=True,
+    help=(
+        "Force cold-start (skip warm-pool reuse even when the target "
+        "opted in with warm_keepalive_seconds). Equivalent to setting "
+        "SHIPYARD_NO_WARM_POOL=1 for this invocation."
+    ),
+)
 @click.pass_obj
 def run(
     ctx: Context,
@@ -148,6 +167,7 @@ def run(
     resume_from: str | None,
     allow_root_mismatch: bool,
     allow_unreachable_targets: bool,
+    no_warm: bool,
 ) -> None:
     """Validate current HEAD on configured targets."""
     config = ctx.config
@@ -201,6 +221,7 @@ def run(
         mode=mode,
         fail_fast=fail_fast,
         resume_from=resume_from,
+        warm_disabled=no_warm,
     )
 
     if ctx.json_mode:
@@ -2537,6 +2558,14 @@ def cloud_status(ctx: Context, identifier: str | None, limit: int, refresh: bool
         "change since the saved state was written."
     ),
 )
+@click.option(
+    "--no-warm",
+    is_flag=True,
+    help=(
+        "Force cold-start (skip warm-pool reuse for every target on this "
+        "ship). Equivalent to setting SHIPYARD_NO_WARM_POOL=1."
+    ),
+)
 @click.pass_obj
 def ship(
     ctx: Context,
@@ -2545,6 +2574,7 @@ def ship(
     allow_unreachable_targets: bool,
     auto_create_base: bool | None,
     resume: bool | None,
+    no_warm: bool,
 ) -> None:
     """Branch -> PR -> validate -> merge on green."""
     from shipyard.ship.pr import create_pr, find_pr_for_branch, merge_pr
@@ -2686,6 +2716,7 @@ def ship(
         fail_fast=False,
         resume_from=None,
         ship_state=existing_state,
+        warm_disabled=no_warm,
     )
 
     if job.passed:
@@ -4174,12 +4205,17 @@ def _execute_job(
     fail_fast: bool,
     resume_from: str | None,
     ship_state: ShipState | None = None,
+    warm_disabled: bool = False,
 ) -> Job:
     job = job.start()
     ctx.queue.update(job)
 
     validation_config = _resolve_validation(config, mode)
     had_failure = False
+    warm_pool = WarmPool(default_pool_path(config.state_dir))
+    # Global kill switch: env var disables everything for this process.
+    warm_globally_off = warm_disabled or warm_reuse_disabled_by_env()
+    warmed_bucket: set[str] = set()  # per-invocation warn-once bucket
 
     for name in job.target_names:
         if had_failure and fail_fast:
@@ -4219,6 +4255,24 @@ def _execute_job(
             if not ctx.json_mode:
                 render_job(job)
             continue
+
+        # Warm-pool reuse gate. When the target opts in via
+        # ``warm_keepalive_seconds > 0`` and a live, same-SHA entry
+        # exists for this ``(target, host)`` pair, re-enter the
+        # previously warmed workdir and skip pre-stage (the bundle
+        # delivery and the ``setup`` step). Validate is always re-run.
+        # See ``src/shipyard/targets/warm_pool.py``.
+        warm_hit, effective_resume = _apply_warm_reuse(
+            pool=warm_pool,
+            target_name=name,
+            target_config=target_config,
+            backend=backend_name,
+            sha=job.sha,
+            requested_resume_from=resume_from,
+            globally_off=warm_globally_off,
+            warn_bucket=warmed_bucket,
+            json_mode=ctx.json_mode,
+        )
 
         running = TargetResult(
             target_name=name,
@@ -4260,10 +4314,24 @@ def _execute_job(
             validation_config=resolved_validation,
             log_path=log_path,
             progress_callback=progress_callback,
-            resume_from=resume_from,
+            resume_from=effective_resume,
         )
         job = state["job"].with_result(result)
         ctx.queue.update(job)
+
+        # Warm-pool bookkeeping. On PASS, refresh / insert the entry;
+        # on any non-PASS outcome during a warm reuse, evict so a
+        # potentially dirty workdir is not served twice.
+        _update_warm_pool_after_run(
+            pool=warm_pool,
+            target_name=name,
+            target_config=target_config,
+            backend=backend_name,
+            sha=job.sha,
+            result=result,
+            warm_was_applied=warm_hit,
+            globally_off=warm_globally_off,
+        )
 
         if not result.passed:
             had_failure = True
@@ -4277,6 +4345,132 @@ def _execute_job(
     if ship_state is not None:
         _update_ship_state_from_job(ctx, ship_state, job)
     return job
+
+
+def _apply_warm_reuse(
+    *,
+    pool: WarmPool,
+    target_name: str,
+    target_config: dict[str, Any],
+    backend: str,
+    sha: str,
+    requested_resume_from: str | None,
+    globally_off: bool,
+    warn_bucket: set[str],
+    json_mode: bool,
+) -> tuple[bool, str | None]:
+    """Consult the warm pool and (if hit) mutate ``target_config`` in place.
+
+    Returns ``(warm_hit, effective_resume_from)``.
+
+    ``warm_hit`` is True when a live pool entry was consumed. The
+    caller uses it to decide whether a subsequent failure should evict
+    the entry.
+
+    ``effective_resume_from`` is the resume stage to pass to the
+    dispatcher. When reuse fires and the caller did not already ask
+    for a more-aggressive resume point, we jump to ``configure`` — i.e.
+    skip the ``setup`` stage (deps install) and re-run configure /
+    build / test. If the caller explicitly asked for a later stage
+    (e.g. ``--resume-from=test``), we honor that instead.
+    """
+    if globally_off:
+        return False, requested_resume_from
+    keepalive = extract_warm_keepalive_seconds(target_config)
+    if keepalive <= 0:
+        return False, requested_resume_from
+    if not is_backend_eligible(backend, target_config):
+        # The target opted in but the backend can't honor it
+        # (workflow-dispatch runners are ephemeral). Warn once per
+        # (target, invocation) so users can reconcile their config.
+        if target_name not in warn_bucket:
+            warn_bucket.add(target_name)
+            if not json_mode:
+                render_message(
+                    f"warning: target '{target_name}' set "
+                    f"warm_keepalive_seconds but backend {backend!r} is "
+                    f"ephemeral — warm-pool reuse ignored",
+                    style="dim yellow",
+                )
+        return False, requested_resume_from
+
+    host = warm_host_key(target_config)
+    entry = pool.get(target_name, host)
+    if entry is None or entry.sha != sha:
+        return False, requested_resume_from
+
+    # Prefer the caller's request if it already skips further than
+    # our default warm resume point — e.g. ``--resume-from=test``
+    # should stay at ``test``.
+    resume_order = ("setup", "configure", "build", "test")
+    warm_default = "configure"  # skip pre-stage, re-run configure+build+test
+    if requested_resume_from in resume_order:
+        try:
+            requested_idx = resume_order.index(requested_resume_from)
+        except ValueError:
+            requested_idx = -1
+        default_idx = resume_order.index(warm_default)
+        effective = requested_resume_from if requested_idx > default_idx else warm_default
+    else:
+        effective = warm_default
+
+    # Re-enter the warmed workdir so the executor finds the repo
+    # already populated. For SSH backends we overwrite ``repo_path``;
+    # other backends treat ``_warm_workdir`` as a hint.
+    target_config["repo_path"] = entry.workdir
+    target_config["_warm_workdir"] = entry.workdir
+    target_config["_warm_reuse"] = True
+    return True, effective
+
+
+def _update_warm_pool_after_run(
+    *,
+    pool: WarmPool,
+    target_name: str,
+    target_config: dict[str, Any],
+    backend: str,
+    sha: str,
+    result: TargetResult,
+    warm_was_applied: bool,
+    globally_off: bool,
+) -> None:
+    """Record / evict warm-pool entries based on run outcome.
+
+    - PASS on an eligible backend: upsert a fresh entry with a new
+      expiry window.
+    - Non-PASS following a warm reuse: evict the entry so the next
+      ship on that ``(target, host)`` pair cold-starts from scratch.
+    - PASS on an ineligible backend or when globally off: no-op.
+    """
+    host = warm_host_key(target_config)
+
+    if result.passed:
+        if globally_off:
+            return
+        keepalive = extract_warm_keepalive_seconds(target_config)
+        if keepalive <= 0:
+            return
+        if not is_backend_eligible(backend, target_config):
+            return
+        workdir = (
+            target_config.get("_warm_workdir")
+            or target_config.get("repo_path")
+            or "~/repo"
+        )
+        entry = PoolEntry(
+            target=target_name,
+            host=host,
+            backend=backend,
+            workdir=str(workdir),
+            sha=sha,
+            expires_at=compute_expires_at(keepalive),
+            created_at=datetime.now(timezone.utc).timestamp(),
+        )
+        pool.upsert(entry)
+        return
+
+    if warm_was_applied:
+        pool.evict(target_name, host)
 
 
 def _maybe_reuse_evidence(
@@ -4927,6 +5121,105 @@ def targets_add(
         ctx.output("targets.add", {"name": name, "config": new_target})
     else:
         render_message(f"Added target '{name}' to {config_path}", style="green")
+
+
+@targets.group("warm", invoke_without_command=True)
+@click.pass_context
+def targets_warm(ctx: click.Context) -> None:
+    """Inspect and drain the warm-pool of reusable runners.
+
+    With no subcommand, lists live entries — same as
+    ``shipyard targets warm status``.
+    """
+    if ctx.invoked_subcommand is None:
+        ctx.invoke(targets_warm_status)
+
+
+@targets_warm.command("status")
+@click.pass_obj
+def targets_warm_status(ctx: Context) -> None:
+    """Show live warm-pool entries (target, host, TTL remaining, SHA).
+
+    Expired entries are pruned from the file as a side effect so
+    repeated calls don't surface stale rows.
+    """
+    pool = WarmPool(default_pool_path(ctx.config.state_dir))
+    pool.prune_expired()
+    entries = pool.all_entries()
+
+    rows: list[dict[str, Any]] = []
+    for entry in entries:
+        rows.append({
+            "target": entry.target,
+            "host": entry.host,
+            "backend": entry.backend,
+            "workdir": entry.workdir,
+            "sha": entry.sha,
+            "ttl_remaining_secs": round(entry.ttl_remaining_secs(), 1),
+            "expires_at": datetime.fromtimestamp(
+                entry.expires_at, tz=timezone.utc
+            ).isoformat(),
+            "created_at": datetime.fromtimestamp(
+                entry.created_at, tz=timezone.utc
+            ).isoformat(),
+        })
+
+    if ctx.json_mode:
+        ctx.output("targets.warm.status", {"entries": rows})
+        return
+
+    if not rows:
+        render_message("Warm pool is empty.", style="dim")
+        return
+
+    console.print()
+    console.print("[bold]Warm pool[/]")
+    for row in rows:
+        ttl = row["ttl_remaining_secs"]
+        console.print(
+            f"  {row['target']:<16} {row['host']:<20} "
+            f"sha={row['sha'][:8]} ttl={ttl:>6.0f}s "
+            f"workdir={row['workdir']}"
+        )
+    console.print()
+
+
+@targets_warm.command("drain")
+@click.option(
+    "--yes",
+    is_flag=True,
+    help="Skip the confirmation prompt.",
+)
+@click.pass_obj
+def targets_warm_drain(ctx: Context, yes: bool) -> None:
+    """Remove every warm-pool entry.
+
+    Useful after a host reboot, a runner image change, or any other
+    event that invalidates the workdirs the pool is tracking. Next
+    ship on every target cold-starts.
+    """
+    pool = WarmPool(default_pool_path(ctx.config.state_dir))
+    entries = pool.all_entries()
+    if not entries:
+        if ctx.json_mode:
+            ctx.output("targets.warm.drain", {"drained": 0})
+        else:
+            render_message("Warm pool already empty.", style="dim")
+        return
+
+    if not yes and not ctx.json_mode and not click.confirm(
+        f"Drain {len(entries)} warm-pool entr"
+        f"{'y' if len(entries) == 1 else 'ies'}?",
+        default=False,
+    ):
+        render_message("Aborted.", style="dim")
+        return
+
+    drained = pool.drain()
+    if ctx.json_mode:
+        ctx.output("targets.warm.drain", {"drained": drained})
+    else:
+        render_message(f"Drained {drained} warm-pool entries.", style="green")
 
 
 @targets.command("remove")

--- a/src/shipyard/targets/warm_pool.py
+++ b/src/shipyard/targets/warm_pool.py
@@ -1,0 +1,296 @@
+"""Warm-pool runner reuse across PRs.
+
+A "warm pool" entry lets a subsequent ship within a configurable TTL
+skip the expensive pre-stage (clone / sync / deps) by re-entering the
+same runner workdir that was left in a known-good state by a recent
+PASS. Validate (configure / build / test) is always re-run, so the
+feature trades a small, bounded correctness risk (stale workdir on the
+same SHA) for a potentially large time saving on SSH and cloud runners.
+
+Design points — mirrors issue #82:
+
+- Opt-in per target via ``warm_keepalive_seconds = <N>`` on the target
+  section (default 0 = feature off). See
+  :func:`extract_warm_keepalive_seconds`.
+- Global kill switch: ``SHIPYARD_NO_WARM_POOL=1`` in the env. See
+  :func:`warm_reuse_disabled_by_env`.
+- Per-ship CLI flag: ``--no-warm`` passed in by the dispatcher.
+- GitHub-hosted cloud targets are silently ineligible (workflow runs
+  are ephemeral) and surface a single warn-once message so users can
+  reconcile the config. See :func:`is_backend_eligible`.
+- Same-SHA reuse only — an entry is consulted only if the current job
+  SHA matches the stored SHA. The feature is not a cross-SHA cache; it
+  only exists to amortise pre-stage cost for back-to-back ships of the
+  exact same commit.
+- Any failure during a warm reuse evicts the entry so the pool never
+  serves a dirty workdir twice.
+
+The pool state is a single JSON file under the machine-global state
+directory. Atomic writes (``<path>.tmp`` → rename) keep concurrent
+Shipyard processes from corrupting it.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+DEFAULT_POOL_FILENAME = "warm_pool.json"
+
+# Backends whose runner identity survives a shipyard invocation.
+# Everything else (cloud/github-hosted) is ephemeral per workflow run.
+_ELIGIBLE_BACKENDS = {"ssh", "ssh-windows", "local"}
+
+
+@dataclass(frozen=True)
+class PoolEntry:
+    """A single warm-pool record.
+
+    Attributes:
+        target: Target name the entry belongs to.
+        host: Host identifier (SSH alias / ``user@host`` / ``local``).
+            Used as the tuple key along with ``target`` so a target
+            that was last warm on host A won't be mis-served when a
+            subsequent config switches it to host B.
+        backend: Backend the entry was warmed on (``ssh`` /
+            ``ssh-windows`` / ``local``).
+        workdir: Remote repository path the pre-stage was performed in.
+            The executor re-enters this directory instead of re-cloning.
+        sha: The exact SHA the pre-stage was run against. Reuse is
+            only honored when the next job is on this same SHA.
+        expires_at: Monotonic-clock-safe UNIX epoch seconds. Entries
+            past this point are ignored and pruned.
+        created_at: UNIX epoch seconds when the entry was recorded,
+            for observability on ``shipyard targets warm status``.
+    """
+
+    target: str
+    host: str
+    backend: str
+    workdir: str
+    sha: str
+    expires_at: float
+    created_at: float
+
+    def is_expired(self, *, now: float | None = None) -> bool:
+        """Return True if ``now`` (default: wall clock) is past expiry."""
+        return (now if now is not None else time.time()) >= self.expires_at
+
+    def ttl_remaining_secs(self, *, now: float | None = None) -> float:
+        """Seconds until expiry; clamped to 0 when past-expiry."""
+        gap = self.expires_at - (now if now is not None else time.time())
+        return max(0.0, gap)
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> PoolEntry:
+        return cls(
+            target=str(data["target"]),
+            host=str(data["host"]),
+            backend=str(data["backend"]),
+            workdir=str(data["workdir"]),
+            sha=str(data["sha"]),
+            expires_at=float(data["expires_at"]),
+            created_at=float(data["created_at"]),
+        )
+
+
+class WarmPool:
+    """JSON-backed persistent warm-pool store.
+
+    Not a process-wide singleton — callers construct one against a
+    specific state directory. The store is keyed by ``(target, host)``
+    so different physical hosts running the same logical target don't
+    collide; the first writer wins per key.
+    """
+
+    def __init__(self, path: Path) -> None:
+        self.path = path
+
+    # ---- load / save -----------------------------------------------
+
+    def _load_raw(self) -> list[dict[str, Any]]:
+        """Read the raw list of entries from disk.
+
+        Returns an empty list when the file is missing, unreadable, or
+        malformed. The pool is best-effort: a corrupt file must not
+        block a ship, so we swallow errors here and let the next save
+        overwrite them.
+        """
+        if not self.path.exists():
+            return []
+        try:
+            payload = json.loads(self.path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return []
+        if not isinstance(payload, dict):
+            return []
+        entries = payload.get("entries", [])
+        if not isinstance(entries, list):
+            return []
+        return [item for item in entries if isinstance(item, dict)]
+
+    def all_entries(self) -> list[PoolEntry]:
+        """Return every entry currently in the pool (expired included)."""
+        out: list[PoolEntry] = []
+        for raw in self._load_raw():
+            try:
+                out.append(PoolEntry.from_dict(raw))
+            except (KeyError, TypeError, ValueError):
+                continue
+        return out
+
+    def save_entries(self, entries: list[PoolEntry]) -> None:
+        """Atomically rewrite the pool file with the given entries."""
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        payload = {"entries": [entry.to_dict() for entry in entries]}
+        tmp = self.path.with_suffix(self.path.suffix + ".tmp")
+        tmp.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+        os.replace(tmp, self.path)
+
+    # ---- lookups ---------------------------------------------------
+
+    def get(self, target: str, host: str) -> PoolEntry | None:
+        """Return the unexpired entry for ``(target, host)`` or None.
+
+        Expired entries are ignored here but not pruned; call
+        :meth:`prune_expired` if you want the file to shrink.
+        """
+        now = time.time()
+        for entry in self.all_entries():
+            if entry.target == target and entry.host == host:
+                if entry.is_expired(now=now):
+                    return None
+                return entry
+        return None
+
+    # ---- mutations -------------------------------------------------
+
+    def upsert(self, entry: PoolEntry) -> None:
+        """Insert or replace the record for ``(target, host)``."""
+        existing = [
+            e for e in self.all_entries()
+            if not (e.target == entry.target and e.host == entry.host)
+        ]
+        existing.append(entry)
+        self.save_entries(existing)
+
+    def evict(self, target: str, host: str) -> bool:
+        """Remove the entry for ``(target, host)``. Return True if removed."""
+        kept: list[PoolEntry] = []
+        removed = False
+        for entry in self.all_entries():
+            if entry.target == target and entry.host == host:
+                removed = True
+                continue
+            kept.append(entry)
+        if removed:
+            self.save_entries(kept)
+        return removed
+
+    def drain(self) -> int:
+        """Remove every entry. Return count drained."""
+        current = self.all_entries()
+        self.save_entries([])
+        return len(current)
+
+    def prune_expired(self) -> int:
+        """Remove expired entries; return how many were pruned."""
+        now = time.time()
+        kept: list[PoolEntry] = []
+        pruned = 0
+        for entry in self.all_entries():
+            if entry.is_expired(now=now):
+                pruned += 1
+                continue
+            kept.append(entry)
+        if pruned:
+            self.save_entries(kept)
+        return pruned
+
+
+# ── helpers used by executor / CLI ───────────────────────────────
+
+
+def default_pool_path(state_dir: Path) -> Path:
+    """Canonical location for the warm-pool JSON file."""
+    return Path(state_dir) / DEFAULT_POOL_FILENAME
+
+
+def warm_reuse_disabled_by_env(env: dict[str, str] | None = None) -> bool:
+    """Return True when ``SHIPYARD_NO_WARM_POOL=1`` is set.
+
+    Accepts any of ``1|true|yes|on`` (case-insensitive) to match how
+    other Shipyard env flags are parsed.
+    """
+    source = env if env is not None else os.environ
+    raw = source.get("SHIPYARD_NO_WARM_POOL", "")
+    return raw.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def extract_warm_keepalive_seconds(target_config: dict[str, Any]) -> int:
+    """Return the configured keepalive in seconds; 0 means "off".
+
+    Tolerant of strings / negatives — anything non-positive maps to 0
+    so a misconfigured target silently keeps the safe default.
+    """
+    raw = target_config.get("warm_keepalive_seconds", 0)
+    try:
+        secs = int(raw)
+    except (TypeError, ValueError):
+        return 0
+    return secs if secs > 0 else 0
+
+
+def is_backend_eligible(backend: str, target_config: dict[str, Any]) -> bool:
+    """Whether ``backend`` is a type where reuse makes sense.
+
+    Cloud + GitHub-hosted runners are excluded because each workflow
+    run gets a fresh VM; there's nothing to keep warm. SSH / local
+    runners keep the workdir across invocations, which is where the
+    whole point of the pool lives.
+
+    ``target_config`` is accepted for future per-target overrides
+    (e.g. a Namespace self-managed pool that does persist) but is
+    otherwise unused.
+    """
+    del target_config  # reserved for future overrides
+    return backend.lower() in _ELIGIBLE_BACKENDS
+
+
+def warm_host_key(target_config: dict[str, Any]) -> str:
+    """Pick a stable host key for pool indexing.
+
+    SSH backends use their ``host`` field; local backends collapse to
+    a literal ``"local"`` so the same machine doesn't spawn dozens of
+    identical entries if hostname lookups vary.
+    """
+    host = target_config.get("host")
+    if isinstance(host, str) and host.strip():
+        return host.strip()
+    return "local"
+
+
+def compute_expires_at(keepalive_seconds: int, *, now: float | None = None) -> float:
+    """Return the absolute expiry time for a new pool entry."""
+    base = now if now is not None else time.time()
+    return base + max(0, int(keepalive_seconds))
+
+
+__all__ = [
+    "DEFAULT_POOL_FILENAME",
+    "PoolEntry",
+    "WarmPool",
+    "compute_expires_at",
+    "default_pool_path",
+    "extract_warm_keepalive_seconds",
+    "is_backend_eligible",
+    "warm_host_key",
+    "warm_reuse_disabled_by_env",
+]

--- a/tests/targets/test_warm_pool.py
+++ b/tests/targets/test_warm_pool.py
@@ -1,0 +1,240 @@
+"""Unit tests for the warm-pool module.
+
+Covers: entry lifecycle (insert / lookup / evict / drain / prune),
+TTL math, env / config opt-outs, backend eligibility, and atomic
+file writes.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from typing import TYPE_CHECKING
+
+import pytest
+
+from shipyard.targets.warm_pool import (
+    DEFAULT_POOL_FILENAME,
+    PoolEntry,
+    WarmPool,
+    compute_expires_at,
+    default_pool_path,
+    extract_warm_keepalive_seconds,
+    is_backend_eligible,
+    warm_host_key,
+    warm_reuse_disabled_by_env,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.fixture
+def pool_path(tmp_path: Path) -> Path:
+    return tmp_path / "warm_pool.json"
+
+
+def _entry(
+    *,
+    target: str = "ubuntu",
+    host: str = "ubuntu",
+    backend: str = "ssh",
+    workdir: str = "~/repo",
+    sha: str = "a" * 40,
+    ttl: float = 600.0,
+    now: float | None = None,
+) -> PoolEntry:
+    base = now if now is not None else time.time()
+    return PoolEntry(
+        target=target,
+        host=host,
+        backend=backend,
+        workdir=workdir,
+        sha=sha,
+        expires_at=base + ttl,
+        created_at=base,
+    )
+
+
+class TestPoolEntry:
+    def test_is_expired_before_ttl(self) -> None:
+        entry = _entry(ttl=60.0)
+        assert not entry.is_expired()
+
+    def test_is_expired_past_ttl(self) -> None:
+        entry = _entry(ttl=-1.0)
+        assert entry.is_expired()
+
+    def test_ttl_remaining_positive(self) -> None:
+        now = 1000.0
+        entry = _entry(now=now, ttl=120.0)
+        assert entry.ttl_remaining_secs(now=now) == 120.0
+
+    def test_ttl_remaining_clamped_to_zero(self) -> None:
+        now = 2000.0
+        entry = _entry(now=now, ttl=-10.0)
+        assert entry.ttl_remaining_secs(now=now) == 0.0
+
+    def test_roundtrip_dict(self) -> None:
+        entry = _entry()
+        round_tripped = PoolEntry.from_dict(entry.to_dict())
+        assert round_tripped == entry
+
+
+class TestWarmPool:
+    def test_missing_file_reads_as_empty(self, pool_path: Path) -> None:
+        pool = WarmPool(pool_path)
+        assert pool.all_entries() == []
+        assert pool.get("anything", "host") is None
+
+    def test_upsert_and_get(self, pool_path: Path) -> None:
+        pool = WarmPool(pool_path)
+        entry = _entry()
+        pool.upsert(entry)
+        got = pool.get("ubuntu", "ubuntu")
+        assert got is not None
+        assert got == entry
+
+    def test_upsert_replaces_same_key(self, pool_path: Path) -> None:
+        pool = WarmPool(pool_path)
+        pool.upsert(_entry(workdir="~/old"))
+        pool.upsert(_entry(workdir="~/new"))
+        entries = pool.all_entries()
+        assert len(entries) == 1
+        assert entries[0].workdir == "~/new"
+
+    def test_different_hosts_are_distinct(self, pool_path: Path) -> None:
+        pool = WarmPool(pool_path)
+        pool.upsert(_entry(host="host-a", workdir="~/a"))
+        pool.upsert(_entry(host="host-b", workdir="~/b"))
+        assert len(pool.all_entries()) == 2
+        assert pool.get("ubuntu", "host-a").workdir == "~/a"  # type: ignore[union-attr]
+        assert pool.get("ubuntu", "host-b").workdir == "~/b"  # type: ignore[union-attr]
+
+    def test_get_returns_none_when_expired(self, pool_path: Path) -> None:
+        pool = WarmPool(pool_path)
+        pool.upsert(_entry(ttl=-1.0))
+        assert pool.get("ubuntu", "ubuntu") is None
+
+    def test_evict(self, pool_path: Path) -> None:
+        pool = WarmPool(pool_path)
+        pool.upsert(_entry())
+        assert pool.evict("ubuntu", "ubuntu") is True
+        assert pool.get("ubuntu", "ubuntu") is None
+        # second evict is a no-op
+        assert pool.evict("ubuntu", "ubuntu") is False
+
+    def test_drain(self, pool_path: Path) -> None:
+        pool = WarmPool(pool_path)
+        pool.upsert(_entry(target="t1"))
+        pool.upsert(_entry(target="t2"))
+        assert pool.drain() == 2
+        assert pool.all_entries() == []
+
+    def test_prune_expired(self, pool_path: Path) -> None:
+        pool = WarmPool(pool_path)
+        pool.upsert(_entry(target="fresh", ttl=600.0))
+        pool.upsert(_entry(target="stale", ttl=-1.0))
+        pruned = pool.prune_expired()
+        assert pruned == 1
+        targets = {e.target for e in pool.all_entries()}
+        assert targets == {"fresh"}
+
+    def test_corrupt_file_ignored(self, pool_path: Path) -> None:
+        pool_path.write_text("{ not valid json")
+        pool = WarmPool(pool_path)
+        # corrupt file doesn't crash lookups
+        assert pool.all_entries() == []
+        # next write overwrites it cleanly
+        pool.upsert(_entry())
+        data = json.loads(pool_path.read_text())
+        assert "entries" in data and len(data["entries"]) == 1
+
+    def test_atomic_write_leaves_no_tmp(self, pool_path: Path) -> None:
+        pool = WarmPool(pool_path)
+        pool.upsert(_entry())
+        siblings = list(pool_path.parent.iterdir())
+        # only the real file should remain; .tmp must be renamed away
+        assert [p.name for p in siblings if p.suffix == ".tmp"] == []
+
+    def test_default_pool_path(self, tmp_path: Path) -> None:
+        assert default_pool_path(tmp_path).name == DEFAULT_POOL_FILENAME
+        assert default_pool_path(tmp_path).parent == tmp_path
+
+
+class TestEnvKill:
+    def test_env_default_off(self) -> None:
+        assert warm_reuse_disabled_by_env({}) is False
+
+    @pytest.mark.parametrize("value", ["1", "true", "yes", "ON", "True"])
+    def test_env_truthy_kills(self, value: str) -> None:
+        assert warm_reuse_disabled_by_env({"SHIPYARD_NO_WARM_POOL": value}) is True
+
+    @pytest.mark.parametrize("value", ["0", "false", "no", ""])
+    def test_env_falsy_allows(self, value: str) -> None:
+        assert warm_reuse_disabled_by_env({"SHIPYARD_NO_WARM_POOL": value}) is False
+
+
+class TestConfigExtractors:
+    def test_missing_key_means_off(self) -> None:
+        assert extract_warm_keepalive_seconds({}) == 0
+
+    def test_zero_means_off(self) -> None:
+        assert extract_warm_keepalive_seconds({"warm_keepalive_seconds": 0}) == 0
+
+    def test_positive_int(self) -> None:
+        assert extract_warm_keepalive_seconds(
+            {"warm_keepalive_seconds": 600}
+        ) == 600
+
+    def test_negative_coerces_to_zero(self) -> None:
+        assert extract_warm_keepalive_seconds(
+            {"warm_keepalive_seconds": -5}
+        ) == 0
+
+    def test_garbage_value_coerces_to_zero(self) -> None:
+        assert extract_warm_keepalive_seconds(
+            {"warm_keepalive_seconds": "nope"}
+        ) == 0
+
+    def test_numeric_string_parses(self) -> None:
+        assert extract_warm_keepalive_seconds(
+            {"warm_keepalive_seconds": "300"}
+        ) == 300
+
+
+class TestBackendEligibility:
+    @pytest.mark.parametrize("backend", ["ssh", "ssh-windows", "local"])
+    def test_eligible(self, backend: str) -> None:
+        assert is_backend_eligible(backend, {}) is True
+
+    @pytest.mark.parametrize("backend", ["cloud", "github-hosted", "namespace"])
+    def test_ineligible(self, backend: str) -> None:
+        assert is_backend_eligible(backend, {}) is False
+
+    def test_case_insensitive(self) -> None:
+        assert is_backend_eligible("SSH", {}) is True
+
+
+class TestHostKey:
+    def test_uses_host_field(self) -> None:
+        assert warm_host_key({"host": "ubuntu"}) == "ubuntu"
+
+    def test_strips_whitespace(self) -> None:
+        assert warm_host_key({"host": "  ubuntu  "}) == "ubuntu"
+
+    def test_missing_collapses_to_local(self) -> None:
+        assert warm_host_key({}) == "local"
+
+    def test_empty_string_collapses_to_local(self) -> None:
+        assert warm_host_key({"host": ""}) == "local"
+
+
+class TestComputeExpiresAt:
+    def test_basic(self) -> None:
+        now = 1000.0
+        assert compute_expires_at(600, now=now) == 1600.0
+
+    def test_negative_clamped(self) -> None:
+        now = 1000.0
+        assert compute_expires_at(-10, now=now) == 1000.0

--- a/tests/test_cli_warm_pool.py
+++ b/tests/test_cli_warm_pool.py
@@ -1,0 +1,455 @@
+"""Integration tests for warm-pool reuse in the run / targets CLI.
+
+Verifies the end-to-end gate in ``_execute_job``: a first PASS
+records an entry, a second ship on the same SHA re-enters that
+workdir with ``resume_from=configure``, and a FAIL evicts the
+entry. Also covers the three disable levels (per-target,
+``SHIPYARD_NO_WARM_POOL`` env, ``--no-warm`` CLI flag), the GitHub-
+hosted ineligibility warning, and the ``targets warm status|drain``
+subcommands.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING
+
+from click.testing import CliRunner
+
+from shipyard.cli import main
+from shipyard.core.config import Config
+from shipyard.core.job import TargetResult, TargetStatus
+from shipyard.preflight import PreflightResult
+from shipyard.targets.warm_pool import WarmPool, default_pool_path
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _config(tmp_path: Path, targets: dict) -> Config:
+    project_dir = tmp_path / ".shipyard"
+    project_dir.mkdir()
+    return Config(
+        data={
+            "project": {"name": "shipyard", "platforms": ["linux"]},
+            "validation": {"default": {"command": "pytest"}},
+            "targets": targets,
+        },
+        project_dir=project_dir,
+    )
+
+
+def _preflight(config: Config) -> PreflightResult:
+    return PreflightResult(
+        git_root=config.project_dir.parent if config.project_dir else None,
+        expected_root=config.project_dir.parent if config.project_dir else None,
+        targets={},
+        warnings=[],
+    )
+
+
+def _install_common_stubs(monkeypatch, config: Config, state_dir: Path) -> None:
+    monkeypatch.setattr("shipyard.cli.Config.load_from_cwd", lambda cwd=None: config)
+    monkeypatch.setattr("shipyard.core.config._default_state_dir", lambda: state_dir)
+    monkeypatch.setattr("shipyard.cli._git_sha", lambda: "a" * 40)
+    monkeypatch.setattr("shipyard.cli._git_branch", lambda: "feature/warm")
+    monkeypatch.setattr(
+        "shipyard.cli.run_submission_preflight",
+        lambda *args, **kwargs: _preflight(config),
+    )
+
+
+def _pass_result() -> TargetResult:
+    now = datetime.now(timezone.utc)
+    return TargetResult(
+        target_name="ubuntu",
+        platform="linux-x64",
+        status=TargetStatus.PASS,
+        backend="ssh",
+        started_at=now,
+        completed_at=now,
+    )
+
+
+def _fail_result() -> TargetResult:
+    now = datetime.now(timezone.utc)
+    return TargetResult(
+        target_name="ubuntu",
+        platform="linux-x64",
+        status=TargetStatus.FAIL,
+        backend="ssh",
+        started_at=now,
+        completed_at=now,
+        error_message="boom",
+    )
+
+
+class TestWarmPoolReuse:
+    def test_first_pass_records_entry(self, tmp_path, monkeypatch) -> None:
+        state_dir = tmp_path / "state"
+        config = _config(
+            tmp_path,
+            {
+                "ubuntu": {
+                    "backend": "ssh",
+                    "platform": "linux-x64",
+                    "host": "ubuntu",
+                    "warm_keepalive_seconds": 600,
+                    "repo_path": "~/repo",
+                }
+            },
+        )
+        _install_common_stubs(monkeypatch, config, state_dir)
+
+        monkeypatch.setattr(
+            "shipyard.executor.ssh.SSHExecutor.validate",
+            lambda self, **kwargs: _pass_result(),
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["--json", "run", "--targets", "ubuntu"])
+        assert result.exit_code == 0, result.output
+
+        pool = WarmPool(default_pool_path(state_dir))
+        entries = pool.all_entries()
+        assert len(entries) == 1
+        assert entries[0].target == "ubuntu"
+        assert entries[0].host == "ubuntu"
+        assert entries[0].sha == "a" * 40
+        assert entries[0].workdir == "~/repo"
+
+    def test_second_run_reuses_with_resume_from_configure(
+        self, tmp_path, monkeypatch,
+    ) -> None:
+        state_dir = tmp_path / "state"
+        config = _config(
+            tmp_path,
+            {
+                "ubuntu": {
+                    "backend": "ssh",
+                    "platform": "linux-x64",
+                    "host": "ubuntu",
+                    "warm_keepalive_seconds": 600,
+                    "repo_path": "~/original",
+                }
+            },
+        )
+        _install_common_stubs(monkeypatch, config, state_dir)
+
+        # Seed a pool entry as if a prior PASS landed.
+        from shipyard.targets.warm_pool import PoolEntry, compute_expires_at
+        now = datetime.now(timezone.utc).timestamp()
+        pool = WarmPool(default_pool_path(state_dir))
+        pool.upsert(PoolEntry(
+            target="ubuntu",
+            host="ubuntu",
+            backend="ssh",
+            workdir="/srv/warm-workdir",
+            sha="a" * 40,
+            expires_at=compute_expires_at(600, now=now),
+            created_at=now,
+        ))
+
+        captured: dict[str, object] = {}
+
+        def fake_validate(self, **kwargs):
+            captured.update(kwargs)
+            return _pass_result()
+
+        monkeypatch.setattr(
+            "shipyard.executor.ssh.SSHExecutor.validate", fake_validate,
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["--json", "run", "--targets", "ubuntu"])
+        assert result.exit_code == 0, result.output
+
+        # The warm workdir overrode the config default and the
+        # dispatcher received resume_from="configure" so pre-stage
+        # was skipped.
+        assert captured["resume_from"] == "configure"
+        assert captured["target_config"]["repo_path"] == "/srv/warm-workdir"
+
+    def test_failure_during_warm_reuse_evicts(self, tmp_path, monkeypatch) -> None:
+        state_dir = tmp_path / "state"
+        config = _config(
+            tmp_path,
+            {
+                "ubuntu": {
+                    "backend": "ssh",
+                    "platform": "linux-x64",
+                    "host": "ubuntu",
+                    "warm_keepalive_seconds": 600,
+                    "repo_path": "~/repo",
+                }
+            },
+        )
+        _install_common_stubs(monkeypatch, config, state_dir)
+
+        from shipyard.targets.warm_pool import PoolEntry, compute_expires_at
+        now = datetime.now(timezone.utc).timestamp()
+        pool = WarmPool(default_pool_path(state_dir))
+        pool.upsert(PoolEntry(
+            target="ubuntu",
+            host="ubuntu",
+            backend="ssh",
+            workdir="/srv/warm-workdir",
+            sha="a" * 40,
+            expires_at=compute_expires_at(600, now=now),
+            created_at=now,
+        ))
+
+        monkeypatch.setattr(
+            "shipyard.executor.ssh.SSHExecutor.validate",
+            lambda self, **kwargs: _fail_result(),
+        )
+
+        runner = CliRunner()
+        runner.invoke(main, ["--json", "run", "--targets", "ubuntu"])
+
+        pool_after = WarmPool(default_pool_path(state_dir))
+        assert pool_after.all_entries() == []
+
+    def test_no_warm_cli_flag_skips_reuse(self, tmp_path, monkeypatch) -> None:
+        state_dir = tmp_path / "state"
+        config = _config(
+            tmp_path,
+            {
+                "ubuntu": {
+                    "backend": "ssh",
+                    "platform": "linux-x64",
+                    "host": "ubuntu",
+                    "warm_keepalive_seconds": 600,
+                    "repo_path": "~/original",
+                }
+            },
+        )
+        _install_common_stubs(monkeypatch, config, state_dir)
+
+        from shipyard.targets.warm_pool import PoolEntry, compute_expires_at
+        now = datetime.now(timezone.utc).timestamp()
+        pool = WarmPool(default_pool_path(state_dir))
+        pool.upsert(PoolEntry(
+            target="ubuntu",
+            host="ubuntu",
+            backend="ssh",
+            workdir="/srv/warm-workdir",
+            sha="a" * 40,
+            expires_at=compute_expires_at(600, now=now),
+            created_at=now,
+        ))
+
+        captured: dict[str, object] = {}
+
+        def fake_validate(self, **kwargs):
+            captured.update(kwargs)
+            return _pass_result()
+
+        monkeypatch.setattr(
+            "shipyard.executor.ssh.SSHExecutor.validate", fake_validate,
+        )
+
+        runner = CliRunner()
+        # --no-warm forces cold-start regardless of pool contents.
+        result = runner.invoke(
+            main, ["--json", "run", "--targets", "ubuntu", "--no-warm"],
+        )
+        assert result.exit_code == 0, result.output
+
+        # resume_from is None (no reuse) and repo_path wasn't
+        # overridden by the warm workdir.
+        assert captured["resume_from"] is None
+        assert captured["target_config"]["repo_path"] == "~/original"
+
+    def test_env_kill_switch_skips_reuse(self, tmp_path, monkeypatch) -> None:
+        state_dir = tmp_path / "state"
+        config = _config(
+            tmp_path,
+            {
+                "ubuntu": {
+                    "backend": "ssh",
+                    "platform": "linux-x64",
+                    "host": "ubuntu",
+                    "warm_keepalive_seconds": 600,
+                    "repo_path": "~/original",
+                }
+            },
+        )
+        _install_common_stubs(monkeypatch, config, state_dir)
+        monkeypatch.setenv("SHIPYARD_NO_WARM_POOL", "1")
+
+        from shipyard.targets.warm_pool import PoolEntry, compute_expires_at
+        now = datetime.now(timezone.utc).timestamp()
+        pool = WarmPool(default_pool_path(state_dir))
+        pool.upsert(PoolEntry(
+            target="ubuntu",
+            host="ubuntu",
+            backend="ssh",
+            workdir="/srv/warm-workdir",
+            sha="a" * 40,
+            expires_at=compute_expires_at(600, now=now),
+            created_at=now,
+        ))
+
+        captured: dict[str, object] = {}
+
+        def fake_validate(self, **kwargs):
+            captured.update(kwargs)
+            return _pass_result()
+
+        monkeypatch.setattr(
+            "shipyard.executor.ssh.SSHExecutor.validate", fake_validate,
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["--json", "run", "--targets", "ubuntu"])
+        assert result.exit_code == 0, result.output
+        assert captured["resume_from"] is None
+        assert captured["target_config"]["repo_path"] == "~/original"
+
+    def test_keepalive_zero_is_off_per_target(self, tmp_path, monkeypatch) -> None:
+        state_dir = tmp_path / "state"
+        config = _config(
+            tmp_path,
+            {
+                "ubuntu": {
+                    "backend": "ssh",
+                    "platform": "linux-x64",
+                    "host": "ubuntu",
+                    "warm_keepalive_seconds": 0,
+                    "repo_path": "~/repo",
+                }
+            },
+        )
+        _install_common_stubs(monkeypatch, config, state_dir)
+
+        monkeypatch.setattr(
+            "shipyard.executor.ssh.SSHExecutor.validate",
+            lambda self, **kwargs: _pass_result(),
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["--json", "run", "--targets", "ubuntu"])
+        assert result.exit_code == 0, result.output
+
+        # PASS on a keepalive=0 target does NOT write a pool entry.
+        pool = WarmPool(default_pool_path(state_dir))
+        assert pool.all_entries() == []
+
+    def test_github_hosted_backend_ignored_with_warn(
+        self, tmp_path, monkeypatch,
+    ) -> None:
+        state_dir = tmp_path / "state"
+        # Cloud backend — workflow runs are ephemeral so warm
+        # reuse is a no-op. The warning goes to human output, not
+        # JSON — exercise the human path here.
+        config = _config(
+            tmp_path,
+            {
+                "win": {
+                    "backend": "cloud",
+                    "platform": "windows-x64",
+                    "warm_keepalive_seconds": 600,
+                    "workflow": "ci.yml",
+                    "repository": "acme/x",
+                }
+            },
+        )
+        _install_common_stubs(monkeypatch, config, state_dir)
+
+        def fake_validate(self, **kwargs):
+            return TargetResult(
+                target_name="win",
+                platform="windows-x64",
+                status=TargetStatus.PASS,
+                backend="cloud",
+                started_at=datetime.now(timezone.utc),
+                completed_at=datetime.now(timezone.utc),
+            )
+
+        monkeypatch.setattr(
+            "shipyard.executor.cloud.CloudExecutor.validate", fake_validate,
+        )
+        monkeypatch.setattr(
+            "shipyard.executor.cloud.CloudExecutor.probe",
+            lambda self, target_config: True,
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["run", "--targets", "win"])
+        assert result.exit_code == 0, result.output
+        assert "warm_keepalive_seconds" in result.output
+        assert "ephemeral" in result.output
+
+        # No pool entry written for an ineligible backend.
+        pool = WarmPool(default_pool_path(state_dir))
+        assert pool.all_entries() == []
+
+
+class TestWarmPoolSubcommands:
+    def test_status_empty(self, tmp_path, monkeypatch) -> None:
+        state_dir = tmp_path / "state"
+        config = _config(tmp_path, {})
+        _install_common_stubs(monkeypatch, config, state_dir)
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["--json", "targets", "warm", "status"])
+        assert result.exit_code == 0, result.output
+        assert json.loads(result.output)["entries"] == []
+
+    def test_status_lists_entries(self, tmp_path, monkeypatch) -> None:
+        state_dir = tmp_path / "state"
+        config = _config(tmp_path, {})
+        _install_common_stubs(monkeypatch, config, state_dir)
+
+        from shipyard.targets.warm_pool import PoolEntry, compute_expires_at
+        now = datetime.now(timezone.utc).timestamp()
+        pool = WarmPool(default_pool_path(state_dir))
+        pool.upsert(PoolEntry(
+            target="ubuntu",
+            host="ubuntu",
+            backend="ssh",
+            workdir="~/repo",
+            sha="b" * 40,
+            expires_at=compute_expires_at(600, now=now),
+            created_at=now,
+        ))
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["--json", "targets", "warm", "status"])
+        assert result.exit_code == 0, result.output
+        entries = json.loads(result.output)["entries"]
+        assert len(entries) == 1
+        assert entries[0]["target"] == "ubuntu"
+        assert entries[0]["sha"] == "b" * 40
+        assert entries[0]["ttl_remaining_secs"] > 0
+
+    def test_drain_removes_all(self, tmp_path, monkeypatch) -> None:
+        state_dir = tmp_path / "state"
+        config = _config(tmp_path, {})
+        _install_common_stubs(monkeypatch, config, state_dir)
+
+        from shipyard.targets.warm_pool import PoolEntry, compute_expires_at
+        now = datetime.now(timezone.utc).timestamp()
+        pool = WarmPool(default_pool_path(state_dir))
+        pool.upsert(PoolEntry(
+            target="ubuntu",
+            host="ubuntu",
+            backend="ssh",
+            workdir="~/repo",
+            sha="b" * 40,
+            expires_at=compute_expires_at(600, now=now),
+            created_at=now,
+        ))
+
+        runner = CliRunner()
+        result = runner.invoke(
+            main, ["--json", "targets", "warm", "drain", "--yes"],
+        )
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload["drained"] == 1
+
+        pool_after = WarmPool(default_pool_path(state_dir))
+        assert pool_after.all_entries() == []

--- a/uv.lock
+++ b/uv.lock
@@ -455,7 +455,7 @@ wheels = [
 
 [[package]]
 name = "shipyard"
-version = "0.17.0"
+version = "0.18.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

- Opt-in, same-SHA workdir reuse so back-to-back ships within a configurable TTL skip the pre-stage (clone / sync / deps) by re-entering the previously warmed remote workdir. Validate always re-runs; any failure during warm reuse evicts the entry.
- Three disable levels: per-target `warm_keepalive_seconds = 0` (default), global `SHIPYARD_NO_WARM_POOL=1` env kill switch, per-ship `--no-warm` flag. GitHub-hosted / cloud backends are silently ineligible with a one-time warn so misconfigured targets surface.
- New CLI surface: `shipyard targets warm status|drain` + `--no-warm` on `shipyard ship` and `shipyard run`. Skill (`skills/ci/SKILL.md`) and plugin command (`commands/targets.md`) updated with cost-safety reasoning and the three disable levels.

## Closes

Closes #82.

## Test plan

- [x] `uv run ruff check src/` green
- [x] `uv run mypy src/` green
- [x] `uv run pytest -x` — 910 passed, 1 skipped (pre-existing yaml skip)
- [x] New tests: `tests/targets/test_warm_pool.py` (45 unit) + `tests/test_cli_warm_pool.py` (10 integration) covering entry lifecycle, TTL, three disable levels, ineligible-backend warn, reuse/evict flow, and `targets warm status|drain`
- [ ] CI validate on PR (runs same ruff/mypy/pytest in GitHub Actions)