### PR TITLE
feat: Phase C doc-sync hook + dedicated state-machine CI lane (#101)

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -25,6 +25,8 @@ PYTHON="${PYTHON:-python3}"
 VBC="$ROOT/scripts/version_bump_check.py"
 SSC="$ROOT/scripts/skill_sync_check.py"
 CFG="$ROOT/scripts/versioning.json"
+DSC="$ROOT/scripts/doc_sync_check.py"
+DSM="$ROOT/scripts/doc_sync_map.json"
 
 if [ ! -f "$VBC" ] || [ ! -f "$SSC" ] || [ ! -f "$CFG" ]; then
     exit 0  # pre-versioning checkout; no-op
@@ -46,6 +48,15 @@ case $? in
     1) fail=1 ;;
     *) echo "[pre-push] version_bump_check: internal error" >&2 ;;
 esac
+
+if [ -f "$DSC" ] && [ -f "$DSM" ]; then
+    "$PYTHON" "$DSC" --base "$BASE" --map "$DSM" --mode=report
+    case $? in
+        0) ;;
+        1) fail=1 ;;
+        *) echo "[pre-push] doc_sync_check: internal error" >&2 ;;
+    esac
+fi
 
 if [ "$fail" = "0" ]; then
     echo "[pre-push] gates clean." >&2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,3 +74,24 @@ jobs:
       - name: Type check
         if: runner.os != 'Windows'
         run: mypy src/
+
+  state-machine:
+    # #101 Phase C — dedicated lane so ship-state-machine failures are
+    # visually distinct from the full-suite run. Fast (ubuntu-only, no
+    # cross-platform matrix) because these tests are pure Python and
+    # don't exercise platform-specific code paths.
+    name: Ship state machine
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: pip install .[dev]
+
+      - name: Run state-machine tests
+        run: pytest -m state_machine -v

--- a/.github/workflows/version-skill-check.yml
+++ b/.github/workflows/version-skill-check.yml
@@ -53,3 +53,10 @@ jobs:
               --base "${{ steps.base.outputs.ref }}" \
               --config scripts/versioning.json \
               --mode=report
+
+      - name: Doc-sync check
+        run: |
+          python3 scripts/doc_sync_check.py \
+              --base "${{ steps.base.outputs.ref }}" \
+              --map scripts/doc_sync_map.json \
+              --mode=report

--- a/docs/ship-state-machine.md
+++ b/docs/ship-state-machine.md
@@ -1,0 +1,338 @@
+# Ship state machine (audit — Phase A)
+
+This document is the [#101](https://github.com/danielraffel/Shipyard/issues/101)
+Phase A deliverable: a hand-written map of every state, every transition,
+and every external dependency in the `shipyard ship` / `shipyard watch` /
+`shipyard auto-merge` flow. It was written by reading the code end-to-end,
+not by executing it, and is therefore a fixed-in-time snapshot. Keep it in
+step with `src/shipyard/core/ship_state.py`, `src/shipyard/cli.py` (the
+`ship`, `watch`, `auto-merge`, `cloud add-lane`, `cloud retarget`, and
+`ship-state` subcommands), and `src/shipyard/ship/*.py`.
+
+**Phase B** (transition tests) and **Phase C** (pre-merge doc-sync hook,
+dedicated CI lane) land in follow-up PRs. This audit's goal is to make
+Phase B mechanical: each edge below becomes a test.
+
+## The core persisted object: `ShipState`
+
+`ShipState` lives at `<state_dir>/ship/<pr>.json` during the active ship.
+On terminal verdict it is moved to `<state_dir>/ship/archive/<pr>-<utc>.json`
+so the active directory only lists live work. The object carries:
+
+| Field               | Purpose                                                                             |
+|---------------------|-------------------------------------------------------------------------------------|
+| `pr`                | GitHub PR number — primary key.                                                     |
+| `repo`              | Owner/name (`danielraffel/pulp`), captured at dispatch so retarget/add-lane routes dispatches correctly. |
+| `branch`            | PR head branch.                                                                     |
+| `base_branch`       | Merge target.                                                                       |
+| `head_sha`          | PR head SHA at dispatch. Drift vs this value refuses resume.                        |
+| `policy_signature`  | SHA-256[:16] of (required_platforms, target_names, mode) at dispatch. Drift refuses resume. |
+| `dispatched_runs`   | One `DispatchedRun` per lane (target + provider + GitHub Actions run id / queue job id + live status). |
+| `evidence_snapshot` | `{target: "pass" | "fail" | "pending" | ...}` — source-of-truth for the verdict computer. |
+| `attempt`           | Monotonic counter bumped by `archive_and_replace` on `--no-resume`.                 |
+| `pr_url`, `pr_title`, `commit_subject` | Human context. Refreshed on every save so a force-push is visible to `ship-state show` without a new attempt. |
+| `created_at`        | Attempt-scoped: stable for the life of an attempt.                                  |
+| `updated_at`        | Last `touch()` — bumped after every mutation helper.                                |
+| `schema_version`    | Currently 1.                                                                        |
+
+`DispatchedRun` is the per-lane record:
+
+| Field                | Purpose                                                                            |
+|----------------------|------------------------------------------------------------------------------------|
+| `target`             | Lane name (`macos`, `ubuntu`, …) — matches `[targets.<name>]` in `.shipyard/config.toml`. |
+| `provider`           | Dispatch channel: `namespace`, `github-hosted`, `ssh`, `ssh-windows`, or a local job id for the queue path. |
+| `run_id`             | GH Actions run ID for cloud, Shipyard job id for local/ssh, or `pending-<target>` while a `cloud add-lane` discovery is in flight. |
+| `status`             | Last observed lifecycle string (`queued`, `in_progress`, `completed`, `failed`, `cancelled`, `reused`). |
+| `attempt`            | `ShipState.attempt` at dispatch time. Survives resume so old attempts don't reattach. |
+| `last_heartbeat_at`  | Additive liveness signal — written by the poller, used by `watch` to mark `stale` runs. |
+| `phase`              | Additive validation-phase tag (setup/configure/build/test), same source as `last_heartbeat_at`. |
+| `required`           | Lane policy at dispatch. `False` = advisory; advisory failures land in the merge check's `advisory` bucket instead of `failing`. |
+
+## State diagram (textual)
+
+```
+                          ┌─────────────────────────────────────────┐
+                          │   No state file exists for this PR      │
+                          └───────────────────┬─────────────────────┘
+                                              │
+                                              ▼  shipyard ship (first run)
+                                   ┌──────────────────────┐
+                                   │   STATE_FRESH        │
+                                   │   (state created,    │
+                                   │    no runs yet)      │
+                                   └───────────┬──────────┘
+                                               │  dispatcher.validate_target(...) / workflow_dispatch
+                                               ▼
+                                   ┌──────────────────────┐
+                                   │   STATE_IN_FLIGHT    │◀────┐
+                                   │   evidence_snapshot  │     │ cloud add-lane / retarget
+                                   │   has "pending"      │─────┘ (adds or replaces a
+                                   │   entries for some   │        DispatchedRun while
+                                   │   targets            │        the ship is still live)
+                                   └───────────┬──────────┘
+                                               │
+                       ┌───────────────────────┼───────────────────────┐
+                       │                       │                       │
+                       ▼                       ▼                       ▼
+              ┌────────────────┐      ┌────────────────┐      ┌────────────────┐
+              │ STATE_VERDICT  │      │ STATE_VERDICT  │      │ STATE_STALE    │
+              │ _PASS          │      │ _FAIL          │      │ (session died; │
+              │                │      │                │      │  --no-resume   │
+              │ all required   │      │ any required   │      │  or drift      │
+              │ targets pass   │      │ target failed  │      │  refuses resume│
+              │ (advisory fails│      │                │      └──────┬─────────┘
+              │  tolerated)    │      │                │             │
+              └──────┬─────────┘      └──────┬─────────┘             │ archive_and_replace
+                     │                       │                       │   (bumps attempt)
+          shipyard   │                       │                       │
+          auto-merge │                       │                       ▼
+          or ship    │                       │              ┌────────────────┐
+                     │                       │              │ STATE_FRESH    │
+                     ▼                       ▼              │  (new attempt) │
+              ┌────────────────┐      ┌────────────────┐    └────────────────┘
+              │ STATE_MERGE    │      │ STATE_MERGE_   │
+              │  _ATTEMPTING   │      │  REFUSED       │
+              │                │      │ (target failed;│
+              │ merge_pr(...)  │      │  no merge call │
+              │                │      │  is issued)    │
+              └──────┬─────────┘      └──────┬─────────┘
+                     │                       │
+          ┌──────────┴──────────┐             │
+          ▼                     ▼             │
+  ┌────────────────┐  ┌────────────────┐      │
+  │ STATE_MERGED   │  │ STATE_MERGE_   │      │
+  │                │  │  FAILED        │      │
+  │ gh pr merge    │  │ (gh error,     │      │
+  │ returned ok    │  │  branch prot,  │      │
+  │                │  │  auth, etc.)   │      │
+  └──────┬─────────┘  └──────┬─────────┘      │
+         │                   │                │
+         │ archive()         │ (no archive:   │ (no archive:
+         │ (terminal)        │  retry-able,   │  final verdict
+         ▼                   │  state lives)  │  retained)
+  ┌────────────────┐         │                │
+  │ STATE_ARCHIVED │         ▼                ▼
+  └────────────────┘   [stays STATE_    [stays STATE_
+                       VERDICT_PASS]    VERDICT_FAIL]
+```
+
+**Note.** Shipyard does not emit or name these state labels at runtime —
+they are derived from the `(evidence_snapshot, dispatched_runs)` pair
+and the presence/archival of the state file. The names exist so Phase B
+tests can reference each edge unambiguously.
+
+## Entry points and which states they read/write
+
+| CLI command                 | Reads                                               | Writes                                                  |
+|-----------------------------|-----------------------------------------------------|---------------------------------------------------------|
+| `shipyard ship`             | `ShipStateStore.get(pr)` (auto-resume decision)     | Creates or refreshes state; calls `_update_ship_state_from_job`; `archive(pr)` on `STATE_MERGED` |
+| `shipyard ship --no-resume` | Same, forces `archive_and_replace`                  | Archives prior attempt and writes new FRESH attempt     |
+| `shipyard ship --resume`    | Refuses on SHA/policy drift via `_detect_ship_state_drift` | Refreshes pr_url / title / commit_subject, touches    |
+| `shipyard cloud add-lane`   | `ShipStateStore.get(pr)`; verdict check; idempotent `has_target` | `append_run` + `save`                                   |
+| `shipyard cloud retarget`   | Same; dry-run default                               | Replaces one lane's DispatchedRun (target+provider) and the backing cloud workflow run |
+| `shipyard watch`            | `ShipStateStore.get(pr)` loop                       | Never mutates; signature-based change detection emits NDJSON |
+| `shipyard auto-merge`       | `ShipStateStore.get(pr)` + `gh pr view` fallback    | `archive(pr)` on success; never mutates on failure     |
+| `shipyard ship-state list`  | `list_active()`                                     | None                                                    |
+| `shipyard ship-state show`  | `get(pr)`                                           | None                                                    |
+| `shipyard ship-state discard` | `get(pr)`                                         | `archive(pr)` (manual tombstone)                        |
+| `shipyard cleanup --ship-state` | `prune(active_days=14, archive_days=30, closed_prs=...)` | Deletes aged-out active + archived state               |
+
+## Transitions — preconditions, postconditions, failure modes
+
+### T1 — Create a fresh ship state
+
+- **From:** no state file exists for `<pr>`
+- **To:** `STATE_FRESH`
+- **Trigger:** `shipyard ship` on a branch that either has no open PR or an open PR without a saved state
+- **Writes:** `ShipStateStore.save(ShipState(..., dispatched_runs=[], evidence_snapshot={}))`
+- **Externals:** `git push`, `gh pr create` / `gh pr list` (for PR number)
+- **Failure modes**
+  - `git push` fails → ship aborts before state is written (no state file created). *Recovery: retry.*
+  - `gh pr create` fails → `create_pr` raises `GhError`; ship exits without writing state. *Recovery: retry.*
+  - `state_path.write` fails (disk full, permission) → `ShipStateStore.save` raises; tmp file is cleaned up by the `except` in `core/ship_state.py:save`. *Recovery: resolve disk issue, retry.*
+
+### T2 — Add a dispatched run to an in-flight ship
+
+- **From:** `STATE_FRESH` or `STATE_IN_FLIGHT`
+- **To:** `STATE_IN_FLIGHT`
+- **Trigger:** `shipyard ship` per-target loop in `_execute_job`; `shipyard cloud add-lane`; `shipyard cloud retarget`
+- **Writes:** `ship_state.upsert_run(...)` (ship loop) or `append_run(...)` (add-lane, after `has_target` guard) → `save()`
+- **Externals:** `workflow_dispatch` (for cloud), the per-lane executor (`CloudExecutor`, `SSHExecutor`, `LocalExecutor`), `ExecutorDispatcher.probe/diagnose`
+- **Failure modes**
+  - `workflow_dispatch` raises (404, auth, transient GH 5xx) → CLI exits 1 before saving the DispatchedRun. The ship state stays at the previous snapshot. *Recovery: retry; the ship continues from the prior snapshot.*
+  - Cloud dispatch succeeds but `find_dispatched_run` times out → DispatchedRun is still saved with `run_id="pending-<target>"`. *Recovery: watch/poller backfills the real run id on next tick. Known latent bug: if backfill also fails, the lane is invisible to `auto-merge`.*
+  - Preflight raises `BackendUnreachableError` / `ValueError` → ship exits 3/1; no DispatchedRun is written. *Recovery: fix backend or use `--skip-target` / `--allow-unreachable-targets`.*
+
+### T3 — Record a terminal target outcome
+
+- **From:** `STATE_IN_FLIGHT`
+- **To:** `STATE_IN_FLIGHT` (with one more target in `evidence_snapshot`) or `STATE_VERDICT_*` once every terminal slot is filled
+- **Trigger:** `_update_ship_state_from_job` after `_execute_job` completes; cloud poller updates via the watch path
+- **Writes:** `update_evidence(target, "pass"|"fail")`, `upsert_run(...)`, `save()`
+- **Externals:** `CloudRecordStore.list_recent` (maps platform → cloud run_id), tip-commit parsing (lane-policy trailer)
+- **Failure modes**
+  - Evidence saved before DispatchedRun fully resolved → next `watch` tick just sees an in-flight lane with evidence present; no divergence.
+  - Process dies between the per-target mutation and `save()` — the prior `save()` already covered the earlier targets. At most one target-outcome event is lost. *Recovery: re-run the target (resume path).*
+  - Known historical bug pattern (Pulp consumer report): a PR landed merged but the post-merge evidence row was never saved. Represent as a Phase B test: inject `save` failure after `merge_pr` returns True.
+
+### T4 — Compute the terminal verdict
+
+- **From:** `STATE_IN_FLIGHT` with a full `evidence_snapshot`
+- **To:** `STATE_VERDICT_PASS` or `STATE_VERDICT_FAIL`
+- **Computation:** `_ship_terminal_verdict(state)` in `cli.py` — returns `True` only if every non-advisory target has `"pass"` evidence, `False` if any non-advisory target failed, `None` while any evidence value is missing or non-terminal
+- **Externals:** none — pure function over the state
+- **Failure modes**
+  - Partial evidence (e.g. evidence present for macos but missing for ubuntu) → verdict stays `None` and `auto-merge` exits 3 for retry. *Recovery: the cloud poller or next `shipyard ship` pass fills the gap.*
+  - An advisory lane reports `"fail"` → verdict ignores it because `required=False`. Reviewers still see the failure in `watch`.
+
+### T5 — Merge on PASS
+
+- **From:** `STATE_VERDICT_PASS`
+- **To:** `STATE_MERGED` → `STATE_ARCHIVED`
+- **Trigger:** `shipyard ship` (end of `_execute_job`) or `shipyard auto-merge <pr>`
+- **Writes:** `merge_pr(...)` (gh), on success `ctx.ship_state.archive(pr)`
+- **Externals:** `gh pr merge` (branch protection, auth, network)
+- **Failure modes**
+  - `GhError` (branch protection rejects admin=false, auth, conflicts) → `STATE_MERGE_FAILED`. The state file is NOT archived so a retry can pick up. *Recovery: `shipyard auto-merge <pr>` re-attempts without re-dispatching.*
+  - `merge_pr` returns True but `archive(pr)` fails (disk error) → the next `auto-merge` tick will see the state file, verdict PASS, and attempt to merge again. `_pr_is_merged(pr)` catches the double-merge: gh returns "already merged"; we treat that as idempotent success per #64 P2. *Recovery: auto.*
+  - Network flake between gh API and our poller: `gh pr merge` succeeded server-side, but our local call timed out; we exit 1 without archiving. Same safe path: next tick sees `STATE_VERDICT_PASS` + a MERGED PR → `_pr_is_merged` returns True → exit 0 + archive.
+
+### T6 — Refuse to merge on FAIL
+
+- **From:** `STATE_VERDICT_FAIL`
+- **To:** `STATE_MERGE_REFUSED` (terminal; state retained for inspection)
+- **Trigger:** `shipyard ship` or `shipyard auto-merge <pr>`
+- **Writes:** none. The state file is intentionally NOT archived — a reviewer may want to inspect `evidence_snapshot` / `dispatched_runs` after the fact. Eventually aged out by `shipyard cleanup --ship-state`.
+- **Externals:** none
+- **Failure modes**: N/A (no action to fail)
+
+### T7 — Resume an interrupted ship
+
+- **From:** state file exists + no drift
+- **To:** `STATE_IN_FLIGHT` (continues where it left off)
+- **Trigger:** `shipyard ship` (auto-resume default) or `shipyard ship --resume`
+- **Writes:** `save()` after refreshing PR metadata; continues `_execute_job` which writes further target outcomes
+- **Externals:** `git rev-parse HEAD` (drift check), `.shipyard/config.toml` (policy signature recomputation)
+- **Failure modes**
+  - SHA drift (`is_sha_drift`): ship refuses to resume. *Recovery: `--no-resume` to archive + fresh attempt.*
+  - Policy drift: required-platforms or target-list changed since the state file was written → refuse. *Recovery: same.*
+  - State file is corrupt (truncated JSON, post-crash): `ShipStateStore.get` catches `JSONDecodeError`/`KeyError` and returns None. Caller sees "no state" and creates a fresh one, overwriting the corrupt file. *This is the ship-state equivalent of the queue-file fix in #102.*
+
+### T8 — Force-restart via `--no-resume`
+
+- **From:** any existing state for `<pr>` (FRESH / IN_FLIGHT / VERDICT_*)
+- **To:** `STATE_STALE` → archived → new `STATE_FRESH` with `attempt += 1`
+- **Trigger:** `shipyard ship --no-resume`
+- **Writes:** `ShipStateStore.archive_and_replace(state)` → `save(replaced)`
+- **Externals:** none beyond the archive rename
+- **Failure modes**: archive rename fails (disk/permission) → exits with OSError, previous state untouched. *Recovery: fix disk, retry.*
+
+### T9 — `cloud retarget` mid-flight
+
+- **From:** `STATE_IN_FLIGHT`
+- **To:** `STATE_IN_FLIGHT` with one lane's `DispatchedRun` replaced (new provider + new run_id) and the stale GH Actions job cancelled
+- **Trigger:** `shipyard cloud retarget --pr <n> --target <lane> --provider <prov> --apply`
+- **Writes:** GH API: cancel old job, dispatch new workflow; `ShipState.upsert_run` → `save()`
+- **Externals:** `gh api`, `gh run list`, `workflow_dispatch`
+- **Failure modes**
+  - Old-job cancel fails → new dispatch proceeds; old job still consumes cloud quota until it finishes. State is consistent.
+  - New dispatch fails → neither state nor old job is touched. Caller gets an error.
+
+### T10 — `cloud add-lane` mid-flight
+
+- **From:** `STATE_IN_FLIGHT` (refuses if already past dispatch per `_ship_terminal_verdict`)
+- **To:** `STATE_IN_FLIGHT` with one more `DispatchedRun` appended
+- **Trigger:** `shipyard cloud add-lane --pr <n> --target <name> --apply`
+- **Writes:** `workflow_dispatch`, then `append_run` → `save()`
+- **Externals:** same as T9
+- **Failure modes**: `workflow_dispatch` failure → no state change; idempotent retry OK.
+
+### T11 — Terminal archive
+
+- **From:** `STATE_MERGED`
+- **To:** `STATE_ARCHIVED`
+- **Trigger:** `ship` end-of-flow, `auto-merge` on success, `ship-state discard` (manual)
+- **Writes:** `os.replace(<pr>.json, archive/<pr>-<timestamp>.json)` — atomic same-directory rename
+- **Externals:** filesystem atomic rename
+- **Failure modes**: rename fails → state file is untouched; next invocation sees it and hits the `_pr_is_merged` idempotency branch (which treats "already merged" as success).
+
+### T12 — Aging prune
+
+- **From:** `STATE_VERDICT_FAIL` or old archived file
+- **To:** deleted
+- **Trigger:** `shipyard cleanup --ship-state --apply`
+- **Rules (per `ShipStateStore.prune`)**
+  - Active state is deleted only if the PR is in the supplied `closed_prs` set AND `updated_at` is older than `active_days` (default 14)
+  - Archived files are deleted when their filesystem mtime is older than `archive_days` (default 30)
+- **Externals:** `gh pr list --state closed` feeds `closed_prs`
+- **Failure modes**: prune is best-effort; a failed `unlink` logs but doesn't abort the cleanup.
+
+## External dependency matrix
+
+Every transition that hits an external system is a potential silent-
+failure site. Phase B tests must inject failure at each of these points.
+
+| External                       | Transitions                         | Failure class            | Silent-mode symptom                                                                 |
+|--------------------------------|-------------------------------------|--------------------------|-------------------------------------------------------------------------------------|
+| Filesystem (`save`/`archive`)  | All (T1, T2, T3, T4-save, T5, T7, T8, T11) | disk full / permission / race | Pre-#102 style truncation; stale tmp files; half-archived state. Fix from core/ship_state.py already uses tmp+replace, but the assumption deserves an explicit test. |
+| `git push`                     | T1                                  | auth / network           | State written without a pushed branch → PR create fails; no state written. Benign. |
+| `gh pr create`                 | T1                                  | auth / network / rate-limit | Ship aborts with a GhError; no state written.                                       |
+| `gh pr list` (find_pr_for_branch) | T1                               | auth / network           | Falls through to create a new PR which may duplicate. Present risk.                |
+| `gh pr view` (auto-merge idempotency) | T5 recovery                   | auth / network           | Auto-merge incorrectly reports "pr-not-found" after a successful merge; operator noise, no data loss. |
+| `workflow_dispatch` (cloud)    | T2, T9, T10                         | 404 / 5xx / rate-limit   | DispatchedRun saved with `pending-<target>` run_id → `auto-merge` blind to that lane's verdict. |
+| `find_dispatched_run`          | T2                                  | timeout                  | DispatchedRun never gets a real run_id; watch cannot tail.                          |
+| `gh pr merge`                  | T5                                  | branch protection / auth | `STATE_MERGE_FAILED`; state retained for retry. Retry path works for all known variants. |
+| `gh run cancel`                | T9                                  | race                     | Old lane keeps running (cost only). New lane proceeds. State stays consistent.      |
+| SSH backend probe              | T2 (preflight)                      | network / auth / host_key | Pre-#100: silent 10-min hang. Post-#100: exit 3 with classified error inside 10s.   |
+| `git rev-parse HEAD` / config read | T7                              | worktree gone            | `_detect_ship_state_drift` falls through to "no drift" (conservative). State resumes. |
+
+## Known silent-failure modes from consumer experience
+
+Pulp's PR history surfaced three real bugs that Phase B regression tests
+must cover:
+
+1. **Post-merge evidence blackhole.** Shipyard merged the PR, returned
+   success, and exited — but the post-merge evidence row for one lane was
+   never saved. Agents could not tell if the ship completed because
+   `evidence_snapshot` didn't match the merge outcome. *Test design: drop
+   `save()` after `merge_pr` returns True and assert the next `auto-merge`
+   tick hits the `_pr_is_merged` idempotency branch, not the "target
+   failed" branch.*
+2. **Resume re-runs a succeeded validation lane.** The resume path trusted
+   the DispatchedRun status string without cross-checking `evidence_snapshot`,
+   re-dispatching a lane that had already posted PASS evidence. *Test
+   design: seed a state with `status="in_progress"` + `evidence="pass"`,
+   assert resume skips dispatch for that lane.*
+3. **Queue state diverged from filesystem after unclean shutdown.**
+   Addressed by #102 for `queue.json`; `ship/<pr>.json` uses the same
+   tmp+replace pattern and should get the same test coverage. *Test
+   design: kill `save()` mid-write via monkeypatching `os.replace` to
+   raise; assert the previous state file is byte-identical.*
+
+## Phase B test plan (preview — not implemented here)
+
+For each transition T1–T12, write at least one test that:
+
+1. Exercises the happy path.
+2. Injects failure at each external-dependency row from the matrix above
+   and asserts the documented recovery behavior.
+3. Asserts that `updated_at` moves forward on every write and stays pinned
+   when the transition is read-only.
+
+Plus the three consumer-experience regression tests under "Known silent-
+failure modes" above.
+
+## Phase C preview
+
+1. **Doc-sync hook.** Add `docs/ship-state-machine.md` to the skill-sync
+   path map so that changes to `src/shipyard/core/ship_state.py` or the
+   relevant chunks of `src/shipyard/cli.py` must update this doc in the
+   same PR. Mechanism is identical to `scripts/skill_path_map.json` and
+   pairs with Pulp's proposed `doc_sync_check.py` (pulp#567).
+2. **Dedicated state-machine CI lane.** A single `pytest -m state_machine`
+   marker run as its own GitHub Actions job, separate from the full
+   suite, so a state-machine failure is visually distinct in the PR
+   checks list.
+
+Neither change lands in Phase A. This doc's role is to make Phase B
+testable and Phase C's path-map additions obvious.

--- a/docs/ship-state-machine.md
+++ b/docs/ship-state-machine.md
@@ -387,15 +387,24 @@ silent-failure regression tests from the list above. Every test should
 name the transition it exercises (`test_T5_merge_on_pass_archives_state`
 etc.) so failure output maps directly to this doc.
 
-## Phase C preview
+## Phase C — doc-sync hook + dedicated CI lane
 
-1. **Doc-sync hook.** Add `docs/ship-state-machine.md` to the skill-sync
-   path map so that changes to `src/shipyard/core/ship_state.py` or the
-   relevant chunks of `src/shipyard/cli.py` must update this doc in the
-   same PR. Mechanism identical to `scripts/skill_path_map.json`.
-2. **Dedicated state-machine CI lane.** A `pytest -m state_machine`
-   marker run as its own GitHub Actions job, so a state-machine
-   failure is visually distinct in the PR checks list.
+Both landed in a follow-up PR:
 
-Neither change lands in Phase A. This doc's role is to make Phase B
-testable and Phase C's path-map additions obvious.
+1. **Doc-sync hook.** `scripts/doc_sync_check.py` + `scripts/doc_sync_map.json`
+   enforce that changes to `src/shipyard/core/ship_state.py` or
+   `src/shipyard/ship/**` include an update to this doc. Runs in
+   `.githooks/pre-push` (advisory; `SHIPYARD_ENFORCE_PREPUSH=1`
+   upgrades to block) and in `.github/workflows/version-skill-check.yml`
+   as a hard CI gate. Bypass via a `Doc-Update: skip doc=<path>
+   reason="..."` trailer on any commit in the diff range.
+2. **Dedicated state-machine CI lane.** A `state-machine` job in
+   `.github/workflows/ci.yml` runs `pytest -m state_machine -v` on its
+   own — ubuntu-only because the tests are pure Python. A failure
+   shows up as a distinctly-named check in the PR status list, so an
+   operator can tell a state-machine regression from a cross-platform
+   infra blip at a glance.
+
+When you touch ship-state transition code, either update this doc in
+the same PR, or record why the update is unnecessary on the tip commit
+with `Doc-Update: skip doc=docs/ship-state-machine.md reason="..."`.

--- a/docs/ship-state-machine.md
+++ b/docs/ship-state-machine.md
@@ -3,50 +3,72 @@
 This document is the [#101](https://github.com/danielraffel/Shipyard/issues/101)
 Phase A deliverable: a hand-written map of every state, every transition,
 and every external dependency in the `shipyard ship` / `shipyard watch` /
-`shipyard auto-merge` flow. It was written by reading the code end-to-end,
-not by executing it, and is therefore a fixed-in-time snapshot. Keep it in
-step with `src/shipyard/core/ship_state.py`, `src/shipyard/cli.py` (the
-`ship`, `watch`, `auto-merge`, `cloud add-lane`, `cloud retarget`, and
-`ship-state` subcommands), and `src/shipyard/ship/*.py`.
+`shipyard auto-merge` flow, written by reading the code end-to-end and
+reviewed by a second pass (Codex via RepoPrompt MCP) that cross-checked
+each claim against `src/shipyard/**` at exact line numbers.
 
-**Phase B** (transition tests) and **Phase C** (pre-merge doc-sync hook,
-dedicated CI lane) land in follow-up PRs. This audit's goal is to make
-Phase B mechanical: each edge below becomes a test.
+Keep this doc in step with `src/shipyard/core/ship_state.py`,
+`src/shipyard/cli.py` (the `ship`, `watch`, `auto-merge`, `cloud add-lane`,
+`cloud retarget`, and `ship-state` subcommands), and `src/shipyard/ship/*.py`.
+
+**Phase B** (transition tests, see below) and **Phase C** (pre-merge
+doc-sync hook, dedicated CI lane) land in follow-up PRs.
+
+## Vocabulary note: the state labels are derived
+
+The labels in the diagram below (`STATE_FRESH`, `STATE_IN_FLIGHT`,
+`STATE_VERDICT_PASS`, etc.) are **not persisted**. `ShipState.to_dict()`
+does not carry a state enum. Every label is a predicate over the tuple
+`(evidence_snapshot, dispatched_runs, state file present?, archive file
+present?)`. The names exist so Phase B tests can reference edges
+unambiguously — they are test vocabulary, not runtime observables.
 
 ## The core persisted object: `ShipState`
 
 `ShipState` lives at `<state_dir>/ship/<pr>.json` during the active ship.
-On terminal verdict it is moved to `<state_dir>/ship/archive/<pr>-<utc>.json`
-so the active directory only lists live work. The object carries:
+The active file is archived to `<state_dir>/ship/archive/<pr>-<utc>.json`
+on one of:
+
+- `shipyard ship` success (`merge_pr` returned a merged PR)
+- `shipyard auto-merge` success (same)
+- `shipyard ship-state discard <pr>` (manual tombstone — works on any
+  active state, not only MERGED)
+
+Failed verdicts (`STATE_VERDICT_FAIL`), refused merges, and merge
+attempts that hit a GhError all leave the active file in place for
+inspection. `shipyard cleanup --ship-state` ages these out (see T12).
+
+`ShipState` carries:
 
 | Field               | Purpose                                                                             |
 |---------------------|-------------------------------------------------------------------------------------|
 | `pr`                | GitHub PR number — primary key.                                                     |
-| `repo`              | Owner/name (`danielraffel/pulp`), captured at dispatch so retarget/add-lane routes dispatches correctly. |
+| `repo`              | Owner/name (`danielraffel/pulp`) captured at dispatch so retarget/add-lane route dispatches correctly. |
 | `branch`            | PR head branch.                                                                     |
 | `base_branch`       | Merge target.                                                                       |
 | `head_sha`          | PR head SHA at dispatch. Drift vs this value refuses resume.                        |
 | `policy_signature`  | SHA-256[:16] of (required_platforms, target_names, mode) at dispatch. Drift refuses resume. |
-| `dispatched_runs`   | One `DispatchedRun` per lane (target + provider + GitHub Actions run id / queue job id + live status). |
-| `evidence_snapshot` | `{target: "pass" | "fail" | "pending" | ...}` — source-of-truth for the verdict computer. |
-| `attempt`           | Monotonic counter bumped by `archive_and_replace` on `--no-resume`.                 |
-| `pr_url`, `pr_title`, `commit_subject` | Human context. Refreshed on every save so a force-push is visible to `ship-state show` without a new attempt. |
+| `dispatched_runs`   | List of `DispatchedRun`. Upsert key is `(target, run_id)`, not just `target` — a single target can hold multiple rows if a new run id was issued (e.g. from a peer dispatch under the same state). Phase B should either add deduplication logic or document the multi-row invariant. |
+| `evidence_snapshot` | `{target: "pass" | "fail"}` written by `_update_ship_state_from_job` (cli.py:4576). No other values are ever written by the normal path — `"pending"` is accepted by `_ship_terminal_verdict` but never produced. |
+| `attempt`           | Intended to be a monotonic counter bumped on `--no-resume`. **Currently broken** — see T8 and "Bugs discovered by this audit" below. |
+| `pr_url`, `pr_title`, `commit_subject` | Human context. Refreshed by the `ship` resume path (cli.py:2679) on each invocation; NOT refreshed by add-lane's `save` (cli.py:2359) or by `_update_ship_state_from_job`. Test coverage: `ship-state show` after a force-push + `shipyard ship` resume should see updated fields; after a `cloud add-lane` against the same state, should not. |
 | `created_at`        | Attempt-scoped: stable for the life of an attempt.                                  |
 | `updated_at`        | Last `touch()` — bumped after every mutation helper.                                |
-| `schema_version`    | Currently 1.                                                                        |
+| `schema_version`    | `SCHEMA_VERSION` (currently 1). `from_dict` defaults to `SCHEMA_VERSION` when reading older files that omit it.                                                                 |
 
-`DispatchedRun` is the per-lane record:
+`DispatchedRun` is the per-dispatch record (not strictly per-target — see
+`dispatched_runs` note above):
 
 | Field                | Purpose                                                                            |
 |----------------------|------------------------------------------------------------------------------------|
 | `target`             | Lane name (`macos`, `ubuntu`, …) — matches `[targets.<name>]` in `.shipyard/config.toml`. |
 | `provider`           | Dispatch channel: `namespace`, `github-hosted`, `ssh`, `ssh-windows`, or a local job id for the queue path. |
-| `run_id`             | GH Actions run ID for cloud, Shipyard job id for local/ssh, or `pending-<target>` while a `cloud add-lane` discovery is in flight. |
-| `status`             | Last observed lifecycle string (`queued`, `in_progress`, `completed`, `failed`, `cancelled`, `reused`). |
-| `attempt`            | `ShipState.attempt` at dispatch time. Survives resume so old attempts don't reattach. |
-| `last_heartbeat_at`  | Additive liveness signal — written by the poller, used by `watch` to mark `stale` runs. |
-| `phase`              | Additive validation-phase tag (setup/configure/build/test), same source as `last_heartbeat_at`. |
-| `required`           | Lane policy at dispatch. `False` = advisory; advisory failures land in the merge check's `advisory` bucket instead of `failing`. |
+| `run_id`             | GH Actions run ID for cloud, Shipyard job id for local/ssh, or `pending-<target>` when `cloud add-lane` couldn't discover the real run id. **No code backfills this sentinel today** — `watch` is read-only with respect to ship state (cli.py:3497). |
+| `status`             | Last observed lifecycle string: `queued`, `in_progress`, `completed`, `failed`, `cancelled`. `reused` is **not** a valid `DispatchedRun.status` — cross-PR evidence reuse synthesizes a `TargetStatus.PASS` with `backend="reused"` (cli.py:4510) and persists it as `status="completed"` (cli.py:4586). |
+| `attempt`            | `ShipState.attempt` at dispatch time. Intended to survive resume so old attempts don't reattach, but coupled to the broken `attempt` counter from T8. |
+| `last_heartbeat_at`  | Additive liveness signal (default `None`) — written by the poller via `_update_ship_state_from_job`, used by `watch` to mark `stale` runs. |
+| `phase`              | Additive validation-phase tag (setup/configure/build/test, default `None`), same source as `last_heartbeat_at`. |
+| `required`           | Lane policy **at dispatch time**, snapshotted in `DispatchedRun.required` by add-lane (cli.py:2357) and by `_update_ship_state_from_job` (cli.py:4593). `from_dict` defaults to `True` for legacy files written before #87. `_ship_terminal_verdict` reads this persisted value (cli.py:3809) to decide which failures tolerate. |
 
 ## State diagram (textual)
 
@@ -55,20 +77,30 @@ so the active directory only lists live work. The object carries:
                           │   No state file exists for this PR      │
                           └───────────────────┬─────────────────────┘
                                               │
-                                              ▼  shipyard ship (first run)
+                                              ▼  shipyard ship (first run — state saved BEFORE preflight)
                                    ┌──────────────────────┐
                                    │   STATE_FRESH        │
-                                   │   (state created,    │
-                                   │    no runs yet)      │
+                                   │   evidence_snapshot  │
+                                   │   is empty; may have │
+                                   │   zero or more       │
+                                   │   DispatchedRuns     │
+                                   │   if add-lane hit    │
+                                   │   this PR before     │
+                                   │   ship completed     │
                                    └───────────┬──────────┘
-                                               │  dispatcher.validate_target(...) / workflow_dispatch
+                                               │  _execute_job ends;
+                                               │  _update_ship_state_from_job writes
+                                               │  one evidence row per terminal target
+                                               │  IN A SINGLE save (not per-target)
                                                ▼
                                    ┌──────────────────────┐
                                    │   STATE_IN_FLIGHT    │◀────┐
-                                   │   evidence_snapshot  │     │ cloud add-lane / retarget
-                                   │   has "pending"      │─────┘ (adds or replaces a
-                                   │   entries for some   │        DispatchedRun while
-                                   │   targets            │        the ship is still live)
+                                   │   some evidence      │     │ cloud add-lane
+                                   │   rows written       │─────┘   (appends DispatchedRun)
+                                   │   but not a full     │
+                                   │   verdict            │         cloud retarget
+                                   │                      │         (dispatches, does NOT
+                                   │                      │◀─────── write ShipState — see T9)
                                    └───────────┬──────────┘
                                                │
                        ┌───────────────────────┼───────────────────────┐
@@ -78,23 +110,34 @@ so the active directory only lists live work. The object carries:
               │ STATE_VERDICT  │      │ STATE_VERDICT  │      │ STATE_STALE    │
               │ _PASS          │      │ _FAIL          │      │ (session died; │
               │                │      │                │      │  --no-resume   │
-              │ all required   │      │ any required   │      │  or drift      │
-              │ targets pass   │      │ target failed  │      │  refuses resume│
-              │ (advisory fails│      │                │      └──────┬─────────┘
-              │  tolerated)    │      │                │             │
-              └──────┬─────────┘      └──────┬─────────┘             │ archive_and_replace
-                     │                       │                       │   (bumps attempt)
-          shipyard   │                       │                       │
-          auto-merge │                       │                       ▼
-          or ship    │                       │              ┌────────────────┐
-                     │                       │              │ STATE_FRESH    │
-                     ▼                       ▼              │  (new attempt) │
-              ┌────────────────┐      ┌────────────────┐    └────────────────┘
+              │ every required │      │ any required   │      │  or drift      │
+              │ target has     │      │ target has     │      │  refuses       │
+              │ "pass" in      │      │ "fail" in      │      │  resume)       │
+              │ evidence AND   │      │ evidence       │      └──────┬─────────┘
+              │ every present  │      │                │             │
+              │ value is       │      │                │             │ archive_and_replace
+              │ terminal       │      │                │             │ (BUG: returned
+              │                │      │                │             │  replacement with
+              │ ⚠ see Bug B1:  │      │                │             │  bumped attempt is
+              │  partial       │      │                │             │  discarded; fresh
+              │  coverage can  │      │                │             │  state uses attempt=1)
+              │  be false-PASS │      │                │             ▼
+              └──────┬─────────┘      └──────┬─────────┘      ┌────────────────┐
+                     │                       │                 │ STATE_FRESH    │
+          ship       │                       │                 │  (attempt=1)   │
+          end-of-    │                       │                 └────────────────┘
+          flow or    │                       │
+          auto-merge │                       │
+                     │                       │
+                     ▼                       ▼
+              ┌────────────────┐      ┌────────────────┐
               │ STATE_MERGE    │      │ STATE_MERGE_   │
               │  _ATTEMPTING   │      │  REFUSED       │
-              │                │      │ (target failed;│
-              │ merge_pr(...)  │      │  no merge call │
-              │                │      │  is issued)    │
+              │ (no local try/ │      │ (auto-merge    │
+              │  catch in      │      │  only; active  │
+              │  `ship`; auto- │      │  state file is │
+              │  merge catches │      │  retained for  │
+              │  GhError)      │      │  inspection)   │
               └──────┬─────────┘      └──────┬─────────┘
                      │                       │
           ┌──────────┴──────────┐             │
@@ -102,40 +145,46 @@ so the active directory only lists live work. The object carries:
   ┌────────────────┐  ┌────────────────┐      │
   │ STATE_MERGED   │  │ STATE_MERGE_   │      │
   │                │  │  FAILED        │      │
-  │ gh pr merge    │  │ (gh error,     │      │
-  │ returned ok    │  │  branch prot,  │      │
-  │                │  │  auth, etc.)   │      │
+  │ merge_pr ok,   │  │ ship: exits 1  │      │
+  │ archive call   │  │  on GhError,   │      │
+  │ then follows   │  │  no archive;   │      │
+  │                │  │ auto-merge:    │      │
+  │                │  │  same, also    │      │
+  │                │  │  no _pr_is_    │      │
+  │                │  │  merged probe  │      │
+  │                │  │  (that only    │      │
+  │                │  │  fires when    │      │
+  │                │  │  the state     │      │
+  │                │  │  file is       │      │
+  │                │  │  absent)       │      │
   └──────┬─────────┘  └──────┬─────────┘      │
          │                   │                │
-         │ archive()         │ (no archive:   │ (no archive:
-         │ (terminal)        │  retry-able,   │  final verdict
-         ▼                   │  state lives)  │  retained)
-  ┌────────────────┐         │                │
-  │ STATE_ARCHIVED │         ▼                ▼
-  └────────────────┘   [stays STATE_    [stays STATE_
-                       VERDICT_PASS]    VERDICT_FAIL]
+         │ archive()         │ (no archive —  │ (no archive —
+         │                   │  state lives   │  final verdict
+         ▼                   │  for retry)    │  retained)
+  ┌────────────────┐         ▼                ▼
+  │ STATE_ARCHIVED │  [stays STATE_    [stays STATE_
+  └────────────────┘   VERDICT_PASS     VERDICT_FAIL]
+                       until archive
+                       succeeds on
+                       next attempt]
 ```
-
-**Note.** Shipyard does not emit or name these state labels at runtime —
-they are derived from the `(evidence_snapshot, dispatched_runs)` pair
-and the presence/archival of the state file. The names exist so Phase B
-tests can reference each edge unambiguously.
 
 ## Entry points and which states they read/write
 
 | CLI command                 | Reads                                               | Writes                                                  |
 |-----------------------------|-----------------------------------------------------|---------------------------------------------------------|
-| `shipyard ship`             | `ShipStateStore.get(pr)` (auto-resume decision)     | Creates or refreshes state; calls `_update_ship_state_from_job`; `archive(pr)` on `STATE_MERGED` |
-| `shipyard ship --no-resume` | Same, forces `archive_and_replace`                  | Archives prior attempt and writes new FRESH attempt     |
-| `shipyard ship --resume`    | Refuses on SHA/policy drift via `_detect_ship_state_drift` | Refreshes pr_url / title / commit_subject, touches    |
-| `shipyard cloud add-lane`   | `ShipStateStore.get(pr)`; verdict check; idempotent `has_target` | `append_run` + `save`                                   |
-| `shipyard cloud retarget`   | Same; dry-run default                               | Replaces one lane's DispatchedRun (target+provider) and the backing cloud workflow run |
-| `shipyard watch`            | `ShipStateStore.get(pr)` loop                       | Never mutates; signature-based change detection emits NDJSON |
-| `shipyard auto-merge`       | `ShipStateStore.get(pr)` + `gh pr view` fallback    | `archive(pr)` on success; never mutates on failure     |
+| `shipyard ship` (fresh)     | `ShipStateStore.get(pr)` (auto-resume decision; returns None) | Saves fresh state BEFORE preflight (cli.py:2675). Calls `_update_ship_state_from_job` once after `_execute_job` ends. `archive(pr)` on MERGED. |
+| `shipyard ship --no-resume` | Same                                                | `ShipStateStore.archive_and_replace(state)` archives prior attempt; then a new `ShipState(...)` is constructed with `attempt=1` (see Bug B2). |
+| `shipyard ship --resume`    | Refuses on SHA/policy drift via `_detect_ship_state_drift` | Refreshes `pr_url` / `pr_title` / `commit_subject` on the existing state and saves (cli.py:2679–2689). |
+| `shipyard cloud add-lane`   | `ShipStateStore.get(pr)`; verdict check; idempotent `has_target` | `append_run` + `save`. Does NOT refresh human-context fields. |
+| `shipyard cloud retarget`   | None (the command operates on the live GH Actions run; it does not load `ShipState` at all) | **None** — cancels old job, dispatches new workflow; never writes `ShipState`. See T9 + Bug B3. |
+| `shipyard watch`            | `ShipStateStore.get(pr)` loop                       | Never mutates; signature-based change detection emits NDJSON. |
+| `shipyard auto-merge`       | `ShipStateStore.get(pr)` + `gh pr view` fallback when state is absent | `archive(pr)` on success; no writes on failure. `_pr_is_merged` only runs on the no-state branch. |
 | `shipyard ship-state list`  | `list_active()`                                     | None                                                    |
 | `shipyard ship-state show`  | `get(pr)`                                           | None                                                    |
-| `shipyard ship-state discard` | `get(pr)`                                         | `archive(pr)` (manual tombstone)                        |
-| `shipyard cleanup --ship-state` | `prune(active_days=14, archive_days=30, closed_prs=...)` | Deletes aged-out active + archived state               |
+| `shipyard ship-state discard` | `get(pr)` (accepts any state, not only MERGED)    | `archive(pr)` (manual tombstone)                        |
+| `shipyard cleanup --ship-state` | `prune(active_days=14, archive_days=30, closed_prs=...)` | Deletes aged-out active (only if PR is in the supplied `closed_prs` set) + archived files. Unlinks are unguarded — a failure raises. |
 
 ## Transitions — preconditions, postconditions, failure modes
 
@@ -143,196 +192,210 @@ tests can reference each edge unambiguously.
 
 - **From:** no state file exists for `<pr>`
 - **To:** `STATE_FRESH`
-- **Trigger:** `shipyard ship` on a branch that either has no open PR or an open PR without a saved state
-- **Writes:** `ShipStateStore.save(ShipState(..., dispatched_runs=[], evidence_snapshot={}))`
-- **Externals:** `git push`, `gh pr create` / `gh pr list` (for PR number)
+- **Trigger:** `shipyard ship` on a branch
+- **Writes:** `ShipStateStore.save(ShipState(..., dispatched_runs=[], evidence_snapshot={}))` at cli.py:2675 — **before** preflight runs at cli.py:2679
+- **Externals:** `git push -u origin <branch>` at cli.py:2602 (return code ignored — see "External matrix" below), `gh pr list` / `gh pr create` for PR number
 - **Failure modes**
-  - `git push` fails → ship aborts before state is written (no state file created). *Recovery: retry.*
-  - `gh pr create` fails → `create_pr` raises `GhError`; ship exits without writing state. *Recovery: retry.*
-  - `state_path.write` fails (disk full, permission) → `ShipStateStore.save` raises; tmp file is cleaned up by the `except` in `core/ship_state.py:save`. *Recovery: resolve disk issue, retry.*
+  - `git push` fails silently → `find_pr_for_branch` may still find an existing PR; the local SHA may not match the remote. A fresh state is saved for a branch whose tip may not be pushed. *Recovery: none automatic — the drift check on the next resume will catch it, but between the stale push and the next resume the state claims a SHA that doesn't exist on the remote.*
+  - `gh pr create` fails → `create_pr` raises `GhError`; `ship` exits without saving state because the save at cli.py:2675 runs only after the PR has been found or created. *Recovery: retry.*
+  - `save` fails (disk, permission) → `save` raises; tmp file is cleaned up by the `except` branch in `core/ship_state.py`. *Recovery: resolve disk issue, retry.*
 
-### T2 — Add a dispatched run to an in-flight ship
+### T2 — Dispatch targets within `_execute_job`
 
 - **From:** `STATE_FRESH` or `STATE_IN_FLIGHT`
 - **To:** `STATE_IN_FLIGHT`
-- **Trigger:** `shipyard ship` per-target loop in `_execute_job`; `shipyard cloud add-lane`; `shipyard cloud retarget`
-- **Writes:** `ship_state.upsert_run(...)` (ship loop) or `append_run(...)` (add-lane, after `has_target` guard) → `save()`
-- **Externals:** `workflow_dispatch` (for cloud), the per-lane executor (`CloudExecutor`, `SSHExecutor`, `LocalExecutor`), `ExecutorDispatcher.probe/diagnose`
+- **Trigger:** `_execute_job` per-target loop; or `shipyard cloud add-lane --apply`; or `shipyard cloud retarget --apply` (see T9 — retarget does NOT advance ship state)
+- **Writes for the `ship` path:** `_execute_job` does NOT save `ShipState` at each target boundary. It only calls `_update_ship_state_from_job` **once** after `job.complete()` (cli.py:4345), which performs one `save()` for the whole batch (cli.py:4595). Within the loop, only the per-job `queue.update(job)` is written.
+- **Writes for `cloud add-lane --apply`:** `append_run(DispatchedRun(..., run_id=discovered or f"pending-{target}"))` then `save`.
+- **Externals:** `workflow_dispatch` (cloud), `find_dispatched_run` (best-effort run id discovery), `ExecutorDispatcher.{probe,diagnose,validate}`.
 - **Failure modes**
-  - `workflow_dispatch` raises (404, auth, transient GH 5xx) → CLI exits 1 before saving the DispatchedRun. The ship state stays at the previous snapshot. *Recovery: retry; the ship continues from the prior snapshot.*
-  - Cloud dispatch succeeds but `find_dispatched_run` times out → DispatchedRun is still saved with `run_id="pending-<target>"`. *Recovery: watch/poller backfills the real run id on next tick. Known latent bug: if backfill also fails, the lane is invisible to `auto-merge`.*
-  - Preflight raises `BackendUnreachableError` / `ValueError` → ship exits 3/1; no DispatchedRun is written. *Recovery: fix backend or use `--skip-target` / `--allow-unreachable-targets`.*
+  - `workflow_dispatch` fails in add-lane → `sys.exit(1)` at cli.py:2328 before any DispatchedRun is appended. *Recovery: retry.*
+  - `workflow_dispatch` succeeds but `find_dispatched_run` times out → DispatchedRun is still appended with `run_id="pending-<target>"` (cli.py:2351). **No code backfills this sentinel** — `watch` emits state but never writes it, and `_update_ship_state_from_job` keys its upsert on `(target, run_id)` so a later real dispatch would *append a second row* for the same target rather than overwrite. Phase B test: assert the watcher does not silently drop the pending lane's verdict.
+  - Preflight raises `BackendUnreachableError` / `ValueError` → `ship` exits (3 / 1) with the fresh state already on disk from T1. *Recovery: fix backend or use `--skip-target` / `--allow-unreachable-targets`; resume picks up the existing state.*
 
-### T3 — Record a terminal target outcome
+### T3 — Record terminal target outcomes
 
 - **From:** `STATE_IN_FLIGHT`
-- **To:** `STATE_IN_FLIGHT` (with one more target in `evidence_snapshot`) or `STATE_VERDICT_*` once every terminal slot is filled
-- **Trigger:** `_update_ship_state_from_job` after `_execute_job` completes; cloud poller updates via the watch path
-- **Writes:** `update_evidence(target, "pass"|"fail")`, `upsert_run(...)`, `save()`
-- **Externals:** `CloudRecordStore.list_recent` (maps platform → cloud run_id), tip-commit parsing (lane-policy trailer)
+- **To:** `STATE_IN_FLIGHT` (with `evidence_snapshot` grown) or `STATE_VERDICT_*` (when `_ship_terminal_verdict` flips; but see Bug B1)
+- **Trigger:** `_update_ship_state_from_job` at the end of `_execute_job`.
+- **Writes:** The loop at cli.py:4572 mutates `update_evidence(target, "pass"|"fail")` and `upsert_run(...)` for every terminal result, and a single `ctx.ship_state.save(ship_state)` runs after the loop (cli.py:4595). **If the process dies mid-loop, the whole batch is lost** — not just the last record.
+- **Externals:** `_cloud_runs_by_platform(ctx, sha)` maps platform → cloud run_id from `CloudRecordStore.list_recent`. See Bug B4: the `sha` parameter is accepted but unused; the map is keyed only by platform, so repeat ships on the same machine can mis-attribute a run_id to a later SHA's DispatchedRun.
 - **Failure modes**
-  - Evidence saved before DispatchedRun fully resolved → next `watch` tick just sees an in-flight lane with evidence present; no divergence.
-  - Process dies between the per-target mutation and `save()` — the prior `save()` already covered the earlier targets. At most one target-outcome event is lost. *Recovery: re-run the target (resume path).*
-  - Known historical bug pattern (Pulp consumer report): a PR landed merged but the post-merge evidence row was never saved. Represent as a Phase B test: inject `save` failure after `merge_pr` returns True.
+  - `save` fails → exception propagates; previous state file is byte-identical thanks to tmp+replace (core/ship_state.py:342–357). *Recovery: retry (the job is terminal in the queue, but the evidence mirror is missing until a future save succeeds).*
+  - Advisory lane (`required=False`) failing → evidence records `"fail"` but the verdict computer tolerates it via the persisted `DispatchedRun.required` flag at cli.py:3809.
 
 ### T4 — Compute the terminal verdict
 
-- **From:** `STATE_IN_FLIGHT` with a full `evidence_snapshot`
-- **To:** `STATE_VERDICT_PASS` or `STATE_VERDICT_FAIL`
-- **Computation:** `_ship_terminal_verdict(state)` in `cli.py` — returns `True` only if every non-advisory target has `"pass"` evidence, `False` if any non-advisory target failed, `None` while any evidence value is missing or non-terminal
-- **Externals:** none — pure function over the state
-- **Failure modes**
-  - Partial evidence (e.g. evidence present for macos but missing for ubuntu) → verdict stays `None` and `auto-merge` exits 3 for retry. *Recovery: the cloud poller or next `shipyard ship` pass fills the gap.*
-  - An advisory lane reports `"fail"` → verdict ignores it because `required=False`. Reviewers still see the failure in `watch`.
+- **From:** `STATE_IN_FLIGHT` with at least one row in `evidence_snapshot`
+- **To:** `STATE_VERDICT_PASS`, `STATE_VERDICT_FAIL`, or still in flight (`None`)
+- **Computation:** `_ship_terminal_verdict(state)` at cli.py:3790
+- **Externals:** none
+- **⚠ Known bug — Bug B1.** The verdict is computed only from `evidence_snapshot.values()` (cli.py:3806) and `evidence_snapshot.items()` (cli.py:3812). The function does **not** check that every `DispatchedRun.target` has a matching evidence row. A ship that dispatched targets `[macos, ubuntu, windows]` and only persisted evidence for `[macos]` (all "pass") will be reported `STATE_VERDICT_PASS` — and `auto-merge` will proceed to `merge_pr`. This is the single highest-impact silent-failure candidate in the state machine; Phase B must have a dedicated regression test for it.
+- **Other failure modes:** none — pure function.
 
 ### T5 — Merge on PASS
 
 - **From:** `STATE_VERDICT_PASS`
 - **To:** `STATE_MERGED` → `STATE_ARCHIVED`
-- **Trigger:** `shipyard ship` (end of `_execute_job`) or `shipyard auto-merge <pr>`
-- **Writes:** `merge_pr(...)` (gh), on success `ctx.ship_state.archive(pr)`
+- **Trigger:** end of `shipyard ship` or `shipyard auto-merge <pr>`
+- **Writes:** `merge_pr(...)` (gh); on success, `ctx.ship_state.archive(pr)`
 - **Externals:** `gh pr merge` (branch protection, auth, network)
-- **Failure modes**
-  - `GhError` (branch protection rejects admin=false, auth, conflicts) → `STATE_MERGE_FAILED`. The state file is NOT archived so a retry can pick up. *Recovery: `shipyard auto-merge <pr>` re-attempts without re-dispatching.*
-  - `merge_pr` returns True but `archive(pr)` fails (disk error) → the next `auto-merge` tick will see the state file, verdict PASS, and attempt to merge again. `_pr_is_merged(pr)` catches the double-merge: gh returns "already merged"; we treat that as idempotent success per #64 P2. *Recovery: auto.*
-  - Network flake between gh API and our poller: `gh pr merge` succeeded server-side, but our local call timed out; we exit 1 without archiving. Same safe path: next tick sees `STATE_VERDICT_PASS` + a MERGED PR → `_pr_is_merged` returns True → exit 0 + archive.
+- **Failure-handling split (key asymmetry):**
+  - `shipyard ship` at cli.py:2723 calls `merge_pr` with **no local try/except**. A `GhError` propagates up and aborts with a traceback. The state file is left active.
+  - `shipyard auto-merge` at cli.py:3333–3347 catches `GhError` + `TypeError` (back-compat) and exits 1 with a `merge-failed` event. The state file is left active.
+- **Archive failure is NOT auto-recoverable.** `_pr_is_merged(pr)` is only consulted when `ctx.ship_state.get(pr)` returns `None` (cli.py:3242). If `archive(pr)` fails (disk error, race) and leaves the active state file present, the next `auto-merge` tick reads the state, recomputes `STATE_VERDICT_PASS`, and attempts `merge_pr` again — which returns `GhError` from gh ("Pull request is already merged"). `auto-merge` exits 1 reporting `merge-failed`, not 0. Phase B test: inject an archive failure after a successful merge; assert the next `auto-merge` tick emits a distinct event (not a false `merge-failed`). The fix may be a new "archive or accept merged PR" probe on the state-present branch.
 
 ### T6 — Refuse to merge on FAIL
 
 - **From:** `STATE_VERDICT_FAIL`
-- **To:** `STATE_MERGE_REFUSED` (terminal; state retained for inspection)
+- **To:** `STATE_MERGE_REFUSED` (test vocabulary; the state file is unchanged)
 - **Trigger:** `shipyard ship` or `shipyard auto-merge <pr>`
-- **Writes:** none. The state file is intentionally NOT archived — a reviewer may want to inspect `evidence_snapshot` / `dispatched_runs` after the fact. Eventually aged out by `shipyard cleanup --ship-state`.
+- **Writes:** none — the file is retained for inspection. Aged out by T12.
 - **Externals:** none
-- **Failure modes**: N/A (no action to fail)
 
 ### T7 — Resume an interrupted ship
 
 - **From:** state file exists + no drift
-- **To:** `STATE_IN_FLIGHT` (continues where it left off)
-- **Trigger:** `shipyard ship` (auto-resume default) or `shipyard ship --resume`
-- **Writes:** `save()` after refreshing PR metadata; continues `_execute_job` which writes further target outcomes
-- **Externals:** `git rev-parse HEAD` (drift check), `.shipyard/config.toml` (policy signature recomputation)
+- **To:** `STATE_IN_FLIGHT` — but note that **every lane is revalidated**, even ones with existing `"pass"` evidence.
+- **Trigger:** `shipyard ship` (auto-resume when state exists) or `shipyard ship --resume`
+- **Writes:** refreshes `pr_url` / `pr_title` / `commit_subject`; then runs `_execute_job` which iterates **every** `job.target_names` at cli.py:4219 regardless of the existing `evidence_snapshot`.
+- **Externals:** `git rev-parse HEAD` (drift check) — the check only runs after `ship` has already confirmed branch/SHA exist (cli.py:2582); a missing HEAD aborts before drift detection, not after.
 - **Failure modes**
-  - SHA drift (`is_sha_drift`): ship refuses to resume. *Recovery: `--no-resume` to archive + fresh attempt.*
-  - Policy drift: required-platforms or target-list changed since the state file was written → refuse. *Recovery: same.*
-  - State file is corrupt (truncated JSON, post-crash): `ShipStateStore.get` catches `JSONDecodeError`/`KeyError` and returns None. Caller sees "no state" and creates a fresh one, overwriting the corrupt file. *This is the ship-state equivalent of the queue-file fix in #102.*
+  - SHA drift (`is_sha_drift`): ship refuses to resume. *Recovery: `--no-resume`.*
+  - Policy drift: required-platforms / target-list / mode changed. *Recovery: same.*
+  - State file is corrupt → `ShipStateStore.get` catches `JSONDecodeError`/`KeyError`/`ValueError` and returns None; the caller creates a fresh state and overwrites the corrupt file.
+- **Observation for Phase B:** resume does NOT skip a lane that already passed. A Phase B test that asserts lane-skip-on-resume would be asserting behavior that doesn't exist today. That may itself be a bug (double-work on resume) — if so, file it as a Phase B-adjacent issue rather than codifying the wrong expectation.
 
 ### T8 — Force-restart via `--no-resume`
 
 - **From:** any existing state for `<pr>` (FRESH / IN_FLIGHT / VERDICT_*)
-- **To:** `STATE_STALE` → archived → new `STATE_FRESH` with `attempt += 1`
+- **To:** prior state archived; new `STATE_FRESH` created with `attempt=1` (see bug below)
 - **Trigger:** `shipyard ship --no-resume`
-- **Writes:** `ShipStateStore.archive_and_replace(state)` → `save(replaced)`
-- **Externals:** none beyond the archive rename
-- **Failure modes**: archive rename fails (disk/permission) → exits with OSError, previous state untouched. *Recovery: fix disk, retry.*
+- **Writes:**
+  1. `ship_state_store.archive_and_replace(existing_state)` at cli.py:2644. The call **archives the prior state and returns a new `ShipState` with `attempt+1`** — but the caller discards the return value.
+  2. The CLI then sets `existing_state = None` and falls through to cli.py:2663 where a fresh `ShipState(...)` is constructed with no `attempt=` kwarg, defaulting to `attempt=1`.
+- **⚠ Known bug — Bug B2.** Every `--no-resume` resets the attempt counter. Phase B test: assert `attempt` is `N+1` after N `--no-resume` invocations; today it stays at 1.
+- **Failure modes**
+  - `archive` succeeds but the subsequent `save(fresh_state)` at cli.py:2675 fails → the prior attempt is archived and no active state file exists for the PR, effectively the "no state" branch. *Recovery: a fresh `shipyard ship` creates a new state.*
+  - `archive` fails (disk) → the prior state file remains active; no new attempt started.
 
 ### T9 — `cloud retarget` mid-flight
 
 - **From:** `STATE_IN_FLIGHT`
-- **To:** `STATE_IN_FLIGHT` with one lane's `DispatchedRun` replaced (new provider + new run_id) and the stale GH Actions job cancelled
+- **To:** `STATE_IN_FLIGHT` — but the `ShipState` file is **not updated**.
 - **Trigger:** `shipyard cloud retarget --pr <n> --target <lane> --provider <prov> --apply`
-- **Writes:** GH API: cancel old job, dispatch new workflow; `ShipState.upsert_run` → `save()`
-- **Externals:** `gh api`, `gh run list`, `workflow_dispatch`
+- **Writes:** **None.** The apply path cancels the matching live job via `gh run` (cli.py:2101) and dispatches the new workflow via `workflow_dispatch` (cli.py:2116). It never loads, mutates, or saves `ShipState`.
+- **⚠ Known bug — Bug B3.** Retarget dispatches a new workflow but leaves the `DispatchedRun` rows unchanged. The watch loop sees the old `DispatchedRun(target, provider=old, run_id=old_id)` alongside a new GH Actions run for the same target but on a different provider. `_update_ship_state_from_job` won't fire for the retargeted lane unless the fresh dispatch flows through `_execute_job` (it does not). Phase B test: retarget + watch + assert that either (a) the `DispatchedRun` is updated in state, or (b) the watch surfaces the drift to the operator. Neither happens today.
 - **Failure modes**
-  - Old-job cancel fails → new dispatch proceeds; old job still consumes cloud quota until it finishes. State is consistent.
-  - New dispatch fails → neither state nor old job is touched. Caller gets an error.
+  - Cancel partial success: retarget proceeds to dispatch. Stale lane consumes cloud quota but does not block merge.
+  - Cancel total failure: retarget aborts at cli.py:2108 **before** dispatching. Old job keeps running; no new lane.
+  - Dispatch failure after cancel success: old job is cancelled, no new lane persisted — the target is effectively gone from the in-flight dispatch set.
 
 ### T10 — `cloud add-lane` mid-flight
 
-- **From:** `STATE_IN_FLIGHT` (refuses if already past dispatch per `_ship_terminal_verdict`)
+- **From:** `STATE_IN_FLIGHT` (refuses if `_ship_terminal_verdict` is not None)
 - **To:** `STATE_IN_FLIGHT` with one more `DispatchedRun` appended
 - **Trigger:** `shipyard cloud add-lane --pr <n> --target <name> --apply`
-- **Writes:** `workflow_dispatch`, then `append_run` → `save()`
-- **Externals:** same as T9
-- **Failure modes**: `workflow_dispatch` failure → no state change; idempotent retry OK.
+- **Writes:** `workflow_dispatch`, then `append_run(DispatchedRun(..., run_id=real or f"pending-{target}"))` → `save()`. Does not refresh `pr_url` / `pr_title` / `commit_subject`.
+- **Externals:** `gh api`, `gh run list`, `workflow_dispatch`
+- **Failure modes**
+  - `workflow_dispatch` fails → exits 1 before any `append_run`. No state change. *Recovery: retry.*
+  - `find_dispatched_run` times out → `DispatchedRun` saved with sentinel `run_id="pending-<target>"` (see T2 — no backfill exists).
 
 ### T11 — Terminal archive
 
-- **From:** `STATE_MERGED`
+- **From:** `STATE_MERGED` (from T5) or **any active state** (via `shipyard ship-state discard`)
 - **To:** `STATE_ARCHIVED`
-- **Trigger:** `ship` end-of-flow, `auto-merge` on success, `ship-state discard` (manual)
-- **Writes:** `os.replace(<pr>.json, archive/<pr>-<timestamp>.json)` — atomic same-directory rename
+- **Trigger:** `ship` end-of-flow merge-success branch; `auto-merge` merge-success branch; `ship-state discard` (works on any active state, regardless of verdict)
+- **Writes:** `os.replace(<pr>.json, archive/<pr>-<timestamp>.json)` at core/ship_state.py:377. The rename is atomic inside the same filesystem store path — the source lives at `self.path / f"{pr}.json"` and the destination at `self._archive_dir / f"{pr}-<ts>.json"` (core/ship_state.py:376). Same filesystem, different subdirectory.
 - **Externals:** filesystem atomic rename
-- **Failure modes**: rename fails → state file is untouched; next invocation sees it and hits the `_pr_is_merged` idempotency branch (which treats "already merged" as success).
+- **Failure modes:** rename fails (permission, disk) → the active state file remains. Next `shipyard ship` / `shipyard auto-merge` tick recomputes the verdict — which means merge is re-attempted and hits `GhError` (see T5's archive-failure-is-not-auto-recoverable note).
 
 ### T12 — Aging prune
 
-- **From:** `STATE_VERDICT_FAIL` or old archived file
+- **From:** any old active state (gated by the PR being closed) or any old archive
 - **To:** deleted
 - **Trigger:** `shipyard cleanup --ship-state --apply`
-- **Rules (per `ShipStateStore.prune`)**
-  - Active state is deleted only if the PR is in the supplied `closed_prs` set AND `updated_at` is older than `active_days` (default 14)
-  - Archived files are deleted when their filesystem mtime is older than `archive_days` (default 30)
-- **Externals:** `gh pr list --state closed` feeds `closed_prs`
-- **Failure modes**: prune is best-effort; a failed `unlink` logs but doesn't abort the cleanup.
+- **Rules (per `ShipStateStore.prune` at core/ship_state.py:399–446)**
+  - Active state is deleted only if the PR is in the supplied `closed_prs` set AND `updated_at` is older than `active_days` (default 14). Without a `closed_prs` set, active files are never deleted.
+  - Archived files are deleted when mtime is older than `archive_days` (default 30).
+- **Externals:** `gh pr list --state closed` (the caller feeds the `closed_prs` set; `prune` itself doesn't call gh)
+- **Failure modes:** `Path.unlink` is unguarded (both `delete` at core/ship_state.py:423 and the direct `archive_path.unlink()` at core/ship_state.py:431). A permission or I/O error interrupts the prune mid-sweep; earlier deletions remain applied, later ones are skipped. Phase B test: inject an `OSError` on the second active deletion; assert the `PruneReport` is accurate for the files that were actually removed.
+
+### T13 — Cross-PR evidence reuse (synthesized PASS)
+
+- **From:** `STATE_FRESH` or `STATE_IN_FLIGHT` with a target configured for `reuse_if_paths_unchanged`
+- **To:** `STATE_IN_FLIGHT` with an extra passing target row, no dispatch
+- **Trigger:** `_maybe_reuse_evidence` inside `_execute_job` (cli.py:4245)
+- **Writes:** Returns a synthesized `TargetResult` with `backend="reused"` (cli.py:4510). `_update_ship_state_from_job` mirrors it as `evidence_snapshot[target]="pass"` and a `DispatchedRun` with `status="completed"` and `provider` = the ancestor's provider. `DispatchedRun.status="reused"` is NOT persisted — that string only appears in `watch`/`--json` envelopes as a display label.
+- **Externals:** git diff vs ancestor SHA (`shipyard.ship.reuse.check_reuse_eligible`)
+- **Failure modes**
+  - Ancestor SHA unknown or diff check fails → falls through to normal dispatch. No false-PASS risk from the reuse path itself.
+  - Stage-list drift or validation-contract drift → reuse is refused by `reuse.py`; normal dispatch runs.
 
 ## External dependency matrix
 
-Every transition that hits an external system is a potential silent-
-failure site. Phase B tests must inject failure at each of these points.
+| External                               | Transitions         | Failure class               | Symptom + audit note                                                                                                 |
+|----------------------------------------|---------------------|------------------------------|----------------------------------------------------------------------------------------------------------------------|
+| `ShipStateStore.save` / `archive`      | T1, T2, T3, T5, T7, T8, T10, T11 | disk full / permission / race | Uses tmp+`os.replace` (core/ship_state.py:342–357). Torn writes prevented. Orphan tmp cleaned on exception path.     |
+| `EvidenceStore.record`                 | T3 (via `_record_evidence` at cli.py:4343) | disk full / race | **Does NOT use tmp+replace** — `core/evidence.py:226` writes directly. Phase B: inject disk-full; assert behavior (crash vs. half-written row). Tracked separately from #102. |
+| `queue.json` writes                    | T2, T3              | disk full / kill mid-write   | On `main` today, `Queue._save` writes `queue.json` directly (core/queue.py:119). Fixed in PR #105 (`fix/102-atomic-queue-writes`). Phase B should run against main OR the fix/102 branch depending on test timing. |
+| `git push`                             | T1                  | auth / network               | Return code is ignored. State can be saved for a branch whose tip isn't pushed — drift check on next resume catches it, but the first run proceeds. |
+| `gh pr create` / `gh pr list`          | T1                  | auth / network / rate-limit  | Raises `GhError`; ship aborts before T1 save.                                                                        |
+| `gh pr view` (idempotency for `auto-merge`) | T5 (no-state branch only) | auth / network | On failure the command falls through to `pr-not-found`. Not reached when the state file is present.                |
+| `workflow_dispatch`                    | T2, T9, T10         | 404 / 5xx / rate-limit       | Add-lane: exits before mutation. Retarget: if dispatch fails after cancel succeeded, the old lane is gone and no new lane exists. `ship` path goes through `CloudExecutor` inside `_execute_job`. |
+| `find_dispatched_run`                  | T2, T10             | timeout                      | DispatchedRun persisted with `pending-<target>` sentinel. **No backfill path exists.**                              |
+| `gh run cancel` (retarget)             | T9                  | race / auth                  | If cancel fails completely, retarget aborts before dispatch. Partial cancellation proceeds to dispatch → stale old job runs alongside new.                                   |
+| `gh pr merge`                          | T5                  | branch protection / auth / already-merged | `ship`: unwrapped, propagates. `auto-merge`: wrapped, exits 1 with `merge-failed`. "Already merged" from a failed-archive retry is currently reported as `merge-failed`, not idempotent success (see T5). |
+| SSH backend probe                      | T2 (preflight)      | network / auth / host_key     | Pre-#100: silent hang. Post-#100: exit 3 with classified error inside 10s.                                           |
+| `git rev-parse HEAD` (branch/SHA)      | T1, T7              | worktree gone                 | `ship` aborts at cli.py:2582 before drift detection if branch or SHA is unavailable.                                 |
 
-| External                       | Transitions                         | Failure class            | Silent-mode symptom                                                                 |
-|--------------------------------|-------------------------------------|--------------------------|-------------------------------------------------------------------------------------|
-| Filesystem (`save`/`archive`)  | All (T1, T2, T3, T4-save, T5, T7, T8, T11) | disk full / permission / race | Pre-#102 style truncation; stale tmp files; half-archived state. Fix from core/ship_state.py already uses tmp+replace, but the assumption deserves an explicit test. |
-| `git push`                     | T1                                  | auth / network           | State written without a pushed branch → PR create fails; no state written. Benign. |
-| `gh pr create`                 | T1                                  | auth / network / rate-limit | Ship aborts with a GhError; no state written.                                       |
-| `gh pr list` (find_pr_for_branch) | T1                               | auth / network           | Falls through to create a new PR which may duplicate. Present risk.                |
-| `gh pr view` (auto-merge idempotency) | T5 recovery                   | auth / network           | Auto-merge incorrectly reports "pr-not-found" after a successful merge; operator noise, no data loss. |
-| `workflow_dispatch` (cloud)    | T2, T9, T10                         | 404 / 5xx / rate-limit   | DispatchedRun saved with `pending-<target>` run_id → `auto-merge` blind to that lane's verdict. |
-| `find_dispatched_run`          | T2                                  | timeout                  | DispatchedRun never gets a real run_id; watch cannot tail.                          |
-| `gh pr merge`                  | T5                                  | branch protection / auth | `STATE_MERGE_FAILED`; state retained for retry. Retry path works for all known variants. |
-| `gh run cancel`                | T9                                  | race                     | Old lane keeps running (cost only). New lane proceeds. State stays consistent.      |
-| SSH backend probe              | T2 (preflight)                      | network / auth / host_key | Pre-#100: silent 10-min hang. Post-#100: exit 3 with classified error inside 10s.   |
-| `git rev-parse HEAD` / config read | T7                              | worktree gone            | `_detect_ship_state_drift` falls through to "no drift" (conservative). State resumes. |
+## Bugs discovered by this audit
 
-## Known silent-failure modes from consumer experience
+The Codex review pass turned up four real bugs, independent of the doc's
+accuracy. Each is a candidate Phase B regression test + a Shipyard issue.
 
-Pulp's PR history surfaced three real bugs that Phase B regression tests
-must cover:
+| ID | Summary | Location | Phase B test name |
+|----|---------|----------|-------------------|
+| B1 | `_ship_terminal_verdict` returns `True` from partial `evidence_snapshot` coverage if every present value is "pass". Can cause a merge to fire before all dispatched lanes have posted evidence. | cli.py:3790–3820 | `test_terminal_verdict_requires_coverage_of_all_required_lanes` |
+| B2 | `--no-resume` discards `archive_and_replace`'s incremented attempt and resets to `attempt=1`. | cli.py:2644 + 2663 | `test_no_resume_increments_attempt_counter` |
+| B3 | `cloud retarget --apply` dispatches a new workflow but never updates `ShipState`; the old `DispatchedRun` remains and the new one is never recorded. | cli.py:2100–2130 | `test_retarget_updates_dispatched_run_row` |
+| B4 | `_cloud_runs_by_platform(ctx, sha)` accepts but ignores `sha`; maps platform → recent run id, so cross-SHA run id attribution is possible on a busy machine. | cli.py:4645–4660 | `test_cloud_runs_by_platform_scopes_to_sha` |
 
-1. **Post-merge evidence blackhole.** Shipyard merged the PR, returned
-   success, and exited — but the post-merge evidence row for one lane was
-   never saved. Agents could not tell if the ship completed because
-   `evidence_snapshot` didn't match the merge outcome. *Test design: drop
-   `save()` after `merge_pr` returns True and assert the next `auto-merge`
-   tick hits the `_pr_is_merged` idempotency branch, not the "target
-   failed" branch.*
-2. **Resume re-runs a succeeded validation lane.** The resume path trusted
-   the DispatchedRun status string without cross-checking `evidence_snapshot`,
-   re-dispatching a lane that had already posted PASS evidence. *Test
-   design: seed a state with `status="in_progress"` + `evidence="pass"`,
-   assert resume skips dispatch for that lane.*
-3. **Queue state diverged from filesystem after unclean shutdown.**
-   Addressed by #102 for `queue.json`; `ship/<pr>.json` uses the same
-   tmp+replace pattern and should get the same test coverage. *Test
-   design: kill `save()` mid-write via monkeypatching `os.replace` to
-   raise; assert the previous state file is byte-identical.*
+These should be filed as issues before Phase B starts, so test names can
+reference `Fixes #<n>` rather than embedding bug descriptions in test
+fixtures.
 
-## Phase B test plan (preview — not implemented here)
+## Silent-failure regression tests
 
-For each transition T1–T12, write at least one test that:
+1. **Archive failure after merge is not idempotent on retry.** `_pr_is_merged` fires only when the state file is absent (cli.py:3242). If archive fails and leaves the state active, the next `auto-merge` reattempts `merge_pr`, GitHub returns "already merged" as an error, and `auto-merge` exits 1 with `merge-failed`. *Test:* archive → force an `OSError` on the rename; assert the next `auto-merge` tick distinguishes "already merged on GH" from "merge genuinely failed" and exits 0 with an event like `already-merged-but-state-not-archived`.
+2. **Partial evidence PASS (Bug B1).** Dispatch 3 targets, write evidence for only 1 (all "pass"), compute verdict. Today returns True. *Test:* seed a `ShipState` with `dispatched_runs=[T1, T2, T3]` and `evidence_snapshot={"T1":"pass"}`; `_ship_terminal_verdict(state)` must return `None`, not `True`. Proposed fix: extend the function to require an evidence row for every non-advisory `DispatchedRun.target`.
+3. **Ship-state tmp-write durability.** `ShipStateStore.save` already uses tmp+`os.replace` (core/ship_state.py:342). *Test:* inject an `os.replace` failure; assert the prior file is byte-identical. (Do NOT couple this test to `queue.json` — `Queue._save` uses a different write pattern on `main`; atomicity for that file lands in PR #105.)
 
-1. Exercises the happy path.
-2. Injects failure at each external-dependency row from the matrix above
-   and asserts the documented recovery behavior.
-3. Asserts that `updated_at` moves forward on every write and stays pinned
-   when the transition is read-only.
+## Phase B test plan
 
-Plus the three consumer-experience regression tests under "Known silent-
-failure modes" above.
+For each transition T1–T13, Phase B should land at least:
+
+1. A happy-path test that writes the expected fields.
+2. A failure-injection test for every external-dependency row the
+   transition touches, asserting the documented recovery behavior.
+3. A `touch()` / `updated_at` assertion: writes must move it forward;
+   read-only helpers must not.
+
+Plus the four bug regression tests from the table above, and the three
+silent-failure regression tests from the list above. Every test should
+name the transition it exercises (`test_T5_merge_on_pass_archives_state`
+etc.) so failure output maps directly to this doc.
 
 ## Phase C preview
 
 1. **Doc-sync hook.** Add `docs/ship-state-machine.md` to the skill-sync
    path map so that changes to `src/shipyard/core/ship_state.py` or the
    relevant chunks of `src/shipyard/cli.py` must update this doc in the
-   same PR. Mechanism is identical to `scripts/skill_path_map.json` and
-   pairs with Pulp's proposed `doc_sync_check.py` (pulp#567).
-2. **Dedicated state-machine CI lane.** A single `pytest -m state_machine`
-   marker run as its own GitHub Actions job, separate from the full
-   suite, so a state-machine failure is visually distinct in the PR
-   checks list.
+   same PR. Mechanism identical to `scripts/skill_path_map.json`.
+2. **Dedicated state-machine CI lane.** A `pytest -m state_machine`
+   marker run as its own GitHub Actions job, so a state-machine
+   failure is visually distinct in the PR checks list.
 
 Neither change lands in Phase A. This doc's role is to make Phase B
 testable and Phase C's path-map additions obvious.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ testpaths = ["tests"]
 addopts = "-ra --strict-markers"
 markers = [
     "integration: marks tests requiring real git repos or SSH",
+    "state_machine: ship-state-machine transition tests (#101 Phase B)",
 ]
 
 [dependency-groups]

--- a/scripts/doc_sync_check.py
+++ b/scripts/doc_sync_check.py
@@ -1,0 +1,289 @@
+#!/usr/bin/env python3
+"""Doc-sync gate.
+
+Mirrors `skill_sync_check.py` but for free-form docs. Given a diff
+range (base..head), check that every doc whose mapped paths were
+touched also has the doc itself updated in the same range — or has a
+`Doc-Update: skip doc=<path> reason="..."` trailer on the tip commit.
+
+Map lives at `scripts/doc_sync_map.json`. Initially maps
+`docs/ship-state-machine.md` to `src/shipyard/core/ship_state.py`
+and `src/shipyard/ship/**`, per #101 Phase C.
+
+Modes
+    report — hard-fail (exit 1) on any finding. CI uses this.
+    hint   — advisory text only (exit 0). Agent hooks use this.
+    apply  — alias for report (no mutations possible here; the script
+             can't write a doc for you).
+
+Exit codes
+    0 — no unresolved findings
+    1 — at least one doc needs updating or a bypass
+    2 — internal error (bad config, git failure)
+"""
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import json
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable
+
+
+# ── Types ───────────────────────────────────────────────────────────────
+
+
+@dataclass
+class DocEntry:
+    doc: str
+    description: str
+    paths: list[str]
+
+
+@dataclass
+class DocMap:
+    docs: list[DocEntry]
+
+
+@dataclass
+class Finding:
+    doc: str
+    touched_paths: list[str]
+    doc_modified: bool
+    bypass_reason: str | None = None
+
+
+# ── Git helpers ────────────────────────────────────────────────────────
+
+
+def repo_root() -> Path:
+    out = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        check=True, capture_output=True, text=True,
+    )
+    return Path(out.stdout.strip())
+
+
+def git_diff_names(base: str, head: str) -> list[str]:
+    out = subprocess.run(
+        ["git", "diff", "--name-only", f"{base}...{head}"],
+        check=True, capture_output=True, text=True,
+    )
+    return [line for line in out.stdout.splitlines() if line]
+
+
+def git_range_trailers(base: str, head: str) -> dict[str, list[str]]:
+    """Collect trailers from every commit in `base..head`, merged.
+
+    Mirrors the skill_sync_check approach so a bypass on ANY commit in
+    the range honors — matches pre-push and CI reality where the tip
+    commit may not be the authored one.
+    """
+    commits = subprocess.run(
+        ["git", "rev-list", f"{base}..{head}"],
+        check=True, capture_output=True, text=True,
+    ).stdout.splitlines()
+
+    merged: dict[str, list[str]] = {}
+    for sha in commits:
+        if not sha:
+            continue
+        msg = subprocess.run(
+            ["git", "log", "-1", "--pretty=%B", sha],
+            check=True, capture_output=True, text=True,
+        ).stdout
+        trailers = subprocess.run(
+            ["git", "interpret-trailers", "--parse"],
+            input=msg, check=True, capture_output=True, text=True,
+        )
+        for line in trailers.stdout.splitlines():
+            if ":" not in line:
+                continue
+            key, _, value = line.partition(":")
+            merged.setdefault(key.strip().lower(), []).append(value.strip())
+    return merged
+
+
+# ── Config loading ─────────────────────────────────────────────────────
+
+
+def _strip_comments(data: dict) -> dict:
+    return {k: v for k, v in data.items() if not k.startswith("_")}
+
+
+def load_doc_map(path: Path) -> DocMap:
+    raw = _strip_comments(json.loads(path.read_text()))
+    docs_raw = raw.get("docs") or {}
+    if not isinstance(docs_raw, dict):
+        raise ValueError(f"{path}: 'docs' must be an object")
+    entries: list[DocEntry] = []
+    for doc_path, spec in docs_raw.items():
+        if not isinstance(spec, dict):
+            raise ValueError(f"{path}: docs.{doc_path} must be an object")
+        paths = spec.get("paths") or []
+        if not isinstance(paths, list) or not all(isinstance(p, str) for p in paths):
+            raise ValueError(f"{path}: docs.{doc_path}.paths must be a list of strings")
+        entries.append(
+            DocEntry(
+                doc=doc_path,
+                description=str(spec.get("description", "")),
+                paths=list(paths),
+            )
+        )
+    return DocMap(docs=entries)
+
+
+# ── Matching ───────────────────────────────────────────────────────────
+
+
+def _matches_any(path: str, patterns: Iterable[str]) -> bool:
+    for pattern in patterns:
+        # Match absolute glob OR the `**` recursive pattern.
+        if fnmatch.fnmatch(path, pattern):
+            return True
+        # fnmatch doesn't know about `**`; fall back to matching against
+        # the pattern minus trailing `/**`.
+        if pattern.endswith("/**") and (
+            path == pattern[:-3] or path.startswith(pattern[:-2])
+        ):
+            return True
+    return False
+
+
+def _parse_skip_trailer(trailer_values: list[str]) -> dict[str, str]:
+    """Parse `Doc-Update: skip doc=<path> reason="..."` entries."""
+    skips: dict[str, str] = {}
+    for value in trailer_values:
+        if not value.lower().startswith("skip"):
+            continue
+        # Match `doc=<path>` — path may contain `/` and `.`; reason may
+        # include spaces if quoted. Keep the parse forgiving.
+        doc: str | None = None
+        reason = ""
+        for part in value.split():
+            if part.startswith("doc="):
+                doc = part.partition("=")[2]
+        low = value.lower()
+        if "reason=" in low:
+            # Extract everything inside the first set of quotes after reason=.
+            idx = low.find('reason="')
+            if idx >= 0:
+                tail = value[idx + len('reason="'):]
+                end = tail.find('"')
+                if end >= 0:
+                    reason = tail[:end]
+        if doc:
+            skips[doc] = reason or "(no reason given)"
+    return skips
+
+
+# ── Core check ─────────────────────────────────────────────────────────
+
+
+def find_violations(
+    doc_map: DocMap,
+    changed: list[str],
+    trailers: dict[str, list[str]],
+    trailer_key: str = "doc-update",
+) -> list[Finding]:
+    skips = _parse_skip_trailer(trailers.get(trailer_key, []))
+
+    findings: list[Finding] = []
+    for entry in doc_map.docs:
+        touched = [p for p in changed if _matches_any(p, entry.paths)]
+        if not touched:
+            continue
+        doc_modified = entry.doc in changed
+        bypass = skips.get(entry.doc)
+        findings.append(
+            Finding(
+                doc=entry.doc,
+                touched_paths=touched,
+                doc_modified=doc_modified,
+                bypass_reason=bypass,
+            )
+        )
+    return findings
+
+
+def format_findings(findings: list[Finding]) -> tuple[str, bool]:
+    """Render a human-readable report + return whether any are unresolved."""
+    lines: list[str] = []
+    unresolved = False
+    for f in findings:
+        if f.doc_modified:
+            lines.append(f"✓ {f.doc}: touched + doc updated in the same diff.")
+            continue
+        if f.bypass_reason is not None:
+            lines.append(
+                f"↷ {f.doc}: touched, doc not updated — bypassed via "
+                f'Doc-Update: skip ("{f.bypass_reason}").'
+            )
+            continue
+        unresolved = True
+        lines.append(
+            f"✗ {f.doc}: mapped paths changed without updating the doc."
+        )
+        for path in f.touched_paths:
+            lines.append(f"    - {path}")
+        lines.append(
+            "  Fix: update the doc in the same diff, or add "
+            f'`Doc-Update: skip doc={f.doc} reason="..."` on the tip commit.'
+        )
+    return "\n".join(lines), unresolved
+
+
+# ── Main ───────────────────────────────────────────────────────────────
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description="Doc-sync gate")
+    parser.add_argument("--base", default="origin/main")
+    parser.add_argument("--head", default="HEAD")
+    parser.add_argument(
+        "--map",
+        default=None,
+        help="Path to doc_sync_map.json (defaults to scripts/doc_sync_map.json).",
+    )
+    parser.add_argument("--mode", choices=("report", "hint", "apply"), default="report")
+    parser.add_argument("--repo-root", default=None)
+    args = parser.parse_args(argv)
+
+    try:
+        root = Path(args.repo_root) if args.repo_root else repo_root()
+        map_path = (
+            Path(args.map)
+            if args.map
+            else root / "scripts" / "doc_sync_map.json"
+        )
+        if not map_path.exists():
+            sys.stderr.write(
+                f"doc_sync_check: map not found: {map_path}\n"
+            )
+            return 2
+        doc_map = load_doc_map(map_path)
+        changed = git_diff_names(args.base, args.head)
+        trailers = git_range_trailers(args.base, args.head)
+    except (subprocess.CalledProcessError, ValueError) as exc:
+        sys.stderr.write(f"doc_sync_check: {exc}\n")
+        return 2
+
+    findings = find_violations(doc_map, changed, trailers)
+    if not findings:
+        print("doc-sync: no mapped paths touched — nothing to verify.")
+        return 0
+
+    report, unresolved = format_findings(findings)
+    print(report)
+
+    if args.mode == "hint":
+        return 0
+    return 1 if unresolved else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/doc_sync_map.json
+++ b/scripts/doc_sync_map.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 1,
+  "_comment": "Doc-sync gate: when any of the mapped code paths are touched in a diff, the corresponding doc must also be updated in the same diff. Bypass via `Doc-Update: skip doc=<path> reason=\"...\"` on the tip commit. Mechanism mirrors skill_sync_check.py but targets free-form docs instead of skills/<name>/SKILL.md.",
+
+  "docs": {
+    "docs/ship-state-machine.md": {
+      "description": "Ship state machine audit (#101). Must update when transitions, schema, or external dependencies change.",
+      "paths": [
+        "src/shipyard/core/ship_state.py",
+        "src/shipyard/ship/**"
+      ]
+    }
+  }
+}

--- a/tests/test_doc_sync_check.py
+++ b/tests/test_doc_sync_check.py
@@ -1,0 +1,218 @@
+"""Tests for the doc-sync gate script (#101 Phase C)."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+
+def _load_script() -> object:
+    """Load scripts/doc_sync_check.py as a module."""
+    script = (
+        Path(__file__).resolve().parent.parent
+        / "scripts"
+        / "doc_sync_check.py"
+    )
+    spec = importlib.util.spec_from_file_location("doc_sync_check", script)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["doc_sync_check"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+doc_sync_check = _load_script()
+
+
+def test_load_doc_map_reads_valid_config(tmp_path: Path) -> None:
+    map_path = tmp_path / "doc_sync_map.json"
+    map_path.write_text(json.dumps({
+        "docs": {
+            "docs/x.md": {
+                "description": "X audit",
+                "paths": ["src/x/**", "src/shared/x.py"],
+            }
+        }
+    }))
+    doc_map = doc_sync_check.load_doc_map(map_path)
+    assert len(doc_map.docs) == 1
+    assert doc_map.docs[0].doc == "docs/x.md"
+    assert "src/x/**" in doc_map.docs[0].paths
+
+
+def test_load_doc_map_strips_underscore_keys(tmp_path: Path) -> None:
+    map_path = tmp_path / "doc_sync_map.json"
+    map_path.write_text(json.dumps({
+        "_comment": "explanatory JSON comment — should be ignored",
+        "schema_version": 1,
+        "docs": {"docs/x.md": {"paths": ["a.py"]}},
+    }))
+    doc_map = doc_sync_check.load_doc_map(map_path)
+    assert len(doc_map.docs) == 1
+
+
+def test_load_doc_map_rejects_bad_shape(tmp_path: Path) -> None:
+    map_path = tmp_path / "bad.json"
+    map_path.write_text(json.dumps({"docs": "not an object"}))
+    with pytest.raises(ValueError):
+        doc_sync_check.load_doc_map(map_path)
+
+
+def test_matches_any_handles_recursive_globs() -> None:
+    patterns = ["src/shipyard/ship/**", "src/shipyard/core/ship_state.py"]
+    assert doc_sync_check._matches_any("src/shipyard/ship/pr.py", patterns)
+    assert doc_sync_check._matches_any(
+        "src/shipyard/ship/subdir/deep.py", patterns
+    )
+    assert doc_sync_check._matches_any(
+        "src/shipyard/core/ship_state.py", patterns
+    )
+    assert not doc_sync_check._matches_any(
+        "src/shipyard/cli.py", patterns
+    )
+
+
+def test_find_violations_clean_when_doc_updated_with_code(
+    tmp_path: Path,
+) -> None:
+    doc_map = doc_sync_check.DocMap(docs=[
+        doc_sync_check.DocEntry(
+            doc="docs/x.md",
+            description="",
+            paths=["src/x/**"],
+        )
+    ])
+    findings = doc_sync_check.find_violations(
+        doc_map,
+        changed=["src/x/changed.py", "docs/x.md"],
+        trailers={},
+    )
+    assert len(findings) == 1
+    assert findings[0].doc_modified is True
+    assert findings[0].bypass_reason is None
+
+
+def test_find_violations_flags_untouched_doc(tmp_path: Path) -> None:
+    doc_map = doc_sync_check.DocMap(docs=[
+        doc_sync_check.DocEntry(
+            doc="docs/x.md",
+            description="",
+            paths=["src/x/**"],
+        )
+    ])
+    findings = doc_sync_check.find_violations(
+        doc_map,
+        changed=["src/x/changed.py"],  # doc not in diff
+        trailers={},
+    )
+    assert len(findings) == 1
+    assert findings[0].doc_modified is False
+    assert findings[0].bypass_reason is None
+
+
+def test_find_violations_honors_skip_trailer() -> None:
+    doc_map = doc_sync_check.DocMap(docs=[
+        doc_sync_check.DocEntry(
+            doc="docs/x.md",
+            description="",
+            paths=["src/x/**"],
+        )
+    ])
+    findings = doc_sync_check.find_violations(
+        doc_map,
+        changed=["src/x/changed.py"],
+        trailers={
+            "doc-update": [
+                'skip doc=docs/x.md reason="mechanical rename, no audit change"'
+            ]
+        },
+    )
+    assert len(findings) == 1
+    assert findings[0].doc_modified is False
+    assert findings[0].bypass_reason == "mechanical rename, no audit change"
+
+
+def test_find_violations_skips_only_named_doc() -> None:
+    """A skip trailer for docs/x.md doesn't bypass docs/y.md."""
+    doc_map = doc_sync_check.DocMap(docs=[
+        doc_sync_check.DocEntry(doc="docs/x.md", description="", paths=["src/x/**"]),
+        doc_sync_check.DocEntry(doc="docs/y.md", description="", paths=["src/y/**"]),
+    ])
+    findings = doc_sync_check.find_violations(
+        doc_map,
+        changed=["src/x/a.py", "src/y/b.py"],
+        trailers={
+            "doc-update": ['skip doc=docs/x.md reason="minor"'],
+        },
+    )
+    assert len(findings) == 2
+    by_doc = {f.doc: f for f in findings}
+    assert by_doc["docs/x.md"].bypass_reason == "minor"
+    assert by_doc["docs/y.md"].bypass_reason is None
+
+
+def test_format_findings_flags_unresolved_as_unresolved() -> None:
+    findings = [
+        doc_sync_check.Finding(
+            doc="docs/x.md",
+            touched_paths=["src/x/changed.py"],
+            doc_modified=False,
+            bypass_reason=None,
+        ),
+    ]
+    report, unresolved = doc_sync_check.format_findings(findings)
+    assert unresolved is True
+    assert "✗ docs/x.md" in report
+    assert "src/x/changed.py" in report
+
+
+def test_format_findings_clean_when_doc_modified() -> None:
+    findings = [
+        doc_sync_check.Finding(
+            doc="docs/x.md",
+            touched_paths=["src/x/changed.py"],
+            doc_modified=True,
+            bypass_reason=None,
+        ),
+    ]
+    report, unresolved = doc_sync_check.format_findings(findings)
+    assert unresolved is False
+    assert "✓ docs/x.md" in report
+
+
+def test_format_findings_clean_when_bypassed() -> None:
+    findings = [
+        doc_sync_check.Finding(
+            doc="docs/x.md",
+            touched_paths=["src/x/changed.py"],
+            doc_modified=False,
+            bypass_reason="mechanical rename",
+        ),
+    ]
+    report, unresolved = doc_sync_check.format_findings(findings)
+    assert unresolved is False
+    assert "↷ docs/x.md" in report
+    assert "mechanical rename" in report
+
+
+def test_shipped_doc_sync_map_maps_ship_state_to_audit_doc() -> None:
+    """Regression: the shipped doc_sync_map.json must wire up the
+    ship-state audit doc to its code paths. If someone removes this
+    mapping without updating the audit, Phase C's protection is gone."""
+    map_path = (
+        Path(__file__).resolve().parent.parent
+        / "scripts"
+        / "doc_sync_map.json"
+    )
+    doc_map = doc_sync_check.load_doc_map(map_path)
+    audit = next(
+        (d for d in doc_map.docs if d.doc == "docs/ship-state-machine.md"),
+        None,
+    )
+    assert audit is not None, "ship-state-machine.md must remain in doc_sync_map"
+    assert "src/shipyard/core/ship_state.py" in audit.paths
+    assert any(p.startswith("src/shipyard/ship/") for p in audit.paths)

--- a/tests/test_ship_state_machine.py
+++ b/tests/test_ship_state_machine.py
@@ -1,0 +1,630 @@
+"""Phase B ship-state transition tests (#101).
+
+Named per-transition (T1–T13) + per-bug (B1–B4) + per-silent-failure
+(SF1–SF3) so failure output maps directly to
+`docs/ship-state-machine.md`.
+
+Bug regression tests are marked `xfail(strict=True)` against the
+filed bug numbers. When a fix lands, the `xfail` is flipped to a
+plain assertion and the state-machine lane catches the regression
+if the behavior reverts.
+
+CI runs this file under the `state_machine` pytest marker so a
+state-machine failure is visually distinct in the PR checks list.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from shipyard.cloud.records import CloudRecordStore, CloudRunRecord
+from shipyard.core.ship_state import (
+    DispatchedRun,
+    ShipState,
+    ShipStateStore,
+    compute_policy_signature,
+)
+
+
+pytestmark = pytest.mark.state_machine
+
+
+# ── Builders ───────────────────────────────────────────────────────
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _run(
+    target: str,
+    *,
+    provider: str = "namespace",
+    run_id: str = "12345",
+    status: str = "in_progress",
+    required: bool = True,
+    at: datetime | None = None,
+) -> DispatchedRun:
+    ts = at or _now()
+    return DispatchedRun(
+        target=target,
+        provider=provider,
+        run_id=run_id,
+        status=status,
+        started_at=ts,
+        updated_at=ts,
+        required=required,
+    )
+
+
+def _state(
+    pr: int = 42,
+    *,
+    runs: list[DispatchedRun] | None = None,
+    evidence: dict[str, str] | None = None,
+    attempt: int = 1,
+    head_sha: str = "a" * 40,
+) -> ShipState:
+    return ShipState(
+        pr=pr,
+        repo="danielraffel/pulp",
+        branch="feat/x",
+        base_branch="main",
+        head_sha=head_sha,
+        policy_signature=compute_policy_signature(
+            ["macos", "linux"], ["macos", "ubuntu"], "FULL"
+        ),
+        dispatched_runs=list(runs or []),
+        evidence_snapshot=dict(evidence or {}),
+        attempt=attempt,
+    )
+
+
+# ── T3 — terminal outcome batch save ──────────────────────────────
+
+
+class TestT3_BatchSave:
+    """A ShipStateStore.save happens once after _execute_job, not per
+    target — a kill mid-loop loses the whole batch, not one record.
+
+    We can't kill _execute_job from a unit test, but we can assert the
+    single-save invariant directly against ShipStateStore: mutating
+    multiple fields and then saving once produces a single on-disk
+    version, and a save failure between mutations preserves the
+    pre-mutation file byte-for-byte.
+    """
+
+    def test_single_save_covers_multiple_mutations(self, tmp_path: Path) -> None:
+        store = ShipStateStore(path=tmp_path / "ship")
+        state = _state()
+        store.save(state)
+
+        state.update_evidence("macos", "pass")
+        state.update_evidence("ubuntu", "pass")
+        state.update_evidence("windows", "fail")
+        store.save(state)
+
+        persisted = store.get(state.pr)
+        assert persisted is not None
+        assert persisted.evidence_snapshot == {
+            "macos": "pass",
+            "ubuntu": "pass",
+            "windows": "fail",
+        }
+
+    def test_mid_batch_save_failure_preserves_prior_state(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Invariant from docs/ship-state-machine.md T3: if save fails,
+        the previous valid state is byte-identical on disk."""
+        store = ShipStateStore(path=tmp_path / "ship")
+        state = _state()
+        store.save(state)
+        original = (store._state_path(state.pr)).read_text()
+
+        state.update_evidence("macos", "pass")
+        state.update_evidence("ubuntu", "pass")
+
+        def _boom(*args: Any, **kwargs: Any) -> None:
+            raise OSError("disk full")
+
+        # os.replace is the atomic-rename step in ShipStateStore.save.
+        monkeypatch.setattr(os, "replace", _boom)
+
+        with pytest.raises(OSError):
+            store.save(state)
+
+        # Prior file intact, no torn half.
+        assert (store._state_path(state.pr)).read_text() == original
+
+
+# ── T7 — resume revalidates every lane (observation test) ──────────
+
+
+class TestT7_ResumeRevalidatesEveryLane:
+    """Observation test (see docs/ship-state-machine.md T7): resume
+    does NOT skip a lane that already has passing evidence. This is
+    not necessarily correct behavior long-term, but it IS the current
+    behavior — test locks it in so a future "skip-on-pass" change is
+    explicit and accompanied by a state-machine-doc update.
+    """
+
+    def test_state_retains_every_dispatched_target_even_if_passed(
+        self, tmp_path: Path
+    ) -> None:
+        store = ShipStateStore(path=tmp_path / "ship")
+        state = _state(
+            runs=[_run("macos", run_id="1"), _run("ubuntu", run_id="2")],
+            evidence={"macos": "pass"},  # ubuntu not yet terminal
+        )
+        store.save(state)
+        loaded = store.get(state.pr)
+        assert loaded is not None
+        # The loaded state keeps both DispatchedRun rows — resume
+        # iterates job.target_names (cli.py:4219), so any lane-skip
+        # decision would have to consult evidence_snapshot, which it
+        # does NOT today. Phase B keeps this invariant until the
+        # skip-on-pass feature is designed.
+        assert {r.target for r in loaded.dispatched_runs} == {"macos", "ubuntu"}
+
+
+# ── T11 — discard archives ANY active state ───────────────────────
+
+
+class TestT11_DiscardArchivesAnyActive:
+    """ship-state discard works on any state, not only STATE_MERGED."""
+
+    def test_discard_archives_fresh_state(self, tmp_path: Path) -> None:
+        store = ShipStateStore(path=tmp_path / "ship")
+        state = _state(runs=[_run("macos", run_id="1")])
+        store.save(state)
+
+        archived = store.archive(state.pr)
+        assert archived is not None
+        assert archived.exists()
+        assert store.get(state.pr) is None  # no longer active
+
+    def test_discard_archives_verdict_fail_state(self, tmp_path: Path) -> None:
+        store = ShipStateStore(path=tmp_path / "ship")
+        state = _state(
+            runs=[_run("macos", run_id="1")],
+            evidence={"macos": "fail"},
+        )
+        store.save(state)
+
+        archived = store.archive(state.pr)
+        assert archived is not None
+        assert "42-" in archived.name
+        assert archived.name.endswith(".json")
+
+
+# ── T12 — prune only deletes active state for closed PRs ──────────
+
+
+class TestT12_PruneGates:
+    def test_active_state_not_deleted_without_closed_prs_set(
+        self, tmp_path: Path
+    ) -> None:
+        store = ShipStateStore(path=tmp_path / "ship")
+        state = _state()
+        state.updated_at = _now() - timedelta(days=365)  # ancient
+        store.save(state)
+
+        report = store.prune(active_days=14, archive_days=30, now=_now())
+        # No closed_prs provided → active files are NEVER auto-deleted.
+        assert state.pr not in report.deleted_active
+        assert store.get(state.pr) is not None
+
+    def test_active_state_deleted_when_closed_and_old(
+        self, tmp_path: Path
+    ) -> None:
+        store = ShipStateStore(path=tmp_path / "ship")
+        state = _state()
+        state.updated_at = _now() - timedelta(days=365)
+        store.save(state)
+
+        report = store.prune(
+            active_days=14,
+            archive_days=30,
+            closed_prs={state.pr},
+            now=_now(),
+        )
+        assert state.pr in report.deleted_active
+        assert store.get(state.pr) is None
+
+
+# ── T13 — cross-PR evidence reuse persists as "completed" ─────────
+
+
+class TestT13_ReusePersistsAsCompleted:
+    """Invariant from docs/ship-state-machine.md T13: reused lanes
+    become DispatchedRun(status="completed"), NOT status="reused".
+    `reused` only appears as a backend/display label, never in the
+    persisted status field.
+    """
+
+    def test_reused_run_persisted_as_completed(self, tmp_path: Path) -> None:
+        store = ShipStateStore(path=tmp_path / "ship")
+        now = _now()
+        reused_run = DispatchedRun(
+            target="macos",
+            provider="namespace",
+            run_id="reused-from-abc1234",
+            status="completed",  # mirroring cli.py:4586
+            started_at=now,
+            updated_at=now,
+            required=True,
+        )
+        state = _state(runs=[reused_run], evidence={"macos": "pass"})
+        store.save(state)
+
+        loaded = store.get(state.pr)
+        assert loaded is not None
+        (mac,) = [r for r in loaded.dispatched_runs if r.target == "macos"]
+        # No "reused" status — the audit's schema row for
+        # DispatchedRun.status says only queued/in_progress/completed/
+        # failed/cancelled are valid.
+        assert mac.status == "completed"
+        assert mac.status != "reused"
+
+
+# ── SF1 — archive failure after merge is not idempotent on retry ──
+
+
+class TestSF1_ArchiveFailureNotIdempotentOnRetry:
+    """From docs/ship-state-machine.md §silent-failure #1.
+
+    If `archive(pr)` fails after a successful merge, the active state
+    file remains. The next auto-merge tick reads it, sees
+    STATE_VERDICT_PASS again, and attempts `merge_pr` a second time.
+    GitHub responds "already merged"; `_pr_is_merged` does NOT save
+    us because it only runs on the state-absent branch (cli.py:3242).
+
+    This test documents the current (undesirable) behavior by proving
+    the exact precondition: after archive() fails and leaves the
+    state present, a subsequent `get(pr)` still returns the PASS
+    state — so the auto-merge retry will in fact re-enter the merge
+    branch, not the no-state branch.
+    """
+
+    def test_failed_archive_leaves_state_visible_to_next_tick(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        store = ShipStateStore(path=tmp_path / "ship")
+        state = _state(
+            runs=[_run("macos", run_id="1", status="completed")],
+            evidence={"macos": "pass"},
+        )
+        store.save(state)
+
+        def _boom(*args: Any, **kwargs: Any) -> None:
+            raise OSError("archive rename failed")
+
+        monkeypatch.setattr(os, "replace", _boom)
+
+        with pytest.raises(OSError):
+            store.archive(state.pr)
+
+        # Precondition for silent-failure #1: the active file is still
+        # present. The next auto-merge tick will read PASS and retry
+        # merge_pr instead of falling through to _pr_is_merged.
+        reread = store.get(state.pr)
+        assert reread is not None
+        assert reread.evidence_snapshot == {"macos": "pass"}
+
+
+# ── SF3 — ShipStateStore.save durability (already uses tmp+replace) ─
+
+
+class TestSF3_SaveTmpWriteDurability:
+    """Regression: ShipStateStore.save must not torn-write.
+
+    Explicitly decoupled from queue.json — Queue._save uses a
+    different pattern on `main` and gets its own atomicity fix in
+    PR #105. This test covers only core/ship_state.py:342–357.
+    """
+
+    def test_save_failure_after_fsync_preserves_prior_file(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        store = ShipStateStore(path=tmp_path / "ship")
+        store.save(_state())
+        before = (store._state_path(42)).read_text()
+
+        def _boom(*args: Any, **kwargs: Any) -> None:
+            raise OSError("rename blocked")
+
+        monkeypatch.setattr(os, "replace", _boom)
+        with pytest.raises(OSError):
+            store.save(_state(evidence={"macos": "fail"}))
+
+        # Prior file byte-for-byte intact.
+        assert (store._state_path(42)).read_text() == before
+
+    def test_save_failure_cleans_up_tmp(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        store = ShipStateStore(path=tmp_path / "ship")
+
+        def _boom(*args: Any, **kwargs: Any) -> None:
+            raise OSError("rename blocked")
+
+        monkeypatch.setattr(os, "replace", _boom)
+        with pytest.raises(OSError):
+            store.save(_state())
+
+        # No leftover `.PR.tmp` files in the store path.
+        leftovers = [
+            p for p in (store.path).glob(".*.tmp")
+        ]
+        assert not leftovers, f"orphan tmp files after failed save: {leftovers}"
+
+
+# ── _update_ship_state_from_job touch() invariants ────────────────
+
+
+class TestTouchInvariants:
+    """Every mutation helper bumps `updated_at`; read-only helpers
+    do not. Part of the generic Phase B assertion layer."""
+
+    def test_update_evidence_bumps_updated_at(self) -> None:
+        state = _state()
+        before = state.updated_at
+        state.update_evidence("macos", "pass")
+        assert state.updated_at > before
+
+    def test_upsert_run_bumps_updated_at(self) -> None:
+        state = _state()
+        before = state.updated_at
+        state.upsert_run(_run("macos"))
+        assert state.updated_at > before
+
+    def test_append_run_bumps_updated_at(self) -> None:
+        state = _state()
+        before = state.updated_at
+        state.append_run(_run("ubuntu", run_id="2"))
+        assert state.updated_at > before
+
+
+# ── Verdict computation — known-good cases ────────────────────────
+
+
+class TestVerdictComputation:
+    """Everything that's NOT Bug B1 — the verdict computer handles
+    these cases correctly today. Phase B locks in the correct paths
+    so a B1 fix doesn't accidentally break them."""
+
+    def test_empty_evidence_returns_none(self) -> None:
+        from shipyard.cli import _ship_terminal_verdict
+        state = _state(runs=[_run("macos", run_id="1")], evidence={})
+        assert _ship_terminal_verdict(state) is None
+
+    def test_all_pass_all_required_returns_true(self) -> None:
+        from shipyard.cli import _ship_terminal_verdict
+        state = _state(
+            runs=[_run("macos", run_id="1"), _run("ubuntu", run_id="2")],
+            evidence={"macos": "pass", "ubuntu": "pass"},
+        )
+        assert _ship_terminal_verdict(state) is True
+
+    def test_any_required_fail_returns_false(self) -> None:
+        from shipyard.cli import _ship_terminal_verdict
+        state = _state(
+            runs=[_run("macos", run_id="1"), _run("ubuntu", run_id="2")],
+            evidence={"macos": "pass", "ubuntu": "fail"},
+        )
+        assert _ship_terminal_verdict(state) is False
+
+    def test_advisory_fail_is_tolerated(self) -> None:
+        from shipyard.cli import _ship_terminal_verdict
+        state = _state(
+            runs=[
+                _run("macos", run_id="1", required=True),
+                _run("advisory-lint", run_id="2", required=False),
+            ],
+            evidence={"macos": "pass", "advisory-lint": "fail"},
+        )
+        assert _ship_terminal_verdict(state) is True
+
+    def test_non_terminal_evidence_value_returns_none(self) -> None:
+        from shipyard.cli import _ship_terminal_verdict
+        state = _state(
+            runs=[_run("macos", run_id="1")],
+            evidence={"macos": "pending"},
+        )
+        assert _ship_terminal_verdict(state) is None
+
+
+# ── Bug regression tests — xfail until filed issue is fixed ───────
+
+
+class TestB1_PartialEvidenceCoverage:
+    """#108: _ship_terminal_verdict returns PASS from partial
+    evidence coverage if every present value is "pass"."""
+
+    @pytest.mark.xfail(
+        reason=(
+            "Bug B1 / #108 — _ship_terminal_verdict does not require "
+            "coverage of every required DispatchedRun.target. When "
+            "fixed, flip xfail to assert."
+        ),
+        strict=True,
+    )
+    def test_B1_partial_evidence_coverage_not_verdict_pass(self) -> None:
+        from shipyard.cli import _ship_terminal_verdict
+        state = _state(
+            runs=[
+                _run("macos", run_id="1"),
+                _run("ubuntu", run_id="2"),
+                _run("windows", run_id="3"),
+            ],
+            evidence={"macos": "pass"},  # ubuntu + windows missing
+        )
+        # Today this incorrectly returns True → xfail.
+        # After fix, verdict must be None because required coverage
+        # is incomplete.
+        assert _ship_terminal_verdict(state) is None
+
+
+class TestB2_NoResumeAttemptCounter:
+    """#109: `--no-resume` resets ShipState.attempt to 1 instead of
+    incrementing the prior attempt."""
+
+    @pytest.mark.xfail(
+        reason=(
+            "Bug B2 / #109 — ship's --no-resume branch discards the "
+            "bumped attempt returned by archive_and_replace. When "
+            "fixed, the CLI should propagate attempt+1 into the new "
+            "ShipState."
+        ),
+        strict=True,
+    )
+    def test_B2_no_resume_increments_attempt_counter(
+        self, tmp_path: Path
+    ) -> None:
+        """Simulates the CLI's --no-resume branch logic.
+
+        We can't spawn `shipyard ship --no-resume` in a unit test
+        (it requires a real PR), but we can assert the store's
+        contract: archive_and_replace returns a state with attempt+1,
+        and the caller is expected to USE that return value.
+        """
+        store = ShipStateStore(path=tmp_path / "ship")
+        prior = _state(attempt=3)
+        store.save(prior)
+
+        # CORRECT: use the return value.
+        replacement = store.archive_and_replace(prior)
+        assert replacement.attempt == 4
+
+        # BROKEN: what cli.py currently does at 2644+2663 — discard
+        # the replacement and build a fresh ShipState with attempt=1.
+        #
+        # This assertion represents the FIXED behavior: the CLI's
+        # saved state must reflect the bumped attempt, not attempt=1.
+        # Today it's 1; after fix it must be 4 (or >=prior.attempt+1).
+        fresh_from_cli = store.get(prior.pr)
+        # After fix the CLI should persist the replacement itself.
+        # Asserting the invariant means: whatever the CLI saves, its
+        # `attempt` must be monotonically greater than the prior's.
+        assert fresh_from_cli is not None
+        assert fresh_from_cli.attempt > prior.attempt
+
+
+class TestB3_RetargetUpdatesState:
+    """#110: `cloud retarget --apply` dispatches a new workflow but
+    never updates ShipState — old DispatchedRun row persists, new
+    run is never recorded."""
+
+    @pytest.mark.xfail(
+        reason=(
+            "Bug B3 / #110 — retarget writes no ShipState. When "
+            "fixed, the retarget apply path should replace the "
+            "matching target's DispatchedRun row with the new "
+            "provider + run_id."
+        ),
+        strict=True,
+    )
+    def test_B3_retarget_updates_dispatched_run_row(
+        self, tmp_path: Path
+    ) -> None:
+        """Documents the expected post-fix contract: after retarget
+        from github-hosted to namespace, the DispatchedRun for that
+        target must reflect the new provider."""
+        store = ShipStateStore(path=tmp_path / "ship")
+        state = _state(
+            runs=[
+                _run(
+                    "macos",
+                    provider="github-hosted",
+                    run_id="old-123",
+                    status="in_progress",
+                )
+            ]
+        )
+        store.save(state)
+
+        # Simulate a retarget that (per fix) replaces the row:
+        # Current cli.py retarget does NOT do this — so reloading
+        # will show provider="github-hosted", not "namespace".
+        reloaded = store.get(state.pr)
+        assert reloaded is not None
+        (mac,) = [r for r in reloaded.dispatched_runs if r.target == "macos"]
+        # Test asserts the POST-FIX invariant: after retarget to
+        # namespace, the row should have the new provider. Today it
+        # still has the old one → xfail.
+        #
+        # Once retarget is fixed to write state, flip the fixture
+        # above to actually invoke retarget's state-mutation path.
+        assert mac.provider == "namespace"
+
+
+class TestB4_CloudRunsByPlatformScopesToSha:
+    """#111: `_cloud_runs_by_platform(ctx, sha)` accepts but ignores
+    `sha`, so cross-SHA run_id attribution is possible."""
+
+    @pytest.mark.xfail(
+        reason=(
+            "Bug B4 / #111 — _cloud_runs_by_platform ignores sha. "
+            "After fix, only records matching the requested SHA's "
+            "requested_ref should be returned."
+        ),
+        strict=True,
+    )
+    def test_B4_cloud_runs_by_platform_scopes_to_sha(
+        self, tmp_path: Path
+    ) -> None:
+        from shipyard.cli import _cloud_runs_by_platform
+
+        class _FakeCtx:
+            def __init__(self, store: CloudRecordStore) -> None:
+                self.cloud_records = store
+
+        store = CloudRecordStore(path=tmp_path / "cloud")
+        now = _now()
+        # Record A: SHA aaa, platform macos, run_id 100
+        store.save(
+            CloudRunRecord(
+                dispatch_id="d1",
+                workflow_key="ci",
+                workflow_file="ci.yml",
+                workflow_name="CI",
+                repository="danielraffel/pulp",
+                requested_ref="a" * 40,
+                provider="namespace",
+                dispatch_fields={"platform": "macos"},
+                status="in_progress",
+                run_id="100",
+                dispatched_at=now,
+                updated_at=now,
+            )
+        )
+        # Record B: SHA bbb, platform macos, run_id 200 — newer
+        store.save(
+            CloudRunRecord(
+                dispatch_id="d2",
+                workflow_key="ci",
+                workflow_file="ci.yml",
+                workflow_name="CI",
+                repository="danielraffel/pulp",
+                requested_ref="b" * 40,
+                provider="namespace",
+                dispatch_fields={"platform": "macos"},
+                status="in_progress",
+                run_id="200",
+                dispatched_at=now + timedelta(seconds=1),
+                updated_at=now + timedelta(seconds=1),
+            )
+        )
+
+        # Asking for SHA `aaa` must return 100, NOT 200. Today it
+        # returns 200 (the most-recent, regardless of SHA) because
+        # the sha parameter is ignored.
+        mapping = _cloud_runs_by_platform(_FakeCtx(store), "a" * 40)
+        assert mapping.get("macos") == "100"


### PR DESCRIPTION
Closes #101 (Phase A + B + C together).

**Base branch: `feat/101-phase-b-transition-tests`** (→ which bases on `fix/101-ship-state-audit`). Merge order: #107 → #112 → this PR.

## Summary

Lands Phase C from `docs/ship-state-machine.md`: a doc-sync gate that requires the audit to move when ship-state code moves, plus a dedicated CI lane for the Phase B transition tests.

## Files

### Doc-sync gate
- `scripts/doc_sync_check.py` — new gate script. CLI contract mirrors `skill_sync_check.py` (`--base`, `--head`, `--mode={report,hint,apply}`, `--map`, `--repo-root`). Exit 0 clean, 1 unresolved findings, 2 internal error.
- `scripts/doc_sync_map.json` — initial map: `docs/ship-state-machine.md` → `src/shipyard/core/ship_state.py` + `src/shipyard/ship/**`.
- `.githooks/pre-push` — runs the gate after version-bump, advisory by default; `SHIPYARD_ENFORCE_PREPUSH=1` upgrades to block (same mechanism as the skill-sync gate).
- `.github/workflows/version-skill-check.yml` — new `Doc-sync check` step runs as a hard CI gate.

### Bypass
`Doc-Update: skip doc=<path> reason="..."` trailer on any commit in the diff range.

### Dedicated CI lane
- `.github/workflows/ci.yml` — new `state-machine` job runs `pytest -m state_machine -v` on ubuntu-latest. Separate from the cross-platform `test` matrix so a state-machine regression shows up as its own check row in the PR status list.

### Docs
- `docs/ship-state-machine.md` — flipped the "Phase C preview" section to "Phase C — doc-sync hook + dedicated CI lane" with the exact bypass trailer syntax.

## Tests

`tests/test_doc_sync_check.py` — 12 tests covering:
- Map loading (valid / with `_comment` keys / bad shape)
- Glob matching (recursive `**`, exact paths, negative matches)
- Violation detection (clean / flagged / bypassed)
- Per-doc skip trailer scoping
- Report formatting (`✓` / `↷` / `✗` markers)
- Regression: shipped map must keep the ship-state-machine entry (otherwise Phase C's protection silently disappears)

All **941 non-integration tests pass, 4 xfail** (the B1–B4 bug regressions from Phase B).

## Verification

Dry-ran locally on this branch by committing a test touch to `src/shipyard/core/ship_state.py`:

```
$ python3 scripts/doc_sync_check.py --base origin/main --mode=report
✓ docs/ship-state-machine.md: touched + doc updated in the same diff.
```

And removed the doc update to confirm the fail path:
```
✗ docs/ship-state-machine.md: mapped paths changed without updating the doc.
    - src/shipyard/core/ship_state.py
  Fix: update the doc in the same diff, or add
  `Doc-Update: skip doc=docs/ship-state-machine.md reason="..."` on the tip commit.
```

## Test plan

- [ ] CI green (existing + new `state-machine` lane + doc-sync step).
- [ ] Reviewer confirms a test PR that touches `src/shipyard/core/ship_state.py` without updating the doc is blocked by the CI gate.
- [ ] Reviewer confirms the `state-machine` check row appears as a separate status entry.

## Closes

With this PR merged the #101 three-phase audit/test/enforcement arc is complete:
- Phase A (audit): PR #107
- Phase B (tests): PR #112
- Phase C (gate + lane): this PR
- Bug regressions filed: #108, #109, #110, #111 — covered as xfail tests until fixed