### PR TITLE
installer: SHIPYARD_VERSION + SHIPYARD_INSTALL_DIR env vars + canonical-location docs + FAQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,52 @@ binaries on 5 platforms when a version is tagged.
 
 ## FAQ
 
+### Where does each install method put the `shipyard` binary?
+
+All three user-facing install paths write the binary to the same
+place:
+
+| Method | Target |
+|---|---|
+| `curl … install.sh` (manual) | `~/.local/bin/shipyard` |
+| Claude Code plugin (auto-installs via `SessionStart` hook if needed) | `~/.local/bin/shipyard` |
+| Codex one-liner (same `install.sh`) | `~/.local/bin/shipyard` |
+
+`~/.local/bin` is the canonical location. Make sure it's on your
+`PATH` and every install method reaches the same binary. `sy` is a
+symlink that resolves to the same `shipyard` binary.
+
+Contributors building from source have two options — see
+[`docs/install.md`](docs/install.md): an **isolated venv install**
+for active development (dev build in the venv, system `shipyard`
+untouched) or **`pipx install .`** which lands at
+`~/.local/bin/shipyard` and overrides the released version.
+
+Project pinners that want a specific version should use
+`SHIPYARD_VERSION="v0.22.1" bash install.sh` — it lands at the same
+`~/.local/bin/shipyard`, no private toolchain dir required.
+
+### Can I install the Claude Code plugin after installing the CLI via the Codex one-liner?
+
+Yes, and you're meant to. The plugin deliberately defers to an
+existing CLI install: on first session its `check-cli.sh` hook runs
+`command -v shipyard` before doing anything else. If it finds a
+binary on `PATH` it skips the auto-install entirely. If it doesn't,
+it runs the same `install.sh` you'd have run by hand and lands at
+`~/.local/bin/shipyard`.
+
+Order doesn't matter. CLI first, then plugin → plugin detects the
+CLI, no duplicate. Plugin first, then CLI → the auto-installer did
+the work already. Both lead to one binary at the canonical location.
+
+### Will installing a newer shipyard via `install.sh` clobber a plugin-installed one (or vice versa)?
+
+Yes, by design. Both land at `~/.local/bin/shipyard` and the later
+install wins. The plugin's `SessionStart` hook doesn't re-install
+when it sees any `shipyard` on `PATH`, so a fresh manual install
+sticks until you explicitly run `install.sh` again. To check which
+version you're on at any moment: `shipyard --version`.
+
 ### Do I need to run `shipyard daemon` / enable live mode?
 
 No. The daemon is an optional optimization for realtime webhook updates. Without it, every shipyard command falls back to polling — behavior is identical to earlier versions. `shipyard run`, `ship`, `watch`, `auto-merge`, and the macOS app all work fine without the daemon.

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,12 +1,63 @@
 # Installation
 
+## Canonical install location
+
+Every supported install path writes the `shipyard` binary to the same
+place by default:
+
+```
+~/.local/bin/shipyard
+```
+
+| Path | Lands at |
+|---|---|
+| `curl … install.sh` | `~/.local/bin/shipyard` |
+| Claude Code plugin (auto-installs on first session if missing) | `~/.local/bin/shipyard` |
+| Codex one-liner (same `install.sh`) | `~/.local/bin/shipyard` |
+| Project pinners (see "Pin a specific version" below) | `~/.local/bin/shipyard` (recommended) |
+
+Make sure `~/.local/bin` is on your `PATH` and every install method
+reaches the same binary. No PATH juggling, no "which shipyard am I
+running" confusion.
+
 ## Quick install
 
 ```bash
 curl -fsSL https://generouscorp.com/Shipyard/install.sh | sh
 ```
 
-Downloads the right binary for your platform and installs it on `$PATH`.
+Downloads the right binary for your platform and installs it at
+`~/.local/bin/shipyard`.
+
+## Pin a specific version
+
+Pass `SHIPYARD_VERSION` to install an exact release instead of the
+latest. Useful for project-pinning so every teammate + agent runs
+the same shipyard build.
+
+```bash
+SHIPYARD_VERSION="v0.22.1" curl -fsSL https://generouscorp.com/Shipyard/install.sh | bash
+# or if you've already fetched the script:
+SHIPYARD_VERSION="v0.22.1" bash install.sh
+```
+
+Accepts `"v0.22.1"`, `"0.22.1"`, or `"latest"` (default).
+
+Project-level pinning pattern: keep the desired version in a small
+pin file (e.g. `tools/shipyard.toml` with `version = "0.22.1"`), read
+it in a wrapper script, and call `install.sh` with
+`SHIPYARD_VERSION="$(read-version)"`. Nothing more complicated is
+needed — every teammate ends up with the same binary at
+`~/.local/bin/shipyard`.
+
+## Install to a different directory
+
+Pass `SHIPYARD_INSTALL_DIR`. Only override when you have a specific
+reason; the default keeps every install path aligned.
+
+```bash
+SHIPYARD_INSTALL_DIR="${HOME}/mytools/bin" bash install.sh
+```
 
 ## Platform binaries
 
@@ -18,7 +69,15 @@ Downloads the right binary for your platform and installs it on `$PATH`.
 | Linux | x64 | `shipyard-linux-x64` |
 | Linux | ARM64 | `shipyard-linux-arm64` |
 
-## Build from source (contributors)
+## Build from source
+
+Two patterns depending on what you want.
+
+### A. Isolated dev install (recommended for active development)
+
+Your dev build lives in a venv; the system `shipyard` at
+`~/.local/bin/shipyard` is unaffected. Activate the venv to use your
+dev build, deactivate to use the system one.
 
 ```bash
 git clone https://github.com/danielraffel/Shipyard.git
@@ -35,7 +94,23 @@ uv sync --extra dev
 uv run pytest
 ```
 
+### B. "My dev build is my system shipyard"
+
+If you want your local checkout to take over at
+`~/.local/bin/shipyard` (same location `install.sh` uses), use
+[`pipx`](https://pipx.pypa.io):
+
+```bash
+pipx install .
+pipx install . --force         # re-install after changes
+```
+
+Or `pip install --user .` achieves the same on most systems. Both
+land at `~/.local/bin/shipyard`, so the Claude Code plugin + any
+project pinners treat your dev build as the canonical install.
+
 ## Optional dependencies
 
 You don't need everything — just what matches your setup. See the
-[main README requirements table](../README.md#requirements) for details.
+[main README requirements table](../README.md#requirements) for
+details.

--- a/install.sh
+++ b/install.sh
@@ -13,6 +13,11 @@ set -euo pipefail
 #                      Where to place the binary + the `sy` symlink.
 #                      Default: "${HOME}/.local/bin".
 #
+#   SHIPYARD_DRY_RUN   When "1", resolve platform + version + install
+#                      dir, print them as KEY=value lines, and exit
+#                      without downloading or writing anything. Used
+#                      by the unit tests; harmless to use manually.
+#
 # Examples:
 #
 #   # Default: latest release to ~/.local/bin
@@ -55,7 +60,9 @@ case "$(uname -m)" in
 esac
 
 ARTIFACT="shipyard-${OS}-${ARCH}"
-echo "Detected platform: ${OS}-${ARCH}"
+if [ "${SHIPYARD_DRY_RUN:-0}" != "1" ]; then
+    echo "Detected platform: ${OS}-${ARCH}"
+fi
 
 # ── version resolution ──────────────────────────────────────────────
 #
@@ -74,6 +81,19 @@ else
     esac
     API_PATH="releases/tags/${TAG}"
     VERSION_LABEL="${TAG}"
+fi
+
+# Dry-run short-circuit — print the resolved config and exit before
+# doing any network or filesystem work. Kept minimal + parseable
+# (KEY=value lines) for test assertions.
+if [ "${SHIPYARD_DRY_RUN:-0}" = "1" ]; then
+    echo "OS=${OS}"
+    echo "ARCH=${ARCH}"
+    echo "ARTIFACT=${ARTIFACT}"
+    echo "INSTALL_DIR=${INSTALL_DIR}"
+    echo "VERSION_LABEL=${VERSION_LABEL}"
+    echo "API_PATH=${API_PATH}"
+    exit 0
 fi
 
 echo "Resolving ${VERSION_LABEL} from ${REPO}..."

--- a/install.sh
+++ b/install.sh
@@ -2,27 +2,54 @@
 set -euo pipefail
 
 # Shipyard installer — downloads the correct binary for your platform.
+#
+# Environment variables (all optional):
+#
+#   SHIPYARD_VERSION   Install a specific version instead of the latest
+#                      release. Accepts "v0.22.1", "0.22.1", or "latest".
+#                      Default: "latest".
+#
+#   SHIPYARD_INSTALL_DIR
+#                      Where to place the binary + the `sy` symlink.
+#                      Default: "${HOME}/.local/bin".
+#
+# Examples:
+#
+#   # Default: latest release to ~/.local/bin
+#   curl -fsSL https://generouscorp.com/Shipyard/install.sh | bash
+#
+#   # Pin to a specific version (useful for project-level pins):
+#   SHIPYARD_VERSION="v0.22.1" bash install.sh
+#
+#   # Install somewhere else (e.g. a project-private toolchain dir):
+#   SHIPYARD_INSTALL_DIR="${HOME}/.mytools/bin" bash install.sh
+#
+# The canonical install location is `${HOME}/.local/bin`; the Claude
+# Code plugin's auto-install hook, the Codex one-liner, and this
+# script all agree on that by default. Override only when you have a
+# good reason (e.g. a project wants versioned artifacts side-by-side).
 
 REPO="danielraffel/Shipyard"
-INSTALL_DIR="${HOME}/.local/bin"
+INSTALL_DIR="${SHIPYARD_INSTALL_DIR:-${HOME}/.local/bin}"
+REQUESTED_VERSION="${SHIPYARD_VERSION:-latest}"
 
-# Detect OS
+# ── platform detection ──────────────────────────────────────────────
+
 case "$(uname -s)" in
     Darwin)  OS="macos" ;;
     Linux)   OS="linux" ;;
     MINGW*|MSYS*|CYGWIN*) OS="windows" ;;
     *)
-        echo "Unsupported OS: $(uname -s)"
+        echo "Unsupported OS: $(uname -s)" >&2
         exit 1
         ;;
 esac
 
-# Detect architecture
 case "$(uname -m)" in
     arm64|aarch64) ARCH="arm64" ;;
     x86_64|amd64)  ARCH="x64" ;;
     *)
-        echo "Unsupported architecture: $(uname -m)"
+        echo "Unsupported architecture: $(uname -m)" >&2
         exit 1
         ;;
 esac
@@ -30,19 +57,41 @@ esac
 ARTIFACT="shipyard-${OS}-${ARCH}"
 echo "Detected platform: ${OS}-${ARCH}"
 
-# Get latest release URL
-RELEASE_URL=$(curl -sL "https://api.github.com/repos/${REPO}/releases/latest" \
+# ── version resolution ──────────────────────────────────────────────
+#
+# Accept "v0.22.1", "0.22.1", and "latest". Normalize to the tag name
+# GitHub's release API uses ("v0.22.1" / "latest").
+
+if [ "${REQUESTED_VERSION}" = "latest" ] || [ -z "${REQUESTED_VERSION}" ]; then
+    API_PATH="releases/latest"
+    VERSION_LABEL="latest"
+else
+    TAG="${REQUESTED_VERSION}"
+    # Allow "0.22.1" as shorthand for "v0.22.1".
+    case "${TAG}" in
+        v*) : ;;
+        *)  TAG="v${TAG}" ;;
+    esac
+    API_PATH="releases/tags/${TAG}"
+    VERSION_LABEL="${TAG}"
+fi
+
+echo "Resolving ${VERSION_LABEL} from ${REPO}..."
+
+# ── fetch release asset URL ─────────────────────────────────────────
+
+RELEASE_URL=$(curl -sL "https://api.github.com/repos/${REPO}/${API_PATH}" \
     | grep "browser_download_url.*${ARTIFACT}" \
     | head -1 \
     | cut -d '"' -f 4)
 
 if [ -z "${RELEASE_URL}" ]; then
-    echo "No binary found for ${ARTIFACT} in latest release."
-    echo "Check https://github.com/${REPO}/releases for available builds."
+    echo "No binary found for ${ARTIFACT} in ${VERSION_LABEL}." >&2
+    echo "Check https://github.com/${REPO}/releases for available builds." >&2
     exit 1
 fi
 
-echo "Downloading ${ARTIFACT}..."
+echo "Downloading ${ARTIFACT} (${VERSION_LABEL})..."
 mkdir -p "${INSTALL_DIR}"
 curl -sL "${RELEASE_URL}" -o "${INSTALL_DIR}/shipyard"
 chmod +x "${INSTALL_DIR}/shipyard"
@@ -68,7 +117,8 @@ if [ "${OS}" = "macos" ]; then
     fi
 fi
 
-# Create sy symlink
+# `sy` is the short-form alias that shipyard's packaging ships as an
+# entry point; mirror it with a symlink here so both names resolve.
 ln -sf "${INSTALL_DIR}/shipyard" "${INSTALL_DIR}/sy"
 
 echo ""
@@ -76,7 +126,8 @@ echo "Installed shipyard to ${INSTALL_DIR}/shipyard"
 echo "Symlink: ${INSTALL_DIR}/sy"
 echo ""
 
-# Check if install dir is in PATH
+# ── PATH hint ───────────────────────────────────────────────────────
+
 if ! echo "${PATH}" | tr ':' '\n' | grep -q "^${INSTALL_DIR}$"; then
     echo "Add ${INSTALL_DIR} to your PATH:"
     echo "  export PATH=\"${INSTALL_DIR}:\$PATH\""

--- a/tests/test_install_sh.py
+++ b/tests/test_install_sh.py
@@ -1,0 +1,113 @@
+"""Tests for the environment-variable contract of install.sh.
+
+install.sh's default install location and version resolution are what
+downstream consumers (Claude Code plugin's auto-installer, Codex one-
+liner, project pinners like pulp) depend on. Regressions here either
+fragment the install footprint (multiple shipyard binaries in
+different places) or break version-pinned installers.
+
+We drive install.sh with ``SHIPYARD_DRY_RUN=1`` which skips the
+network + filesystem work and prints the resolved config as
+KEY=value pairs. Platform detection (OS=macos/linux/windows) is
+whatever host runs the test; we only assert invariants that hold on
+every platform.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+INSTALL_SH = REPO_ROOT / "install.sh"
+
+
+def _run_dry(env: dict[str, str] | None = None) -> dict[str, str]:
+    """Run install.sh in dry-run mode; parse KEY=value output."""
+    merged_env = {**os.environ, "SHIPYARD_DRY_RUN": "1"}
+    if env:
+        merged_env.update(env)
+    result = subprocess.run(
+        ["bash", str(INSTALL_SH)],
+        env=merged_env,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    out: dict[str, str] = {}
+    for line in result.stdout.splitlines():
+        if "=" in line:
+            key, _, value = line.partition("=")
+            out[key.strip()] = value.strip()
+    return out
+
+
+def test_default_install_dir_is_local_bin() -> None:
+    # The canonical install location is `~/.local/bin`. Downstream
+    # consumers (plugin's check-cli.sh, Codex one-liner, any wrapper)
+    # rely on this. Changing the default is a compatibility break.
+    home = os.environ["HOME"]
+    config = _run_dry()
+    assert config["INSTALL_DIR"] == f"{home}/.local/bin"
+
+
+def test_shipyard_install_dir_env_overrides(tmp_path: Path) -> None:
+    config = _run_dry({"SHIPYARD_INSTALL_DIR": str(tmp_path / "bin")})
+    assert config["INSTALL_DIR"] == str(tmp_path / "bin")
+
+
+def test_default_version_resolves_to_latest() -> None:
+    config = _run_dry()
+    assert config["VERSION_LABEL"] == "latest"
+    assert config["API_PATH"] == "releases/latest"
+
+
+def test_explicit_latest_matches_default() -> None:
+    config = _run_dry({"SHIPYARD_VERSION": "latest"})
+    assert config["API_PATH"] == "releases/latest"
+
+
+@pytest.mark.parametrize(
+    "raw,expected_label,expected_api",
+    [
+        ("v0.22.1", "v0.22.1", "releases/tags/v0.22.1"),
+        ("0.22.1", "v0.22.1", "releases/tags/v0.22.1"),  # shorthand normalization
+        ("v1.0.0-rc.1", "v1.0.0-rc.1", "releases/tags/v1.0.0-rc.1"),
+    ],
+)
+def test_shipyard_version_pins_specific_tag(
+    raw: str, expected_label: str, expected_api: str
+) -> None:
+    config = _run_dry({"SHIPYARD_VERSION": raw})
+    assert config["VERSION_LABEL"] == expected_label
+    assert config["API_PATH"] == expected_api
+
+
+def test_empty_shipyard_version_falls_back_to_latest() -> None:
+    config = _run_dry({"SHIPYARD_VERSION": ""})
+    assert config["API_PATH"] == "releases/latest"
+
+
+def test_artifact_matches_platform() -> None:
+    # ARTIFACT should always start with "shipyard-" and combine the
+    # detected OS + ARCH. Exact values depend on the test host.
+    config = _run_dry()
+    assert config["ARTIFACT"].startswith("shipyard-")
+    assert config["OS"] in ("macos", "linux", "windows")
+    assert config["ARCH"] in ("arm64", "x64")
+    assert config["ARTIFACT"] == f"shipyard-{config['OS']}-{config['ARCH']}"
+
+
+def test_install_dir_override_does_not_affect_version_resolution() -> None:
+    # Sanity: env vars are independent.
+    config = _run_dry(
+        {
+            "SHIPYARD_INSTALL_DIR": "/tmp/foo",
+            "SHIPYARD_VERSION": "v0.22.1",
+        }
+    )
+    assert config["INSTALL_DIR"] == "/tmp/foo"
+    assert config["API_PATH"] == "releases/tags/v0.22.1"


### PR DESCRIPTION
Aligns every install path on one canonical location and gives
project pinners a way to use shipyard's own installer instead of
forking their own.

## Why

Prior state: shipyard's \`install.sh\` wrote to \`~/.local/bin/shipyard\`. Pulp's private installer wrote to \`~/.pulp/bin/shipyard\`. The Claude Code plugin's \`check-cli.sh\` hook also used shipyard's \`install.sh\` → \`~/.local/bin/shipyard\`. Result: a user with a pulp pin who then installed the plugin could end up with two shipyard binaries in two places, with PATH precedence deciding which one \`shipyard --version\` reported.

## What changed

### \`install.sh\`

- **\`SHIPYARD_VERSION\`** env var — pin an exact release (\`v0.22.1\` / \`0.22.1\` / \`latest\`). Default \`latest\`, unchanged from before.
- **\`SHIPYARD_INSTALL_DIR\`** env var — override target directory. Default \`~/.local/bin\`, unchanged from before.
- Comment block at the top documents both with examples.
- No change to the default install behavior: \`curl … install.sh | sh\` still writes to \`~/.local/bin/shipyard\` at the latest release.

### \`docs/install.md\`

- Top-level "Canonical install location" section with the table mapping each install path → \`~/.local/bin/shipyard\`.
- "Pin a specific version" recipe using \`SHIPYARD_VERSION\`.
- "Install to a different directory" recipe using \`SHIPYARD_INSTALL_DIR\`.
- Build-from-source split: isolated venv (default) vs \`pipx install .\` (same location as \`install.sh\`, so your dev build IS your system shipyard).

### README FAQ additions

- Where each install method puts the binary (with the canonical-location table).
- \"Can I install the plugin after the CLI (or vice versa)?\" — yes, the plugin is deferential.
- \"Will a newer install clobber an older one?\" — yes, by design; plugin won't re-install over an existing binary.

## Follow-up to hand to pulp's agent

Once this lands in a shipyard release, pulp's \`tools/install-shipyard.sh\` can be simplified to a thin wrapper:

\`\`\`bash
SHIPYARD_VERSION="$(read_pin tools/shipyard.toml)" \
  bash <(curl -fsSL https://raw.githubusercontent.com/danielraffel/Shipyard/main/install.sh)
\`\`\`

No more private \`~/.pulp/bin\` / \`~/.pulp/shipyard/<ver>\` directory, no duplicate download/verify logic, binaries land at \`~/.local/bin/shipyard\` same as everyone else. Pulp's pin model still works — the pin is just an input to shipyard's installer now.

## Test plan

- [x] \`bash -n install.sh\` — syntax clean.
- [x] Default behavior unchanged (same location, same release resolution).
- [ ] Manual: \`SHIPYARD_VERSION=v0.22.1 bash install.sh\` fetches the 0.22.1 release (once that release exists).
- [ ] Manual: \`SHIPYARD_INSTALL_DIR=/tmp/syd bash install.sh\` writes to the override dir.

## Coordinates with

- #130 (0.22.1 daemon spawn fix) — independent; lands first.
- #131 (plugin install simplification) — docs-only, independent of this.