### PR TITLE
ci skill: add "Iterating on a single-platform failure" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,72 @@ macOS, Linux, and Windows on every push. The release workflow at
 [`.github/workflows/release.yml`](.github/workflows/release.yml) builds
 binaries on 5 platforms when a version is tagged.
 
+## FAQ
+
+### Do I need to run `shipyard daemon` / enable live mode?
+
+No. The daemon is an optional optimization for realtime webhook updates. Without it, every shipyard command falls back to polling — behavior is identical to earlier versions. `shipyard run`, `ship`, `watch`, `auto-merge`, and the macOS app all work fine without the daemon.
+
+### Does it hurt if I don't enable live mode?
+
+No. You'll still get the same results; they just arrive on a poll cadence (60 s worst case) rather than push-instant. Webhooks aren't registered on your repos unless the daemon is running. No Tailscale Funnel is created if you don't run `shipyard daemon start`.
+
+### I pushed to a repo without running `shipyard ship`. Will it appear in the macOS app?
+
+Depends on whether you've ever shipped from that repo on this machine:
+
+- **Never shipped from that repo before** → nothing appears. The app only tracks repos it knows about via local ship-state.
+- **You've shipped at least one PR from that repo before** → pushes show up in the "GitHub Actions" section of the app (polled via `gh run list` for known repos), but not as a tracked PR card. Tracked PR cards only appear for PRs that have ship-state — i.e. PRs you invoked `shipyard ship` or `shipyard pr` on.
+
+If live mode is on, the daemon will deliver webhook events for those pushes too, so the "GitHub Actions" section updates in realtime — but it still won't promote an un-shipped PR into a tracked card.
+
+### How do I turn off live mode?
+
+- **From the macOS app**: Settings → Live updates → **Off**. The app sends a stop command to the daemon, which unregisters webhooks and resets the Tailscale Funnel config. Nothing persists after that.
+- **From the CLI**: `shipyard daemon stop` does the same teardown.
+
+### How do I remove everything shipyard installed?
+
+Shipyard doesn't leave much footprint, but here's the complete list:
+
+```bash
+# 1. Stop + unregister the daemon (if running)
+shipyard daemon stop
+
+# 2. Uninstall the CLI (method depends on how you installed)
+pip uninstall shipyard                # if installed via pip
+rm -rf ~/.pulp                        # if installed via install.sh
+
+# 3. Remove state directory (ship-state, daemon config, webhook secret)
+#    macOS:
+rm -rf ~/Library/Application\ Support/shipyard
+#    Linux:
+rm -rf ~/.local/state/shipyard
+
+# 4. (macOS only) Keychain entry for the webhook secret
+security delete-generic-password -s com.danielraffel.shipyard.webhook
+```
+
+The macOS menu-bar app (`shipyard-macos-gui`) is separate: drag it out of `/Applications` to uninstall.
+
+### I don't have Tailscale. Is live mode usable?
+
+Not in v1. Tailscale Funnel is the only tunnel backend shipped currently; others (Cloudflare Tunnel, ngrok, user-supplied reverse proxy) are tracked in [issue #126](https://github.com/danielraffel/Shipyard/issues/126). Until those land, live mode requires Tailscale + Funnel. The rest of shipyard (polling path) works fine without either.
+
+### Does shipyard read or store any secrets besides the webhook HMAC?
+
+- The webhook HMAC secret is the only secret shipyard stores — in macOS Keychain or a `600`-perm file on Linux. It's generated locally, only sent to GitHub (as part of the webhook registration), and only used to verify that incoming deliveries actually came from GitHub.
+- `gh` auth is read through the `gh` CLI's existing token storage. Shipyard doesn't duplicate or persist it.
+- SSH keys for remote targets are whatever's already in your `~/.ssh/`.
+
+### My macOS app says "shipyard CLI not found on PATH"
+
+Live mode requires the `shipyard` CLI to be installed on the Mac running the app. Install it (`curl -fsSL https://install.shipyard.sh | sh` or via `pip install shipyard`). If you don't want live mode, you can ignore this — the app will keep working in polling mode.
+
+### Will pushing without `shipyard ship` break anything I've already shipped?
+
+No. A branch force-push or one-off commit on a tracked PR leaves the existing ship-state entry as-is (still scoped to the old SHA) until you explicitly re-ship or archive it. The app may show stale evidence for that PR until then. [Issue #128](https://github.com/danielraffel/Shipyard/issues/128) tracks improving this with passive observer mode.
+
 ## Learn more
 
 - [Blog post: Shipyard is a cross-platform CI orchestration layer](https://danielraffel.me/2026/04/09/shipyard-is-a-cross-platform-ci-orchestration-layer-that-coordinates-validation-for-ai-agents-working-across-parallel-worktrees/)

--- a/skills/ci/SKILL.md
+++ b/skills/ci/SKILL.md
@@ -13,6 +13,7 @@ Shipyard coordinates validation across local, SSH, and cloud targets.
 |------|---------|
 | Validate current branch | `shipyard run --json` |
 | Validate specific targets | `shipyard run --targets mac,ubuntu --json` |
+| Iterate on one platform's CI failure | `shipyard run --skip-target <others>` (see [Iterating on a single-platform failure](#iterating-on-a-single-platform-failure)) |
 | Fast smoke check | `shipyard run --smoke --json` |
 | Full ship (PR + validate + merge) | `shipyard ship --json` |
 | Ship to develop instead of main | `shipyard ship --base develop --json` |
@@ -167,11 +168,77 @@ See `docs/cloud-retarget.md` for full context; add-lane complements retarget.
 1. Work on a feature branch. Commit your changes.
 2. Run `shipyard ship --json` — this pushes, creates a PR, validates on all
    platforms, and merges when green.
-3. If a target fails, read the logs with `shipyard logs <id> --target <name>`,
-   fix the issue, and run `shipyard ship --json` again.
+3. If a target fails, read the logs with `shipyard logs <id> --target <name>`.
+   If the failure is confined to one platform (which it usually is), **iterate
+   locally against that target instead of re-shipping the full matrix** — see
+   [Iterating on a single-platform failure](#iterating-on-a-single-platform-failure)
+   below. Once the local lane is green, `shipyard ship --json` again.
 
 Shipyard refuses to merge unless every required platform has passing evidence
 for the exact HEAD SHA.
+
+### Iterating on a single-platform failure
+
+When CI goes red on exactly one platform (e.g. only the Windows leg of a
+matrix, only the macOS sanitizer), **do not default to push → wait for full
+matrix → read one platform's result → repeat**. That burns the dispatch cost
+on every platform you didn't touch — typically 15–25 minutes per iteration
+re-validating lanes that were already green.
+
+Use `shipyard run` with target selection to validate the fix against the real
+target, fast:
+
+```bash
+# Iterate on the Windows lane only (skips mac + ubuntu)
+shipyard run --skip-target mac --skip-target ubuntu --json
+
+# Or, equivalent inclusive form
+shipyard run --targets windows --json
+```
+
+`run` validates locally via the configured backend for that target (SSH host,
+local VM, or cloud runner — whichever `.shipyard/config.toml` assigns). You
+get a real result in ~5–10 minutes per target with no GitHub Actions runner
+minutes burned and no re-validation of lanes you didn't change. Once the
+local lane passes cleanly, `shipyard ship --json` to kick the final cross-
+platform gate.
+
+**When this loop doesn't fit:**
+
+- **Final pre-merge gate.** `shipyard ship` / `shipyard pr` is still the
+  only command that produces a merge-eligible evidence record. `shipyard run`
+  iteration is for getting-to-green; `ship` is for landing it.
+- **Platform-specific to a backend you don't have.** If the failure is
+  specific to a GitHub-hosted runner (e.g. the `[github-hosted]` leg of a
+  matrix where your local lane is SSH or Namespace), the local lane is a
+  good proxy but not identical. Consider `shipyard cloud run build <branch>`
+  as the middle ground — dispatches to the same cloud backend CI uses
+  without re-running everything.
+- **Cross-target behavioral differences you're actually testing.** If the
+  bug only manifests when two targets interact (rare but real — e.g.
+  shared caches), the single-target loop hides it.
+
+**When `shipyard run` fails for reasons that don't match your change:**
+
+Long-running SSH or VM backends accumulate per-run state — stale build
+artifacts, partially-applied branches from interrupted earlier runs,
+environment drift. If `run` errors on a lane with messages that look
+unrelated to the code you changed (`cmake` complaining about files you
+didn't touch, configure steps timing out on line one, paths pointing at
+an earlier branch), check the host before assuming your code is wrong.
+
+Typical diagnostic pass on an SSH backend:
+
+```bash
+ssh <backend-host>
+cd <worktree>
+git log -1 && git status             # did we land on the expected SHA?
+ls -la .shipyard-stage-*             # old stage dirs still pinning files?
+rm -rf .shipyard-stage-*             # nuclear reset; safe — always re-staged
+```
+
+Local VM backends usually have their own `reset` path in the project's
+`.shipyard/` config. Re-run `shipyard run` after cleanup.
 
 ### Recovering an interrupted ship
 

--- a/skills/ci/SKILL.md
+++ b/skills/ci/SKILL.md
@@ -15,6 +15,9 @@ Shipyard coordinates validation across local, SSH, and cloud targets.
 | Validate specific targets | `shipyard run --targets mac,ubuntu --json` |
 | Iterate on one platform's CI failure | `shipyard run --skip-target <others>` (see [Iterating on a single-platform failure](#iterating-on-a-single-platform-failure)) |
 | Fast smoke check | `shipyard run --smoke --json` |
+| Start the live-mode webhook daemon | `shipyard daemon start` |
+| Inspect the daemon | `shipyard daemon status --json` |
+| Stop the daemon | `shipyard daemon stop` |
 | Full ship (PR + validate + merge) | `shipyard ship --json` |
 | Ship to develop instead of main | `shipyard ship --base develop --json` |
 | Resume an interrupted ship | `shipyard ship --resume --json` (auto when state exists) |
@@ -64,6 +67,37 @@ Shipyard coordinates validation across local, SSH, and cloud targets.
 | List quarantined targets | `shipyard quarantine list --json` |
 | Quarantine a flaky target | `shipyard quarantine add <target> --reason "..."` |
 | Remove from quarantine | `shipyard quarantine remove <target>` |
+
+## Live mode (`shipyard daemon`) — when it helps and when to ignore it
+
+Shipyard has a long-running webhook receiver that converts GitHub
+Actions events into a push-based event stream. When it's running,
+`shipyard watch` can subscribe to the daemon instead of polling —
+near-realtime updates with zero GitHub API budget spent on the watch
+itself.
+
+| You're here | Does live mode matter? |
+|---|---|
+| Solo macOS dev with Tailscale + Funnel enabled | **Yes, big win.** `shipyard daemon start` registers webhooks on tracked repos and streams events; the macOS menu-bar app and any `shipyard watch` invocation in a terminal both consume the same stream. |
+| CI / headless server / someone without Tailscale | **Ignore it.** The daemon needs a public tunnel (Tailscale Funnel in v1) to receive webhooks. Without that, `shipyard watch` and everything else fall back to polling — behavior is unchanged from the pre-daemon CLI. |
+| Agent running one-shot `shipyard ship` + `watch --follow` | **Probably doesn't matter.** The daemon helps most when multiple sessions or the GUI are tracking the same state concurrently; a single session blocking on `watch --follow` already has its own connection. |
+
+**When in doubt, don't start the daemon.** The daemon is an
+optimization, not a requirement. Polling is the correct fallback
+for everything it doesn't cover and is always safe. The `run` /
+`ship` / `watch` / `auto-merge` commands don't require the daemon
+to be running.
+
+`shipyard daemon status` is free (no `gh api` calls, just reads
+the local socket) and cheap to probe from an agent — use it if
+you want to know whether the user has live mode on before
+deciding whether to rely on webhook-speed updates vs polling
+cadence.
+
+See [`docs/live-mode.md`](../../docs/live-mode.md) for setup (≈1
+click on a Tailscale-ready Mac) and troubleshooting. The macOS
+menu-bar app (`shipyard-macos-gui`) is a thin subscriber to this
+same daemon.
 
 ## When to use `watch` (agent decision guide)
 


### PR DESCRIPTION
Closes the gap a teammate flagged: when CI goes red on exactly one platform, the skill didn't teach agents to iterate locally via \`shipyard run --skip-target <others>\`. Default behavior was push → full-matrix → wait → read one platform's result → push again, burning ~15–25 min per iteration on platforms that were already green.

## What changed in \`skills/ci/SKILL.md\`

**New section — \"Iterating on a single-platform failure\"** under \"Ship workflow\". Explains:

- The anti-pattern (re-shipping full matrix for a one-platform failure) and why it's costly.
- The preferred loop: \`shipyard run --skip-target\` / \`--targets\` to validate the fix against the real target in ~5–10 min, no GitHub Actions burn.
- When the loop **doesn't** fit:
  - Final pre-merge gate — \`shipyard ship\` / \`pr\` is still the only evidence producer Shipyard accepts for merge.
  - GitHub-hosted-specific failures — local lane is a good proxy but not identical; recommends \`shipyard cloud run build\` as the middle ground.
  - Cross-target behavioral differences (rare but real).
- **Stale backend state caveat** — SSH hosts and long-running VMs accumulate \`.shipyard-stage-*\` dirs / partial branches. A diagnostic pass (\`git log -1 && git status\` / \`rm -rf .shipyard-stage-*\`) before assuming code is wrong.

**Step 3 of \"Ship workflow\"** now cross-references the new section so the main flow doesn't silently imply \"re-ship the whole matrix\" for every failure.

**Quick reference table** gets one line pointing at the new section so agents reading top-to-bottom discover the pattern without scanning the whole skill.

## Non-changes

- \`shipyard ship\` / \`shipyard pr\` are still the only merge-eligible paths. The addition is explicit about that.
- The existing \`--skip-target\` and \`--allow-unreachable-targets\` entries are unchanged — the new section frames them as an iteration loop rather than replacing them.
- No code changes; pure skill update. \`Skill-Update: ci\` trailer on the commit per repo convention.

## Context

Surfaced when an agent iterating on a Windows-only coverage fix kept pushing to CI matrix rather than reaching for \`shipyard run --skip-target mac --skip-target ubuntu\`. Adapted to shipyard's audience (less Pulp-specific framing; generic backend-hygiene advice).