### PR TITLE
docs: simplify Claude Code plugin install (2 commands, no settings.json edit)

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,11 +53,17 @@ Then set up your project:
 /shipyard:init
 ```
 
-The plugin uses the CLI under the hood. If the `shipyard` binary isn't
-installed, the plugin will offer to install it for you — or grab it
-yourself via the [Codex / CLI install](#codex--cli) below. Plugin +
-CLI are independently versioned; installing one doesn't affect the
-other, and it's safe to install both.
+The plugin uses the CLI under the hood. On first session start it
+auto-installs the binary if it can't find `shipyard` on PATH — and
+skips the install if it can. If you've already installed the CLI
+(via `install.sh` or a project pinner like pulp's
+`tools/install-shipyard.sh`), make sure its bin directory is on
+PATH before you install the plugin; that way the plugin respects
+your existing pin instead of installing its own copy alongside it.
+
+Plugin + CLI are independently versioned; the plugin's version
+covers slash commands / skills / hooks, while the CLI's version
+covers the binary. It's safe to have both.
 
 ### Codex / CLI
 

--- a/README.md
+++ b/README.md
@@ -40,35 +40,24 @@ shipyard changelog init    # opt in to post-release CHANGELOG auto-sync
 
 ### Claude Code (recommended)
 
-**Step 1:** Add the Shipyard marketplace to `~/.claude/settings.json`:
+Two commands to register the marketplace and install the plugin:
 
-```json
-{
-  "extraKnownMarketplaces": {
-    "shipyard": {
-      "source": {
-        "source": "github",
-        "repo": "danielraffel/Shipyard"
-      }
-    }
-  }
-}
+```bash
+claude plugin marketplace add danielraffel/Shipyard
+claude plugin install shipyard
 ```
 
-**Step 2:** Install the plugin:
-
-```
-/plugin install shipyard@shipyard
-```
-
-**Step 3:** Set up your project:
+Then set up your project:
 
 ```
 /shipyard:init
 ```
 
 The plugin uses the CLI under the hood. If the `shipyard` binary isn't
-installed, the plugin will offer to install it for you.
+installed, the plugin will offer to install it for you — or grab it
+yourself via the [Codex / CLI install](#codex--cli) below. Plugin +
+CLI are independently versioned; installing one doesn't affect the
+other, and it's safe to install both.
 
 ### Codex / CLI
 


### PR DESCRIPTION
The README asks users to hand-edit \`~/.claude/settings.json\` with an \`extraKnownMarketplaces\` entry before \`/plugin install\` — an older, manual pattern. The \`.claude-plugin/marketplace.json\` already in the repo supports the native two-command flow pulp uses:

\`\`\`bash
claude plugin marketplace add danielraffel/Shipyard
claude plugin install shipyard
\`\`\`

No other changes required — the plugin manifest is already correctly structured.

Also clarifies that plugin + CLI are independently versioned so users understand installing one doesn't conflict with the other.

No functional change; docs only.