### PR TITLE
fix(preflight): SSH fail-fast with rich diagnosis + exit code 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to Shipyard are documented here. Each entry links
 to its [GitHub Release](https://github.com/danielraffel/Shipyard/releases).
 
 <a id="v0190"></a>
+## [0.20.0]
+
 ## [0.19.0] - 2026-04-19
 
 - feat: warm-pool runner reuse across PRs (closes #82) ([#98](https://github.com/danielraffel/Shipyard/pull/98))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "shipyard"
-version = "0.19.1"
+version = "0.20.0"
 description = "Cross-platform CI coordination — local VMs, SSH hosts, cloud runners"
 readme = "README.md"
 license = "MIT"

--- a/skills/ci/SKILL.md
+++ b/skills/ci/SKILL.md
@@ -52,6 +52,8 @@ Shipyard coordinates validation across local, SSH, and cloud targets.
 | Add a new lane to an in-flight PR | `shipyard cloud add-lane --pr <n> --target windows [--provider namespace]` (dry-run; add `--apply`) |
 | Skip a version-bump gate | `shipyard pr --skip-bump sdk --bump-reason "docs only"` |
 | Skip a skill-sync gate | `shipyard pr --skip-skill-update ci --skill-reason "mechanical"` |
+| Deliberately skip one lane | `shipyard run --skip-target windows` (repeatable; no probe run) |
+| Proceed with unreachable lanes (VALIDATION GAP) | `shipyard run --allow-unreachable-targets` (prints a loud warning; exits 3 without the flag) |
 | Inspect tracked cloud runs | `shipyard cloud status --json` |
 | Environment check | `shipyard doctor --json` |
 | Probe SSH runner reachability | `shipyard doctor --runners --json` |
@@ -459,8 +461,9 @@ Remove a target from quarantine the moment the underlying flakiness is fixed —
 - `shipyard doctor --json` — checks git, ssh, gh, nsc are installed
 - `shipyard status --json` — shows configured targets, queue state, and live target status
 - `shipyard logs <id> --target <name>` — full log for a failed target
-- If a target is unreachable with no fallback, it reports unreachable
-- `shipyard run --allow-unreachable-targets --json` — override preflight if you intentionally want to queue anyway
+- If a target is unreachable with no fallback, `run` / `ship` / `pr` exit **3** (distinct from 1 validation-failed and 2 config-error) with a message that names the target, the failure category (`auth`, `host_key`, `network`, `timeout`, `unknown`), and the last ssh error.
+- `shipyard run --allow-unreachable-targets --json` — proceed with the lane **SKIPPED, NOT validated**. The warning is loud by design because muscle-memory use of this flag (Pulp pre-2026-04-20) hid real backend outages.
+- `shipyard run --skip-target <name>` — **deliberately** skip a lane (no probe run). Use this when you already know you don't want to validate the target — `--allow-unreachable-targets` is for "I want this target, but the backend is down right now."
 - `shipyard cloud defaults --json` — inspect the current cloud workflow/provider dispatch plan
 
 ## Shipping a PR (the `shipyard pr` path)

--- a/src/shipyard/__init__.py
+++ b/src/shipyard/__init__.py
@@ -1,3 +1,3 @@
 """Shipyard — Cross-platform CI coordination."""
 
-__version__ = "0.19.1"
+__version__ = "0.20.0"

--- a/src/shipyard/cli.py
+++ b/src/shipyard/cli.py
@@ -41,7 +41,11 @@ from shipyard.output.human import (
 )
 from shipyard.output.json_output import render_json
 from shipyard.output.schema import OutputEnvelope
-from shipyard.preflight import run_submission_preflight
+from shipyard.preflight import (
+    EXIT_BACKEND_UNREACHABLE,
+    BackendUnreachableError,
+    run_submission_preflight,
+)
 from shipyard.release_bot.setup import (
     ReleaseBotError,
     describe_state,
@@ -147,7 +151,24 @@ def main(ctx: click.Context, json_mode: bool) -> None:
 @click.option(
     "--allow-unreachable-targets",
     is_flag=True,
-    help="Queue the run even if no backend is reachable for one or more targets",
+    help=(
+        "Proceed even if a target's backend is unreachable. The lane "
+        "is SKIPPED, NOT validated — a validation gap is recorded and "
+        "printed loudly. Distinct from --skip-target, which is a "
+        "deliberate skip not tied to backend health."
+    ),
+)
+@click.option(
+    "--skip-target",
+    "skip_target",
+    multiple=True,
+    metavar="NAME",
+    help=(
+        "Deliberately skip a lane (not tied to backend reachability). "
+        "Repeatable. Unlike --allow-unreachable-targets, this does not "
+        "run a probe — it's the right flag when the user knows they "
+        "don't want to validate that target at all."
+    ),
 )
 @click.option(
     "--no-warm",
@@ -167,6 +188,7 @@ def run(
     resume_from: str | None,
     allow_root_mismatch: bool,
     allow_unreachable_targets: bool,
+    skip_target: tuple[str, ...],
     no_warm: bool,
 ) -> None:
     """Validate current HEAD on configured targets."""
@@ -194,10 +216,22 @@ def run(
             dispatcher=dispatcher,
             allow_root_mismatch=allow_root_mismatch,
             allow_unreachable_targets=allow_unreachable_targets,
+            skip_targets=skip_target,
         )
+    except BackendUnreachableError as exc:
+        render_error(str(exc))
+        sys.exit(EXIT_BACKEND_UNREACHABLE)
     except ValueError as exc:
         render_error(str(exc))
         sys.exit(1)
+
+    # Honor --skip-target by dropping the skipped names from the job
+    # target set. The preflight already recorded them in
+    # `skipped_targets` for the output envelope.
+    target_names = [n for n in target_names if n not in set(skip_target)]
+    if not target_names:
+        render_error("No targets remain after --skip-target filtering.")
+        sys.exit(2)
 
     # Create and enqueue job
     job = Job.create(
@@ -2535,7 +2569,23 @@ def cloud_status(ctx: Context, identifier: str | None, limit: int, refresh: bool
 @click.option(
     "--allow-unreachable-targets",
     is_flag=True,
-    help="Queue the run even if no backend is reachable for one or more targets",
+    help=(
+        "Proceed even if a target's backend is unreachable. The lane "
+        "is SKIPPED, NOT validated — a validation gap is recorded and "
+        "printed loudly. Distinct from --skip-target."
+    ),
+)
+@click.option(
+    "--skip-target",
+    "skip_target",
+    multiple=True,
+    metavar="NAME",
+    help=(
+        "Deliberately skip a lane (not tied to backend reachability). "
+        "Repeatable. Use this when you know you don't want to validate "
+        "the target at all; use --allow-unreachable-targets only when "
+        "the target SHOULD be validated but the backend is down."
+    ),
 )
 @click.option(
     "--auto-create-base/--no-auto-create-base",
@@ -2572,6 +2622,7 @@ def ship(
     base: str,
     allow_root_mismatch: bool,
     allow_unreachable_targets: bool,
+    skip_target: tuple[str, ...],
     auto_create_base: bool | None,
     resume: bool | None,
     no_warm: bool,
@@ -2696,7 +2747,11 @@ def ship(
             dispatcher=dispatcher,
             allow_root_mismatch=allow_root_mismatch,
             allow_unreachable_targets=allow_unreachable_targets,
+            skip_targets=skip_target,
         )
+    except BackendUnreachableError as exc:
+        render_error(str(exc))
+        sys.exit(EXIT_BACKEND_UNREACHABLE)
     except ValueError as exc:
         render_error(str(exc))
         sys.exit(1)
@@ -2704,6 +2759,11 @@ def ship(
     if not ctx.json_mode:
         for warning in preflight.warnings:
             render_message(f"warning: {warning}", style="bold yellow")
+
+    target_names = [n for n in target_names if n not in set(skip_target)]
+    if not target_names:
+        render_error("No targets remain after --skip-target filtering.")
+        sys.exit(2)
 
     job = Job.create(sha=sha, branch=branch, target_names=target_names)
     job = ctx.queue.enqueue(job)
@@ -3857,7 +3917,14 @@ def ship_state_discard(ctx: Context, pr: int) -> None:
 @click.option(
     "--allow-unreachable-targets",
     is_flag=True,
-    help="Forwarded to `shipyard ship`.",
+    help="Forwarded to `shipyard ship`. Lane is skipped, validation gap recorded.",
+)
+@click.option(
+    "--skip-target",
+    "skip_target",
+    multiple=True,
+    metavar="NAME",
+    help="Forwarded to `shipyard ship`. Deliberate skip (not tied to reachability).",
 )
 @click.option(
     "--skip-bump",
@@ -3899,6 +3966,7 @@ def pr(
     base: str,
     apply_bumps: bool,
     allow_unreachable_targets: bool,
+    skip_target: tuple[str, ...],
     skip_bump: tuple[str, ...],
     bump_reason: str | None,
     skip_skill_update: tuple[str, ...],
@@ -4064,6 +4132,7 @@ def pr(
         base=base,
         allow_root_mismatch=False,
         allow_unreachable_targets=allow_unreachable_targets,
+        skip_target=skip_target,
         auto_create_base=None,
     )
 

--- a/src/shipyard/executor/dispatch.py
+++ b/src/shipyard/executor/dispatch.py
@@ -103,6 +103,19 @@ class ExecutorDispatcher:
         executor = self._resolve_executor(target_config)
         return executor.probe(target_config)
 
+    def diagnose(self, target_config: dict[str, Any]) -> dict[str, Any] | None:
+        """Richer reachability info for preflight's unreachable branch.
+
+        Returns None when the underlying executor doesn't implement a
+        diagnosis — preflight falls back to a generic "unreachable"
+        message in that case.
+        """
+        executor = self._resolve_executor(target_config)
+        diagnose = getattr(executor, "diagnose", None)
+        if callable(diagnose):
+            return diagnose(target_config)
+        return None
+
     def backend_name(self, target_config: dict[str, Any]) -> str:
         return _normalize_backend_name(target_config)
 

--- a/src/shipyard/executor/ssh.py
+++ b/src/shipyard/executor/ssh.py
@@ -287,15 +287,44 @@ class SSHExecutor:
 
     def probe(self, target_config: dict[str, Any]) -> bool:
         """Check SSH reachability with a quick echo command."""
+        diag = self._probe_ssh(target_config)
+        return diag["reachable"]
+
+    def diagnose(self, target_config: dict[str, Any]) -> dict[str, Any]:
+        """Return a rich reachability diagnosis for preflight.
+
+        The preflight surfaces `message` + `category` in the
+        user-facing error on fail-fast. Categories are stable strings
+        callers can branch on: "auth", "host_key", "network",
+        "timeout", "unknown".
+        """
+        diag = self._probe_ssh(target_config)
+        return {
+            "reachable": diag["reachable"],
+            "message": _format_ssh_diagnosis(target_config, diag),
+            "category": diag["category"],
+        }
+
+    def _probe_ssh(self, target_config: dict[str, Any]) -> dict[str, Any]:
         host = target_config.get("host")
         if not host:
-            return False
+            return {
+                "reachable": False,
+                "category": "configuration",
+                "last_error": "target has no host configured",
+                "timed_out": False,
+            }
 
         ssh_options = _ssh_options(target_config)
         cmd = (
             ["ssh"]
             + list(ssh_options)
-            + ["-o", "ConnectTimeout=5", host, "echo ok"]
+            + [
+                "-o", "ConnectTimeout=5",
+                "-o", "BatchMode=yes",
+                host,
+                "echo ok",
+            ]
         )
 
         try:
@@ -305,9 +334,36 @@ class SSHExecutor:
                 text=True,
                 timeout=10,
             )
-            return result.returncode == 0
-        except (subprocess.TimeoutExpired, OSError):
-            return False
+        except subprocess.TimeoutExpired:
+            return {
+                "reachable": False,
+                "category": "timeout",
+                "last_error": "ssh probe exceeded 10s",
+                "timed_out": True,
+            }
+        except OSError as exc:
+            return {
+                "reachable": False,
+                "category": "network",
+                "last_error": str(exc),
+                "timed_out": False,
+            }
+
+        if result.returncode == 0:
+            return {
+                "reachable": True,
+                "category": None,
+                "last_error": None,
+                "timed_out": False,
+            }
+
+        stderr = (result.stderr or "").strip()
+        return {
+            "reachable": False,
+            "category": _classify_probe_error(stderr, result.returncode),
+            "last_error": stderr or f"ssh exited {result.returncode}",
+            "timed_out": False,
+        }
 
 
 def _remote_head_sha(
@@ -647,3 +703,61 @@ def _extract_ssh_error(output: str) -> str | None:
         if line.strip():
             return line.strip()
     return None
+
+
+def _classify_probe_error(stderr: str, returncode: int) -> str:
+    """Best-effort classification of an ssh probe failure.
+
+    Stable string buckets — preflight surfaces these back to the user
+    and tooling can branch on them without pattern-matching the raw
+    ssh error text.
+    """
+    lowered = stderr.lower()
+    if (
+        "permission denied" in lowered
+        or "publickey" in lowered
+        or "too many authentication failures" in lowered
+    ):
+        return "auth"
+    if (
+        "host key verification failed" in lowered
+        or "remote host identification has changed" in lowered
+        or "offending" in lowered
+    ):
+        return "host_key"
+    if (
+        "could not resolve hostname" in lowered
+        or "name or service not known" in lowered
+        or "nodename nor servname" in lowered  # macOS variant
+        or "no route to host" in lowered
+        or "network is unreachable" in lowered
+        or "connection refused" in lowered
+    ):
+        return "network"
+    if "connection timed out" in lowered:
+        return "timeout"
+    if returncode == 255:
+        return "network"
+    return "unknown"
+
+
+def _format_ssh_diagnosis(
+    target_config: dict[str, Any], diag: dict[str, Any]
+) -> str:
+    """Compose the preflight error message for an unreachable SSH target."""
+    host = target_config.get("host") or "<no host>"
+    user_at_host = host if "@" in host else host
+    port = target_config.get("port")
+    if port:
+        user_at_host = f"{user_at_host}:{port}"
+    lines = [
+        f"SSH backend unreachable at {user_at_host}.",
+        f"  Attempted: 10s probe with ConnectTimeout=5, BatchMode=yes.",
+    ]
+    category = diag.get("category")
+    if category:
+        lines.append(f"  Failure category: {category}")
+    last = diag.get("last_error")
+    if last:
+        lines.append(f"  Last error: {last}")
+    return "\n".join(lines)

--- a/src/shipyard/executor/ssh.py
+++ b/src/shipyard/executor/ssh.py
@@ -752,7 +752,7 @@ def _format_ssh_diagnosis(
         user_at_host = f"{user_at_host}:{port}"
     lines = [
         f"SSH backend unreachable at {user_at_host}.",
-        f"  Attempted: 10s probe with ConnectTimeout=5, BatchMode=yes.",
+        "  Attempted: 10s probe with ConnectTimeout=5, BatchMode=yes.",
     ]
     category = diag.get("category")
     if category:

--- a/src/shipyard/preflight.py
+++ b/src/shipyard/preflight.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import subprocess
-from collections.abc import Iterable
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -11,6 +10,8 @@ from typing import TYPE_CHECKING, Any
 from shipyard.failover.auto import apply_auto_cloud_fallback
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
+
     from shipyard.core.config import Config
     from shipyard.executor.dispatch import ExecutorDispatcher
 

--- a/src/shipyard/preflight.py
+++ b/src/shipyard/preflight.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import subprocess
+from collections.abc import Iterable
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -14,6 +15,22 @@ if TYPE_CHECKING:
     from shipyard.executor.dispatch import ExecutorDispatcher
 
 
+# Exit codes surfaced by the CLI. ValueError → 1 (validation/config); we
+# want a distinct exit for "backend physically can't be reached" so
+# automation can branch without parsing error strings.
+EXIT_BACKEND_UNREACHABLE = 3
+
+
+class BackendUnreachableError(RuntimeError):
+    """At least one target's primary + fallback backends are unreachable.
+
+    Deliberately not a ValueError subclass — the CLI distinguishes
+    between configuration problems (exit 2) and hitting a real dead
+    backend (exit 3) so cron/agent automation can react without
+    parsing error strings.
+    """
+
+
 @dataclass(frozen=True)
 class TargetPreflight:
     """Preflight result for a single target."""
@@ -23,6 +40,7 @@ class TargetPreflight:
     reachable: bool
     selected_backend: str
     message: str | None = None
+    failure_category: str | None = None
 
     def to_dict(self) -> dict[str, Any]:
         data = {
@@ -33,6 +51,8 @@ class TargetPreflight:
         }
         if self.message:
             data["message"] = self.message
+        if self.failure_category:
+            data["failure_category"] = self.failure_category
         return data
 
 
@@ -44,6 +64,7 @@ class PreflightResult:
     expected_root: Path | None
     targets: dict[str, TargetPreflight] = field(default_factory=dict)
     warnings: list[str] = field(default_factory=list)
+    skipped_targets: list[str] = field(default_factory=list)
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -51,6 +72,7 @@ class PreflightResult:
             "expected_root": str(self.expected_root) if self.expected_root else None,
             "targets": {name: state.to_dict() for name, state in self.targets.items()},
             "warnings": list(self.warnings),
+            "skipped_targets": list(self.skipped_targets),
         }
 
 
@@ -61,9 +83,17 @@ def run_submission_preflight(
     dispatcher: ExecutorDispatcher,
     allow_root_mismatch: bool = False,
     allow_unreachable_targets: bool = False,
+    skip_targets: Iterable[str] = (),
     cwd: Path | None = None,
 ) -> PreflightResult:
-    """Check repo root and target reachability before enqueueing a job."""
+    """Check repo root and target reachability before enqueueing a job.
+
+    `skip_targets` deliberately removes a lane before the probe runs —
+    the caller is asserting "I don't want to validate this target at
+    all" (semantics distinct from `allow_unreachable_targets`, which
+    means "I'll accept a validation gap if this lane can't be reached
+    right now").
+    """
     workdir = (cwd or Path.cwd()).resolve()
     expected_root = config.project_dir.parent.resolve() if config.project_dir else workdir
     git_root = _git_root_for(workdir)
@@ -75,6 +105,23 @@ def run_submission_preflight(
             warnings.append(message)
         else:
             raise ValueError(message)
+
+    # Apply --skip-target BEFORE the probe so a deliberate skip never
+    # wastes a 10-second ssh handshake. This is the semantics
+    # difference vs --allow-unreachable-targets.
+    skip_set = {name for name in skip_targets}
+    skipped_present = [n for n in target_names if n in skip_set]
+    skipped_unknown = sorted(skip_set - set(target_names))
+    if skipped_unknown:
+        raise ValueError(
+            "skip-target names no configured target: "
+            + ", ".join(skipped_unknown)
+        )
+    for name in skipped_present:
+        warnings.append(
+            f"Target '{name}' deliberately skipped (--skip-target)."
+        )
+    effective_targets = [n for n in target_names if n not in skip_set]
 
     # Inject an implicit cloud fallback on SSH targets when the
     # project opts into [failover.cloud_auto]. Targets that already
@@ -89,18 +136,15 @@ def run_submission_preflight(
         )
 
     target_states: dict[str, TargetPreflight] = {}
-    for target_name in target_names:
+    unreachable: list[TargetPreflight] = []
+    for target_name in effective_targets:
         target_config = dict(config.targets.get(target_name, {}))
         target_config["name"] = target_name
         primary_backend = dispatcher.backend_name(target_config)
 
         probe_result = _probe_target_path(target_config, dispatcher)
         if not probe_result.reachable:
-            message = probe_result.message or f"Target '{target_name}' is unreachable"
-            if allow_unreachable_targets:
-                warnings.append(message)
-            else:
-                raise ValueError(message)
+            unreachable.append(probe_result)
 
         if probe_result.selected_backend != primary_backend:
             warnings.append(
@@ -110,12 +154,63 @@ def run_submission_preflight(
 
         target_states[target_name] = probe_result
 
+    if unreachable:
+        if allow_unreachable_targets:
+            # Loud warning: the user asked for this escape hatch, but
+            # they probably didn't realize they were buying a
+            # validation gap. Surfacing it prominently gives agents
+            # a fighting chance of not "just adding --allow-…" as a
+            # muscle-memory workaround for a real backend outage.
+            names = ", ".join(u.target_name for u in unreachable)
+            warnings.append(
+                f"⚠︎ VALIDATION GAP — the following targets are unreachable "
+                f"and will be SKIPPED, NOT validated: {names}. "
+                f"Each lane's evidence will be absent from the merge "
+                f"gate. Fix the backend, or use --skip-target <name> to "
+                f"record the skip deliberately."
+            )
+            for u in unreachable:
+                detail = u.message or f"Target '{u.target_name}' is unreachable"
+                warnings.append(f"  - {detail}")
+        else:
+            raise BackendUnreachableError(
+                _format_unreachable_error(unreachable)
+            )
+
     return PreflightResult(
         git_root=git_root,
         expected_root=expected_root,
         targets=target_states,
         warnings=warnings,
+        skipped_targets=skipped_present,
     )
+
+
+def _format_unreachable_error(unreachable: list[TargetPreflight]) -> str:
+    """Compose the multi-line error that fires on fail-fast."""
+    lines: list[str] = []
+    for u in unreachable:
+        header = f"Target '{u.target_name}' ({u.backend}) is unreachable."
+        lines.append(header)
+        if u.message:
+            for detail_line in u.message.splitlines():
+                lines.append(f"  {detail_line}")
+        if u.failure_category:
+            lines.append(f"  category: {u.failure_category}")
+
+    lines.append("")
+    lines.append("Options:")
+    lines.append(
+        "  - Fix the backend (check network, SSH key, hostname in ~/.ssh/config)"
+    )
+    lines.append(
+        "  - Re-run with --skip-target <name> to deliberately skip this lane"
+    )
+    lines.append(
+        "  - Re-run with --allow-unreachable-targets to proceed "
+        "(LANE WILL BE SKIPPED, NOT VALIDATED)"
+    )
+    return "\n".join(lines)
 
 
 def _probe_target_path(
@@ -145,12 +240,46 @@ def _probe_target_path(
                 message=f"Primary backend '{primary_backend}' unreachable; failover '{fallback_backend}' is available",
             )
 
+    # Neither primary nor any fallback is reachable — ask the
+    # dispatcher for a richer diagnosis if it offers one, so the
+    # user sees "auth refused" instead of a generic "unreachable".
+    diagnosis = _collect_diagnosis(target_config, dispatcher)
     return TargetPreflight(
         target_name=target_name,
         backend=primary_backend,
         reachable=False,
         selected_backend=primary_backend,
-        message=f"Target '{target_name}' has no reachable backend",
+        message=diagnosis.message,
+        failure_category=diagnosis.category,
+    )
+
+
+@dataclass(frozen=True)
+class _ProbeDiagnosis:
+    message: str
+    category: str | None
+
+
+def _collect_diagnosis(
+    target_config: dict[str, Any],
+    dispatcher: ExecutorDispatcher,
+) -> _ProbeDiagnosis:
+    """Best-effort richer error for the unreachable case."""
+    diagnose = getattr(dispatcher, "diagnose", None)
+    if callable(diagnose):
+        try:
+            result = diagnose(target_config)
+        except Exception:
+            result = None
+        if result is not None:
+            return _ProbeDiagnosis(
+                message=result.get("message")
+                or f"Target '{target_config.get('name','unknown')}' has no reachable backend",
+                category=result.get("category"),
+            )
+    return _ProbeDiagnosis(
+        message=f"Target '{target_config.get('name','unknown')}' has no reachable backend",
+        category=None,
     )
 
 

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -6,7 +6,7 @@ import pytest
 
 from shipyard.core.config import Config
 from shipyard.executor.dispatch import ExecutorDispatcher
-from shipyard.preflight import run_submission_preflight
+from shipyard.preflight import BackendUnreachableError, run_submission_preflight
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -76,7 +76,7 @@ def test_unreachable_target_rejected_without_override(tmp_path, monkeypatch) -> 
     monkeypatch.setattr("shipyard.preflight._git_root_for", lambda _: tmp_path)
     monkeypatch.setattr(dispatcher, "probe", lambda target_config: False)
 
-    with pytest.raises(ValueError, match="no reachable backend"):
+    with pytest.raises(BackendUnreachableError, match="unreachable"):
         run_submission_preflight(
             config,
             target_names=["ubuntu"],

--- a/tests/test_preflight_ssh_fail_fast.py
+++ b/tests/test_preflight_ssh_fail_fast.py
@@ -1,0 +1,263 @@
+"""Tests for SSH fail-fast preflight behavior (#100)."""
+
+from __future__ import annotations
+
+import subprocess
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from shipyard.core.config import Config
+from shipyard.executor.dispatch import ExecutorDispatcher
+from shipyard.executor.ssh import SSHExecutor, _classify_probe_error
+from shipyard.preflight import BackendUnreachableError, run_submission_preflight
+
+
+def _config(tmp_path: Path, targets: dict[str, dict[str, Any]]) -> Config:
+    project_dir = tmp_path / ".shipyard"
+    project_dir.mkdir()
+    return Config(
+        data={"project": {"name": "test"}, "targets": targets},
+        project_dir=project_dir,
+    )
+
+
+class TestSSHClassifier:
+    """The classifier's buckets are load-bearing for the CLI error output."""
+
+    @pytest.mark.parametrize(
+        "stderr,expected",
+        [
+            ("Permission denied (publickey).", "auth"),
+            ("Too many authentication failures", "auth"),
+            ("Host key verification failed.", "host_key"),
+            ("REMOTE HOST IDENTIFICATION HAS CHANGED!", "host_key"),
+            ("ssh: Could not resolve hostname bogus: Name or service not known", "network"),
+            ("ssh: Could not resolve hostname bogus: nodename nor servname provided", "network"),
+            ("ssh: connect to host bogus port 22: No route to host", "network"),
+            ("ssh: connect to host 10.0.0.1 port 22: Connection refused", "network"),
+            ("ssh: connect to host 10.0.0.1 port 22: Connection timed out", "timeout"),
+            ("some weird unrelated output", "unknown"),
+            ("", "network"),  # rc=255 fallback
+        ],
+    )
+    def test_stable_categories(self, stderr: str, expected: str) -> None:
+        rc = 255 if not stderr else 1
+        assert _classify_probe_error(stderr, rc) == expected
+
+
+class TestSSHProbeDiagnosis:
+    """SSHExecutor.diagnose() surfaces rich reachability context."""
+
+    def test_probe_honors_10s_budget(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A hung ssh probe must surface within ~10s, not the full cmd timeout."""
+        calls: list[int] = []
+
+        def fake_run(cmd: list[str], **kw: Any) -> subprocess.CompletedProcess:
+            calls.append(kw.get("timeout", 0))
+            raise subprocess.TimeoutExpired(cmd=cmd, timeout=kw.get("timeout", 0))
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        start = time.monotonic()
+        diag = SSHExecutor().diagnose({"host": "bogus.invalid"})
+        assert time.monotonic() - start < 2.0  # fake_run raises immediately
+        assert diag["reachable"] is False
+        assert diag["category"] == "timeout"
+        assert calls == [10], (
+            "probe must pass a 10s timeout to subprocess.run, "
+            "not the validation timeout"
+        )
+
+    def test_missing_host_reports_configuration(self) -> None:
+        diag = SSHExecutor().diagnose({})  # no host
+        assert diag["reachable"] is False
+        assert diag["category"] == "configuration"
+        assert "no host configured" in diag["message"].lower()
+
+    def test_auth_refused_is_classified(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def fake_run(*args: Any, **kw: Any) -> subprocess.CompletedProcess:
+            return subprocess.CompletedProcess(
+                args=[], returncode=255, stdout="",
+                stderr="Permission denied (publickey).\r\n",
+            )
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        diag = SSHExecutor().diagnose({"host": "user@host"})
+        assert diag["reachable"] is False
+        assert diag["category"] == "auth"
+        assert "permission denied" in diag["message"].lower()
+        assert "host" in diag["message"]
+
+    def test_reachable_host_round_trips(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def fake_run(*args: Any, **kw: Any) -> subprocess.CompletedProcess:
+            return subprocess.CompletedProcess(
+                args=[], returncode=0, stdout="ok\n", stderr="",
+            )
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        diag = SSHExecutor().diagnose({"host": "ubuntu"})
+        assert diag["reachable"] is True
+        assert diag["category"] is None
+
+
+class TestPreflightSkipAndAllowSemantics:
+    """--skip-target and --allow-unreachable-targets differ by design."""
+
+    def test_skip_target_bypasses_probe_entirely(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        config = _config(
+            tmp_path,
+            {
+                "ubuntu": {"backend": "ssh", "platform": "linux-x64", "host": "u"},
+                "mac": {"backend": "local", "platform": "macos-arm64"},
+            },
+        )
+        dispatcher = ExecutorDispatcher()
+        monkeypatch.setattr("shipyard.preflight._git_root_for", lambda _: tmp_path)
+
+        probe_calls: list[dict[str, Any]] = []
+
+        def fake_probe(target_config: dict[str, Any]) -> bool:
+            probe_calls.append(target_config)
+            return True
+
+        monkeypatch.setattr(dispatcher, "probe", fake_probe)
+
+        result = run_submission_preflight(
+            config,
+            target_names=["ubuntu", "mac"],
+            dispatcher=dispatcher,
+            skip_targets=["ubuntu"],
+            cwd=tmp_path,
+        )
+        # Skipped target was excluded before the probe — no probe call.
+        assert [c.get("name") for c in probe_calls] == ["mac"]
+        assert result.skipped_targets == ["ubuntu"]
+        assert any("deliberately skipped" in w for w in result.warnings)
+
+    def test_skip_target_rejects_unknown_name(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        config = _config(
+            tmp_path,
+            {"mac": {"backend": "local", "platform": "macos-arm64"}},
+        )
+        dispatcher = ExecutorDispatcher()
+        monkeypatch.setattr("shipyard.preflight._git_root_for", lambda _: tmp_path)
+
+        with pytest.raises(ValueError, match="no configured target"):
+            run_submission_preflight(
+                config,
+                target_names=["mac"],
+                dispatcher=dispatcher,
+                skip_targets=["windows"],  # not configured
+                cwd=tmp_path,
+            )
+
+    def test_allow_unreachable_emits_loud_validation_gap_warning(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        config = _config(
+            tmp_path,
+            {"ubuntu": {"backend": "ssh", "platform": "linux-x64", "host": "u"}},
+        )
+        dispatcher = ExecutorDispatcher()
+        monkeypatch.setattr("shipyard.preflight._git_root_for", lambda _: tmp_path)
+        monkeypatch.setattr(dispatcher, "probe", lambda _c: False)
+
+        result = run_submission_preflight(
+            config,
+            target_names=["ubuntu"],
+            dispatcher=dispatcher,
+            allow_unreachable_targets=True,
+            cwd=tmp_path,
+        )
+
+        # The warning has to be impossible to miss — the whole reason
+        # this flag exists is that consumers were using it as muscle
+        # memory when a real backend outage hit.
+        joined = "\n".join(result.warnings)
+        assert "VALIDATION GAP" in joined
+        assert "SKIPPED, NOT validated" in joined
+        assert "ubuntu" in joined
+
+    def test_backend_unreachable_error_carries_rich_detail(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        config = _config(
+            tmp_path,
+            {"ubuntu": {"backend": "ssh", "platform": "linux-x64", "host": "u"}},
+        )
+        dispatcher = ExecutorDispatcher()
+        monkeypatch.setattr("shipyard.preflight._git_root_for", lambda _: tmp_path)
+        monkeypatch.setattr(dispatcher, "probe", lambda _c: False)
+        monkeypatch.setattr(
+            dispatcher,
+            "diagnose",
+            lambda _c: {
+                "reachable": False,
+                "message": "SSH backend unreachable at u.\n  Failure category: auth",
+                "category": "auth",
+            },
+        )
+
+        with pytest.raises(BackendUnreachableError) as exc:
+            run_submission_preflight(
+                config,
+                target_names=["ubuntu"],
+                dispatcher=dispatcher,
+                cwd=tmp_path,
+            )
+        msg = str(exc.value)
+        # Names the target
+        assert "'ubuntu'" in msg
+        # Includes the rich diagnosis from the dispatcher
+        assert "category: auth" in msg.lower()
+        # Explains the three escape hatches with their semantics
+        assert "--skip-target" in msg
+        assert "--allow-unreachable-targets" in msg
+        assert "LANE WILL BE SKIPPED, NOT VALIDATED" in msg
+
+
+class TestIntegrationWithUnresolvableHost:
+    """Acceptance: unresolvable hostname surfaces within 10s."""
+
+    @pytest.mark.integration
+    def test_real_ssh_probe_fails_fast_on_unresolvable_host(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Real ssh binary hit, no mocking. Must return within ~15s."""
+        config = _config(
+            tmp_path,
+            {
+                "ghost": {
+                    "backend": "ssh",
+                    "platform": "linux-x64",
+                    "host": "ghost-backend-that-does-not-exist.invalid",
+                }
+            },
+        )
+        dispatcher = ExecutorDispatcher()
+        monkeypatch.setattr("shipyard.preflight._git_root_for", lambda _: tmp_path)
+
+        start = time.monotonic()
+        with pytest.raises(BackendUnreachableError) as exc:
+            run_submission_preflight(
+                config,
+                target_names=["ghost"],
+                dispatcher=dispatcher,
+                cwd=tmp_path,
+            )
+        elapsed = time.monotonic() - start
+
+        assert elapsed < 15.0, f"probe took {elapsed:.1f}s (budget 10s + margin)"
+        assert "ghost" in str(exc.value)


### PR DESCRIPTION
Closes #100

## Summary

Unreachable SSH backends now fail the preflight inside 10s with a message that names the target, classifies the failure (`auth`, `host_key`, `network`, `timeout`, `configuration`, `unknown`), and prints the last ssh stderr. A new exit code **3** (`EXIT_BACKEND_UNREACHABLE`) distinguishes "backend is down" from "validation failed" (1) and "config error" (2), so automation can branch without parsing error strings.

`--skip-target NAME` and `--allow-unreachable-targets` now have distinct semantics:

- **`--skip-target`** — drops the lane *before* the probe runs. Use when you know you don't want to validate that target at all. No probe, no warning noise.
- **`--allow-unreachable-targets`** — runs the probe, accepts an unreachable backend, prints a loud "⚠︎ VALIDATION GAP" warning with the target name and "SKIPPED, NOT validated". Pulp agents were using this flag as muscle-memory for real backend outages — the loud warning is on purpose.

## Files
- `src/shipyard/executor/ssh.py` — new `diagnose()` method, `_classify_probe_error()` bucketing, `_format_ssh_diagnosis()` message composer. Probe now runs with `BatchMode=yes`.
- `src/shipyard/executor/dispatch.py` — `ExecutorDispatcher.diagnose()` forwards to the chosen executor when it implements diagnose.
- `src/shipyard/preflight.py` — `BackendUnreachableError` (not a ValueError subclass), `skip_targets` parameter, loud warning on allow-unreachable, rich error message on fail-fast.
- `src/shipyard/cli.py` — `--skip-target` on `run`, `ship`, `pr`; exit 3 on `BackendUnreachableError`.
- `skills/ci/SKILL.md` — documents the flag semantics and the exit-code table.
- `tests/test_preflight.py` — updated existing test to expect `BackendUnreachableError` (kept all other assertions).
- `tests/test_preflight_ssh_fail_fast.py` — 20 new tests, see below.

## Tests added

- **Classifier stability** (10 parametrized cases) — every failure string pattern maps to a stable category.
- **Probe 10s budget** — probe passes `timeout=10` to `subprocess.run`, surfaces within 10s even on a hung ssh.
- **Missing-host config error** — surfaces as `category=configuration`.
- **Auth classification** — `Permission denied (publickey)` → `category=auth`.
- **Reachable round-trip** — `diagnose()` returns `reachable=True, category=None` for a working host.
- **`--skip-target` bypasses probe entirely** — verified by counting probe calls.
- **`--skip-target` rejects unknown names** with a clear error.
- **`--allow-unreachable-targets` emits loud VALIDATION GAP warning** with the target named.
- **`BackendUnreachableError` carries rich detail** — names target, failure category, and the three escape hatches with their semantics.
- **Integration** (marked `integration`): real ssh binary + unresolvable hostname surfaces within 15s.

All 929 non-integration tests pass; integration test passes under 15s.

## Version gate

- CLI 0.19.0 → 0.20.0 (minor, gate verdict preserved).
- Plugin 0.11.0 → 0.11.1 (SKILL.md updated for the three-surface rule).

## Test plan

- [ ] CI green on this PR.
- [ ] Pulp agents can drop the muscle-memory `--allow-unreachable-targets` flag once this lands; the exit-3 signal lets their cron automation distinguish backend outages from real validation failures.