### PR TITLE
feat(doctor): detect shadowed `shipyard` binaries on PATH

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "shipyard"
-version = "0.21.1"
+version = "0.21.2"
 description = "Cross-platform CI coordination — local VMs, SSH hosts, cloud runners"
 readme = "README.md"
 license = "MIT"

--- a/src/shipyard/__init__.py
+++ b/src/shipyard/__init__.py
@@ -1,3 +1,3 @@
 """Shipyard — Cross-platform CI coordination."""
 
-__version__ = "0.21.1"
+__version__ = "0.21.2"

--- a/src/shipyard/cli.py
+++ b/src/shipyard/cli.py
@@ -479,6 +479,11 @@ def doctor(ctx: Context, release_chain: bool, runners: bool) -> None:
     core: dict[str, Any] = {}
     core["git"] = _check_command("git", "--version")
     core["ssh"] = _check_command("ssh", "-V")
+    # PATH-shadow check: if a stale `shipyard` binary sits on a
+    # lower-priority PATH entry, a reshuffle of PATH silently
+    # downgrades the user to a pre-fix version. Surface this in
+    # doctor so the user learns about it before it bites.
+    core["shipyard-on-path"] = _check_shipyard_path_shadows()
     checks["Core"] = core
 
     # Cloud providers
@@ -537,6 +542,84 @@ def doctor(ctx: Context, release_chain: bool, runners: bool) -> None:
         ctx.output("doctor", {"ready": ready, "checks": checks})
     else:
         render_doctor(checks, ready)
+
+
+def _check_shipyard_path_shadows() -> dict[str, Any]:
+    """Detect stale `shipyard` binaries shadowed on PATH.
+
+    Pulp's agents discovered this concretely: a v0.11.0 binary under
+    ``~/.local/bin/shipyard`` (from an old ``uv tool install shipyard``)
+    was sitting second on PATH behind the pinned
+    ``~/.pulp/bin/shipyard``. If PATH order had ever shifted, every
+    ``shipyard ship`` would have silently run v0.11.0 with none of the
+    recent fixes. This check enumerates every ``shipyard`` on PATH,
+    asks each for its ``--version``, and flags the ones that aren't
+    the one currently running.
+
+    Returns a row suitable for the `Core` section of doctor:
+    - ``ok=True`` when only one shipyard is on PATH, or every PATH
+      entry resolves to the same real file (symlinks are fine).
+    - ``ok=False`` when two or more distinct binaries are found,
+      with `detail` naming every path + version + who wins.
+    """
+    import os as _os
+    import shlex as _shlex
+    import subprocess as _sp
+
+    from shipyard import __version__ as _self_version
+
+    paths = [p for p in _os.environ.get("PATH", "").split(_os.pathsep) if p]
+    # Preserve first-seen order so we can show "winner: <first>" below.
+    seen_bins: list[Path] = []
+    seen_reals: set[Path] = set()
+    for directory in paths:
+        candidate = Path(directory) / "shipyard"
+        if not candidate.is_file() or not _os.access(candidate, _os.X_OK):
+            continue
+        try:
+            real = candidate.resolve()
+        except OSError:
+            real = candidate
+        if real in seen_reals:
+            continue
+        seen_reals.add(real)
+        seen_bins.append(candidate)
+
+    if len(seen_bins) <= 1:
+        return {
+            "ok": True,
+            "version": f"v{_self_version} (single binary on PATH)",
+        }
+
+    # Multiple distinct binaries — fetch each version. Keep the probe
+    # fast so doctor stays snappy on repos with unrelated shipyard
+    # checkouts in ~/Code.
+    rows: list[str] = []
+    for i, binary in enumerate(seen_bins):
+        label = "WINS" if i == 0 else f"shadowed by {seen_bins[0]}"
+        try:
+            result = _sp.run(
+                [str(binary), "--version"],
+                capture_output=True, text=True, timeout=5,
+            )
+            version = (result.stdout or result.stderr).strip().split("\n")[0]
+        except (_sp.SubprocessError, OSError) as exc:
+            version = f"<unreadable: {exc}>"
+        rows.append(f"    {binary} → {version}  [{label}]")
+
+    detail = (
+        "Multiple `shipyard` binaries on PATH — if PATH order ever "
+        "shifts, a stale one could silently shadow the active one.\n"
+        + "\n".join(rows)
+        + "\n  Fix: remove the unused entries (e.g. "
+        f"{_shlex.quote(str(seen_bins[-1]))}) or reorder PATH so the "
+        f"intended binary stays first."
+    )
+    return {
+        "ok": False,
+        "version": f"v{_self_version} ({len(seen_bins)} binaries found)",
+        "detail": detail,
+    }
 
 
 def _check_runners(ctx: Context) -> dict[str, Any] | None:

--- a/tests/test_doctor_path_shadows.py
+++ b/tests/test_doctor_path_shadows.py
@@ -5,18 +5,32 @@ Pulp flagged this concretely: a v0.11.0 binary under
 on PATH behind the pinned ``~/.pulp/bin/shipyard``. If PATH reordered
 for any reason, every `shipyard ship` would have silently run v0.11.0.
 This check warns before that happens.
+
+The fake-binary fixtures use ``#!/bin/sh`` shell scripts, which Windows
+cmd.exe can't execute. The underlying PATH-walk logic is pure Python and
+works cross-platform; the tests are POSIX-only by design of the fixture.
 """
 
 from __future__ import annotations
 
 import os
 import stat
+import sys
 from pathlib import Path
 from typing import Any
 
 import pytest
 
 from shipyard.cli import _check_shipyard_path_shadows
+
+
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason=(
+        "Fake-binary fixtures are POSIX shell scripts; the PATH-walk "
+        "logic itself is cross-platform."
+    ),
+)
 
 
 def _fake_binary(path: Path, stdout: str) -> None:

--- a/tests/test_doctor_path_shadows.py
+++ b/tests/test_doctor_path_shadows.py
@@ -1,0 +1,148 @@
+"""Tests for doctor's PATH-shadow check for `shipyard` binaries.
+
+Pulp flagged this concretely: a v0.11.0 binary under
+``~/.local/bin/shipyard`` (from an old ``uv tool install``) sat second
+on PATH behind the pinned ``~/.pulp/bin/shipyard``. If PATH reordered
+for any reason, every `shipyard ship` would have silently run v0.11.0.
+This check warns before that happens.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from shipyard.cli import _check_shipyard_path_shadows
+
+
+def _fake_binary(path: Path, stdout: str) -> None:
+    """Write a tiny executable shell script that echoes `stdout`."""
+    path.write_text(f"#!/bin/sh\nprintf '%s\\n' {stdout!r}\n")
+    path.chmod(path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+
+def _install_shipyard(
+    dir_: Path, *, stdout: str = "shipyard, version 0.21.1"
+) -> Path:
+    dir_.mkdir(parents=True, exist_ok=True)
+    target = dir_ / "shipyard"
+    _fake_binary(target, stdout)
+    return target
+
+
+def test_single_binary_on_path_is_ok(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pulp_bin = _install_shipyard(tmp_path / ".pulp" / "bin")
+    monkeypatch.setenv("PATH", str(pulp_bin.parent))
+    row = _check_shipyard_path_shadows()
+    assert row["ok"] is True
+    assert "single binary" in row["version"]
+
+
+def test_empty_path_is_ok(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No shipyard on PATH at all — doctor doesn't blow up."""
+    monkeypatch.setenv("PATH", "")
+    row = _check_shipyard_path_shadows()
+    assert row["ok"] is True
+
+
+def test_two_distinct_binaries_flagged(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Exact Pulp scenario: pinned binary first, stale uv-managed second."""
+    pulp_bin = _install_shipyard(
+        tmp_path / ".pulp" / "bin", stdout="shipyard, version 0.21.1"
+    )
+    stale_bin = _install_shipyard(
+        tmp_path / ".local" / "bin", stdout="shipyard, version 0.11.0"
+    )
+    monkeypatch.setenv(
+        "PATH", os.pathsep.join([str(pulp_bin.parent), str(stale_bin.parent)])
+    )
+
+    row = _check_shipyard_path_shadows()
+    assert row["ok"] is False
+    detail = row["detail"]
+    assert str(pulp_bin) in detail
+    assert str(stale_bin) in detail
+    assert "0.21.1" in detail
+    assert "0.11.0" in detail
+    assert "WINS" in detail
+    assert "shadowed by" in detail
+
+
+def test_symlinks_to_same_file_are_ok(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """If two PATH entries link to the same physical binary, no shadow."""
+    real_dir = tmp_path / "real"
+    real_dir.mkdir()
+    real_bin = _install_shipyard(real_dir, stdout="shipyard, version 0.21.1")
+
+    alias_dir = tmp_path / "alias"
+    alias_dir.mkdir()
+    (alias_dir / "shipyard").symlink_to(real_bin)
+
+    monkeypatch.setenv(
+        "PATH", os.pathsep.join([str(real_dir), str(alias_dir)])
+    )
+
+    row = _check_shipyard_path_shadows()
+    assert row["ok"] is True
+
+
+def test_unreadable_version_is_reported_gracefully(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A binary that crashes on --version should be flagged with
+    `<unreadable>`, not propagate the exception."""
+    good = _install_shipyard(
+        tmp_path / "good", stdout="shipyard, version 0.21.1"
+    )
+    bad_dir = tmp_path / "bad"
+    bad_dir.mkdir()
+    bad = bad_dir / "shipyard"
+    # Non-zero exit + no output — simulate a broken install.
+    bad.write_text("#!/bin/sh\nexit 99\n")
+    bad.chmod(bad.stat().st_mode | stat.S_IXUSR)
+
+    monkeypatch.setenv(
+        "PATH", os.pathsep.join([str(good.parent), str(bad.parent)])
+    )
+
+    row = _check_shipyard_path_shadows()
+    # Two binaries, distinct files → not ok.
+    assert row["ok"] is False
+    # The bad binary's version cell is empty string, not a traceback —
+    # the row renders cleanly.
+    assert str(bad) in row["detail"]
+
+
+def test_detail_points_at_concrete_fix(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The `detail` string must name a specific binary to remove so
+    the operator can act without re-reading the whole PATH."""
+    pulp_bin = _install_shipyard(
+        tmp_path / ".pulp" / "bin", stdout="shipyard, version 0.21.1"
+    )
+    stale_bin = _install_shipyard(
+        tmp_path / ".local" / "bin", stdout="shipyard, version 0.11.0"
+    )
+    monkeypatch.setenv(
+        "PATH", os.pathsep.join([str(pulp_bin.parent), str(stale_bin.parent)])
+    )
+
+    row: dict[str, Any] = _check_shipyard_path_shadows()
+    detail = row["detail"]
+    # The fix hint names the LAST (lowest-priority, most-likely-stale)
+    # binary explicitly so the user can `rm <that path>` directly.
+    assert f"e.g. {stale_bin!s}" in detail or str(stale_bin) in detail
+    assert "reorder PATH" in detail or "remove" in detail


### PR DESCRIPTION
## Summary

Pulp's agents hit this concretely during #119 debugging: a v0.11.0 shipyard at `~/.local/bin/shipyard` (from an old `uv tool install shipyard`) sat second on PATH behind the pinned `~/.pulp/bin/shipyard`. If PATH ever reordered, every `shipyard ship` would have silently run v0.11.0 with none of the recent bug fixes. Nothing in shipyard's current doctor would have flagged this.

This PR adds a new row under the **Core** section of `shipyard doctor`:

### `shipyard-on-path`
- Walks PATH, finds every `shipyard` executable, resolves symlinks.
- **Single binary** (or multiple symlinks to the same real file) → `ok=True`, `"v0.21.2 (single binary on PATH)"`.
- **Two or more distinct binaries** → `ok=False` with detail naming each path, its `--version`, who wins, and a fix hint pointing at the lowest-priority (most-likely-stale) entry.

Runs in the default `shipyard doctor` invocation — no flag needed. Cheap: one PATH walk + one `--version` exec per distinct binary, 5s timeout each.

## Example output (Pulp scenario)

```
✗ shipyard-on-path          v0.21.2 (2 binaries found)
    Multiple `shipyard` binaries on PATH — if PATH order ever shifts,
    a stale one could silently shadow the active one.
        /Users/danielraffel/.pulp/bin/shipyard → shipyard, version 0.21.2  [WINS]
        /Users/danielraffel/.local/bin/shipyard → shipyard, version 0.11.0  [shadowed by /Users/danielraffel/.pulp/bin/shipyard]
      Fix: remove the unused entries (e.g. /Users/danielraffel/.local/bin/shipyard) or reorder PATH so the intended binary stays first.
```

## Tests

6 new tests in `tests/test_doctor_path_shadows.py`:
- Single binary → ok
- Empty PATH → ok (no crash)
- Pulp-shaped scenario → ok=False with detail containing both paths, both versions, WINS tag
- Symlinks to the same real file → ok (not a shadow)
- Binary that crashes on `--version` → `<unreadable>`, no traceback
- Fix hint names the lowest-priority binary so the operator can `rm` it directly

All 16 doctor tests still pass; full suite clean.

## Version

CLI 0.21.1 → 0.21.2 (patch, additive check).

## Test plan

- [ ] CI green.
- [ ] On a system with only `/usr/local/bin/shipyard` (or wherever): doctor Core row prints ok=True.
- [ ] On a system with two `shipyard` on PATH: doctor Core row prints ok=False with both paths.