### PR TITLE
fix(daemon): spawn detached daemon correctly from standalone-binary installs (0.22.1)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "shipyard"
-version = "0.22.0"
+version = "0.22.1"
 description = "Cross-platform CI coordination — local VMs, SSH hosts, cloud runners"
 readme = "README.md"
 license = "MIT"

--- a/src/shipyard/__init__.py
+++ b/src/shipyard/__init__.py
@@ -1,3 +1,3 @@
 """Shipyard — Cross-platform CI coordination."""
 
-__version__ = "0.22.0"
+__version__ = "0.22.1"


### PR DESCRIPTION
Patch fix for a bug introduced in #127 / v0.22.0.

## Symptom

On a shiv / zipapp / PyOxidizer install (what \`install.sh\` produces at \`~/.pulp/bin/shipyard\`), \`shipyard daemon start\` reports success but no daemon is actually running. \`shipyard daemon status\` says \"daemon is not running\". The macOS menu-bar app falls back to polling with the error \"Couldn't start Tailscale Funnel: daemon socket not available\". \`daemon.log\` contains:

\`\`\`
Usage: shipyard [OPTIONS] COMMAND [ARGS]...
Try 'shipyard --help' for help.
Error: No such option: -m
\`\`\`

## Cause

\`spawn_detached\` used \`[sys.executable, \"-m\", \"shipyard\", ...]\` to launch the background daemon. That works for \`pip install\`-style installs where \`sys.executable\` is a Python interpreter, but for a standalone-binary install \`sys.executable\` IS the shipyard binary — Click parses \`-m\` as a command-line option and errors before the daemon logic ever runs.

## Fix

Detect when \`sys.executable\` is the shipyard binary itself (basename \`shipyard\` or \`sy\`) and invoke it directly (no \`-m\`). pip installs are unaffected.

## Affected surfaces

- \`shipyard daemon start\` (the default \`--detach\` path) — broken on standalone installs pre-fix.
- \`shipyard daemon run\` (foreground) — unaffected, was already fine.
- macOS menu-bar app's live mode — depends on \`daemon start\` succeeding; fixed here.

## Version

0.22.0 → 0.22.1 (patch). No other behavior change.

## Test plan

- [x] 44 daemon tests still pass locally.
- [x] Ruff + mypy clean.
- [ ] Manual: on a standalone install, \`shipyard daemon start\` + \`shipyard daemon status\` shows the daemon running.
- [ ] Manual: macOS app Settings → Live updates → Auto transitions from the polling-fallback banner to \"Live · via Tailscale Funnel\".

## Workaround for users on 0.22.0

\`shipyard daemon run\` (foreground) works fine. Run it in a separate terminal until 0.22.1 ships.