### PR TITLE
feat: Phase C doc-sync hook + dedicated state-machine CI lane (#101)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "shipyard",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "description": "Cross-platform CI coordination",
   "commands": "./commands",
   "agents": "./agents",

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -25,6 +25,8 @@ PYTHON="${PYTHON:-python3}"
 VBC="$ROOT/scripts/version_bump_check.py"
 SSC="$ROOT/scripts/skill_sync_check.py"
 CFG="$ROOT/scripts/versioning.json"
+DSC="$ROOT/scripts/doc_sync_check.py"
+DSM="$ROOT/scripts/doc_sync_map.json"
 
 if [ ! -f "$VBC" ] || [ ! -f "$SSC" ] || [ ! -f "$CFG" ]; then
     exit 0  # pre-versioning checkout; no-op
@@ -46,6 +48,15 @@ case $? in
     1) fail=1 ;;
     *) echo "[pre-push] version_bump_check: internal error" >&2 ;;
 esac
+
+if [ -f "$DSC" ] && [ -f "$DSM" ]; then
+    "$PYTHON" "$DSC" --base "$BASE" --map "$DSM" --mode=report
+    case $? in
+        0) ;;
+        1) fail=1 ;;
+        *) echo "[pre-push] doc_sync_check: internal error" >&2 ;;
+    esac
+fi
 
 if [ "$fail" = "0" ]; then
     echo "[pre-push] gates clean." >&2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,3 +74,24 @@ jobs:
       - name: Type check
         if: runner.os != 'Windows'
         run: mypy src/
+
+  state-machine:
+    # #101 Phase C — dedicated lane so ship-state-machine failures are
+    # visually distinct from the full-suite run. Fast (ubuntu-only, no
+    # cross-platform matrix) because these tests are pure Python and
+    # don't exercise platform-specific code paths.
+    name: Ship state machine
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: pip install .[dev]
+
+      - name: Run state-machine tests
+        run: pytest -m state_machine -v

--- a/.github/workflows/version-skill-check.yml
+++ b/.github/workflows/version-skill-check.yml
@@ -53,3 +53,10 @@ jobs:
               --base "${{ steps.base.outputs.ref }}" \
               --config scripts/versioning.json \
               --mode=report
+
+      - name: Doc-sync check
+        run: |
+          python3 scripts/doc_sync_check.py \
+              --base "${{ steps.base.outputs.ref }}" \
+              --map scripts/doc_sync_map.json \
+              --mode=report

--- a/docs/ship-state-machine.md
+++ b/docs/ship-state-machine.md
@@ -387,15 +387,24 @@ silent-failure regression tests from the list above. Every test should
 name the transition it exercises (`test_T5_merge_on_pass_archives_state`
 etc.) so failure output maps directly to this doc.
 
-## Phase C preview
+## Phase C — doc-sync hook + dedicated CI lane
 
-1. **Doc-sync hook.** Add `docs/ship-state-machine.md` to the skill-sync
-   path map so that changes to `src/shipyard/core/ship_state.py` or the
-   relevant chunks of `src/shipyard/cli.py` must update this doc in the
-   same PR. Mechanism identical to `scripts/skill_path_map.json`.
-2. **Dedicated state-machine CI lane.** A `pytest -m state_machine`
-   marker run as its own GitHub Actions job, so a state-machine
-   failure is visually distinct in the PR checks list.
+Both landed in a follow-up PR:
 
-Neither change lands in Phase A. This doc's role is to make Phase B
-testable and Phase C's path-map additions obvious.
+1. **Doc-sync hook.** `scripts/doc_sync_check.py` + `scripts/doc_sync_map.json`
+   enforce that changes to `src/shipyard/core/ship_state.py` or
+   `src/shipyard/ship/**` include an update to this doc. Runs in
+   `.githooks/pre-push` (advisory; `SHIPYARD_ENFORCE_PREPUSH=1`
+   upgrades to block) and in `.github/workflows/version-skill-check.yml`
+   as a hard CI gate. Bypass via a `Doc-Update: skip doc=<path>
+   reason="..."` trailer on any commit in the diff range.
+2. **Dedicated state-machine CI lane.** A `state-machine` job in
+   `.github/workflows/ci.yml` runs `pytest -m state_machine -v` on its
+   own — ubuntu-only because the tests are pure Python. A failure
+   shows up as a distinctly-named check in the PR status list, so an
+   operator can tell a state-machine regression from a cross-platform
+   infra blip at a glance.
+
+When you touch ship-state transition code, either update this doc in
+the same PR, or record why the update is unnecessary on the tip commit
+with `Doc-Update: skip doc=docs/ship-state-machine.md reason="..."`.

--- a/scripts/doc_sync_check.py
+++ b/scripts/doc_sync_check.py
@@ -1,0 +1,289 @@
+#!/usr/bin/env python3
+"""Doc-sync gate.
+
+Mirrors `skill_sync_check.py` but for free-form docs. Given a diff
+range (base..head), check that every doc whose mapped paths were
+touched also has the doc itself updated in the same range — or has a
+`Doc-Update: skip doc=<path> reason="..."` trailer on the tip commit.
+
+Map lives at `scripts/doc_sync_map.json`. Initially maps
+`docs/ship-state-machine.md` to `src/shipyard/core/ship_state.py`
+and `src/shipyard/ship/**`, per #101 Phase C.
+
+Modes
+    report — hard-fail (exit 1) on any finding. CI uses this.
+    hint   — advisory text only (exit 0). Agent hooks use this.
+    apply  — alias for report (no mutations possible here; the script
+             can't write a doc for you).
+
+Exit codes
+    0 — no unresolved findings
+    1 — at least one doc needs updating or a bypass
+    2 — internal error (bad config, git failure)
+"""
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import json
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable
+
+
+# ── Types ───────────────────────────────────────────────────────────────
+
+
+@dataclass
+class DocEntry:
+    doc: str
+    description: str
+    paths: list[str]
+
+
+@dataclass
+class DocMap:
+    docs: list[DocEntry]
+
+
+@dataclass
+class Finding:
+    doc: str
+    touched_paths: list[str]
+    doc_modified: bool
+    bypass_reason: str | None = None
+
+
+# ── Git helpers ────────────────────────────────────────────────────────
+
+
+def repo_root() -> Path:
+    out = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        check=True, capture_output=True, text=True,
+    )
+    return Path(out.stdout.strip())
+
+
+def git_diff_names(base: str, head: str) -> list[str]:
+    out = subprocess.run(
+        ["git", "diff", "--name-only", f"{base}...{head}"],
+        check=True, capture_output=True, text=True,
+    )
+    return [line for line in out.stdout.splitlines() if line]
+
+
+def git_range_trailers(base: str, head: str) -> dict[str, list[str]]:
+    """Collect trailers from every commit in `base..head`, merged.
+
+    Mirrors the skill_sync_check approach so a bypass on ANY commit in
+    the range honors — matches pre-push and CI reality where the tip
+    commit may not be the authored one.
+    """
+    commits = subprocess.run(
+        ["git", "rev-list", f"{base}..{head}"],
+        check=True, capture_output=True, text=True,
+    ).stdout.splitlines()
+
+    merged: dict[str, list[str]] = {}
+    for sha in commits:
+        if not sha:
+            continue
+        msg = subprocess.run(
+            ["git", "log", "-1", "--pretty=%B", sha],
+            check=True, capture_output=True, text=True,
+        ).stdout
+        trailers = subprocess.run(
+            ["git", "interpret-trailers", "--parse"],
+            input=msg, check=True, capture_output=True, text=True,
+        )
+        for line in trailers.stdout.splitlines():
+            if ":" not in line:
+                continue
+            key, _, value = line.partition(":")
+            merged.setdefault(key.strip().lower(), []).append(value.strip())
+    return merged
+
+
+# ── Config loading ─────────────────────────────────────────────────────
+
+
+def _strip_comments(data: dict) -> dict:
+    return {k: v for k, v in data.items() if not k.startswith("_")}
+
+
+def load_doc_map(path: Path) -> DocMap:
+    raw = _strip_comments(json.loads(path.read_text()))
+    docs_raw = raw.get("docs") or {}
+    if not isinstance(docs_raw, dict):
+        raise ValueError(f"{path}: 'docs' must be an object")
+    entries: list[DocEntry] = []
+    for doc_path, spec in docs_raw.items():
+        if not isinstance(spec, dict):
+            raise ValueError(f"{path}: docs.{doc_path} must be an object")
+        paths = spec.get("paths") or []
+        if not isinstance(paths, list) or not all(isinstance(p, str) for p in paths):
+            raise ValueError(f"{path}: docs.{doc_path}.paths must be a list of strings")
+        entries.append(
+            DocEntry(
+                doc=doc_path,
+                description=str(spec.get("description", "")),
+                paths=list(paths),
+            )
+        )
+    return DocMap(docs=entries)
+
+
+# ── Matching ───────────────────────────────────────────────────────────
+
+
+def _matches_any(path: str, patterns: Iterable[str]) -> bool:
+    for pattern in patterns:
+        # Match absolute glob OR the `**` recursive pattern.
+        if fnmatch.fnmatch(path, pattern):
+            return True
+        # fnmatch doesn't know about `**`; fall back to matching against
+        # the pattern minus trailing `/**`.
+        if pattern.endswith("/**") and (
+            path == pattern[:-3] or path.startswith(pattern[:-2])
+        ):
+            return True
+    return False
+
+
+def _parse_skip_trailer(trailer_values: list[str]) -> dict[str, str]:
+    """Parse `Doc-Update: skip doc=<path> reason="..."` entries."""
+    skips: dict[str, str] = {}
+    for value in trailer_values:
+        if not value.lower().startswith("skip"):
+            continue
+        # Match `doc=<path>` — path may contain `/` and `.`; reason may
+        # include spaces if quoted. Keep the parse forgiving.
+        doc: str | None = None
+        reason = ""
+        for part in value.split():
+            if part.startswith("doc="):
+                doc = part.partition("=")[2]
+        low = value.lower()
+        if "reason=" in low:
+            # Extract everything inside the first set of quotes after reason=.
+            idx = low.find('reason="')
+            if idx >= 0:
+                tail = value[idx + len('reason="'):]
+                end = tail.find('"')
+                if end >= 0:
+                    reason = tail[:end]
+        if doc:
+            skips[doc] = reason or "(no reason given)"
+    return skips
+
+
+# ── Core check ─────────────────────────────────────────────────────────
+
+
+def find_violations(
+    doc_map: DocMap,
+    changed: list[str],
+    trailers: dict[str, list[str]],
+    trailer_key: str = "doc-update",
+) -> list[Finding]:
+    skips = _parse_skip_trailer(trailers.get(trailer_key, []))
+
+    findings: list[Finding] = []
+    for entry in doc_map.docs:
+        touched = [p for p in changed if _matches_any(p, entry.paths)]
+        if not touched:
+            continue
+        doc_modified = entry.doc in changed
+        bypass = skips.get(entry.doc)
+        findings.append(
+            Finding(
+                doc=entry.doc,
+                touched_paths=touched,
+                doc_modified=doc_modified,
+                bypass_reason=bypass,
+            )
+        )
+    return findings
+
+
+def format_findings(findings: list[Finding]) -> tuple[str, bool]:
+    """Render a human-readable report + return whether any are unresolved."""
+    lines: list[str] = []
+    unresolved = False
+    for f in findings:
+        if f.doc_modified:
+            lines.append(f"✓ {f.doc}: touched + doc updated in the same diff.")
+            continue
+        if f.bypass_reason is not None:
+            lines.append(
+                f"↷ {f.doc}: touched, doc not updated — bypassed via "
+                f'Doc-Update: skip ("{f.bypass_reason}").'
+            )
+            continue
+        unresolved = True
+        lines.append(
+            f"✗ {f.doc}: mapped paths changed without updating the doc."
+        )
+        for path in f.touched_paths:
+            lines.append(f"    - {path}")
+        lines.append(
+            "  Fix: update the doc in the same diff, or add "
+            f'`Doc-Update: skip doc={f.doc} reason="..."` on the tip commit.'
+        )
+    return "\n".join(lines), unresolved
+
+
+# ── Main ───────────────────────────────────────────────────────────────
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description="Doc-sync gate")
+    parser.add_argument("--base", default="origin/main")
+    parser.add_argument("--head", default="HEAD")
+    parser.add_argument(
+        "--map",
+        default=None,
+        help="Path to doc_sync_map.json (defaults to scripts/doc_sync_map.json).",
+    )
+    parser.add_argument("--mode", choices=("report", "hint", "apply"), default="report")
+    parser.add_argument("--repo-root", default=None)
+    args = parser.parse_args(argv)
+
+    try:
+        root = Path(args.repo_root) if args.repo_root else repo_root()
+        map_path = (
+            Path(args.map)
+            if args.map
+            else root / "scripts" / "doc_sync_map.json"
+        )
+        if not map_path.exists():
+            sys.stderr.write(
+                f"doc_sync_check: map not found: {map_path}\n"
+            )
+            return 2
+        doc_map = load_doc_map(map_path)
+        changed = git_diff_names(args.base, args.head)
+        trailers = git_range_trailers(args.base, args.head)
+    except (subprocess.CalledProcessError, ValueError) as exc:
+        sys.stderr.write(f"doc_sync_check: {exc}\n")
+        return 2
+
+    findings = find_violations(doc_map, changed, trailers)
+    if not findings:
+        print("doc-sync: no mapped paths touched — nothing to verify.")
+        return 0
+
+    report, unresolved = format_findings(findings)
+    print(report)
+
+    if args.mode == "hint":
+        return 0
+    return 1 if unresolved else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/doc_sync_map.json
+++ b/scripts/doc_sync_map.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 1,
+  "_comment": "Doc-sync gate: when any of the mapped code paths are touched in a diff, the corresponding doc must also be updated in the same diff. Bypass via `Doc-Update: skip doc=<path> reason=\"...\"` on the tip commit. Mechanism mirrors skill_sync_check.py but targets free-form docs instead of skills/<name>/SKILL.md.",
+
+  "docs": {
+    "docs/ship-state-machine.md": {
+      "description": "Ship state machine audit (#101). Must update when transitions, schema, or external dependencies change.",
+      "paths": [
+        "src/shipyard/core/ship_state.py",
+        "src/shipyard/ship/**"
+      ]
+    }
+  }
+}

--- a/skills/ci/SKILL.md
+++ b/skills/ci/SKILL.md
@@ -490,12 +490,19 @@ Never run `gh pr create` + release separately. Never run the Python gate scripts
 
 Missing-script errors list every probed location and every override knob. Consumer repos that keep their tooling under `tools/scripts/` need no configuration; other layouts should set the env var or the `[validation]` key rather than moving the script.
 
+## State-machine lane + doc-sync gate
+
+A dedicated `state-machine` CI job runs `pytest -m state_machine -v` on ubuntu-latest. Failures show up as a distinct check row (not mixed into the cross-platform `test` matrix), so a ship-state regression is visually separable from an infra blip. When writing a test that exercises ship-state transitions, add `pytestmark = pytest.mark.state_machine` at module scope.
+
+A doc-sync gate enforces that `docs/ship-state-machine.md` moves whenever `src/shipyard/core/ship_state.py` or `src/shipyard/ship/**` does. Mechanism is `scripts/doc_sync_check.py` + `scripts/doc_sync_map.json` (mirrors `skill_sync_check.py` but targets free-form docs). Bypass via `Doc-Update: skip doc=<path> reason="..."` trailer.
+
 ## Bypass trailers (tip commit)
 
 | Gate          | Trailer                                                      |
 |---------------|--------------------------------------------------------------|
 | Version bump  | `Version-Bump: <surface>=<patch\|minor\|major\|skip> reason="..."` |
 | Skill update  | `Skill-Update: skip skill=<name> reason="..."`              |
+| Doc-sync      | `Doc-Update: skip doc=<path> reason="..."`                  |
 | Auto-release  | `Release: skip reason="..."`                                 |
 | Lane policy   | `Lane-Policy: <target>=required\|advisory` (escalate/demote for this PR only) |
 

--- a/tests/test_doc_sync_check.py
+++ b/tests/test_doc_sync_check.py
@@ -1,0 +1,218 @@
+"""Tests for the doc-sync gate script (#101 Phase C)."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+
+def _load_script() -> object:
+    """Load scripts/doc_sync_check.py as a module."""
+    script = (
+        Path(__file__).resolve().parent.parent
+        / "scripts"
+        / "doc_sync_check.py"
+    )
+    spec = importlib.util.spec_from_file_location("doc_sync_check", script)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["doc_sync_check"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+doc_sync_check = _load_script()
+
+
+def test_load_doc_map_reads_valid_config(tmp_path: Path) -> None:
+    map_path = tmp_path / "doc_sync_map.json"
+    map_path.write_text(json.dumps({
+        "docs": {
+            "docs/x.md": {
+                "description": "X audit",
+                "paths": ["src/x/**", "src/shared/x.py"],
+            }
+        }
+    }))
+    doc_map = doc_sync_check.load_doc_map(map_path)
+    assert len(doc_map.docs) == 1
+    assert doc_map.docs[0].doc == "docs/x.md"
+    assert "src/x/**" in doc_map.docs[0].paths
+
+
+def test_load_doc_map_strips_underscore_keys(tmp_path: Path) -> None:
+    map_path = tmp_path / "doc_sync_map.json"
+    map_path.write_text(json.dumps({
+        "_comment": "explanatory JSON comment — should be ignored",
+        "schema_version": 1,
+        "docs": {"docs/x.md": {"paths": ["a.py"]}},
+    }))
+    doc_map = doc_sync_check.load_doc_map(map_path)
+    assert len(doc_map.docs) == 1
+
+
+def test_load_doc_map_rejects_bad_shape(tmp_path: Path) -> None:
+    map_path = tmp_path / "bad.json"
+    map_path.write_text(json.dumps({"docs": "not an object"}))
+    with pytest.raises(ValueError):
+        doc_sync_check.load_doc_map(map_path)
+
+
+def test_matches_any_handles_recursive_globs() -> None:
+    patterns = ["src/shipyard/ship/**", "src/shipyard/core/ship_state.py"]
+    assert doc_sync_check._matches_any("src/shipyard/ship/pr.py", patterns)
+    assert doc_sync_check._matches_any(
+        "src/shipyard/ship/subdir/deep.py", patterns
+    )
+    assert doc_sync_check._matches_any(
+        "src/shipyard/core/ship_state.py", patterns
+    )
+    assert not doc_sync_check._matches_any(
+        "src/shipyard/cli.py", patterns
+    )
+
+
+def test_find_violations_clean_when_doc_updated_with_code(
+    tmp_path: Path,
+) -> None:
+    doc_map = doc_sync_check.DocMap(docs=[
+        doc_sync_check.DocEntry(
+            doc="docs/x.md",
+            description="",
+            paths=["src/x/**"],
+        )
+    ])
+    findings = doc_sync_check.find_violations(
+        doc_map,
+        changed=["src/x/changed.py", "docs/x.md"],
+        trailers={},
+    )
+    assert len(findings) == 1
+    assert findings[0].doc_modified is True
+    assert findings[0].bypass_reason is None
+
+
+def test_find_violations_flags_untouched_doc(tmp_path: Path) -> None:
+    doc_map = doc_sync_check.DocMap(docs=[
+        doc_sync_check.DocEntry(
+            doc="docs/x.md",
+            description="",
+            paths=["src/x/**"],
+        )
+    ])
+    findings = doc_sync_check.find_violations(
+        doc_map,
+        changed=["src/x/changed.py"],  # doc not in diff
+        trailers={},
+    )
+    assert len(findings) == 1
+    assert findings[0].doc_modified is False
+    assert findings[0].bypass_reason is None
+
+
+def test_find_violations_honors_skip_trailer() -> None:
+    doc_map = doc_sync_check.DocMap(docs=[
+        doc_sync_check.DocEntry(
+            doc="docs/x.md",
+            description="",
+            paths=["src/x/**"],
+        )
+    ])
+    findings = doc_sync_check.find_violations(
+        doc_map,
+        changed=["src/x/changed.py"],
+        trailers={
+            "doc-update": [
+                'skip doc=docs/x.md reason="mechanical rename, no audit change"'
+            ]
+        },
+    )
+    assert len(findings) == 1
+    assert findings[0].doc_modified is False
+    assert findings[0].bypass_reason == "mechanical rename, no audit change"
+
+
+def test_find_violations_skips_only_named_doc() -> None:
+    """A skip trailer for docs/x.md doesn't bypass docs/y.md."""
+    doc_map = doc_sync_check.DocMap(docs=[
+        doc_sync_check.DocEntry(doc="docs/x.md", description="", paths=["src/x/**"]),
+        doc_sync_check.DocEntry(doc="docs/y.md", description="", paths=["src/y/**"]),
+    ])
+    findings = doc_sync_check.find_violations(
+        doc_map,
+        changed=["src/x/a.py", "src/y/b.py"],
+        trailers={
+            "doc-update": ['skip doc=docs/x.md reason="minor"'],
+        },
+    )
+    assert len(findings) == 2
+    by_doc = {f.doc: f for f in findings}
+    assert by_doc["docs/x.md"].bypass_reason == "minor"
+    assert by_doc["docs/y.md"].bypass_reason is None
+
+
+def test_format_findings_flags_unresolved_as_unresolved() -> None:
+    findings = [
+        doc_sync_check.Finding(
+            doc="docs/x.md",
+            touched_paths=["src/x/changed.py"],
+            doc_modified=False,
+            bypass_reason=None,
+        ),
+    ]
+    report, unresolved = doc_sync_check.format_findings(findings)
+    assert unresolved is True
+    assert "✗ docs/x.md" in report
+    assert "src/x/changed.py" in report
+
+
+def test_format_findings_clean_when_doc_modified() -> None:
+    findings = [
+        doc_sync_check.Finding(
+            doc="docs/x.md",
+            touched_paths=["src/x/changed.py"],
+            doc_modified=True,
+            bypass_reason=None,
+        ),
+    ]
+    report, unresolved = doc_sync_check.format_findings(findings)
+    assert unresolved is False
+    assert "✓ docs/x.md" in report
+
+
+def test_format_findings_clean_when_bypassed() -> None:
+    findings = [
+        doc_sync_check.Finding(
+            doc="docs/x.md",
+            touched_paths=["src/x/changed.py"],
+            doc_modified=False,
+            bypass_reason="mechanical rename",
+        ),
+    ]
+    report, unresolved = doc_sync_check.format_findings(findings)
+    assert unresolved is False
+    assert "↷ docs/x.md" in report
+    assert "mechanical rename" in report
+
+
+def test_shipped_doc_sync_map_maps_ship_state_to_audit_doc() -> None:
+    """Regression: the shipped doc_sync_map.json must wire up the
+    ship-state audit doc to its code paths. If someone removes this
+    mapping without updating the audit, Phase C's protection is gone."""
+    map_path = (
+        Path(__file__).resolve().parent.parent
+        / "scripts"
+        / "doc_sync_map.json"
+    )
+    doc_map = doc_sync_check.load_doc_map(map_path)
+    audit = next(
+        (d for d in doc_map.docs if d.doc == "docs/ship-state-machine.md"),
+        None,
+    )
+    assert audit is not None, "ship-state-machine.md must remain in doc_sync_map"
+    assert "src/shipyard/core/ship_state.py" in audit.paths
+    assert any(p.startswith("src/shipyard/ship/") for p in audit.paths)


### PR DESCRIPTION
Partial fix for #101 — Phase C (doc-sync hook + dedicated CI lane). Replaces PR #113, auto-closed when its base branch was deleted after merging #115.

## Summary

`scripts/doc_sync_check.py` + `scripts/doc_sync_map.json` enforce that changes to ship-state code also update `docs/ship-state-machine.md`. Wired into pre-push hook (advisory → blocks with `SHIPYARD_ENFORCE_PREPUSH=1`) and `version-skill-check.yml` (hard gate).

Dedicated `state-machine` job in `ci.yml` runs `pytest -m state_machine -v` on ubuntu-latest.

12 unit tests for the gate in `tests/test_doc_sync_check.py`.

Bypass: `Doc-Update: skip doc=<path> reason="..."` trailer.