### PR TITLE
fix(pr): resolve gate scripts from tools/scripts/ or scripts/

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "shipyard",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Cross-platform CI coordination",
   "commands": "./commands",
   "agents": "./agents",

--- a/docs/gate-scripts.md
+++ b/docs/gate-scripts.md
@@ -1,0 +1,56 @@
+# Gate script path resolution
+
+`shipyard pr` runs two Python gate scripts before handing off to
+`shipyard ship`:
+
+- `skill_sync_check.py` — hard-fails when a mapped path was touched
+  without a `SKILL.md` update.
+- `version_bump_check.py` — rewrites per-surface version files.
+
+It also needs to read the versioning config: `versioning.json`.
+
+Shipyard's own repo keeps these under `scripts/`. Pulp keeps them
+under `tools/scripts/`. Other consumer repos may keep them elsewhere
+(or outside the repo entirely).
+
+## Resolution order
+
+For each file, `shipyard pr` tries these sources in order and uses the
+first one that exists:
+
+1. **Environment variable.** Highest priority; absolute or
+   repo-root-relative path.
+
+   | Script                  | Env var                         |
+   |-------------------------|---------------------------------|
+   | `skill_sync_check.py`   | `SHIPYARD_SKILL_SYNC_SCRIPT`    |
+   | `version_bump_check.py` | `SHIPYARD_VERSION_BUMP_SCRIPT`  |
+   | `versioning.json`       | `SHIPYARD_VERSIONING_CONFIG`    |
+
+2. **`.shipyard/config.toml`** (per-repo override).
+
+   ```toml
+   [validation]
+   skill_sync_script   = "tools/ci/skill_sync.py"
+   version_bump_script = "tools/ci/version_bump.py"
+   versioning_config   = "tools/ci/versioning.json"
+   ```
+
+3. **`tools/scripts/<file>`** — common CI-tooling layout.
+
+4. **`scripts/<file>`** — Shipyard's own default.
+
+## Error behavior
+
+If a file can't be resolved, `shipyard pr` exits with code 2 and
+prints every path it probed plus the override knobs. An env-var or
+config override pointing to a missing path is a hard error — it will
+not silently fall through to the defaults, because a broken override
+almost always hides a typo or a stale path rather than an intentional
+"fall back."
+
+## Precedence between env var and config
+
+Env wins. This mirrors every other Shipyard config lever so a
+one-shot CI override (`SHIPYARD_SKILL_SYNC_SCRIPT=... shipyard pr`)
+works without editing committed config.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "shipyard"
-version = "0.19.0"
+version = "0.19.1"
 description = "Cross-platform CI coordination — local VMs, SSH hosts, cloud runners"
 readme = "README.md"
 license = "MIT"

--- a/skills/ci/SKILL.md
+++ b/skills/ci/SKILL.md
@@ -469,12 +469,23 @@ When the user says "push a PR", "ship this", "ship it", "we're done", "merge thi
 
 The orchestration, in order:
 
-1. `scripts/skill_sync_check.py --mode=report` — hard-fails if a mapped path was touched without a `SKILL.md` update or a `Skill-Update:` trailer on the tip commit.
-2. `scripts/version_bump_check.py --mode=apply` — rewrites `pyproject.toml` + `src/shipyard/__init__.py` for CLI-surface bumps and `.claude-plugin/plugin.json` for plugin-surface bumps. The two version streams are independent per `RELEASING.md`.
+1. `skill_sync_check.py --mode=report` — hard-fails if a mapped path was touched without a `SKILL.md` update or a `Skill-Update:` trailer on the tip commit.
+2. `version_bump_check.py --mode=apply` — rewrites `pyproject.toml` + `src/shipyard/__init__.py` for CLI-surface bumps and `.claude-plugin/plugin.json` for plugin-surface bumps. The two version streams are independent per `RELEASING.md`.
 3. `git commit` + `gh pr create` + `shipyard ship`.
 4. On merge, `.github/workflows/auto-release.yml` tags the CLI bump as `v<x.y.z>`. The existing tag-triggered `release.yml` builds the 5-platform binaries and publishes the GitHub Release.
 
 Never run `gh pr create` + release separately. Never run the Python gate scripts by hand.
+
+### Gate-script path resolution
+
+`shipyard pr` looks up each gate script in this order — the first hit wins:
+
+1. Env var (`SHIPYARD_SKILL_SYNC_SCRIPT`, `SHIPYARD_VERSION_BUMP_SCRIPT`, `SHIPYARD_VERSIONING_CONFIG`).
+2. `.shipyard/config.toml` `[validation]` keys (`skill_sync_script`, `version_bump_script`, `versioning_config`).
+3. `tools/scripts/<file>` — common CI-tooling layout (used by Pulp).
+4. `scripts/<file>` — Shipyard's own default.
+
+Missing-script errors list every probed location and every override knob. Consumer repos that keep their tooling under `tools/scripts/` need no configuration; other layouts should set the env var or the `[validation]` key rather than moving the script.
 
 ## Bypass trailers (tip commit)
 

--- a/src/shipyard/__init__.py
+++ b/src/shipyard/__init__.py
@@ -1,3 +1,3 @@
 """Shipyard — Cross-platform CI coordination."""
 
-__version__ = "0.19.0"
+__version__ = "0.19.1"

--- a/src/shipyard/cli.py
+++ b/src/shipyard/cli.py
@@ -3954,7 +3954,9 @@ def pr(
         SKILL_SYNC,
         VERSION_BUMP,
         VERSIONING_CONFIG,
-        GateScriptNotFound,
+        GateScriptNotFoundError,
+    )
+    from shipyard.gate_scripts import (
         resolve as resolve_gate_script,
     )
 
@@ -3962,7 +3964,7 @@ def pr(
         ssc = resolve_gate_script(SKILL_SYNC, repo_root, config=ctx.obj.config)
         vbc = resolve_gate_script(VERSION_BUMP, repo_root, config=ctx.obj.config)
         cfg = resolve_gate_script(VERSIONING_CONFIG, repo_root, config=ctx.obj.config)
-    except GateScriptNotFound as exc:
+    except GateScriptNotFoundError as exc:
         render_error(str(exc))
         sys.exit(2)
 

--- a/src/shipyard/cli.py
+++ b/src/shipyard/cli.py
@@ -3944,19 +3944,26 @@ def pr(
             for line in added:
                 click.echo(f"▸ Added trailer: {line}")
 
-    repo_root = subprocess.check_output(
-        ["git", "rev-parse", "--show-toplevel"], text=True
-    ).strip()
-    ssc = Path(repo_root) / "scripts" / "skill_sync_check.py"
-    vbc = Path(repo_root) / "scripts" / "version_bump_check.py"
-    cfg = Path(repo_root) / "scripts" / "versioning.json"
+    repo_root = Path(
+        subprocess.check_output(
+            ["git", "rev-parse", "--show-toplevel"], text=True
+        ).strip()
+    )
 
-    if not ssc.exists() or not vbc.exists() or not cfg.exists():
-        render_error(
-            "shipyard pr requires scripts/skill_sync_check.py, "
-            "scripts/version_bump_check.py, and scripts/versioning.json "
-            "to be present. Install them via the versioning-sync port."
-        )
+    from shipyard.gate_scripts import (
+        SKILL_SYNC,
+        VERSION_BUMP,
+        VERSIONING_CONFIG,
+        GateScriptNotFound,
+        resolve as resolve_gate_script,
+    )
+
+    try:
+        ssc = resolve_gate_script(SKILL_SYNC, repo_root, config=ctx.obj.config)
+        vbc = resolve_gate_script(VERSION_BUMP, repo_root, config=ctx.obj.config)
+        cfg = resolve_gate_script(VERSIONING_CONFIG, repo_root, config=ctx.obj.config)
+    except GateScriptNotFound as exc:
+        render_error(str(exc))
         sys.exit(2)
 
     python = shutil.which("python3") or "python3"

--- a/src/shipyard/gate_scripts.py
+++ b/src/shipyard/gate_scripts.py
@@ -1,0 +1,174 @@
+"""Resolve the paths of the version-bump / skill-sync gate scripts.
+
+Shipyard's own repo keeps these scripts under `scripts/`. Pulp — the
+first external consumer — keeps them under `tools/scripts/`. Other
+repos may move them elsewhere entirely. Hard-coding `scripts/` makes
+`shipyard pr` unusable on any layout that isn't Shipyard's.
+
+Resolution order (highest priority first):
+
+  1. Environment variable override (per script).
+  2. `[validation]` key in `.shipyard/config.toml` (per script).
+  3. `tools/scripts/<name>` — common for repos that group CI tooling.
+  4. `scripts/<name>` — Shipyard's own default.
+
+If none of those resolves, `resolve()` raises GateScriptNotFound with
+every path it probed plus the override knobs. Callers are expected to
+print that message verbatim and exit.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from shipyard.core.config import Config
+
+
+@dataclass(frozen=True)
+class GateScript:
+    """One resolvable gate-script file."""
+
+    name: str
+    env_var: str
+    config_key: str
+    filename: str
+
+
+SKILL_SYNC = GateScript(
+    name="skill_sync_check",
+    env_var="SHIPYARD_SKILL_SYNC_SCRIPT",
+    config_key="validation.skill_sync_script",
+    filename="skill_sync_check.py",
+)
+
+VERSION_BUMP = GateScript(
+    name="version_bump_check",
+    env_var="SHIPYARD_VERSION_BUMP_SCRIPT",
+    config_key="validation.version_bump_script",
+    filename="version_bump_check.py",
+)
+
+VERSIONING_CONFIG = GateScript(
+    name="versioning_config",
+    env_var="SHIPYARD_VERSIONING_CONFIG",
+    config_key="validation.versioning_config",
+    filename="versioning.json",
+)
+
+DEFAULT_DIRS: tuple[str, ...] = ("tools/scripts", "scripts")
+
+
+class GateScriptNotFound(FileNotFoundError):
+    """Raised when a gate script cannot be resolved from any source."""
+
+
+def resolve(
+    script: GateScript,
+    repo_root: Path,
+    *,
+    config: Config | None = None,
+    env: dict[str, str] | None = None,
+) -> Path:
+    """Return the resolved on-disk path of `script` or raise.
+
+    `env` defaults to `os.environ`. `config` is optional — when
+    provided, its `validation.<key>` entries are consulted. Relative
+    paths in env/config are resolved against `repo_root`.
+    """
+    env_map = os.environ if env is None else env
+
+    # 1. Environment variable
+    env_val = env_map.get(script.env_var)
+    if env_val:
+        candidate = _absolute(Path(env_val), repo_root)
+        if candidate.exists():
+            return candidate
+        raise GateScriptNotFound(
+            _not_found_message(
+                script,
+                repo_root,
+                probed=[(f"env {script.env_var}", candidate)],
+                env_val=env_val,
+            )
+        )
+
+    # 2. Config override
+    config_val: str | None = None
+    if config is not None:
+        val = config.get(script.config_key)
+        if isinstance(val, str) and val:
+            config_val = val
+            candidate = _absolute(Path(val), repo_root)
+            if candidate.exists():
+                return candidate
+            raise GateScriptNotFound(
+                _not_found_message(
+                    script,
+                    repo_root,
+                    probed=[(f"config {script.config_key}", candidate)],
+                    config_val=val,
+                )
+            )
+
+    # 3 + 4. Probe default directories
+    probed: list[tuple[str, Path]] = []
+    for rel_dir in DEFAULT_DIRS:
+        candidate = repo_root / rel_dir / script.filename
+        probed.append((f"{rel_dir}/", candidate))
+        if candidate.exists():
+            return candidate
+
+    raise GateScriptNotFound(
+        _not_found_message(
+            script,
+            repo_root,
+            probed=probed,
+            env_val=None,
+            config_val=config_val,
+        )
+    )
+
+
+def _absolute(path: Path, repo_root: Path) -> Path:
+    return path if path.is_absolute() else (repo_root / path).resolve()
+
+
+def _not_found_message(
+    script: GateScript,
+    repo_root: Path,
+    *,
+    probed: list[tuple[str, Path]],
+    env_val: str | None = None,
+    config_val: str | None = None,
+) -> str:
+    lines = [f"shipyard: could not find {script.filename}."]
+    lines.append("  Tried:")
+    for label, path in probed:
+        lines.append(f"    - {label} {path}")
+    lines.append("")
+    lines.append("  Override by setting one of:")
+    lines.append(f"    - env {script.env_var}=<path>")
+    lines.append(
+        f"    - {script.config_key} in .shipyard/config.toml"
+    )
+    lines.append(
+        f"    - place the file at {repo_root / 'tools' / 'scripts' / script.filename}"
+    )
+    lines.append(
+        f"    - or at {repo_root / 'scripts' / script.filename}"
+    )
+    if env_val:
+        lines.append("")
+        lines.append(
+            f"  Note: env {script.env_var}={env_val!r} did not resolve to an existing file."
+        )
+    if config_val and not env_val:
+        lines.append("")
+        lines.append(
+            f"  Note: config {script.config_key}={config_val!r} did not resolve to an existing file."
+        )
+    return "\n".join(lines)

--- a/src/shipyard/gate_scripts.py
+++ b/src/shipyard/gate_scripts.py
@@ -12,7 +12,7 @@ Resolution order (highest priority first):
   3. `tools/scripts/<name>` — common for repos that group CI tooling.
   4. `scripts/<name>` — Shipyard's own default.
 
-If none of those resolves, `resolve()` raises GateScriptNotFound with
+If none of those resolves, `resolve()` raises GateScriptNotFoundError with
 every path it probed plus the override knobs. Callers are expected to
 print that message verbatim and exit.
 """
@@ -62,7 +62,7 @@ VERSIONING_CONFIG = GateScript(
 DEFAULT_DIRS: tuple[str, ...] = ("tools/scripts", "scripts")
 
 
-class GateScriptNotFound(FileNotFoundError):
+class GateScriptNotFoundError(FileNotFoundError):
     """Raised when a gate script cannot be resolved from any source."""
 
 
@@ -87,7 +87,7 @@ def resolve(
         candidate = _absolute(Path(env_val), repo_root)
         if candidate.exists():
             return candidate
-        raise GateScriptNotFound(
+        raise GateScriptNotFoundError(
             _not_found_message(
                 script,
                 repo_root,
@@ -105,7 +105,7 @@ def resolve(
             candidate = _absolute(Path(val), repo_root)
             if candidate.exists():
                 return candidate
-            raise GateScriptNotFound(
+            raise GateScriptNotFoundError(
                 _not_found_message(
                     script,
                     repo_root,
@@ -122,7 +122,7 @@ def resolve(
         if candidate.exists():
             return candidate
 
-    raise GateScriptNotFound(
+    raise GateScriptNotFoundError(
         _not_found_message(
             script,
             repo_root,

--- a/tests/test_gate_scripts.py
+++ b/tests/test_gate_scripts.py
@@ -1,0 +1,116 @@
+"""Unit tests for gate-script path resolution (#103)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from shipyard.core.config import Config
+from shipyard.gate_scripts import (
+    SKILL_SYNC,
+    VERSION_BUMP,
+    VERSIONING_CONFIG,
+    GateScriptNotFound,
+    resolve,
+)
+
+
+def _touch(path: Path) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("# placeholder\n")
+    return path
+
+
+def test_resolves_shipyard_default_layout(tmp_path: Path) -> None:
+    script = _touch(tmp_path / "scripts" / "skill_sync_check.py")
+    assert resolve(SKILL_SYNC, tmp_path, env={}) == script
+
+
+def test_resolves_pulp_tools_scripts_layout(tmp_path: Path) -> None:
+    script = _touch(tmp_path / "tools" / "scripts" / "skill_sync_check.py")
+    assert resolve(SKILL_SYNC, tmp_path, env={}) == script
+
+
+def test_tools_scripts_wins_over_scripts_when_both_present(tmp_path: Path) -> None:
+    _touch(tmp_path / "scripts" / "skill_sync_check.py")
+    pulp = _touch(tmp_path / "tools" / "scripts" / "skill_sync_check.py")
+    # tools/scripts is probed first per DEFAULT_DIRS order — documents the
+    # precedence so migrations that ship both layouts during a cutover
+    # resolve deterministically.
+    assert resolve(SKILL_SYNC, tmp_path, env={}) == pulp
+
+
+def test_config_override_wins_over_defaults(tmp_path: Path) -> None:
+    _touch(tmp_path / "scripts" / "skill_sync_check.py")
+    custom = _touch(tmp_path / "custom" / "my-sync.py")
+    config = Config(data={"validation": {"skill_sync_script": "custom/my-sync.py"}})
+    assert resolve(SKILL_SYNC, tmp_path, config=config, env={}) == custom
+
+
+def test_env_var_wins_over_config(tmp_path: Path) -> None:
+    _touch(tmp_path / "scripts" / "skill_sync_check.py")
+    config_target = _touch(tmp_path / "from-config" / "sync.py")
+    env_target = _touch(tmp_path / "from-env" / "sync.py")
+    config = Config(data={"validation": {"skill_sync_script": "from-config/sync.py"}})
+    resolved = resolve(
+        SKILL_SYNC,
+        tmp_path,
+        config=config,
+        env={"SHIPYARD_SKILL_SYNC_SCRIPT": "from-env/sync.py"},
+    )
+    assert resolved == env_target
+    assert resolved != config_target  # env beats config
+
+
+def test_absolute_env_override_resolves(tmp_path: Path) -> None:
+    target = _touch(tmp_path / "elsewhere" / "skill_sync_check.py")
+    resolved = resolve(
+        SKILL_SYNC,
+        tmp_path,
+        env={"SHIPYARD_SKILL_SYNC_SCRIPT": str(target)},
+    )
+    assert resolved == target
+
+
+def test_env_override_that_points_to_missing_file_errors_cleanly(tmp_path: Path) -> None:
+    # A bad override shouldn't silently fall through to the default — the
+    # user asked for a specific path, we honor the ask and surface the
+    # broken override instead of masking it.
+    with pytest.raises(GateScriptNotFound) as exc:
+        resolve(
+            SKILL_SYNC,
+            tmp_path,
+            env={"SHIPYARD_SKILL_SYNC_SCRIPT": "nope/missing.py"},
+        )
+    message = str(exc.value)
+    assert "SHIPYARD_SKILL_SYNC_SCRIPT" in message
+    assert "nope/missing.py" in message
+
+
+def test_config_override_missing_file_errors_cleanly(tmp_path: Path) -> None:
+    config = Config(data={"validation": {"skill_sync_script": "nope/missing.py"}})
+    with pytest.raises(GateScriptNotFound) as exc:
+        resolve(SKILL_SYNC, tmp_path, config=config, env={})
+    message = str(exc.value)
+    assert "validation.skill_sync_script" in message
+    assert "nope/missing.py" in message
+
+
+def test_not_found_lists_every_probed_location(tmp_path: Path) -> None:
+    with pytest.raises(GateScriptNotFound) as exc:
+        resolve(SKILL_SYNC, tmp_path, env={})
+    message = str(exc.value)
+    assert "tools/scripts/" in message
+    assert "scripts/" in message
+    assert "SHIPYARD_SKILL_SYNC_SCRIPT" in message
+    assert "validation.skill_sync_script" in message
+
+
+def test_all_three_scripts_independently_resolve(tmp_path: Path) -> None:
+    ssc = _touch(tmp_path / "scripts" / "skill_sync_check.py")
+    vbc = _touch(tmp_path / "tools" / "scripts" / "version_bump_check.py")
+    cfg = _touch(tmp_path / "scripts" / "versioning.json")
+    assert resolve(SKILL_SYNC, tmp_path, env={}) == ssc
+    assert resolve(VERSION_BUMP, tmp_path, env={}) == vbc
+    assert resolve(VERSIONING_CONFIG, tmp_path, env={}) == cfg

--- a/tests/test_gate_scripts.py
+++ b/tests/test_gate_scripts.py
@@ -11,7 +11,7 @@ from shipyard.gate_scripts import (
     SKILL_SYNC,
     VERSION_BUMP,
     VERSIONING_CONFIG,
-    GateScriptNotFound,
+    GateScriptNotFoundError,
     resolve,
 )
 
@@ -77,7 +77,7 @@ def test_env_override_that_points_to_missing_file_errors_cleanly(tmp_path: Path)
     # A bad override shouldn't silently fall through to the default — the
     # user asked for a specific path, we honor the ask and surface the
     # broken override instead of masking it.
-    with pytest.raises(GateScriptNotFound) as exc:
+    with pytest.raises(GateScriptNotFoundError) as exc:
         resolve(
             SKILL_SYNC,
             tmp_path,
@@ -90,7 +90,7 @@ def test_env_override_that_points_to_missing_file_errors_cleanly(tmp_path: Path)
 
 def test_config_override_missing_file_errors_cleanly(tmp_path: Path) -> None:
     config = Config(data={"validation": {"skill_sync_script": "nope/missing.py"}})
-    with pytest.raises(GateScriptNotFound) as exc:
+    with pytest.raises(GateScriptNotFoundError) as exc:
         resolve(SKILL_SYNC, tmp_path, config=config, env={})
     message = str(exc.value)
     assert "validation.skill_sync_script" in message
@@ -98,7 +98,7 @@ def test_config_override_missing_file_errors_cleanly(tmp_path: Path) -> None:
 
 
 def test_not_found_lists_every_probed_location(tmp_path: Path) -> None:
-    with pytest.raises(GateScriptNotFound) as exc:
+    with pytest.raises(GateScriptNotFoundError) as exc:
         resolve(SKILL_SYNC, tmp_path, env={})
     message = str(exc.value)
     assert "tools/scripts/" in message


### PR DESCRIPTION
Closes #103

## Summary

`shipyard pr` hard-coded `scripts/skill_sync_check.py` etc. That broke every consumer repo that kept its CI tooling elsewhere — Pulp's agents fell back to `pulp pr --native` today (2026-04-20) because of it.

This change adds a resolver (`shipyard.gate_scripts`) that finds each gate script through a chain of sources and uses the first one that exists:

1. **Env var** — `SHIPYARD_SKILL_SYNC_SCRIPT`, `SHIPYARD_VERSION_BUMP_SCRIPT`, `SHIPYARD_VERSIONING_CONFIG`
2. **`.shipyard/config.toml` `[validation]`** — `skill_sync_script`, `version_bump_script`, `versioning_config`
3. **`tools/scripts/<file>`** — Pulp's layout
4. **`scripts/<file>`** — Shipyard's own default

If nothing resolves, the error lists every probed path and every override knob. An env/config override that points to a missing file is a hard error (does not silently fall through).

## Files
- `src/shipyard/gate_scripts.py` — new resolver module (independently testable).
- `src/shipyard/cli.py` — `shipyard pr` now uses the resolver.
- `skills/ci/SKILL.md` — documents the resolution chain.
- `docs/gate-scripts.md` — consumer-facing docs for the override knobs.
- `tests/test_gate_scripts.py` — 10 unit tests covering every branch.

## Tests added

- Default Shipyard (`scripts/`) layout resolves.
- Pulp (`tools/scripts/`) layout resolves.
- `tools/scripts/` wins when both dirs hold the file (documented precedence).
- Config override beats defaults.
- Env var beats config override.
- Absolute path in env var works.
- Env-pointing-to-missing-file errors with the env var name in the message.
- Config-pointing-to-missing-file errors with the config key in the message.
- Not-found error lists every probed location + both override knobs.
- All three scripts (`skill_sync_check`, `version_bump_check`, `versioning.json`) can resolve from different sources in the same repo.

All 920 pre-existing tests still pass.

## Test plan

- [ ] CI green on this PR.
- [ ] Pulp can run `shipyard pr` without its `tools/scripts/` fallback workaround once this lands + a new Shipyard version ships.