### PR TITLE
Add `shipyard daemon`: webhook receiver with Tailscale Funnel + local IPC (#125)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "shipyard"
-version = "0.21.2"
+version = "0.22.0"
 description = "Cross-platform CI coordination — local VMs, SSH hosts, cloud runners"
 readme = "README.md"
 license = "MIT"

--- a/src/shipyard/__init__.py
+++ b/src/shipyard/__init__.py
@@ -1,3 +1,3 @@
 """Shipyard — Cross-platform CI coordination."""
 
-__version__ = "0.21.2"
+__version__ = "0.22.0"

--- a/src/shipyard/cli.py
+++ b/src/shipyard/cli.py
@@ -6211,5 +6211,137 @@ def release_bot_hook_run(ctx: Context, tag: str | None) -> None:
         sys.exit(1)
 
 
+# --- shipyard daemon ------------------------------------------------
+#
+# Webhook receiver daemon — see Shipyard issue #125. Runs a local
+# webhook server behind a Tailscale Funnel tunnel, registers GitHub
+# webhooks on tracked repos, and fans out events to IPC subscribers
+# (including the macOS menu-bar app and other shipyard CLI
+# invocations).
+
+
+@main.group()
+def daemon() -> None:
+    """Run the live-mode webhook receiver + IPC event broker."""
+
+
+@daemon.command("start")
+@click.option(
+    "--repo",
+    "repos",
+    multiple=True,
+    help="Repo(s) to register webhooks on (overrides ship-state detection)",
+)
+@click.option(
+    "--detach/--no-detach",
+    default=True,
+    help="Fork into the background (default). Use --no-detach for dev/debug.",
+)
+@pass_context
+def daemon_start(ctx: Context, repos: tuple[str, ...], detach: bool) -> None:
+    """Start the webhook daemon."""
+    import os as _os
+
+    from shipyard.daemon.runner import run_blocking, spawn_detached
+
+    repo_list = _resolve_repo_list(ctx, repos)
+    state_dir = ctx.config.state_dir
+    if detach:
+        pid = spawn_detached(state_dir=state_dir, repos=repo_list)
+        if ctx.json_mode:
+            ctx.output("daemon:start", {"pid": pid, "repos": repo_list})
+        else:
+            render_message(
+                f"daemon started (pid {pid}); registering {len(repo_list)} repo(s).",
+                style="green",
+            )
+        return
+    # Foreground mode — helpful for `shipyard daemon run`-equivalent
+    # debugging. Blocks until SIGINT/SIGTERM.
+    _os.environ.setdefault("SHIPYARD_DAEMON_FOREGROUND", "1")
+    exit_code = run_blocking(state_dir=state_dir, repos=repo_list)
+    if exit_code != 0:
+        sys.exit(exit_code)
+
+
+@daemon.command("run")
+@click.option("--repo", "repos", multiple=True)
+@pass_context
+def daemon_run(ctx: Context, repos: tuple[str, ...]) -> None:
+    """Run the daemon in the foreground (logs to stdout). Useful for
+    systemd / launchd unit files and for debugging."""
+    from shipyard.daemon.runner import run_blocking
+
+    repo_list = _resolve_repo_list(ctx, repos)
+    exit_code = run_blocking(state_dir=ctx.config.state_dir, repos=repo_list)
+    if exit_code != 0:
+        sys.exit(exit_code)
+
+
+@daemon.command("stop")
+@pass_context
+def daemon_stop(ctx: Context) -> None:
+    """Ask a running daemon to exit gracefully."""
+    from shipyard.daemon.runner import stop_running
+
+    state_dir = ctx.config.state_dir
+    stopped = stop_running(state_dir)
+    if ctx.json_mode:
+        ctx.output("daemon:stop", {"stopped": stopped})
+    else:
+        if stopped:
+            render_message("daemon stopped.", style="green")
+        else:
+            render_message("daemon wasn't running.", style="dim")
+
+
+@daemon.command("status")
+@pass_context
+def daemon_status(ctx: Context) -> None:
+    """Report whether the daemon is running + tunnel + subscribers."""
+    from shipyard.daemon.controller import read_daemon_status
+
+    status = read_daemon_status(ctx.config.state_dir)
+    if status is None:
+        if ctx.json_mode:
+            ctx.output("daemon:status", {"running": False})
+        else:
+            render_message("daemon is not running.", style="dim")
+        return
+    if ctx.json_mode:
+        ctx.output("daemon:status", {"running": True, **status})
+    else:
+        tunnel = status.get("tunnel") or {}
+        url = tunnel.get("url") or "—"
+        backend = tunnel.get("backend") or "—"
+        subs = status.get("subscribers", 0)
+        repos_text = ", ".join(status.get("registered_repos") or []) or "—"
+        render_message(
+            f"daemon running · tunnel={backend} · {url}\n"
+            f"subscribers={subs} · repos={repos_text}",
+            style="green",
+        )
+
+
+def _resolve_repo_list(ctx: Context, explicit: tuple[str, ...]) -> list[str]:
+    """If the user passed `--repo` args, honor them. Otherwise derive
+    the list from the ship-state store so the daemon registers hooks
+    on every repo the user has shipped from this machine."""
+    if explicit:
+        return list(explicit)
+    try:
+        states = ctx.ship_state.list_active()
+    except Exception:  # pragma: no cover — defensive against uninit state dir
+        return []
+    repos: list[str] = []
+    seen: set[str] = set()
+    for state in states:
+        repo = getattr(state, "repo", None)
+        if repo and repo not in seen:
+            seen.add(repo)
+            repos.append(repo)
+    return repos
+
+
 if __name__ == "__main__":
     main()

--- a/src/shipyard/cli.py
+++ b/src/shipyard/cli.py
@@ -6311,11 +6311,16 @@ def daemon_status(ctx: Context) -> None:
     if ctx.json_mode:
         ctx.output("daemon:status", {"running": True, **status})
     else:
-        tunnel = status.get("tunnel") or {}
+        tunnel_raw = status.get("tunnel")
+        tunnel: dict[str, Any] = tunnel_raw if isinstance(tunnel_raw, dict) else {}
         url = tunnel.get("url") or "—"
         backend = tunnel.get("backend") or "—"
         subs = status.get("subscribers", 0)
-        repos_text = ", ".join(status.get("registered_repos") or []) or "—"
+        repos_raw = status.get("registered_repos")
+        repos_list: list[str] = [
+            str(r) for r in (repos_raw if isinstance(repos_raw, list) else [])
+        ]
+        repos_text = ", ".join(repos_list) or "—"
         render_message(
             f"daemon running · tunnel={backend} · {url}\n"
             f"subscribers={subs} · repos={repos_text}",

--- a/src/shipyard/daemon/__init__.py
+++ b/src/shipyard/daemon/__init__.py
@@ -1,0 +1,14 @@
+"""Webhook receiver daemon.
+
+Ports the live-mode pipeline originally implemented in the macOS menu-
+bar app (``shipyard-macos-gui``) so it can run on any platform and be
+consumed by any CLI command. See Shipyard issue #125 for the design
+and tracking. The GUI becomes a thin subscriber to this daemon.
+
+The daemon is composed of several small modules that mirror the Swift
+implementation; the goal is byte-for-byte behavioral parity on the
+things that matter (HMAC validation, event decoding, Tailscale
+readiness rules, idempotent tunnel reconcile) so the macOS app can
+swap its in-process webhook server for a subprocess without users
+noticing.
+"""

--- a/src/shipyard/daemon/controller.py
+++ b/src/shipyard/daemon/controller.py
@@ -40,6 +40,7 @@ from shipyard.daemon.tunnels.base import TunnelInfo, TunnelNotReadyError, Tunnel
 from shipyard.daemon.tunnels.tailscale import TailscaleFunnelBackend
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
     from pathlib import Path
 
 logger = logging.getLogger(__name__)
@@ -228,7 +229,9 @@ class _DaemonPaths:
         self.root.mkdir(parents=True, exist_ok=True)
 
 
-def _make_delivery_handler(secret: str, daemon: Daemon):
+def _make_delivery_handler(
+    secret: str, daemon: Daemon
+) -> Callable[[dict[str, str], bytes], HandlerResult]:
     """Produce a callback suitable for ``WebhookServer``.
 
     The HTTP server runs on a background thread; we schedule the

--- a/src/shipyard/daemon/controller.py
+++ b/src/shipyard/daemon/controller.py
@@ -21,13 +21,14 @@ State directory layout::
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 import logging
 import os
 import signal
 import time
 from dataclasses import dataclass
-from pathlib import Path
+from typing import TYPE_CHECKING
 
 from shipyard.daemon import events as events_mod
 from shipyard.daemon import secrets as secrets_mod
@@ -37,6 +38,9 @@ from shipyard.daemon.registrar import Registrar, RegistrarError
 from shipyard.daemon.server import HandlerResult, WebhookServer
 from shipyard.daemon.tunnels.base import TunnelInfo, TunnelNotReadyError, TunnelStartError
 from shipyard.daemon.tunnels.tailscale import TailscaleFunnelBackend
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
@@ -130,11 +134,11 @@ class Daemon:
         """Block until a stop is requested."""
         loop = asyncio.get_running_loop()
         for sig in (signal.SIGINT, signal.SIGTERM):
-            try:
+            # Windows doesn't support add_signal_handler — suppress so
+            # CI on Windows can at least reach the wait path (even
+            # though the daemon as a whole isn't Windows-supported).
+            with contextlib.suppress(NotImplementedError):
                 loop.add_signal_handler(sig, lambda: self._stop_event.set())
-            except NotImplementedError:
-                # Windows doesn't support add_signal_handler.
-                pass
         await self._stop_event.wait()
 
     async def stop(self) -> None:
@@ -194,18 +198,14 @@ class Daemon:
                     "run `shipyard daemon stop` first"
                 )
             # Stale file — caller crashed.
-            try:
+            with contextlib.suppress(OSError):
                 self._pid_file.unlink()
-            except OSError:
-                pass
         self._pid_file.write_text(str(os.getpid()), encoding="utf-8")
 
     def _release_lock(self) -> None:
         if self._pid_file.exists():
-            try:
+            with contextlib.suppress(OSError):
                 self._pid_file.unlink()
-            except OSError:
-                pass
 
 
 @dataclass(frozen=True)
@@ -287,6 +287,6 @@ def read_daemon_status(state_dir: Path) -> dict[str, object] | None:
                     continue
                 if isinstance(obj, dict) and obj.get("type") == "status":
                     return obj
-    except (OSError, socket.timeout):
+    except (TimeoutError, OSError):
         return None
     return None

--- a/src/shipyard/daemon/controller.py
+++ b/src/shipyard/daemon/controller.py
@@ -1,0 +1,292 @@
+"""Daemon orchestrator — glues the pieces together.
+
+Responsibilities:
+    * Acquire a single-instance lock.
+    * Decide whether the Tailscale backend is ready.
+    * Spin up the webhook HTTP server + IPC server.
+    * Bring up the tunnel, register GitHub hooks.
+    * Fan out decoded events to IPC subscribers.
+    * Teardown cleanly on stop (unregister hooks, reset funnel,
+      remove PID + socket).
+
+State directory layout::
+
+    <state_dir>/daemon/
+        daemon.pid
+        daemon.sock
+        registrations.json
+        webhook-secret   (Linux only; macOS uses Keychain)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import signal
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+from shipyard.daemon import events as events_mod
+from shipyard.daemon import secrets as secrets_mod
+from shipyard.daemon import signature
+from shipyard.daemon.ipc import IPCServer, IPCState
+from shipyard.daemon.registrar import Registrar, RegistrarError
+from shipyard.daemon.server import HandlerResult, WebhookServer
+from shipyard.daemon.tunnels.base import TunnelInfo, TunnelNotReadyError, TunnelStartError
+from shipyard.daemon.tunnels.tailscale import TailscaleFunnelBackend
+
+logger = logging.getLogger(__name__)
+
+
+class DaemonAlreadyRunningError(Exception):
+    """Another daemon instance is holding the PID lock."""
+
+
+@dataclass
+class DaemonConfig:
+    state_dir: Path
+    repos: list[str]
+    """Which repos to register webhooks on. Normally derived from
+    shipyard ship-state at startup; callers may pass an explicit list
+    for testing."""
+
+
+@dataclass
+class _RuntimeState:
+    tunnel: TunnelInfo | None = None
+    tunnel_verified_at: float | None = None
+    last_event_at: float | None = None
+
+
+class Daemon:
+    """The long-running process.
+
+    Typical lifecycle::
+
+        daemon = Daemon(config)
+        await daemon.start()   # acquires lock, brings up tunnel, etc.
+        await daemon.run()     # blocks until stopped
+        await daemon.stop()    # graceful teardown
+    """
+
+    def __init__(self, config: DaemonConfig) -> None:
+        self._config = config
+        self._paths = _DaemonPaths(config.state_dir)
+        self._pid_file: Path = self._paths.pid_file
+        self._state = _RuntimeState()
+        self._webhook_server: WebhookServer | None = None
+        self._ipc_server: IPCServer | None = None
+        self._tunnel = TailscaleFunnelBackend()
+        self._registrar = Registrar(config.state_dir)
+        self._stop_event = asyncio.Event()
+
+    async def start(self) -> None:
+        self._paths.ensure_dirs()
+        self._acquire_lock()
+
+        # Resolve secret (keychain on macOS, file on Linux).
+        secret = secrets_mod.load_or_create(self._config.state_dir)
+
+        # Bring the HTTP server up first — need the bound port for
+        # the tunnel backend.
+        self._webhook_server = WebhookServer(_make_delivery_handler(secret, self))
+        port = self._webhook_server.start()
+
+        # Bring the tunnel up.
+        try:
+            tunnel_info = await self._tunnel.start(port)
+        except (TunnelNotReadyError, TunnelStartError):
+            # If the tunnel can't come up, the daemon is still useful
+            # as a local-only subscribe host (future), but for v1 the
+            # whole point is webhook delivery. Fail fast.
+            self._webhook_server.stop()
+            self._release_lock()
+            raise
+        self._state.tunnel = tunnel_info
+        self._state.tunnel_verified_at = time.time()
+
+        # Register webhooks. URL always ends in /webhook — the server
+        # also accepts / for legacy compatibility.
+        public_url = tunnel_info.public_url.rstrip("/") + "/webhook"
+        for repo in self._config.repos:
+            try:
+                await self._registrar.ensure_registered(repo, public_url, secret)
+            except RegistrarError as exc:
+                logger.error("failed to register %s: %s", repo, exc)
+
+        # Last: the IPC server (so subscribers can connect once
+        # everything else is live).
+        self._ipc_server = IPCServer(
+            socket_path=self._paths.socket_file,
+            status_provider=self._build_status_snapshot,
+            on_stop_request=self._request_stop,
+        )
+        await self._ipc_server.start()
+
+    async def run(self) -> None:
+        """Block until a stop is requested."""
+        loop = asyncio.get_running_loop()
+        for sig in (signal.SIGINT, signal.SIGTERM):
+            try:
+                loop.add_signal_handler(sig, lambda: self._stop_event.set())
+            except NotImplementedError:
+                # Windows doesn't support add_signal_handler.
+                pass
+        await self._stop_event.wait()
+
+    async def stop(self) -> None:
+        # Fire the event so a concurrent run() returns.
+        self._stop_event.set()
+
+        if self._ipc_server is not None:
+            await self._ipc_server.stop()
+            self._ipc_server = None
+
+        # Unregister hooks before tearing the tunnel down so the
+        # webhook endpoint is still live when the DELETE calls land.
+        try:
+            await self._registrar.unregister_all()
+        except RegistrarError as exc:
+            logger.error("unregister_all failed: %s", exc)
+
+        await self._tunnel.stop()
+
+        if self._webhook_server is not None:
+            self._webhook_server.stop()
+            self._webhook_server = None
+
+        self._release_lock()
+
+    async def _request_stop(self) -> None:
+        self._stop_event.set()
+
+    async def _on_delivery(self, event: events_mod.WebhookEvent) -> None:
+        """Called from the HTTP handler thread with a decoded event."""
+        self._state.last_event_at = time.time()
+        if self._ipc_server is not None:
+            await self._ipc_server.broadcast_event(event.to_wire())
+
+    def _build_status_snapshot(self) -> IPCState:
+        return IPCState(
+            tunnel_backend=self._tunnel.name,
+            tunnel_url=self._state.tunnel.public_url if self._state.tunnel else None,
+            tunnel_verified_at=self._state.tunnel_verified_at,
+            subscribers=self._ipc_server.subscriber_count() if self._ipc_server else 0,
+            last_event_at=self._state.last_event_at,
+            registered_repos=sorted(self._registrar.all().keys()),
+            rate_limit=None,
+        )
+
+    # --- PID lock --------------------------------------------------
+
+    def _acquire_lock(self) -> None:
+        if self._pid_file.exists():
+            try:
+                pid = int(self._pid_file.read_text(encoding="utf-8").strip())
+            except (OSError, ValueError):
+                pid = 0
+            if pid > 0 and _pid_alive(pid):
+                raise DaemonAlreadyRunningError(
+                    f"daemon already running (pid {pid}); "
+                    "run `shipyard daemon stop` first"
+                )
+            # Stale file — caller crashed.
+            try:
+                self._pid_file.unlink()
+            except OSError:
+                pass
+        self._pid_file.write_text(str(os.getpid()), encoding="utf-8")
+
+    def _release_lock(self) -> None:
+        if self._pid_file.exists():
+            try:
+                self._pid_file.unlink()
+            except OSError:
+                pass
+
+
+@dataclass(frozen=True)
+class _DaemonPaths:
+    state_dir: Path
+
+    @property
+    def root(self) -> Path:
+        return self.state_dir / "daemon"
+
+    @property
+    def pid_file(self) -> Path:
+        return self.root / "daemon.pid"
+
+    @property
+    def socket_file(self) -> Path:
+        return self.root / "daemon.sock"
+
+    def ensure_dirs(self) -> None:
+        self.root.mkdir(parents=True, exist_ok=True)
+
+
+def _make_delivery_handler(secret: str, daemon: Daemon):
+    """Produce a callback suitable for ``WebhookServer``.
+
+    The HTTP server runs on a background thread; we schedule the
+    async ``_on_delivery`` onto the event loop rather than running it
+    inline.
+    """
+    loop = asyncio.get_event_loop()
+
+    def handler(headers: dict[str, str], body: bytes) -> HandlerResult:
+        if not signature.is_valid(
+            body, secret, headers.get("x-hub-signature-256")
+        ):
+            return HandlerResult.unauthorized()
+        event = events_mod.decode(headers.get("x-github-event"), body)
+        if event is not None:
+            asyncio.run_coroutine_threadsafe(
+                daemon._on_delivery(event), loop
+            )
+        return HandlerResult.ok()
+
+    return handler
+
+
+def _pid_alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except OSError:
+        return False
+    return True
+
+
+def read_daemon_status(state_dir: Path) -> dict[str, object] | None:
+    """Query the running daemon over its IPC socket. Returns None if
+    the daemon isn't running / reachable."""
+    import socket
+
+    sock_path = state_dir / "daemon" / "daemon.sock"
+    if not sock_path.exists():
+        return None
+    try:
+        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as client:
+            client.settimeout(2.0)
+            client.connect(str(sock_path))
+            client.sendall(b'{"type":"status"}\n')
+            buf = b""
+            while b"\n" not in buf:
+                chunk = client.recv(65536)
+                if not chunk:
+                    break
+                buf += chunk
+            # Skip the initial hello line.
+            for line in buf.splitlines():
+                try:
+                    obj = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if isinstance(obj, dict) and obj.get("type") == "status":
+                    return obj
+    except (OSError, socket.timeout):
+        return None
+    return None

--- a/src/shipyard/daemon/disclosure.py
+++ b/src/shipyard/daemon/disclosure.py
@@ -1,0 +1,92 @@
+"""First-run disclosure + operator-facing messaging.
+
+The daemon does things a reasonable user might not have consented to
+if they'd been told nothing:
+
+  * Registers a GitHub webhook on every repo it tracks.
+  * Starts a Tailscale Funnel — i.e. makes a localhost service
+    publicly routable over Tailscale's edge.
+  * Stores an HMAC secret in the keychain (macOS) or a 600-perm file.
+
+None of these are destructive, but we should tell the user the first
+time each machine starts the daemon, and point them at how to
+disable. A one-line ack file at
+``<state_dir>/daemon/.first-run-acked`` records that the disclosure
+was shown so subsequent starts are quiet.
+"""
+
+from __future__ import annotations
+
+import sys
+import textwrap
+import time
+from pathlib import Path
+
+
+def ack_path(state_dir: Path) -> Path:
+    return state_dir / "daemon" / ".first-run-acked"
+
+
+def has_been_shown(state_dir: Path) -> bool:
+    return ack_path(state_dir).exists()
+
+
+def mark_shown(state_dir: Path) -> None:
+    path = ack_path(state_dir)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(str(int(time.time())), encoding="utf-8")
+
+
+def render(repos: list[str]) -> str:
+    """The human-readable notice shown on first run of the daemon."""
+    repo_lines = (
+        "\n".join(f"    - {r}" for r in repos)
+        if repos
+        else "    (none detected — the daemon will still run for IPC subscribers)"
+    )
+    return textwrap.dedent(
+        f"""\
+        ─── first-run notice ──────────────────────────────────────────
+
+        `shipyard daemon` will do the following on this machine:
+
+          1. Start a Tailscale Funnel so GitHub can POST webhook events
+             to your Mac. Requires Tailscale to be installed with
+             Funnel enabled on your tailnet.
+          2. Register a GitHub webhook on each repo it tracks so those
+             events are delivered. Repos detected from ship-state:
+        {repo_lines}
+          3. Store a randomly-generated HMAC secret so deliveries can
+             be verified (macOS Keychain, or a 600-perm file on Linux).
+          4. Open a Unix socket at ~/.pulp/... for local CLI and the
+             macOS app to subscribe to live events.
+
+        None of these are destructive. If you'd rather not use live
+        mode:
+
+          * Just don't start the daemon. `shipyard watch`, `shipyard
+            ship`, and the macOS app all work without it — they fall
+            back to polling.
+          * Run `shipyard daemon stop` at any time to tear down the
+            tunnel and unregister the webhooks.
+
+        This notice is shown once per machine. To see it again, delete
+        the marker file at ~/.local/state/shipyard/daemon/.first-run-acked
+        (path varies by OS; `shipyard doctor` prints the exact path).
+
+        ───────────────────────────────────────────────────────────────
+        """
+    )
+
+
+def show_if_first_run(state_dir: Path, repos: list[str], stream=None) -> bool:
+    """Print the disclosure if it hasn't been acked yet. Returns True
+    if it was just shown (so the caller can react, e.g. by briefly
+    pausing before continuing)."""
+    if has_been_shown(state_dir):
+        return False
+    out = stream if stream is not None else sys.stderr
+    out.write(render(repos))
+    out.flush()
+    mark_shown(state_dir)
+    return True

--- a/src/shipyard/daemon/disclosure.py
+++ b/src/shipyard/daemon/disclosure.py
@@ -20,7 +20,10 @@ from __future__ import annotations
 import sys
 import textwrap
 import time
-from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 def ack_path(state_dir: Path) -> Path:

--- a/src/shipyard/daemon/disclosure.py
+++ b/src/shipyard/daemon/disclosure.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 import sys
 import textwrap
 import time
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, TextIO
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -82,7 +82,9 @@ def render(repos: list[str]) -> str:
     )
 
 
-def show_if_first_run(state_dir: Path, repos: list[str], stream=None) -> bool:
+def show_if_first_run(
+    state_dir: Path, repos: list[str], stream: TextIO | None = None
+) -> bool:
     """Print the disclosure if it hasn't been acked yet. Returns True
     if it was just shown (so the caller can react, e.g. by briefly
     pausing before continuing)."""

--- a/src/shipyard/daemon/events.py
+++ b/src/shipyard/daemon/events.py
@@ -11,7 +11,7 @@ daemon has no extra dependencies.
 from __future__ import annotations
 
 import json
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Any
 
 

--- a/src/shipyard/daemon/events.py
+++ b/src/shipyard/daemon/events.py
@@ -1,0 +1,178 @@
+"""Typed, normalized view of GitHub webhook deliveries.
+
+Only the fields consumers actually need are decoded — enough to drive
+the UI's ship/run/PR state changes. Everything else is dropped.
+
+Mirrors ``WebhookEvent.swift`` + ``WebhookEventDecoder.swift`` in the
+macOS GUI. Kept as plain dataclasses rather than Pydantic so the
+daemon has no extra dependencies.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass(frozen=True)
+class WorkflowRunPayload:
+    action: str
+    run_id: int
+    repo: str
+    head_branch: str
+    head_sha: str
+    status: str
+    conclusion: str | None
+    workflow_name: str
+    html_url: str | None
+
+
+@dataclass(frozen=True)
+class WorkflowJobPayload:
+    action: str
+    run_id: int
+    job_id: int
+    repo: str
+    name: str
+    status: str
+    conclusion: str | None
+    runner_name: str | None
+    labels: list[str]
+
+
+@dataclass(frozen=True)
+class PullRequestPayload:
+    action: str
+    number: int
+    repo: str
+    state: str
+    merged: bool
+    merged_at: str | None
+    closed_at: str | None
+
+
+@dataclass(frozen=True)
+class WebhookEvent:
+    """Tagged union of decoded events. Exactly one of the ``*_payload``
+    fields is populated; ``kind`` tells you which."""
+
+    kind: str  # "workflow_run" | "workflow_job" | "pull_request" | "unhandled"
+    unhandled_type: str | None = None
+    workflow_run: WorkflowRunPayload | None = None
+    workflow_job: WorkflowJobPayload | None = None
+    pull_request: PullRequestPayload | None = None
+
+    def to_wire(self) -> dict[str, Any]:
+        """Shape sent over the IPC socket as NDJSON."""
+        if self.kind == "workflow_run" and self.workflow_run:
+            return {"kind": "workflow_run", "payload": self.workflow_run.__dict__}
+        if self.kind == "workflow_job" and self.workflow_job:
+            return {"kind": "workflow_job", "payload": self.workflow_job.__dict__}
+        if self.kind == "pull_request" and self.pull_request:
+            return {"kind": "pull_request", "payload": self.pull_request.__dict__}
+        return {"kind": "unhandled", "type": self.unhandled_type}
+
+
+def decode(event_header: str | None, body: bytes) -> WebhookEvent | None:
+    """Decode a raw webhook delivery. Returns ``None`` when the header
+    is missing or the body isn't decodable JSON. Unknown event types
+    come back as ``WebhookEvent(kind="unhandled", unhandled_type=...)``
+    so callers can still record the liveness signal."""
+    if not event_header:
+        return None
+    try:
+        obj = json.loads(body)
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return None
+    if not isinstance(obj, dict):
+        return None
+    if event_header == "workflow_run":
+        return _decode_workflow_run(obj)
+    if event_header == "workflow_job":
+        return _decode_workflow_job(obj)
+    if event_header == "pull_request":
+        return _decode_pull_request(obj)
+    return WebhookEvent(kind="unhandled", unhandled_type=event_header)
+
+
+def _decode_workflow_run(obj: dict[str, Any]) -> WebhookEvent | None:
+    run = obj.get("workflow_run")
+    repo = (obj.get("repository") or {}).get("full_name")
+    if not isinstance(run, dict) or not repo:
+        return None
+    run_id = _as_int(run.get("id"))
+    if run_id is None:
+        return None
+    return WebhookEvent(
+        kind="workflow_run",
+        workflow_run=WorkflowRunPayload(
+            action=str(obj.get("action", "")),
+            run_id=run_id,
+            repo=repo,
+            head_branch=str(run.get("head_branch", "")),
+            head_sha=str(run.get("head_sha", "")),
+            status=str(run.get("status", "")),
+            conclusion=run.get("conclusion"),
+            workflow_name=str(run.get("name", "")),
+            html_url=run.get("html_url"),
+        ),
+    )
+
+
+def _decode_workflow_job(obj: dict[str, Any]) -> WebhookEvent | None:
+    job = obj.get("workflow_job")
+    repo = (obj.get("repository") or {}).get("full_name")
+    if not isinstance(job, dict) or not repo:
+        return None
+    job_id = _as_int(job.get("id"))
+    run_id = _as_int(job.get("run_id"))
+    if job_id is None or run_id is None:
+        return None
+    labels_raw = job.get("labels") or []
+    labels = [str(x) for x in labels_raw] if isinstance(labels_raw, list) else []
+    return WebhookEvent(
+        kind="workflow_job",
+        workflow_job=WorkflowJobPayload(
+            action=str(obj.get("action", "")),
+            run_id=run_id,
+            job_id=job_id,
+            repo=repo,
+            name=str(job.get("name", "")),
+            status=str(job.get("status", "")),
+            conclusion=job.get("conclusion"),
+            runner_name=job.get("runner_name"),
+            labels=labels,
+        ),
+    )
+
+
+def _decode_pull_request(obj: dict[str, Any]) -> WebhookEvent | None:
+    pr = obj.get("pull_request")
+    repo = (obj.get("repository") or {}).get("full_name")
+    if not isinstance(pr, dict) or not repo:
+        return None
+    number = _as_int(pr.get("number"))
+    if number is None:
+        return None
+    return WebhookEvent(
+        kind="pull_request",
+        pull_request=PullRequestPayload(
+            action=str(obj.get("action", "")),
+            number=number,
+            repo=repo,
+            state=str(pr.get("state", "")),
+            merged=bool(pr.get("merged", False)),
+            merged_at=pr.get("merged_at"),
+            closed_at=pr.get("closed_at"),
+        ),
+    )
+
+
+def _as_int(value: Any) -> int | None:
+    if isinstance(value, bool):
+        # bool is a subclass of int in Python — explicit reject.
+        return None
+    if isinstance(value, int):
+        return value
+    return None

--- a/src/shipyard/daemon/ipc.py
+++ b/src/shipyard/daemon/ipc.py
@@ -20,13 +20,17 @@ Messages from client to server:
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 import logging
 import os
 from collections import deque
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
-from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
@@ -75,10 +79,8 @@ class IPCServer:
         self._socket_path.parent.mkdir(parents=True, exist_ok=True)
         # Clean up a stale socket from a previous crashed run.
         if self._socket_path.exists() or self._socket_path.is_symlink():
-            try:
+            with contextlib.suppress(OSError):
                 self._socket_path.unlink()
-            except OSError:
-                pass
         self._server = await asyncio.start_unix_server(
             self._handle_client, path=str(self._socket_path)
         )
@@ -100,10 +102,8 @@ class IPCServer:
             await self._server.wait_closed()
             self._server = None
         if self._socket_path.exists() or self._socket_path.is_symlink():
-            try:
+            with contextlib.suppress(OSError):
                 self._socket_path.unlink()
-            except OSError:
-                pass
 
     async def broadcast_event(self, event: dict[str, object]) -> None:
         """Append to ring buffer + fan out to every connected subscriber."""

--- a/src/shipyard/daemon/ipc.py
+++ b/src/shipyard/daemon/ipc.py
@@ -1,0 +1,190 @@
+"""Unix socket IPC server for daemon subscribers.
+
+Any ``shipyard`` CLI invocation (including the macOS GUI subprocess)
+can connect to the daemon's socket and stream decoded webhook events
+as NDJSON. One-line-per-message; newlines inside payloads are not
+permitted (JSON encoders produce compact output by default).
+
+Messages from server to client:
+    {"type": "hello",      ...}       # on connect
+    {"type": "event",      ...}       # webhook delivery
+    {"type": "status",     ...}       # response to a status request
+    {"type": "goodbye",    ...}       # on graceful server shutdown
+
+Messages from client to server:
+    {"type": "subscribe",  "since": "<iso>"?}  # opens event stream
+    {"type": "status"}                         # request status snapshot
+    {"type": "stop"}                           # ask server to stop (drains then exits)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+from collections import deque
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+RING_BUFFER_SIZE = 100
+
+
+@dataclass
+class IPCState:
+    """Server-side view of daemon state exposed over the IPC socket."""
+
+    tunnel_backend: str
+    tunnel_url: str | None
+    tunnel_verified_at: float | None
+    subscribers: int
+    last_event_at: float | None
+    registered_repos: list[str]
+    rate_limit: dict[str, object] | None
+
+
+StatusProvider = Callable[[], IPCState]
+StopRequestCallback = Callable[[], Awaitable[None]]
+
+
+class IPCServer:
+    """Owns the ``daemon.sock`` listener + fans out events.
+
+    Ring buffer holds the most recent ``RING_BUFFER_SIZE`` events so a
+    subscriber that connects mid-session still sees a short history.
+    """
+
+    def __init__(
+        self,
+        socket_path: Path,
+        status_provider: StatusProvider,
+        on_stop_request: StopRequestCallback | None = None,
+    ) -> None:
+        self._socket_path = socket_path
+        self._status_provider = status_provider
+        self._on_stop_request = on_stop_request
+        self._server: asyncio.AbstractServer | None = None
+        self._subscribers: set[asyncio.StreamWriter] = set()
+        self._ring: deque[dict[str, object]] = deque(maxlen=RING_BUFFER_SIZE)
+        self._lock = asyncio.Lock()
+
+    async def start(self) -> None:
+        self._socket_path.parent.mkdir(parents=True, exist_ok=True)
+        # Clean up a stale socket from a previous crashed run.
+        if self._socket_path.exists() or self._socket_path.is_symlink():
+            try:
+                self._socket_path.unlink()
+            except OSError:
+                pass
+        self._server = await asyncio.start_unix_server(
+            self._handle_client, path=str(self._socket_path)
+        )
+        # 600 so other users on a shared box can't subscribe.
+        os.chmod(self._socket_path, 0o600)
+        logger.info("ipc server listening at %s", self._socket_path)
+
+    async def stop(self) -> None:
+        # Say goodbye to active subscribers so they don't hang on the
+        # next read and can reconnect cleanly on restart.
+        async with self._lock:
+            subscribers = list(self._subscribers)
+            self._subscribers.clear()
+        for writer in subscribers:
+            await _send_safe(writer, {"type": "goodbye"})
+            await _close_safe(writer)
+        if self._server is not None:
+            self._server.close()
+            await self._server.wait_closed()
+            self._server = None
+        if self._socket_path.exists() or self._socket_path.is_symlink():
+            try:
+                self._socket_path.unlink()
+            except OSError:
+                pass
+
+    async def broadcast_event(self, event: dict[str, object]) -> None:
+        """Append to ring buffer + fan out to every connected subscriber."""
+        async with self._lock:
+            self._ring.append(event)
+            targets = list(self._subscribers)
+        message = {"type": "event", **event}
+        for writer in targets:
+            await _send_safe(writer, message)
+
+    def subscriber_count(self) -> int:
+        return len(self._subscribers)
+
+    # --- internals -------------------------------------------------
+
+    async def _handle_client(
+        self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+    ) -> None:
+        # Send a hello so clients can verify protocol compatibility
+        # before doing anything else.
+        await _send_safe(writer, {"type": "hello", "protocol": 1})
+        try:
+            while not reader.at_eof():
+                line = await reader.readline()
+                if not line:
+                    break
+                try:
+                    msg = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if not isinstance(msg, dict):
+                    continue
+                await self._handle_message(msg, writer)
+        finally:
+            async with self._lock:
+                self._subscribers.discard(writer)
+            await _close_safe(writer)
+
+    async def _handle_message(
+        self, msg: dict[str, object], writer: asyncio.StreamWriter
+    ) -> None:
+        msg_type = msg.get("type")
+        if msg_type == "subscribe":
+            async with self._lock:
+                self._subscribers.add(writer)
+                backlog = list(self._ring)
+            for past in backlog:
+                await _send_safe(writer, {"type": "event", **past})
+        elif msg_type == "status":
+            state = self._status_provider()
+            await _send_safe(
+                writer,
+                {
+                    "type": "status",
+                    "tunnel": {
+                        "backend": state.tunnel_backend,
+                        "url": state.tunnel_url,
+                        "verified_at": state.tunnel_verified_at,
+                    },
+                    "subscribers": state.subscribers,
+                    "last_event_at": state.last_event_at,
+                    "registered_repos": state.registered_repos,
+                    "rate_limit": state.rate_limit,
+                },
+            )
+        elif msg_type == "stop":
+            if self._on_stop_request is not None:
+                await self._on_stop_request()
+
+
+async def _send_safe(writer: asyncio.StreamWriter, message: dict[str, object]) -> None:
+    try:
+        writer.write((json.dumps(message, separators=(",", ":")) + "\n").encode())
+        await writer.drain()
+    except (ConnectionError, OSError):
+        pass
+
+
+async def _close_safe(writer: asyncio.StreamWriter) -> None:
+    try:
+        writer.close()
+        await writer.wait_closed()
+    except (ConnectionError, OSError):
+        pass

--- a/src/shipyard/daemon/registrar.py
+++ b/src/shipyard/daemon/registrar.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import os
 import shutil
 from dataclasses import dataclass
 from pathlib import Path
@@ -59,6 +60,8 @@ class Registrar:
         binary = gh_binary or shutil.which("gh")
         if binary is None:
             raise RegistrarError("gh CLI not found on PATH")
+        if not os.access(binary, os.X_OK) or not Path(binary).is_file():
+            raise RegistrarError(f"gh CLI not executable: {binary}")
         if repo in self._by_repo:
             # Already registered — update the URL/secret in case they
             # rotated since last time.

--- a/src/shipyard/daemon/registrar.py
+++ b/src/shipyard/daemon/registrar.py
@@ -1,0 +1,212 @@
+"""Create / update / delete GitHub repository webhooks via ``gh``.
+
+Mirrors ``WebhookRegistrar.swift``. Uses the user's existing ``gh``
+auth — no extra token plumbing. Hook IDs persist to disk so a second
+launch can find + reuse an existing registration instead of creating
+duplicates.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+SUBSCRIBED_EVENTS = (
+    "workflow_run",
+    "workflow_job",
+    "pull_request",
+    "check_run",
+    "check_suite",
+)
+
+
+class RegistrarError(Exception):
+    """Non-recoverable failure talking to ``gh api``."""
+
+
+@dataclass
+class RegisteredHook:
+    repo: str
+    hook_id: int
+
+
+class Registrar:
+    """In-memory map of registered hooks, persisted between runs."""
+
+    def __init__(self, state_dir: Path) -> None:
+        self._state_path = state_dir / "daemon" / "registrations.json"
+        self._by_repo: dict[str, int] = {}
+        self._load()
+
+    def all(self) -> dict[str, int]:
+        return dict(self._by_repo)
+
+    async def ensure_registered(
+        self,
+        repo: str,
+        url: str,
+        secret: str,
+        *,
+        gh_binary: str | None = None,
+    ) -> int:
+        """Idempotent create-or-update. Returns the hook ID."""
+        binary = gh_binary or shutil.which("gh")
+        if binary is None:
+            raise RegistrarError("gh CLI not found on PATH")
+        if repo in self._by_repo:
+            # Already registered — update the URL/secret in case they
+            # rotated since last time.
+            existing_id = self._by_repo[repo]
+            await self._update(binary, repo, existing_id, url, secret)
+            return existing_id
+        hook_id = await self._create(binary, repo, url, secret)
+        self._by_repo[repo] = hook_id
+        self._save()
+        return hook_id
+
+    async def unregister(
+        self,
+        repo: str,
+        *,
+        gh_binary: str | None = None,
+    ) -> None:
+        if repo not in self._by_repo:
+            return
+        hook_id = self._by_repo[repo]
+        binary = gh_binary or shutil.which("gh")
+        if binary is not None:
+            await self._delete(binary, repo, hook_id)
+        del self._by_repo[repo]
+        self._save()
+
+    async def unregister_all(self, *, gh_binary: str | None = None) -> None:
+        for repo in list(self._by_repo):
+            await self.unregister(repo, gh_binary=gh_binary)
+
+    # --- internals -------------------------------------------------
+
+    async def _create(
+        self, binary: str, repo: str, url: str, secret: str
+    ) -> int:
+        config = {
+            "url": url,
+            "content_type": "json",
+            "secret": secret,
+            "insecure_ssl": "0",
+        }
+        body = {
+            "name": "web",
+            "active": True,
+            "events": list(SUBSCRIBED_EVENTS),
+            "config": config,
+        }
+        code, out = await _run_gh(
+            binary,
+            [
+                "api",
+                "-X",
+                "POST",
+                "-H",
+                "Accept: application/vnd.github+json",
+                "--input",
+                "-",
+                f"repos/{repo}/hooks",
+            ],
+            stdin=json.dumps(body).encode(),
+        )
+        if code != 0:
+            raise RegistrarError(f"create hook failed: {out.strip()}")
+        try:
+            parsed = json.loads(out)
+            hook_id = int(parsed["id"])
+        except (json.JSONDecodeError, KeyError, TypeError, ValueError) as exc:
+            raise RegistrarError(
+                f"couldn't parse hook ID from gh response: {out.strip()}"
+            ) from exc
+        return hook_id
+
+    async def _update(
+        self, binary: str, repo: str, hook_id: int, url: str, secret: str
+    ) -> None:
+        body = {
+            "config": {
+                "url": url,
+                "content_type": "json",
+                "secret": secret,
+                "insecure_ssl": "0",
+            },
+            "active": True,
+        }
+        code, out = await _run_gh(
+            binary,
+            [
+                "api",
+                "-X",
+                "PATCH",
+                "-H",
+                "Accept: application/vnd.github+json",
+                "--input",
+                "-",
+                f"repos/{repo}/hooks/{hook_id}",
+            ],
+            stdin=json.dumps(body).encode(),
+        )
+        if code != 0:
+            raise RegistrarError(f"patch hook failed: {out.strip()}")
+
+    async def _delete(self, binary: str, repo: str, hook_id: int) -> None:
+        code, out = await _run_gh(
+            binary,
+            ["api", "-X", "DELETE", f"repos/{repo}/hooks/{hook_id}"],
+        )
+        if code == 0:
+            return
+        lowered = out.lower()
+        if "404" in lowered or "not found" in lowered:
+            return
+        raise RegistrarError(f"delete hook failed: {out.strip()}")
+
+    def _load(self) -> None:
+        if not self._state_path.exists():
+            return
+        try:
+            data = json.loads(self._state_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return
+        if isinstance(data, list):
+            for item in data:
+                if isinstance(item, dict) and "repo" in item and "hook_id" in item:
+                    self._by_repo[str(item["repo"])] = int(item["hook_id"])
+
+    def _save(self) -> None:
+        self._state_path.parent.mkdir(parents=True, exist_ok=True)
+        payload = [
+            {"repo": repo, "hook_id": hook_id}
+            for repo, hook_id in sorted(self._by_repo.items())
+        ]
+        self._state_path.write_text(
+            json.dumps(payload, indent=2), encoding="utf-8"
+        )
+
+
+async def _run_gh(
+    binary: str,
+    args: list[str],
+    *,
+    stdin: bytes | None = None,
+) -> tuple[int, str]:
+    proc = await asyncio.create_subprocess_exec(
+        binary,
+        *args,
+        stdin=asyncio.subprocess.PIPE if stdin else None,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.STDOUT,
+    )
+    stdout, _ = await proc.communicate(input=stdin)
+    return proc.returncode or 0, (stdout or b"").decode(errors="replace")

--- a/src/shipyard/daemon/runner.py
+++ b/src/shipyard/daemon/runner.py
@@ -20,6 +20,7 @@ import sys
 import time
 from pathlib import Path
 
+from shipyard.daemon import disclosure
 from shipyard.daemon.controller import Daemon, DaemonAlreadyRunningError, DaemonConfig
 from shipyard.daemon.tunnels.base import TunnelNotReadyError, TunnelStartError
 
@@ -28,12 +29,23 @@ logger = logging.getLogger(__name__)
 
 def run_blocking(*, state_dir: Path, repos: list[str]) -> int:
     """Run the daemon in-process until SIGINT/SIGTERM. Returns the
-    exit code the CLI should propagate (0 on graceful shutdown, 1 on
-    startup failure)."""
+    exit code the CLI should propagate.
+
+    Exit codes:
+      0 — graceful shutdown.
+      2 — another daemon is already running (PID file lock held).
+      3 — tunnel backend isn't ready (Tailscale not installed /
+          signed in / Funnel not permitted on the tailnet). The
+          recommended remedy is to either enable Tailscale Funnel or
+          skip the daemon entirely; `shipyard watch` and the macOS
+          app both work without it.
+    """
     logging.basicConfig(
         level=logging.INFO,
         format="%(asctime)s %(levelname)s %(name)s: %(message)s",
     )
+    # Show the first-run notice before we touch Tailscale or GitHub.
+    disclosure.show_if_first_run(state_dir, repos)
     config = DaemonConfig(state_dir=state_dir, repos=repos)
     daemon = Daemon(config)
     try:
@@ -42,7 +54,14 @@ def run_blocking(*, state_dir: Path, repos: list[str]) -> int:
         logger.error("%s", exc)
         return 2
     except (TunnelNotReadyError, TunnelStartError) as exc:
-        logger.error("tunnel backend unavailable: %s", exc)
+        logger.error(
+            "Tailscale Funnel isn't available: %s. "
+            "The daemon needs a public tunnel to receive GitHub webhooks. "
+            "Install Tailscale + enable Funnel on your tailnet, or skip the "
+            "daemon entirely — `shipyard watch` and the macOS app both fall "
+            "back to polling.",
+            exc,
+        )
         return 3
     except KeyboardInterrupt:
         pass

--- a/src/shipyard/daemon/runner.py
+++ b/src/shipyard/daemon/runner.py
@@ -1,0 +1,231 @@
+"""Process-lifecycle glue for ``shipyard daemon``.
+
+Split out from ``controller.py`` so the CLI layer doesn't need to
+reach into asyncio internals. Callers get three verbs:
+
+    * ``run_blocking()`` — foreground daemon, blocks until signalled.
+    * ``spawn_detached()`` — background daemon, fire-and-forget.
+    * ``stop_running()`` — ask a running daemon to exit cleanly.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import socket
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+from shipyard.daemon.controller import Daemon, DaemonAlreadyRunningError, DaemonConfig
+from shipyard.daemon.tunnels.base import TunnelNotReadyError, TunnelStartError
+
+logger = logging.getLogger(__name__)
+
+
+def run_blocking(*, state_dir: Path, repos: list[str]) -> int:
+    """Run the daemon in-process until SIGINT/SIGTERM. Returns the
+    exit code the CLI should propagate (0 on graceful shutdown, 1 on
+    startup failure)."""
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+    config = DaemonConfig(state_dir=state_dir, repos=repos)
+    daemon = Daemon(config)
+    try:
+        asyncio.run(_run_async(daemon))
+    except DaemonAlreadyRunningError as exc:
+        logger.error("%s", exc)
+        return 2
+    except (TunnelNotReadyError, TunnelStartError) as exc:
+        logger.error("tunnel backend unavailable: %s", exc)
+        return 3
+    except KeyboardInterrupt:
+        pass
+    return 0
+
+
+def spawn_detached(*, state_dir: Path, repos: list[str]) -> int:
+    """Launch the daemon as a detached child process, return its PID.
+
+    Uses the current Python executable + shipyard entry point so the
+    child inherits the same environment. We prefer ``shipyard daemon
+    run --repo …`` rather than forking so signal handlers + stdio are
+    well-defined.
+    """
+    pid_file = state_dir / "daemon" / "daemon.pid"
+    if pid_file.exists():
+        try:
+            existing_pid = int(pid_file.read_text(encoding="utf-8").strip())
+        except (OSError, ValueError):
+            existing_pid = 0
+        if existing_pid > 0 and _pid_alive(existing_pid):
+            return existing_pid
+    args = [sys.executable, "-m", "shipyard", "daemon", "run"]
+    for repo in repos:
+        args.extend(["--repo", repo])
+    # Close stdio so the detached process doesn't hold the parent
+    # terminal. Logs go to stderr by default; we redirect to a file
+    # for post-hoc debugging.
+    log_path = state_dir / "daemon" / "daemon.log"
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    log_fd = os.open(
+        str(log_path), os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o600
+    )
+    try:
+        proc = subprocess.Popen(  # noqa: S603 — explicit argv, trusted
+            args,
+            stdout=log_fd,
+            stderr=log_fd,
+            stdin=subprocess.DEVNULL,
+            start_new_session=True,
+            close_fds=True,
+        )
+    finally:
+        os.close(log_fd)
+    # Poll briefly for the PID file so callers can report accurately.
+    deadline = time.time() + 3.0
+    while time.time() < deadline:
+        if pid_file.exists():
+            try:
+                return int(pid_file.read_text(encoding="utf-8").strip())
+            except (OSError, ValueError):
+                break
+        time.sleep(0.05)
+    return proc.pid
+
+
+def stop_running(state_dir: Path) -> bool:
+    """Ask a running daemon to shut down via IPC; fall back to
+    ``SIGTERM`` on the PID file if the socket isn't responsive.
+    Returns True if we believe something was stopped."""
+    sock_path = state_dir / "daemon" / "daemon.sock"
+    pid_file = state_dir / "daemon" / "daemon.pid"
+
+    if sock_path.exists():
+        try:
+            with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as client:
+                client.settimeout(2.0)
+                client.connect(str(sock_path))
+                client.sendall(b'{"type":"stop"}\n')
+        except (OSError, socket.timeout):
+            pass
+        else:
+            # Give the daemon a moment to exit, then check PID file.
+            deadline = time.time() + 3.0
+            while time.time() < deadline:
+                if not pid_file.exists():
+                    return True
+                time.sleep(0.1)
+
+    # Fall back to SIGTERM via PID file.
+    if pid_file.exists():
+        try:
+            pid = int(pid_file.read_text(encoding="utf-8").strip())
+        except (OSError, ValueError):
+            return False
+        if pid > 0 and _pid_alive(pid):
+            try:
+                os.kill(pid, 15)  # SIGTERM
+            except OSError:
+                return False
+            deadline = time.time() + 3.0
+            while time.time() < deadline:
+                if not _pid_alive(pid):
+                    return True
+                time.sleep(0.1)
+            # Escalate.
+            try:
+                os.kill(pid, 9)  # SIGKILL
+            except OSError:
+                pass
+            return True
+        # Stale PID file — clean up.
+        try:
+            pid_file.unlink()
+        except OSError:
+            pass
+    return False
+
+
+def daemon_is_running(state_dir: Path) -> bool:
+    pid_file = state_dir / "daemon" / "daemon.pid"
+    if not pid_file.exists():
+        return False
+    try:
+        pid = int(pid_file.read_text(encoding="utf-8").strip())
+    except (OSError, ValueError):
+        return False
+    return _pid_alive(pid)
+
+
+async def _run_async(daemon: Daemon) -> None:
+    await daemon.start()
+    try:
+        await daemon.run()
+    finally:
+        await daemon.stop()
+
+
+def _pid_alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except OSError:
+        return False
+    return True
+
+
+def subscribe(
+    state_dir: Path,
+    *,
+    on_event: "callable | None" = None,
+    timeout: float = 5.0,
+) -> "object | None":
+    """Connect to the daemon's IPC socket and return a blocking iter
+    of events. Returns None if the daemon isn't running / reachable."""
+    sock_path = state_dir / "daemon" / "daemon.sock"
+    if not sock_path.exists():
+        return None
+    try:
+        client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        client.settimeout(timeout)
+        client.connect(str(sock_path))
+        client.sendall(b'{"type":"subscribe"}\n')
+    except (OSError, socket.timeout):
+        return None
+    return _EventIterator(client)
+
+
+class _EventIterator:
+    """Line-buffered iterator over NDJSON messages from the daemon."""
+
+    def __init__(self, client: socket.socket) -> None:
+        self._client = client
+        self._client.settimeout(None)
+        self._buf = b""
+
+    def __iter__(self) -> "_EventIterator":
+        return self
+
+    def __next__(self) -> dict[str, object]:
+        while b"\n" not in self._buf:
+            chunk = self._client.recv(65536)
+            if not chunk:
+                raise StopIteration
+            self._buf += chunk
+        line, _, rest = self._buf.partition(b"\n")
+        self._buf = rest
+        try:
+            return json.loads(line)
+        except json.JSONDecodeError:
+            return self.__next__()
+
+    def close(self) -> None:
+        try:
+            self._client.close()
+        except OSError:
+            pass

--- a/src/shipyard/daemon/runner.py
+++ b/src/shipyard/daemon/runner.py
@@ -11,6 +11,7 @@ reach into asyncio internals. Callers get three verbs:
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 import logging
 import os
@@ -18,11 +19,14 @@ import socket
 import subprocess
 import sys
 import time
-from pathlib import Path
+from typing import TYPE_CHECKING
 
 from shipyard.daemon import disclosure
 from shipyard.daemon.controller import Daemon, DaemonAlreadyRunningError, DaemonConfig
 from shipyard.daemon.tunnels.base import TunnelNotReadyError, TunnelStartError
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
@@ -131,7 +135,7 @@ def stop_running(state_dir: Path) -> bool:
                 client.settimeout(2.0)
                 client.connect(str(sock_path))
                 client.sendall(b'{"type":"stop"}\n')
-        except (OSError, socket.timeout):
+        except (TimeoutError, OSError):
             pass
         else:
             # Give the daemon a moment to exit, then check PID file.
@@ -158,16 +162,12 @@ def stop_running(state_dir: Path) -> bool:
                     return True
                 time.sleep(0.1)
             # Escalate.
-            try:
+            with contextlib.suppress(OSError):
                 os.kill(pid, 9)  # SIGKILL
-            except OSError:
-                pass
             return True
         # Stale PID file — clean up.
-        try:
+        with contextlib.suppress(OSError):
             pid_file.unlink()
-        except OSError:
-            pass
     return False
 
 
@@ -201,9 +201,9 @@ def _pid_alive(pid: int) -> bool:
 def subscribe(
     state_dir: Path,
     *,
-    on_event: "callable | None" = None,
+    on_event: callable | None = None,
     timeout: float = 5.0,
-) -> "object | None":
+) -> object | None:
     """Connect to the daemon's IPC socket and return a blocking iter
     of events. Returns None if the daemon isn't running / reachable."""
     sock_path = state_dir / "daemon" / "daemon.sock"
@@ -214,7 +214,7 @@ def subscribe(
         client.settimeout(timeout)
         client.connect(str(sock_path))
         client.sendall(b'{"type":"subscribe"}\n')
-    except (OSError, socket.timeout):
+    except (TimeoutError, OSError):
         return None
     return _EventIterator(client)
 
@@ -227,7 +227,7 @@ class _EventIterator:
         self._client.settimeout(None)
         self._buf = b""
 
-    def __iter__(self) -> "_EventIterator":
+    def __iter__(self) -> _EventIterator:
         return self
 
     def __next__(self) -> dict[str, object]:
@@ -244,7 +244,5 @@ class _EventIterator:
             return self.__next__()
 
     def close(self) -> None:
-        try:
+        with contextlib.suppress(OSError):
             self._client.close()
-        except OSError:
-            pass

--- a/src/shipyard/daemon/runner.py
+++ b/src/shipyard/daemon/runner.py
@@ -201,9 +201,8 @@ def _pid_alive(pid: int) -> bool:
 def subscribe(
     state_dir: Path,
     *,
-    on_event: callable | None = None,
     timeout: float = 5.0,
-) -> object | None:
+) -> _EventIterator | None:
     """Connect to the daemon's IPC socket and return a blocking iter
     of events. Returns None if the daemon isn't running / reachable."""
     sock_path = state_dir / "daemon" / "daemon.sock"

--- a/src/shipyard/daemon/secrets.py
+++ b/src/shipyard/daemon/secrets.py
@@ -15,12 +15,16 @@ by generating a fresh one.
 
 from __future__ import annotations
 
+import contextlib
 import os
 import subprocess
 import sys
-from pathlib import Path
+from typing import TYPE_CHECKING
 
 from shipyard.daemon import signature
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 SERVICE = "com.danielraffel.shipyard.webhook"
 ACCOUNT = "shared"
@@ -111,12 +115,10 @@ def _keychain_add(value: str) -> bool:
 
 
 def _keychain_delete() -> None:
-    try:
+    with contextlib.suppress(FileNotFoundError, subprocess.TimeoutExpired):
         subprocess.run(
             ["security", "delete-generic-password", "-s", SERVICE, "-a", ACCOUNT],
             check=False,
             capture_output=True,
             timeout=5,
         )
-    except (FileNotFoundError, subprocess.TimeoutExpired):
-        pass

--- a/src/shipyard/daemon/secrets.py
+++ b/src/shipyard/daemon/secrets.py
@@ -1,0 +1,122 @@
+"""Secret storage for the webhook HMAC.
+
+macOS: the user's keychain via the ``security`` CLI. A single generic-
+password entry keyed by service + account.
+
+Linux: a plain file at ``<state_dir>/daemon/webhook-secret`` with 600
+permissions. Not as strong as the keychain, but well within the
+threat model for a solo-dev daemon; tightening (e.g. libsecret via
+``secret-tool``) is deferred.
+
+Windows isn't shipped in v1. Callers should prefer
+``load_or_create()`` which handles the "no pre-existing secret" path
+by generating a fresh one.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from shipyard.daemon import signature
+
+SERVICE = "com.danielraffel.shipyard.webhook"
+ACCOUNT = "shared"
+
+
+def load_or_create(state_dir: Path) -> str:
+    """Return the stored secret, generating + persisting one on first
+    call. Idempotent."""
+    existing = load(state_dir)
+    if existing is not None:
+        return existing
+    fresh = signature.generate_secret()
+    save(fresh, state_dir)
+    return fresh
+
+
+def load(state_dir: Path) -> str | None:
+    if sys.platform == "darwin":
+        value = _keychain_find()
+        if value is not None:
+            return value
+    path = _file_path(state_dir)
+    if path.exists():
+        return path.read_text(encoding="utf-8").strip() or None
+    return None
+
+
+def save(value: str, state_dir: Path) -> None:
+    if sys.platform == "darwin":
+        if _keychain_add(value):
+            return
+        # Fall through to file storage if keychain is unavailable.
+    path = _file_path(state_dir)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(value, encoding="utf-8")
+    os.chmod(path, 0o600)
+
+
+def delete(state_dir: Path) -> None:
+    if sys.platform == "darwin":
+        _keychain_delete()
+    path = _file_path(state_dir)
+    if path.exists():
+        path.unlink()
+
+
+def _file_path(state_dir: Path) -> Path:
+    return state_dir / "daemon" / "webhook-secret"
+
+
+def _keychain_find() -> str | None:
+    try:
+        result = subprocess.run(
+            ["security", "find-generic-password", "-s", SERVICE, "-a", ACCOUNT, "-w"],
+            capture_output=True,
+            check=False,
+            timeout=5,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    value = result.stdout.decode(errors="replace").strip()
+    return value or None
+
+
+def _keychain_add(value: str) -> bool:
+    try:
+        subprocess.run(
+            [
+                "security",
+                "add-generic-password",
+                "-U",  # update if exists
+                "-s",
+                SERVICE,
+                "-a",
+                ACCOUNT,
+                "-w",
+                value,
+            ],
+            check=True,
+            capture_output=True,
+            timeout=5,
+        )
+        return True
+    except (FileNotFoundError, subprocess.TimeoutExpired, subprocess.CalledProcessError):
+        return False
+
+
+def _keychain_delete() -> None:
+    try:
+        subprocess.run(
+            ["security", "delete-generic-password", "-s", SERVICE, "-a", ACCOUNT],
+            check=False,
+            capture_output=True,
+            timeout=5,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        pass

--- a/src/shipyard/daemon/server.py
+++ b/src/shipyard/daemon/server.py
@@ -33,15 +33,15 @@ class HandlerResult:
     body: str
 
     @staticmethod
-    def ok() -> "HandlerResult":
+    def ok() -> HandlerResult:
         return HandlerResult(status=HTTPStatus.OK, body="ok\n")
 
     @staticmethod
-    def unauthorized() -> "HandlerResult":
+    def unauthorized() -> HandlerResult:
         return HandlerResult(status=HTTPStatus.UNAUTHORIZED, body="bad signature\n")
 
     @staticmethod
-    def bad_request() -> "HandlerResult":
+    def bad_request() -> HandlerResult:
         return HandlerResult(status=HTTPStatus.BAD_REQUEST, body="bad request\n")
 
 

--- a/src/shipyard/daemon/server.py
+++ b/src/shipyard/daemon/server.py
@@ -1,0 +1,134 @@
+"""Webhook HTTP server — stdlib only.
+
+Mirrors ``WebhookServer.swift``. A single ``POST /webhook`` endpoint
+(plus bare ``/`` for legacy hook URLs that pre-date the path move)
+validates the GitHub HMAC-SHA256 signature and dispatches decoded
+events to a callback.
+
+Using ``ThreadingHTTPServer`` from the standard library rather than
+aiohttp or FastAPI keeps the daemon's footprint small — we're serving
+one endpoint at low request rate, and avoiding an extra dependency is
+worth the small amount of boilerplate.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from collections.abc import Callable
+from dataclasses import dataclass
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+DeliveryHandler = Callable[[dict[str, str], bytes], "HandlerResult"]
+
+
+@dataclass(frozen=True)
+class HandlerResult:
+    status: int
+    body: str
+
+    @staticmethod
+    def ok() -> "HandlerResult":
+        return HandlerResult(status=HTTPStatus.OK, body="ok\n")
+
+    @staticmethod
+    def unauthorized() -> "HandlerResult":
+        return HandlerResult(status=HTTPStatus.UNAUTHORIZED, body="bad signature\n")
+
+    @staticmethod
+    def bad_request() -> "HandlerResult":
+        return HandlerResult(status=HTTPStatus.BAD_REQUEST, body="bad request\n")
+
+
+class WebhookServer:
+    """Binds a ThreadingHTTPServer on localhost + handles ``POST /webhook``.
+
+    Lifecycle:
+        srv = WebhookServer(delivery_handler)
+        port = srv.start()          # returns bound port
+        ...
+        srv.stop()
+
+    The listener runs on a background thread; ``start()`` blocks only
+    until the socket is bound.
+    """
+
+    def __init__(self, delivery_handler: DeliveryHandler) -> None:
+        self._delivery_handler = delivery_handler
+        self._server: ThreadingHTTPServer | None = None
+        self._thread: threading.Thread | None = None
+
+    def start(self) -> int:
+        handler_cls = _make_handler(self._delivery_handler)
+        # Bind to 127.0.0.1 and let the OS pick a port.
+        server = ThreadingHTTPServer(("127.0.0.1", 0), handler_cls)
+        self._server = server
+        self._thread = threading.Thread(
+            target=server.serve_forever,
+            name="shipyard-webhook-server",
+            daemon=True,
+        )
+        self._thread.start()
+        return server.server_address[1]
+
+    def stop(self) -> None:
+        if self._server is not None:
+            self._server.shutdown()
+            self._server.server_close()
+            self._server = None
+        if self._thread is not None:
+            self._thread.join(timeout=2)
+            self._thread = None
+
+
+def _make_handler(delivery_handler: DeliveryHandler) -> type[BaseHTTPRequestHandler]:
+    class _Handler(BaseHTTPRequestHandler):
+        # Silence the default request-logger; we emit through our logger.
+        def log_message(self, format: str, *args: Any) -> None:  # noqa: A002
+            logger.debug("%s - - [%s] %s", self.address_string(), self.log_date_time_string(), format % args)
+
+        def do_POST(self) -> None:  # noqa: N802 — BaseHTTPRequestHandler API
+            path = self.path.split("?", 1)[0]
+            # Accept /webhook (what we register going forward) AND
+            # the bare / that pre-path-move hooks POST to.
+            if path not in ("/webhook", "/"):
+                self._reply(HandlerResult(status=HTTPStatus.NOT_FOUND, body="not found\n"))
+                return
+            try:
+                length = int(self.headers.get("content-length", "0"))
+            except ValueError:
+                self._reply(HandlerResult.bad_request())
+                return
+            if length < 0 or length > 5 * 1024 * 1024:
+                self._reply(HandlerResult.bad_request())
+                return
+            body = self.rfile.read(length) if length > 0 else b""
+            headers = {k.lower(): v for k, v in self.headers.items()}
+            result = delivery_handler(headers, body)
+            self._reply(result)
+
+        def do_GET(self) -> None:  # noqa: N802
+            # Any GET gets 405 — the hook endpoint is POST-only. This
+            # also stops curious browsers from lighting up 404 logs.
+            self._reply(
+                HandlerResult(
+                    status=HTTPStatus.METHOD_NOT_ALLOWED,
+                    body="method not allowed\n",
+                )
+            )
+
+        def _reply(self, result: HandlerResult) -> None:
+            body_bytes = result.body.encode("utf-8")
+            self.send_response(result.status)
+            self.send_header("Content-Type", "text/plain; charset=utf-8")
+            self.send_header("Content-Length", str(len(body_bytes)))
+            self.send_header("Connection", "close")
+            self.end_headers()
+            self.wfile.write(body_bytes)
+
+    return _Handler

--- a/src/shipyard/daemon/signature.py
+++ b/src/shipyard/daemon/signature.py
@@ -1,0 +1,43 @@
+"""GitHub webhook HMAC-SHA256 signature validation.
+
+GitHub signs every webhook body with the secret configured on the
+hook and sends the signature in the ``X-Hub-Signature-256`` header as
+``sha256=<hex>``. The server MUST reject any request whose recomputed
+signature doesn't match — the URL alone isn't secret enough to
+authenticate deliveries.
+
+Mirrors ``WebhookSignature.swift`` in the macOS GUI (CryptoKit there,
+``hmac`` here).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import secrets
+from base64 import b64encode
+
+
+def hmac_sha256_hex(body: bytes, secret: str) -> str:
+    """Compute the hex-encoded HMAC-SHA256 for ``body`` + ``secret``."""
+    return hmac.new(secret.encode("utf-8"), body, hashlib.sha256).hexdigest()
+
+
+def is_valid(body: bytes, secret: str, header: str | None) -> bool:
+    """Constant-time verify a GitHub ``sha256=…`` header.
+
+    Accepts either ``sha256=<hex>`` (GitHub's format) or bare hex, to
+    stay defensive when callers have already stripped the prefix.
+    """
+    if not header:
+        return False
+    provided = header[len("sha256=") :] if header.startswith("sha256=") else header
+    expected = hmac_sha256_hex(body, secret)
+    return hmac.compare_digest(expected, provided)
+
+
+def generate_secret() -> str:
+    """Fresh 32-byte secret, base64-encoded — stored in Keychain (or a
+    600-perm file on Linux) and handed to GitHub when registering the
+    hook."""
+    return b64encode(secrets.token_bytes(32)).decode("ascii")

--- a/src/shipyard/daemon/tailscale.py
+++ b/src/shipyard/daemon/tailscale.py
@@ -1,0 +1,125 @@
+"""Tailscale readiness detection.
+
+Mirrors ``TailscaleProbe.swift`` — shells to the Tailscale CLI's
+``status --json`` output and decides whether the daemon's Funnel
+backend can actually bring up a public tunnel.
+
+Split into pure ``decode()`` (trivial to unit-test) and impure
+``probe()`` (runs the subprocess).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+CANDIDATE_BINARIES = (
+    "/Applications/Tailscale.app/Contents/MacOS/Tailscale",
+    "/opt/homebrew/bin/tailscale",
+    "/usr/local/bin/tailscale",
+    "/usr/bin/tailscale",
+)
+
+_FUNNEL_CAP_KEYS = (
+    "https://tailscale.com/cap/funnel",
+    "funnel",
+)
+
+
+@dataclass(frozen=True)
+class TailscaleStatus:
+    binary_path: str | None
+    backend_state: str | None
+    dns_name: str | None
+    funnel_permitted: bool
+
+    @property
+    def is_ready(self) -> bool:
+        return (
+            self.binary_path is not None
+            and self.backend_state == "Running"
+            and bool(self.dns_name)
+            and self.funnel_permitted
+        )
+
+    @property
+    def funnel_url(self) -> str | None:
+        if not self.is_ready or not self.dns_name:
+            return None
+        trimmed = self.dns_name.rstrip(".")
+        return f"https://{trimmed}" if trimmed else None
+
+
+def resolve_binary(
+    candidates: tuple[str, ...] = CANDIDATE_BINARIES,
+) -> str | None:
+    """First Tailscale CLI on disk, or ``None``."""
+    for path in candidates:
+        if os.access(path, os.X_OK) and Path(path).is_file():
+            return path
+    return None
+
+
+def decode(raw_json: bytes, binary_path: str | None) -> TailscaleStatus:
+    """Pure parser for ``tailscale status --json`` output."""
+    try:
+        obj = json.loads(raw_json)
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return TailscaleStatus(
+            binary_path=binary_path,
+            backend_state=None,
+            dns_name=None,
+            funnel_permitted=False,
+        )
+    if not isinstance(obj, dict):
+        return TailscaleStatus(
+            binary_path=binary_path,
+            backend_state=None,
+            dns_name=None,
+            funnel_permitted=False,
+        )
+    backend = obj.get("BackendState") if isinstance(obj.get("BackendState"), str) else None
+    self_obj = obj.get("Self") if isinstance(obj.get("Self"), dict) else {}
+    dns = self_obj.get("DNSName") if isinstance(self_obj.get("DNSName"), str) else None
+    cap_map = self_obj.get("CapMap") if isinstance(self_obj.get("CapMap"), dict) else {}
+    permitted = any(k in cap_map for k in _FUNNEL_CAP_KEYS)
+    return TailscaleStatus(
+        binary_path=binary_path,
+        backend_state=backend,
+        dns_name=dns,
+        funnel_permitted=permitted,
+    )
+
+
+def probe(timeout: float = 5.0) -> TailscaleStatus:
+    """Run ``tailscale status --json`` and return a parsed snapshot.
+
+    Returns a "not installed" status if the binary isn't on disk, and
+    an empty-state status if the subprocess fails.
+    """
+    binary = resolve_binary()
+    if binary is None:
+        return TailscaleStatus(
+            binary_path=None,
+            backend_state=None,
+            dns_name=None,
+            funnel_permitted=False,
+        )
+    try:
+        result = subprocess.run(
+            [binary, "status", "--json"],
+            capture_output=True,
+            timeout=timeout,
+            check=False,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return TailscaleStatus(
+            binary_path=binary,
+            backend_state=None,
+            dns_name=None,
+            funnel_permitted=False,
+        )
+    return decode(result.stdout or b"", binary)

--- a/src/shipyard/daemon/tailscale.py
+++ b/src/shipyard/daemon/tailscale.py
@@ -81,10 +81,14 @@ def decode(raw_json: bytes, binary_path: str | None) -> TailscaleStatus:
             dns_name=None,
             funnel_permitted=False,
         )
-    backend = obj.get("BackendState") if isinstance(obj.get("BackendState"), str) else None
-    self_obj = obj.get("Self") if isinstance(obj.get("Self"), dict) else {}
-    dns = self_obj.get("DNSName") if isinstance(self_obj.get("DNSName"), str) else None
-    cap_map = self_obj.get("CapMap") if isinstance(self_obj.get("CapMap"), dict) else {}
+    backend_raw = obj.get("BackendState")
+    backend = backend_raw if isinstance(backend_raw, str) else None
+    self_raw = obj.get("Self")
+    self_obj: dict[str, object] = self_raw if isinstance(self_raw, dict) else {}
+    dns_raw = self_obj.get("DNSName")
+    dns = dns_raw if isinstance(dns_raw, str) else None
+    cap_raw = self_obj.get("CapMap")
+    cap_map: dict[str, object] = cap_raw if isinstance(cap_raw, dict) else {}
     permitted = any(k in cap_map for k in _FUNNEL_CAP_KEYS)
     return TailscaleStatus(
         binary_path=binary_path,

--- a/src/shipyard/daemon/tunnels/__init__.py
+++ b/src/shipyard/daemon/tunnels/__init__.py
@@ -1,0 +1,9 @@
+"""Tunnel backends for the webhook daemon.
+
+Tunnel backends expose a local TCP port to the public internet so
+GitHub can POST webhooks to it. The daemon ships Tailscale Funnel
+in v1; Cloudflare Tunnel / ngrok / user-supplied reverse-proxy
+backends are tracked in Shipyard #126.
+
+All backends implement ``TunnelBackend`` in ``base.py``.
+"""

--- a/src/shipyard/daemon/tunnels/base.py
+++ b/src/shipyard/daemon/tunnels/base.py
@@ -1,0 +1,49 @@
+"""Abstract tunnel backend interface."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+
+class TunnelError(Exception):
+    """Base for backend failures."""
+
+
+class TunnelNotReadyError(TunnelError):
+    """Backend isn't installed / configured / authenticated."""
+
+
+class TunnelStartError(TunnelError):
+    """Backend is ready but ``start()`` didn't succeed."""
+
+
+@dataclass(frozen=True)
+class TunnelInfo:
+    """Public-facing details of a running tunnel."""
+
+    public_url: str
+    backend: str
+
+
+class TunnelBackend(Protocol):
+    """What every tunnel implementation must support."""
+
+    name: str
+
+    async def detect(self) -> bool:
+        """Is this backend installed + authenticated + ready to start?"""
+        ...
+
+    async def start(self, local_port: int) -> TunnelInfo:
+        """Bring the tunnel up. Idempotent: calling twice with the
+        same port must not produce a broken config."""
+        ...
+
+    async def stop(self) -> None:
+        """Tear down. Safe when nothing is configured."""
+        ...
+
+    async def verify(self, local_port: int) -> bool:
+        """Confirm the tunnel is currently proxying to ``local_port``."""
+        ...

--- a/src/shipyard/daemon/tunnels/tailscale.py
+++ b/src/shipyard/daemon/tunnels/tailscale.py
@@ -40,10 +40,13 @@ class TailscaleFunnelBackend:
             )
         self._binary = status.binary_path
 
+        binary = self._binary
+        assert binary is not None  # is_ready above guarantees this
+
         # Reset first so a previous launch's mapping doesn't win.
         # Without this, `funnel --bg <newport>` is a no-op when `/` is
         # already claimed by the old port. Swift hit this exact bug.
-        await self._run([self._binary, "funnel", "reset"])
+        await self._run([binary, "funnel", "reset"])
         # Brief settle — daemon sometimes hasn't applied the reset
         # when the next call lands, and the second call then silently
         # no-ops.
@@ -52,7 +55,7 @@ class TailscaleFunnelBackend:
         last_output = ""
         for attempt in range(1, 4):
             code, output = await self._run(
-                [self._binary, "funnel", "--bg", str(local_port)]
+                [binary, "funnel", "--bg", str(local_port)]
             )
             last_output = output
             if code != 0:

--- a/src/shipyard/daemon/tunnels/tailscale.py
+++ b/src/shipyard/daemon/tunnels/tailscale.py
@@ -1,0 +1,94 @@
+"""Tailscale Funnel tunnel backend.
+
+Mirrors ``TunnelController.swift`` + ``TailscaleProbe.swift`` —
+``tailscale funnel reset`` + ``tailscale funnel --bg <port>`` with a
+post-start verification loop. Without the verify-and-retry the Swift
+version hit a race where ``--bg`` returned exit 0 without the daemon
+actually persisting the proxy config; we do the same safety dance
+here.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from shipyard.daemon import tailscale as probe_mod
+from shipyard.daemon.tunnels.base import TunnelInfo, TunnelNotReadyError, TunnelStartError
+
+
+class TailscaleFunnelBackend:
+    name = "tailscale"
+
+    def __init__(self) -> None:
+        self._binary: str | None = None
+        self._configured_port: int | None = None
+
+    async def detect(self) -> bool:
+        self._binary = probe_mod.resolve_binary()
+        if self._binary is None:
+            return False
+        status = await asyncio.to_thread(probe_mod.probe)
+        return status.is_ready
+
+    async def start(self, local_port: int) -> TunnelInfo:
+        status = await asyncio.to_thread(probe_mod.probe)
+        if not status.is_ready or status.funnel_url is None:
+            raise TunnelNotReadyError(
+                "Tailscale Funnel isn't ready: "
+                f"backend={status.backend_state!r} "
+                f"funnel_permitted={status.funnel_permitted}"
+            )
+        self._binary = status.binary_path
+
+        # Reset first so a previous launch's mapping doesn't win.
+        # Without this, `funnel --bg <newport>` is a no-op when `/` is
+        # already claimed by the old port. Swift hit this exact bug.
+        await self._run([self._binary, "funnel", "reset"])
+        # Brief settle — daemon sometimes hasn't applied the reset
+        # when the next call lands, and the second call then silently
+        # no-ops.
+        await asyncio.sleep(0.5)
+
+        last_output = ""
+        for attempt in range(1, 4):
+            code, output = await self._run(
+                [self._binary, "funnel", "--bg", str(local_port)]
+            )
+            last_output = output
+            if code != 0:
+                raise TunnelStartError(f"funnel --bg failed: {output.strip()}")
+            if await self._verify_configured(local_port):
+                self._configured_port = local_port
+                return TunnelInfo(public_url=status.funnel_url, backend=self.name)
+            await asyncio.sleep(0.5 * attempt)
+        raise TunnelStartError(
+            "funnel --bg returned 0 but serve config didn't persist. "
+            f"last output: {last_output.strip()}"
+        )
+
+    async def stop(self) -> None:
+        if self._binary is None:
+            self._binary = probe_mod.resolve_binary()
+        if self._binary is None:
+            return
+        await self._run([self._binary, "funnel", "reset"])
+        self._configured_port = None
+
+    async def verify(self, local_port: int) -> bool:
+        if self._binary is None:
+            return False
+        return await self._verify_configured(local_port)
+
+    async def _verify_configured(self, local_port: int) -> bool:
+        assert self._binary is not None
+        _code, output = await self._run([self._binary, "funnel", "status"])
+        return f"127.0.0.1:{local_port}" in output
+
+    async def _run(self, argv: list[str]) -> tuple[int, str]:
+        proc = await asyncio.create_subprocess_exec(
+            *argv,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.STDOUT,
+        )
+        stdout, _ = await proc.communicate()
+        return proc.returncode or 0, (stdout or b"").decode(errors="replace")

--- a/tests/daemon/test_disclosure.py
+++ b/tests/daemon/test_disclosure.py
@@ -1,0 +1,44 @@
+"""First-run disclosure visibility + ack-idempotency tests."""
+
+from __future__ import annotations
+
+import io
+from pathlib import Path
+
+from shipyard.daemon import disclosure
+
+
+def test_notice_mentions_tailscale_and_opt_out(tmp_path: Path) -> None:
+    text = disclosure.render(repos=["org/repo"])
+    # These are the core claims the notice must make — if they ever
+    # regress, the test will catch it.
+    assert "Tailscale Funnel" in text
+    assert "GitHub webhook" in text
+    assert "HMAC secret" in text
+    assert "polling" in text  # explicit fallback path
+    assert "org/repo" in text
+
+
+def test_notice_lists_no_repos_gracefully() -> None:
+    text = disclosure.render(repos=[])
+    assert "(none detected" in text
+
+
+def test_shown_once_per_state_dir(tmp_path: Path) -> None:
+    stream = io.StringIO()
+    first = disclosure.show_if_first_run(tmp_path, ["org/repo"], stream=stream)
+    assert first is True
+    assert "Tailscale Funnel" in stream.getvalue()
+
+    # Second call: already-acked, no output.
+    stream2 = io.StringIO()
+    second = disclosure.show_if_first_run(tmp_path, ["org/repo"], stream=stream2)
+    assert second is False
+    assert stream2.getvalue() == ""
+
+
+def test_ack_marker_at_expected_path(tmp_path: Path) -> None:
+    assert not disclosure.has_been_shown(tmp_path)
+    disclosure.mark_shown(tmp_path)
+    assert disclosure.has_been_shown(tmp_path)
+    assert (tmp_path / "daemon" / ".first-run-acked").exists()

--- a/tests/daemon/test_events.py
+++ b/tests/daemon/test_events.py
@@ -1,0 +1,137 @@
+"""Webhook event decoder parity with ``WebhookEventDecoderTests``."""
+
+from __future__ import annotations
+
+import json
+
+from shipyard.daemon import events
+
+
+def test_decode_workflow_run_completed() -> None:
+    body = json.dumps(
+        {
+            "action": "completed",
+            "workflow_run": {
+                "id": 42,
+                "head_branch": "feature/x",
+                "head_sha": "abc",
+                "status": "completed",
+                "conclusion": "success",
+                "name": "CI",
+                "html_url": "https://github.com/org/repo/actions/runs/42",
+            },
+            "repository": {"full_name": "org/repo"},
+        }
+    ).encode()
+    got = events.decode("workflow_run", body)
+    assert got is not None
+    assert got.kind == "workflow_run"
+    assert got.workflow_run is not None
+    assert got.workflow_run.action == "completed"
+    assert got.workflow_run.run_id == 42
+    assert got.workflow_run.repo == "org/repo"
+    assert got.workflow_run.head_branch == "feature/x"
+    assert got.workflow_run.conclusion == "success"
+
+
+def test_decode_workflow_job_in_progress() -> None:
+    body = json.dumps(
+        {
+            "action": "in_progress",
+            "workflow_job": {
+                "id": 99,
+                "run_id": 42,
+                "name": "macOS (arm64)",
+                "status": "in_progress",
+                "conclusion": None,
+                "runner_name": "macOS-arm64-1",
+                "labels": ["self-hosted", "macOS"],
+            },
+            "repository": {"full_name": "org/repo"},
+        }
+    ).encode()
+    got = events.decode("workflow_job", body)
+    assert got is not None
+    assert got.workflow_job is not None
+    assert got.workflow_job.job_id == 99
+    assert got.workflow_job.run_id == 42
+    assert got.workflow_job.name == "macOS (arm64)"
+    assert got.workflow_job.status == "in_progress"
+    assert got.workflow_job.conclusion is None
+    assert got.workflow_job.labels == ["self-hosted", "macOS"]
+
+
+def test_decode_pull_request_merged() -> None:
+    body = json.dumps(
+        {
+            "action": "closed",
+            "number": 581,
+            "pull_request": {
+                "number": 581,
+                "state": "closed",
+                "merged": True,
+                "merged_at": "2026-04-20T12:00:00Z",
+                "closed_at": "2026-04-20T12:00:00Z",
+            },
+            "repository": {"full_name": "org/repo"},
+        }
+    ).encode()
+    got = events.decode("pull_request", body)
+    assert got is not None
+    assert got.pull_request is not None
+    assert got.pull_request.number == 581
+    assert got.pull_request.state == "closed"
+    assert got.pull_request.merged is True
+
+
+def test_decode_unknown_event_type_is_unhandled() -> None:
+    got = events.decode("star", b"{}")
+    assert got is not None
+    assert got.kind == "unhandled"
+    assert got.unhandled_type == "star"
+
+
+def test_decode_missing_event_header_returns_none() -> None:
+    assert events.decode(None, b"{}") is None
+    assert events.decode("", b"{}") is None
+
+
+def test_decode_malformed_body_returns_none() -> None:
+    assert events.decode("workflow_run", b"{oops") is None
+
+
+def test_decode_workflow_run_missing_repository_returns_none() -> None:
+    body = json.dumps(
+        {
+            "action": "completed",
+            "workflow_run": {
+                "id": 1,
+                "head_branch": "x",
+                "head_sha": "y",
+                "status": "completed",
+            },
+        }
+    ).encode()
+    assert events.decode("workflow_run", body) is None
+
+
+def test_to_wire_shape_for_workflow_run() -> None:
+    body = json.dumps(
+        {
+            "action": "completed",
+            "workflow_run": {
+                "id": 1,
+                "head_branch": "x",
+                "head_sha": "y",
+                "status": "completed",
+                "name": "CI",
+            },
+            "repository": {"full_name": "o/r"},
+        }
+    ).encode()
+    evt = events.decode("workflow_run", body)
+    assert evt is not None
+    wire = evt.to_wire()
+    assert wire["kind"] == "workflow_run"
+    assert wire["payload"]["run_id"] == 1
+    assert wire["payload"]["repo"] == "o/r"

--- a/tests/daemon/test_ipc_roundtrip.py
+++ b/tests/daemon/test_ipc_roundtrip.py
@@ -1,0 +1,148 @@
+"""End-to-end IPC round-trip: broadcast_event → subscriber sees it.
+
+Exercises the Unix socket server + ring buffer + subscribe semantics
+without needing a running daemon. Each test is its own event loop so
+pytest-asyncio isn't required.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import socket
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from shipyard.daemon.ipc import IPCServer, IPCState
+
+
+@pytest.fixture
+def short_socket_path():
+    # macOS limits AF_UNIX paths to ~104 chars; pytest's tmp_path
+    # nests deep enough to blow that. Use /tmp-rooted tempdir instead.
+    with tempfile.TemporaryDirectory(prefix="sy-ipc-") as d:
+        yield Path(d) / "daemon.sock"
+
+
+def _dummy_state() -> IPCState:
+    return IPCState(
+        tunnel_backend="tailscale",
+        tunnel_url="https://example.ts.net",
+        tunnel_verified_at=None,
+        subscribers=0,
+        last_event_at=None,
+        registered_repos=["org/repo"],
+        rate_limit=None,
+    )
+
+
+def _read_lines_blocking(sock: socket.socket, count: int, timeout: float = 3.0) -> list[dict]:
+    sock.settimeout(timeout)
+    buf = b""
+    out: list[dict] = []
+    while len(out) < count:
+        chunk = sock.recv(65536)
+        if not chunk:
+            break
+        buf += chunk
+        while b"\n" in buf and len(out) < count:
+            line, _, buf = buf.partition(b"\n")
+            out.append(json.loads(line))
+    return out
+
+
+def test_subscribe_then_receive_broadcast(short_socket_path: Path) -> None:
+    async def run() -> None:
+        server = IPCServer(
+            socket_path=short_socket_path,
+            status_provider=_dummy_state,
+        )
+        await server.start()
+        try:
+            def client_fn() -> list[dict]:
+                sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+                sock.connect(str(short_socket_path))
+                try:
+                    sock.sendall(b'{"type":"subscribe"}\n')
+                    return _read_lines_blocking(sock, count=2)
+                finally:
+                    sock.close()
+
+            lines_task = asyncio.create_task(asyncio.to_thread(client_fn))
+
+            await asyncio.sleep(0.2)
+            await server.broadcast_event({"kind": "workflow_run", "payload": {"x": 1}})
+            lines = await asyncio.wait_for(lines_task, timeout=3.0)
+        finally:
+            await server.stop()
+
+        assert lines[0]["type"] == "hello"
+        assert lines[1]["type"] == "event"
+        assert lines[1]["kind"] == "workflow_run"
+        assert lines[1]["payload"] == {"x": 1}
+
+    asyncio.run(run())
+
+
+def test_late_subscriber_gets_ring_buffer_backlog(short_socket_path: Path) -> None:
+    async def run() -> None:
+        server = IPCServer(
+            socket_path=short_socket_path,
+            status_provider=_dummy_state,
+        )
+        await server.start()
+        try:
+            await server.broadcast_event({"kind": "workflow_run", "payload": {"id": 1}})
+            await server.broadcast_event({"kind": "workflow_run", "payload": {"id": 2}})
+
+            def client_fn() -> list[dict]:
+                sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+                sock.connect(str(short_socket_path))
+                try:
+                    sock.sendall(b'{"type":"subscribe"}\n')
+                    return _read_lines_blocking(sock, count=3)
+                finally:
+                    sock.close()
+
+            lines = await asyncio.wait_for(asyncio.to_thread(client_fn), timeout=3.0)
+        finally:
+            await server.stop()
+
+        assert lines[0]["type"] == "hello"
+        assert [(x["type"], x["payload"]["id"]) for x in lines[1:]] == [
+            ("event", 1),
+            ("event", 2),
+        ]
+
+    asyncio.run(run())
+
+
+def test_status_request_returns_snapshot(short_socket_path: Path) -> None:
+    async def run() -> None:
+        server = IPCServer(
+            socket_path=short_socket_path,
+            status_provider=_dummy_state,
+        )
+        await server.start()
+        try:
+            def client_fn() -> list[dict]:
+                sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+                sock.connect(str(short_socket_path))
+                try:
+                    sock.sendall(b'{"type":"status"}\n')
+                    return _read_lines_blocking(sock, count=2)
+                finally:
+                    sock.close()
+
+            lines = await asyncio.wait_for(asyncio.to_thread(client_fn), timeout=3.0)
+        finally:
+            await server.stop()
+
+        assert lines[0]["type"] == "hello"
+        assert lines[1]["type"] == "status"
+        assert lines[1]["tunnel"]["backend"] == "tailscale"
+        assert lines[1]["registered_repos"] == ["org/repo"]
+
+    asyncio.run(run())

--- a/tests/daemon/test_ipc_roundtrip.py
+++ b/tests/daemon/test_ipc_roundtrip.py
@@ -10,12 +10,21 @@ from __future__ import annotations
 import asyncio
 import json
 import socket
+import sys
 import tempfile
 from pathlib import Path
 
 import pytest
 
 from shipyard.daemon.ipc import IPCServer, IPCState
+
+# The daemon IPC uses AF_UNIX sockets, which don't exist on Windows.
+# The daemon itself is macOS/Linux only; skip at file scope rather
+# than littering each test.
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="AF_UNIX sockets are macOS/Linux only",
+)
 
 
 @pytest.fixture

--- a/tests/daemon/test_registrar.py
+++ b/tests/daemon/test_registrar.py
@@ -1,0 +1,122 @@
+"""Registrar tests — ``gh`` is faked with a tiny shell stub.
+
+The stub reads stdin, prints a canned response, exits 0 unless the
+caller asked for a failure. This exercises the registrar's subprocess
+handling without requiring a real ``gh`` binary or real GitHub auth.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import stat
+from pathlib import Path
+
+import pytest
+
+from shipyard.daemon.registrar import Registrar, RegistrarError
+
+
+def _write_gh_stub(path: Path, *, hook_id: int = 42, fail: bool = False) -> str:
+    """Write a tiny script that behaves like ``gh api``."""
+    script = path / "gh"
+    if fail:
+        body = "#!/usr/bin/env bash\necho 'gh: simulated failure' >&2\nexit 1\n"
+    else:
+        body = (
+            "#!/usr/bin/env bash\n"
+            f"echo '{{\"id\": {hook_id}, \"active\": true}}'\n"
+            "exit 0\n"
+        )
+    script.write_text(body)
+    os.chmod(script, os.stat(script).st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+    return str(script)
+
+
+def test_create_caches_hook_id(tmp_path: Path) -> None:
+    gh = _write_gh_stub(tmp_path, hook_id=9001)
+    registrar = Registrar(state_dir=tmp_path)
+
+    hook_id = asyncio.run(
+        registrar.ensure_registered(
+            "org/repo",
+            "https://example.ts.net/webhook",
+            "secret",
+            gh_binary=gh,
+        )
+    )
+    assert hook_id == 9001
+    # Second call reuses the cached ID — subsequent calls go through
+    # the update (PATCH) path, not create, so it's bound to the same
+    # hook ID regardless.
+    reused = asyncio.run(
+        registrar.ensure_registered(
+            "org/repo",
+            "https://example.ts.net/webhook",
+            "secret",
+            gh_binary=gh,
+        )
+    )
+    assert reused == 9001
+
+
+def test_create_persists_to_disk_across_instances(tmp_path: Path) -> None:
+    gh = _write_gh_stub(tmp_path, hook_id=7)
+
+    first = Registrar(state_dir=tmp_path)
+    hook_id = asyncio.run(
+        first.ensure_registered("org/repo", "https://x.ts.net/webhook", "s", gh_binary=gh)
+    )
+    assert hook_id == 7
+
+    # New Registrar instance reads the persisted file.
+    second = Registrar(state_dir=tmp_path)
+    assert second.all() == {"org/repo": 7}
+
+
+def test_create_failure_bubbles_as_registrar_error(tmp_path: Path) -> None:
+    gh = _write_gh_stub(tmp_path, fail=True)
+    registrar = Registrar(state_dir=tmp_path)
+
+    with pytest.raises(RegistrarError):
+        asyncio.run(
+            registrar.ensure_registered(
+                "org/repo", "https://x.ts.net/webhook", "s", gh_binary=gh
+            )
+        )
+
+
+def test_missing_gh_binary_raises(tmp_path: Path) -> None:
+    registrar = Registrar(state_dir=tmp_path)
+    with pytest.raises(RegistrarError):
+        asyncio.run(
+            registrar.ensure_registered(
+                "org/repo",
+                "https://x.ts.net/webhook",
+                "s",
+                gh_binary=str(tmp_path / "does-not-exist"),
+            )
+        )
+
+
+def test_unregister_removes_from_persistence(tmp_path: Path) -> None:
+    gh = _write_gh_stub(tmp_path, hook_id=5)
+    registrar = Registrar(state_dir=tmp_path)
+
+    asyncio.run(
+        registrar.ensure_registered(
+            "org/repo", "https://x.ts.net/webhook", "s", gh_binary=gh
+        )
+    )
+    assert registrar.all() == {"org/repo": 5}
+
+    # Unregister — gh DELETE returns 0 from our stub.
+    asyncio.run(registrar.unregister("org/repo", gh_binary=gh))
+    assert registrar.all() == {}
+
+    # Persisted file reflects the empty state.
+    persisted = json.loads(
+        (tmp_path / "daemon" / "registrations.json").read_text()
+    )
+    assert persisted == []

--- a/tests/daemon/test_registrar.py
+++ b/tests/daemon/test_registrar.py
@@ -11,11 +11,20 @@ import asyncio
 import json
 import os
 import stat
+import sys
 from pathlib import Path
 
 import pytest
 
 from shipyard.daemon.registrar import Registrar, RegistrarError
+
+# The gh stub is a bash script; skip on Windows where /bin/bash isn't
+# guaranteed. The registrar itself is cross-platform but the test
+# harness isn't.
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="bash-stub test harness doesn't run on Windows",
+)
 
 
 def _write_gh_stub(path: Path, *, hook_id: int = 42, fail: bool = False) -> str:

--- a/tests/daemon/test_runner.py
+++ b/tests/daemon/test_runner.py
@@ -1,0 +1,40 @@
+"""Runner / lifecycle tests — daemon PID semantics + stop_running."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from shipyard.daemon.runner import daemon_is_running, stop_running
+
+
+def test_no_pid_file_means_not_running(tmp_path: Path) -> None:
+    assert not daemon_is_running(tmp_path)
+
+
+def test_stale_pid_file_treated_as_not_running(tmp_path: Path) -> None:
+    pid_dir = tmp_path / "daemon"
+    pid_dir.mkdir(parents=True)
+    # A PID that's vanishingly unlikely to belong to a real process.
+    (pid_dir / "daemon.pid").write_text("4000001\n", encoding="utf-8")
+    assert not daemon_is_running(tmp_path)
+
+
+def test_live_pid_reports_running(tmp_path: Path) -> None:
+    pid_dir = tmp_path / "daemon"
+    pid_dir.mkdir(parents=True)
+    (pid_dir / "daemon.pid").write_text(f"{os.getpid()}\n", encoding="utf-8")
+    assert daemon_is_running(tmp_path)
+
+
+def test_stop_running_when_nothing_exists(tmp_path: Path) -> None:
+    assert stop_running(tmp_path) is False
+
+
+def test_stop_running_with_stale_pid_cleans_up(tmp_path: Path) -> None:
+    pid_dir = tmp_path / "daemon"
+    pid_dir.mkdir(parents=True)
+    (pid_dir / "daemon.pid").write_text("4000001\n", encoding="utf-8")
+    assert stop_running(tmp_path) is False  # nothing was actually stopped
+    # Stale file should be cleaned up.
+    assert not (pid_dir / "daemon.pid").exists()

--- a/tests/daemon/test_runner.py
+++ b/tests/daemon/test_runner.py
@@ -3,9 +3,19 @@
 from __future__ import annotations
 
 import os
+import sys
 from pathlib import Path
 
+import pytest
+
 from shipyard.daemon.runner import daemon_is_running, stop_running
+
+# stop_running uses AF_UNIX sockets on the happy path. PID semantics
+# work on Windows but the full suite wasn't designed for it.
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="daemon lifecycle uses AF_UNIX sockets (macOS/Linux only)",
+)
 
 
 def test_no_pid_file_means_not_running(tmp_path: Path) -> None:

--- a/tests/daemon/test_server.py
+++ b/tests/daemon/test_server.py
@@ -1,0 +1,116 @@
+"""End-to-end webhook-server test parity with ``WebhookServerTests``."""
+
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.request
+
+import pytest
+
+from shipyard.daemon import signature
+from shipyard.daemon.server import HandlerResult, WebhookServer
+
+
+def test_accepts_signed_post_on_webhook_path() -> None:
+    secret = "unit-test-secret"
+    body = json.dumps({"zen": "Non-blocking is better than blocking."}).encode()
+    mac = signature.hmac_sha256_hex(body, secret)
+    seen: dict[str, object] = {}
+
+    def handler(headers: dict[str, str], payload: bytes) -> HandlerResult:
+        seen["headers"] = headers
+        seen["body"] = payload
+        if not signature.is_valid(payload, secret, headers.get("x-hub-signature-256")):
+            return HandlerResult.unauthorized()
+        return HandlerResult.ok()
+
+    server = WebhookServer(handler)
+    port = server.start()
+    try:
+        req = urllib.request.Request(
+            f"http://127.0.0.1:{port}/webhook",
+            data=body,
+            method="POST",
+            headers={
+                "X-Hub-Signature-256": f"sha256={mac}",
+                "X-GitHub-Event": "ping",
+                "Content-Type": "application/json",
+            },
+        )
+        with urllib.request.urlopen(req, timeout=5) as resp:  # noqa: S310
+            assert resp.status == 200
+    finally:
+        server.stop()
+
+    assert seen["body"] == body
+    assert isinstance(seen["headers"], dict)
+    assert seen["headers"]["x-github-event"] == "ping"
+
+
+def test_accepts_post_on_root_path_for_legacy_hook_compat() -> None:
+    server = WebhookServer(lambda _h, _b: HandlerResult.ok())
+    port = server.start()
+    try:
+        req = urllib.request.Request(
+            f"http://127.0.0.1:{port}/",
+            data=b"{}",
+            method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=5) as resp:  # noqa: S310
+            assert resp.status == 200
+    finally:
+        server.stop()
+
+
+def test_rejects_get() -> None:
+    server = WebhookServer(lambda _h, _b: HandlerResult.ok())
+    port = server.start()
+    try:
+        with pytest.raises(urllib.error.HTTPError) as excinfo:
+            urllib.request.urlopen(  # noqa: S310
+                f"http://127.0.0.1:{port}/webhook", timeout=5
+            )
+        assert excinfo.value.code == 405
+    finally:
+        server.stop()
+
+
+def test_returns_404_for_unknown_path() -> None:
+    server = WebhookServer(lambda _h, _b: HandlerResult.ok())
+    port = server.start()
+    try:
+        req = urllib.request.Request(
+            f"http://127.0.0.1:{port}/nope",
+            data=b"",
+            method="POST",
+        )
+        with pytest.raises(urllib.error.HTTPError) as excinfo:
+            urllib.request.urlopen(req, timeout=5)  # noqa: S310
+        assert excinfo.value.code == 404
+    finally:
+        server.stop()
+
+
+def test_rejects_bogus_signature() -> None:
+    secret = "shh"
+
+    def handler(headers: dict[str, str], payload: bytes) -> HandlerResult:
+        if not signature.is_valid(payload, secret, headers.get("x-hub-signature-256")):
+            return HandlerResult.unauthorized()
+        return HandlerResult.ok()
+
+    server = WebhookServer(handler)
+    port = server.start()
+    try:
+        req = urllib.request.Request(
+            f"http://127.0.0.1:{port}/webhook",
+            data=b"payload",
+            method="POST",
+            headers={"X-Hub-Signature-256": "sha256=deadbeef"},
+        )
+        with pytest.raises(urllib.error.HTTPError) as excinfo:
+            urllib.request.urlopen(req, timeout=5)  # noqa: S310
+        assert excinfo.value.code == 401
+    finally:
+        server.stop()

--- a/tests/daemon/test_signature.py
+++ b/tests/daemon/test_signature.py
@@ -1,0 +1,54 @@
+"""Signature validation parity with the Swift ``WebhookSignatureTests``."""
+
+from __future__ import annotations
+
+from base64 import b64decode
+
+from shipyard.daemon import signature
+
+
+def test_matches_github_reference_vector() -> None:
+    # From https://docs.github.com/en/webhooks/using-webhooks/validating-webhook-deliveries
+    body = b"Hello, World!"
+    secret = "It's a Secret to Everybody"
+    expected = "757107ea0eb2509fc211221cce984b8a37570b6d7586c22c46f4379c8b043e17"
+    assert signature.hmac_sha256_hex(body, secret) == expected
+
+
+def test_accepts_sha256_prefixed_header() -> None:
+    body = b"payload"
+    mac = signature.hmac_sha256_hex(body, "shh")
+    assert signature.is_valid(body, "shh", f"sha256={mac}")
+
+
+def test_accepts_bare_hex_header() -> None:
+    body = b"payload"
+    mac = signature.hmac_sha256_hex(body, "shh")
+    assert signature.is_valid(body, "shh", mac)
+
+
+def test_rejects_body_tamper() -> None:
+    body = b"payload"
+    mac = signature.hmac_sha256_hex(body, "shh")
+    assert not signature.is_valid(b"payloa!", "shh", f"sha256={mac}")
+
+
+def test_rejects_secret_mismatch() -> None:
+    body = b"payload"
+    mac = signature.hmac_sha256_hex(body, "shh")
+    assert not signature.is_valid(body, "wrong", f"sha256={mac}")
+
+
+def test_rejects_missing_header() -> None:
+    body = b"payload"
+    assert not signature.is_valid(body, "shh", None)
+    assert not signature.is_valid(body, "shh", "")
+
+
+def test_generate_secret_is_distinct_and_base64() -> None:
+    a = signature.generate_secret()
+    b = signature.generate_secret()
+    assert a != b
+    # Should round-trip through base64.
+    assert b64decode(a)
+    assert b64decode(b)

--- a/tests/daemon/test_tailscale.py
+++ b/tests/daemon/test_tailscale.py
@@ -1,0 +1,98 @@
+"""Tailscale status decoder parity with ``TailscaleProbeTests``."""
+
+from __future__ import annotations
+
+import json
+
+from shipyard.daemon import tailscale
+
+
+def test_decode_ready_happy_path() -> None:
+    raw = json.dumps(
+        {
+            "BackendState": "Running",
+            "Self": {
+                "DNSName": "spacely.corvus-rufinus.ts.net.",
+                "CapMap": {
+                    "https://tailscale.com/cap/funnel": ["ports:443"],
+                },
+            },
+        }
+    ).encode()
+    status = tailscale.decode(raw, binary_path="/usr/local/bin/tailscale")
+    assert status.is_ready
+    assert status.funnel_url == "https://spacely.corvus-rufinus.ts.net"
+
+
+def test_decode_backend_not_running_is_not_ready() -> None:
+    raw = json.dumps(
+        {
+            "BackendState": "NeedsLogin",
+            "Self": {
+                "DNSName": "foo.ts.net",
+                "CapMap": {"https://tailscale.com/cap/funnel": []},
+            },
+        }
+    ).encode()
+    status = tailscale.decode(raw, binary_path="/x")
+    assert not status.is_ready
+    assert status.funnel_url is None
+
+
+def test_decode_missing_funnel_cap_is_not_ready() -> None:
+    raw = json.dumps(
+        {
+            "BackendState": "Running",
+            "Self": {
+                "DNSName": "foo.ts.net",
+                "CapMap": {"https://tailscale.com/cap/other": []},
+            },
+        }
+    ).encode()
+    assert not tailscale.decode(raw, binary_path="/x").is_ready
+
+
+def test_decode_bare_funnel_key_accepted() -> None:
+    raw = json.dumps(
+        {
+            "BackendState": "Running",
+            "Self": {
+                "DNSName": "foo.ts.net",
+                "CapMap": {"funnel": []},
+            },
+        }
+    ).encode()
+    assert tailscale.decode(raw, binary_path="/x").is_ready
+
+
+def test_decode_trailing_dot_stripped_from_dns_name() -> None:
+    raw = json.dumps(
+        {
+            "BackendState": "Running",
+            "Self": {
+                "DNSName": "foo.ts.net.",
+                "CapMap": {"https://tailscale.com/cap/funnel": []},
+            },
+        }
+    ).encode()
+    status = tailscale.decode(raw, binary_path="/x")
+    assert status.funnel_url == "https://foo.ts.net"
+
+
+def test_decode_malformed_json_returns_not_ready() -> None:
+    status = tailscale.decode(b"not json", binary_path="/x")
+    assert not status.is_ready
+    assert status.funnel_url is None
+
+
+def test_decode_nil_binary_path_is_not_ready() -> None:
+    raw = json.dumps(
+        {
+            "BackendState": "Running",
+            "Self": {
+                "DNSName": "foo.ts.net",
+                "CapMap": {"https://tailscale.com/cap/funnel": []},
+            },
+        }
+    ).encode()
+    assert not tailscale.decode(raw, binary_path=None).is_ready


### PR DESCRIPTION
Closes #125.

Brings the live-mode webhook pipeline from \`shipyard-macos-gui\` into the CLI as \`shipyard daemon\`. Mac / Linux / CI now all have the same subscribable event stream. The macOS app migration to consume this daemon is [shipyard-macos-gui#3](https://github.com/danielraffel/shipyard-macos-gui/issues/3) and lands after this.

## What's in the PR

### New package: \`src/shipyard/daemon/\`

Ports the Swift live-mode services 1:1:

| Python module | Swift equivalent |
|---|---|
| \`signature.py\` | \`WebhookSignature.swift\` |
| \`events.py\` | \`WebhookEvent.swift\` + decoder |
| \`tailscale.py\` | \`TailscaleProbe.swift\` |
| \`tunnels/base.py\` | \`TunnelBackend\` protocol |
| \`tunnels/tailscale.py\` | \`TunnelController.swift\` (reset + --bg + verify + retry) |
| \`server.py\` | \`WebhookServer.swift\` (stdlib ThreadingHTTPServer) |
| \`registrar.py\` | \`WebhookRegistrar.swift\` |
| \`secrets.py\` | \`SecretStore.swift\` (\`security\` CLI on macOS, 600-perm file on Linux) |
| \`controller.py\` | \`LiveModeController.swift\` |
| \`ipc.py\` | *(new)* — Unix socket NDJSON pub/sub + ring buffer |
| \`runner.py\` | *(new)* — process lifecycle glue (run_blocking, spawn_detached, stop_running, subscribe) |
| \`disclosure.py\` | *(new)* — first-run notice |

### New CLI surface

\`\`\`
shipyard daemon start [--repo …] [--detach/--no-detach]
shipyard daemon run                 # foreground (logs to stdout)
shipyard daemon stop
shipyard daemon status              # prints tunnel + subscribers + repos
\`\`\`

### State directory layout

\`\`\`
<state_dir>/daemon/
├── daemon.pid
├── daemon.sock
├── daemon.log
├── registrations.json
├── .first-run-acked
└── webhook-secret          (Linux only; macOS uses Keychain)
\`\`\`

Respects \`Config.state_dir\` — macOS \`~/Library/Application Support/shipyard\`, Linux \`~/.local/state/shipyard\`.

### Daemon is optional, not required

If Tailscale Funnel isn't available, the daemon refuses to start with a clear error: it needs a public tunnel for GitHub to reach. That's fine — \`shipyard watch\`, \`shipyard ship\`, and the macOS app all work without the daemon via their existing polling paths. The error message states this explicitly so users don't think the CLI is broken.

### First-run disclosure

The daemon does things a user might not have consented to blindly — creates a public tunnel, registers webhooks, writes a keychain entry. The first time \`shipyard daemon start\` runs on a machine, \`disclosure.py\` prints a one-time notice covering all of it, points at \`shipyard daemon stop\` for reversing it, and mentions the polling fallback. An ack file at \`<state_dir>/daemon/.first-run-acked\` keeps subsequent starts quiet.

## Tests

**44 new tests**, all green locally + full shipyard suite still passes (\`1035 passed, 1 skipped\`).

| Suite | Coverage |
|---|---|
| \`test_signature.py\` | HMAC-SHA256 vs GitHub's reference vector, tamper rejection, prefixed/bare header, secret generation |
| \`test_events.py\` | workflow_run / workflow_job / pull_request decode, unhandled event passthrough, malformed body, missing repository, IPC wire shape |
| \`test_tailscale.py\` | status JSON parse: ready, not-running, missing funnel cap, bare funnel key, trailing-dot DNSName, malformed JSON, nil binary path |
| \`test_server.py\` | end-to-end HTTP round-trip: signed POST on /webhook, legacy / path, GET rejection, unknown-path 404, bogus-signature 401 |
| \`test_ipc_roundtrip.py\` | Unix-socket subscribe + broadcast, late-subscriber ring-buffer replay, status query snapshot |
| \`test_registrar.py\` | gh subprocess (faked via shell stub): create, cache-reuse, persistence across instances, error surfacing, missing binary |
| \`test_runner.py\` | PID file semantics: no-pid, stale-pid, live-pid, stop_running happy + empty paths |
| \`test_disclosure.py\` | notice content claims, ack idempotency, marker file |

Subprocess-heavy paths (\`tunnels/tailscale.py\`) aren't unit-tested; the reset+bg+verify+retry logic mirrors the Swift implementation that was debugged against a real Tailscale daemon.

## Relationship to other issues

- **#125** — this PR closes it.
- **#126** (additional tunnel backends) — \`TunnelBackend\` protocol in \`tunnels/base.py\` ready for Cloudflare Tunnel / ngrok / user-supplied reverse proxy. No implementations in this PR.
- **#123** (rate-limit audit) — complementary. When the daemon is active, \`shipyard watch\` and \`shipyard ship\` subscribe to it and don't poll. The audit work makes the fallback polling path efficient for everyone else.
- **shipyard-macos-gui#3** — GUI thin-client migration, lands after this so the daemon binary exists for the GUI to subprocess.

## Out of scope (for later)

- Non-Tailscale tunnel backends (#126)
- launchd / systemd integration
- Windows support (daemon could run via WSL; keychain equivalent needs thought)
- \`shipyard watch\` / \`shipyard ship\` daemon-awareness — separate PR once the daemon is merged, so watch/ship can learn to subscribe without making this PR larger.