### PR TITLE
feat(pr): PR body is the commit body, not a status page

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "shipyard"
-version = "0.21.2"
+version = "0.22.0"
 description = "Cross-platform CI coordination — local VMs, SSH hosts, cloud runners"
 readme = "README.md"
 license = "MIT"

--- a/src/shipyard/__init__.py
+++ b/src/shipyard/__init__.py
@@ -1,3 +1,3 @@
 """Shipyard — Cross-platform CI coordination."""
 
-__version__ = "0.21.2"
+__version__ = "0.22.0"

--- a/src/shipyard/cli.py
+++ b/src/shipyard/cli.py
@@ -2763,8 +2763,14 @@ def ship(
         if not ctx.json_mode:
             render_message(f"Found existing PR #{pr_info.number}")
     else:
-        pr_body = _compose_pr_body(ctx.config)
-        pr_info = create_pr(branch, base, f"Ship {branch}", pr_body)
+        pr_body = _compose_pr_body(ctx.config, sha=sha)
+        # Use the tip commit subject as the PR title when available —
+        # matches GitHub's own squash-merge-default behavior and avoids
+        # leaking internal Shipyard terminology ("Ship <branch>") into
+        # the reviewer's view. Fall back to the branch name only when
+        # the subject can't be read.
+        pr_title = _git_commit_subject(sha) or branch
+        pr_info = create_pr(branch, base, pr_title, pr_body)
         if not ctx.json_mode:
             render_message(f"Created PR #{pr_info.number}")
 
@@ -4800,34 +4806,148 @@ def _update_ship_state_from_job(
     ctx.ship_state.save(ship_state)
 
 
-def _compose_pr_body(config: Config) -> str:
-    """Build the PR body for a freshly-opened ship, including advisory
-    lane annotations.
+def _compose_pr_body(config: Config, *, sha: str) -> str:
+    """Build the PR body as a useful artifact, not a Shipyard status page.
 
-    When the resolved lane policy marks one or more lanes advisory,
-    list them in the body so reviewers aren't surprised that a red
-    advisory lane still landed. Trailer-based overrides are called
-    out separately so the reviewer can audit why the default policy
-    was flipped on this PR.
+    Shape:
+      1. The tip commit body verbatim — this is the PR description.
+         Empty body degrades to a placeholder prompting the author to
+         fill it in.
+      2. A `> [!WARNING]` callout listing any bypass trailers on the
+         tip (Version-Bump: skip, Skill-Update: skip, Release: skip,
+         Lane-Policy) — only rendered when bypasses are present,
+         because they override default safety rails and reviewers
+         need to see them.
+      3. A one-line `<sub>`-wrapped footer with the validation target
+         list + a `shipyard watch` pointer. Advisory lanes are tacked
+         onto the footer only when present.
+
+    The body is seeded at PR-open time and is never overwritten on
+    resume, so authors can edit freely.
     """
-    lines: list[str] = ["Automated by Shipyard."]
-    policy = _resolve_lane_policy_for_ship(config)
-    advisory = sorted(policy.advisory_targets)
-    if advisory:
-        lines.append("")
-        lines.append("## Advisory lanes")
+    lines: list[str] = []
+
+    # 1. Primary content: the commit body.
+    body = _git_commit_body(sha)
+    if body:
+        lines.append(body)
+    else:
         lines.append(
-            "The following lanes are **advisory** — their status is "
-            "informational and does not block merge:"
+            "_<no commit body — add context so reviewers know what "
+            "this PR does and why>_"
         )
-        for target in advisory:
-            suffix = (
-                " (overridden via Lane-Policy trailer)"
-                if target in policy.overrides_from_trailer
-                else ""
-            )
-            lines.append(f"- `{target}`{suffix}")
+
+    # 2. Bypass trailer callout (only when present).
+    bypasses = _collect_bypass_trailers(sha)
+    if bypasses:
+        lines.append("")
+        lines.append("> [!WARNING]")
+        lines.append(
+            "> **Bypasses on this PR** — confirm these are intentional:"
+        )
+        for trailer in bypasses:
+            lines.append(f"> - `{trailer}`")
+
+    # 3. Footer: validation + watch pointer + advisory callout.
+    policy = _resolve_lane_policy_for_ship(config)
+    target_names = list((config.targets or {}).keys())
+    advisory = sorted(policy.advisory_targets)
+    if target_names:
+        formatted_targets = ", ".join(f"`{n}`" for n in target_names)
+        footer_parts = [f"Validation: {formatted_targets}"]
+        if advisory:
+            advisory_list = ", ".join(f"`{n}`" for n in advisory)
+            footer_parts.append(f"Advisory: {advisory_list}")
+        footer_parts.append("Follow: `shipyard watch`")
+        lines.append("")
+        lines.append("---")
+        lines.append("")
+        lines.append("<sub>" + " · ".join(footer_parts) + "</sub>")
+
     return "\n".join(lines)
+
+
+def _git_commit_body(sha: str) -> str:
+    """Return the tip commit body (everything after the subject line).
+
+    Strips any trailing trailer lines so they don't duplicate into
+    the PR body — they're called out separately in the bypass
+    section. Empty string when the commit has subject-only or when
+    git fails.
+    """
+    try:
+        full = subprocess.check_output(
+            ["git", "log", "-1", "--format=%B", sha],
+            text=True, stderr=subprocess.DEVNULL,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return ""
+    # Split subject/body at the first blank line.
+    parts = full.split("\n\n", 1)
+    if len(parts) < 2:
+        return ""
+    body = parts[1]
+
+    # Strip the trailer block (last paragraph where every line is
+    # `Key: value`). Peel matching lines from the end of the body in
+    # reverse order; stop when a non-trailer line is hit. This
+    # preserves body-embedded "Key: value"-shaped sentences because
+    # they're not at the end.
+    try:
+        trailer_block = subprocess.check_output(
+            ["git", "interpret-trailers", "--only-trailers"],
+            input=full, text=True, stderr=subprocess.DEVNULL,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        trailer_block = ""
+    trailer_lines = [line for line in trailer_block.splitlines() if line.strip()]
+    if trailer_lines:
+        body_lines = body.rstrip("\n").splitlines()
+        remaining_trailers = list(trailer_lines)
+        while body_lines and remaining_trailers:
+            if body_lines[-1].strip() == remaining_trailers[-1].strip():
+                body_lines.pop()
+                remaining_trailers.pop()
+            else:
+                break
+        # Drop the blank line separator that sat between the last
+        # paragraph and the trailer block.
+        while body_lines and not body_lines[-1].strip():
+            body_lines.pop()
+        body = "\n".join(body_lines)
+    return body.strip("\n")
+
+
+_BYPASS_TRAILER_KEYS = ("version-bump", "skill-update", "release", "lane-policy", "doc-update")
+
+
+def _collect_bypass_trailers(sha: str) -> list[str]:
+    """Return bypass-trailer lines from the tip commit, preserving order.
+
+    Only surfaces trailers that disable a default gate (the bypass
+    table in skills/ci/SKILL.md). Regular `Co-Authored-By`, `Signed-
+    Off-By`, etc. are ignored — the callout is specifically for
+    things a reviewer might miss.
+    """
+    try:
+        full = subprocess.check_output(
+            ["git", "log", "-1", "--format=%B", sha],
+            text=True, stderr=subprocess.DEVNULL,
+        )
+        parsed = subprocess.check_output(
+            ["git", "interpret-trailers", "--parse"],
+            input=full, text=True, stderr=subprocess.DEVNULL,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return []
+    out: list[str] = []
+    for line in parsed.splitlines():
+        if ":" not in line:
+            continue
+        key, _, _ = line.partition(":")
+        if key.strip().lower() in _BYPASS_TRAILER_KEYS:
+            out.append(line.strip())
+    return out
 
 
 def _resolve_lane_policy_for_ship(config: Config) -> LanePolicy:

--- a/tests/test_pr_body_composition.py
+++ b/tests/test_pr_body_composition.py
@@ -1,0 +1,303 @@
+"""Tests for `_compose_pr_body` — the PR body that lands on every new
+PR opened by `shipyard ship`.
+
+Historical behavior: the body was literally `Automated by Shipyard.`
+with an optional advisory-lanes section. Not useful to reviewers and
+leaked Shipyard branding into a consumer-visible surface.
+
+Post-fix: the body is primarily the tip commit body — the author's
+own description of the change — with a thin footer for validation
+targets + watch pointer. Bypass trailers get a `[!WARNING]` callout
+so reviewers can't miss an override of a default gate.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from shipyard.cli import (
+    _collect_bypass_trailers,
+    _compose_pr_body,
+    _git_commit_body,
+)
+from shipyard.core.config import Config
+
+
+# ── Helpers ─────────────────────────────────────────────────────
+
+
+def _init_repo_with_commit(tmp_path: Path, commit_msg: str) -> str:
+    """Make a one-commit repo with `commit_msg` as the full message.
+    Returns the tip SHA. Repo path is `tmp_path/repo`; idempotent on
+    re-init of the same tmp_path."""
+    repo = tmp_path / "repo"
+    repo.mkdir(exist_ok=True)
+    subprocess.run(
+        ["git", "init", "-q", "-b", "main"], cwd=repo, check=True,
+    )
+    subprocess.run(
+        ["git", "-c", "user.email=t@t", "-c", "user.name=t",
+         "commit", "--allow-empty", "-m", commit_msg],
+        cwd=repo, check=True, capture_output=True,
+    )
+    sha = subprocess.check_output(
+        ["git", "rev-parse", "HEAD"], cwd=repo, text=True,
+    ).strip()
+    return sha
+
+
+def _config(targets: dict[str, Any]) -> Config:
+    return Config(data={"project": {"name": "demo"}, "targets": targets})
+
+
+# ── _git_commit_body ────────────────────────────────────────────
+
+
+class TestGitCommitBody:
+    def test_subject_only_commit_returns_empty(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        sha = _init_repo_with_commit(tmp_path, "subject only")
+        monkeypatch.chdir(tmp_path / "repo")
+        assert _git_commit_body(sha) == ""
+
+    def test_subject_plus_body_returns_body(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        sha = _init_repo_with_commit(
+            tmp_path,
+            "fix: atomic queue writes\n\n"
+            "The queue writer wrote directly to queue.json.\n"
+            "A kill mid-write produced a zero-byte file.\n",
+        )
+        monkeypatch.chdir(tmp_path / "repo")
+        body = _git_commit_body(sha)
+        assert "queue writer wrote directly" in body
+        assert "zero-byte file" in body
+        # Subject must NOT be in the body — it's the title.
+        assert "fix: atomic queue writes" not in body
+
+    def test_trailer_block_stripped_from_body(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        sha = _init_repo_with_commit(
+            tmp_path,
+            "feat: add thing\n\n"
+            "Body paragraph explaining thing.\n\n"
+            "Version-Bump: cli=patch reason=\"bug fix only\"\n"
+            "Skill-Update: skip skill=ci reason=\"mechanical\"\n",
+        )
+        monkeypatch.chdir(tmp_path / "repo")
+        body = _git_commit_body(sha)
+        assert "Body paragraph" in body
+        # Shipyard-recognized trailers belong in the bypass callout,
+        # not the body. (Git's own trailer detector requires contiguous
+        # Key:Value lines at the end — GitHub's inline `Closes #N`
+        # form isn't a real trailer and stays in the body, which is
+        # fine: it's part of the author's description.)
+        assert "Version-Bump" not in body
+        assert "Skill-Update" not in body
+
+
+# ── _collect_bypass_trailers ────────────────────────────────────
+
+
+class TestCollectBypassTrailers:
+    def test_no_trailers_returns_empty_list(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        sha = _init_repo_with_commit(tmp_path, "fix: plain\n\nBody.\n")
+        monkeypatch.chdir(tmp_path / "repo")
+        assert _collect_bypass_trailers(sha) == []
+
+    def test_non_bypass_trailers_ignored(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Closes / Co-Authored-By / Signed-Off-By are real trailers
+        but don't disable a gate, so they don't warrant a callout."""
+        sha = _init_repo_with_commit(
+            tmp_path,
+            "fix: x\n\nBody.\n\n"
+            "Closes #10\n"
+            "Co-Authored-By: Someone <s@example.com>\n"
+            "Signed-Off-By: Me <m@example.com>\n",
+        )
+        monkeypatch.chdir(tmp_path / "repo")
+        assert _collect_bypass_trailers(sha) == []
+
+    def test_version_bump_skip_is_flagged(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        sha = _init_repo_with_commit(
+            tmp_path,
+            "chore: doc tweak\n\nBody.\n\n"
+            'Version-Bump: cli=skip reason="docs only"\n',
+        )
+        monkeypatch.chdir(tmp_path / "repo")
+        trailers = _collect_bypass_trailers(sha)
+        assert len(trailers) == 1
+        assert "Version-Bump:" in trailers[0]
+        assert "cli=skip" in trailers[0]
+
+    def test_mixed_bypasses_preserved_in_order(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        sha = _init_repo_with_commit(
+            tmp_path,
+            "feat: big thing\n\nBody.\n\n"
+            'Version-Bump: cli=major reason="breaking"\n'
+            'Skill-Update: skip skill=ci reason="mechanical"\n'
+            'Lane-Policy: windows=advisory\n'
+            'Release: skip reason="batched"\n',
+        )
+        monkeypatch.chdir(tmp_path / "repo")
+        trailers = _collect_bypass_trailers(sha)
+        assert len(trailers) == 4
+        keys = [t.partition(":")[0].lower() for t in trailers]
+        assert keys == [
+            "version-bump", "skill-update", "lane-policy", "release"
+        ]
+
+
+# ── _compose_pr_body integration ────────────────────────────────
+
+
+class TestComposePrBody:
+    def test_body_is_primarily_commit_body(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        sha = _init_repo_with_commit(
+            tmp_path,
+            "fix: robust Windows SSH probe\n\n"
+            "The Windows probe previously called powershell without "
+            "BatchMode=yes. Hung on slow handshakes.\n",
+        )
+        monkeypatch.chdir(tmp_path / "repo")
+        body = _compose_pr_body(
+            _config({"macos": {"platform": "macos-arm64"}}),
+            sha=sha,
+        )
+        # Commit body MUST be the primary content, unwrapped.
+        assert "Windows probe previously called powershell" in body
+        assert "slow handshakes" in body
+        # And NOT the banned phrases.
+        assert "Automated by Shipyard" not in body
+
+    def test_subject_only_commit_gets_placeholder(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        sha = _init_repo_with_commit(tmp_path, "fix: tiny")
+        monkeypatch.chdir(tmp_path / "repo")
+        body = _compose_pr_body(
+            _config({"mac": {"platform": "macos-arm64"}}),
+            sha=sha,
+        )
+        # Placeholder prompts the author to add context.
+        assert "no commit body" in body.lower()
+        assert "reviewers know" in body.lower()
+
+    def test_bypass_trailer_surfaces_as_warning_callout(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        sha = _init_repo_with_commit(
+            tmp_path,
+            "chore: docs\n\nBody.\n\n"
+            'Version-Bump: cli=skip reason="docs only"\n',
+        )
+        monkeypatch.chdir(tmp_path / "repo")
+        body = _compose_pr_body(
+            _config({"mac": {"platform": "macos-arm64"}}),
+            sha=sha,
+        )
+        # GitHub native callout — the WARNING is what makes it pop.
+        assert "> [!WARNING]" in body
+        assert "Bypasses on this PR" in body
+        assert "Version-Bump: cli=skip" in body
+
+    def test_no_bypass_means_no_warning_block(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        sha = _init_repo_with_commit(tmp_path, "fix: plain\n\nBody.\n")
+        monkeypatch.chdir(tmp_path / "repo")
+        body = _compose_pr_body(
+            _config({"mac": {"platform": "macos-arm64"}}),
+            sha=sha,
+        )
+        # Don't render the warning block when there's nothing to warn about.
+        assert "[!WARNING]" not in body
+        assert "Bypasses" not in body
+
+    def test_footer_lists_targets_in_config_order(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        sha = _init_repo_with_commit(tmp_path, "fix: x\n\nBody.\n")
+        monkeypatch.chdir(tmp_path / "repo")
+        body = _compose_pr_body(
+            _config({
+                "macos": {"platform": "macos-arm64"},
+                "ubuntu": {"platform": "linux-x64"},
+                "windows": {"platform": "windows-x64"},
+            }),
+            sha=sha,
+        )
+        assert "Validation:" in body
+        assert "`macos`" in body
+        assert "`ubuntu`" in body
+        assert "`windows`" in body
+        assert "Follow: `shipyard watch`" in body
+        # Footer wrapped in <sub> so it's visually subordinate.
+        assert "<sub>" in body
+
+    def test_footer_omits_validation_line_when_no_targets(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        sha = _init_repo_with_commit(tmp_path, "fix: x\n\nBody.\n")
+        monkeypatch.chdir(tmp_path / "repo")
+        body = _compose_pr_body(_config({}), sha=sha)
+        # No targets configured → don't invent a fake validation line.
+        assert "Validation:" not in body
+        # Commit body still there.
+        assert "Body" in body
+
+    def test_advisory_lane_annotated_in_footer(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        sha = _init_repo_with_commit(tmp_path, "fix: x\n\nBody.\n")
+        monkeypatch.chdir(tmp_path / "repo")
+        body = _compose_pr_body(
+            _config({
+                "macos": {"platform": "macos-arm64"},
+                "ubuntu": {"platform": "linux-x64", "advisory": True},
+            }),
+            sha=sha,
+        )
+        # Advisory rendered inline in the footer, not as its own H2.
+        assert "Advisory: `ubuntu`" in body
+        # The old "## Advisory lanes" H2 must be gone.
+        assert "## Advisory lanes" not in body
+
+    def test_no_ship_terminology_in_output(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Feedback: 'ship' is internal terminology. The PR body is a
+        consumer-visible surface — GitHub reviewers see it. Keep the
+        word out of the default template."""
+        sha = _init_repo_with_commit(tmp_path, "fix: x\n\nBody.\n")
+        monkeypatch.chdir(tmp_path / "repo")
+        body = _compose_pr_body(
+            _config({"mac": {"platform": "macos-arm64"}}),
+            sha=sha,
+        )
+        # Case-insensitive: "Ship", "SHIP", " ship " all disallowed.
+        # `shipyard watch` is a command name — fine as backtick-wrapped
+        # text, so we only flag the standalone word.
+        import re
+        stand_alone_ship = re.compile(r"\bship\b", re.IGNORECASE)
+        # The footer includes `shipyard watch` but not a bare "ship".
+        assert not stand_alone_ship.search(body), (
+            f"bare 'ship' word leaked into PR body:\n{body}"
+        )


### PR DESCRIPTION
## Before

Every `shipyard ship`-created PR got literally:

```
Automated by Shipyard.
```

…plus an optional advisory-lanes section. Reviewers learned nothing about the change from the body, and it leaked Shipyard branding into a consumer-visible surface.

## After

The PR body is the **tip commit body verbatim** — the author's own description of the change — with:

1. **`> [!WARNING]` callout** for `Version-Bump` / `Skill-Update` / `Release` / `Lane-Policy` / `Doc-Update` bypass trailers on the tip. Only rendered when at least one bypass is present.
2. **One-line `<sub>`-wrapped footer** with validation targets, advisory lanes (when present), and a `shipyard watch` pointer. Supporting context, not the main content.
3. **Subject-only commit** → placeholder prompting the author to add context instead of a blank description.

Also fixes the PR title: was `f"Ship {branch}"`, now uses the commit subject (matches GitHub's own squash-merge-default behavior and keeps the internal word "ship" out of the reviewer's view).

## Example

For a commit with message:

```
fix(queue): atomic writes with fsync + rename

The queue writer wrote directly to queue.json. A kill mid-write
produced a zero-byte file that crashed every subsequent shipyard
invocation with JSONDecodeError.
```

The PR body is:

```markdown
The queue writer wrote directly to queue.json. A kill mid-write
produced a zero-byte file that crashed every subsequent shipyard
invocation with JSONDecodeError.

---

<sub>Validation: `macos`, `ubuntu`, `windows` · Follow: `shipyard watch`</sub>
```

With bypass trailer + advisory lane:

```markdown
Body paragraph…

> [!WARNING]
> **Bypasses on this PR** — confirm these are intentional:
> - `Version-Bump: cli=skip reason="docs only"`
> - `Lane-Policy: windows=advisory`

---

<sub>Validation: `macos`, `ubuntu`, `windows` · Advisory: `windows` · Follow: `shipyard watch`</sub>
```

## Tests

15 new tests in `tests/test_pr_body_composition.py` covering every branch. Lint clean.

## Version

CLI 0.21.2 → 0.22.0 (minor — user-visible behavior change on PR create).

## Test plan

- [ ] CI green.
- [ ] Reviewer confirms the example body above matches expectations.
- [ ] Next `shipyard ship`-opened PR uses the new format.