### PR TITLE
fix(plugin): drop invalid `agents` manifest field (unblocks `claude plugin install shipyard`)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
   "name": "shipyard",
   "owner": {"name": "Daniel Raffel"},
-  "metadata": {"description": "Cross-platform CI coordination", "version": "0.1.1"},
-  "plugins": [{"name": "shipyard", "source": "./", "description": "Cross-platform CI coordination — local VMs, SSH hosts, cloud runners", "version": "0.1.1", "author": {"name": "Daniel Raffel"}, "repository": "https://github.com/danielraffel/shipyard", "license": "MIT", "keywords": ["ci", "testing", "cross-platform", "validation"]}]
+  "metadata": {"description": "Cross-platform CI coordination", "version": "0.1.2"},
+  "plugins": [{"name": "shipyard", "source": "./", "description": "Cross-platform CI coordination — local VMs, SSH hosts, cloud runners", "version": "0.11.3", "author": {"name": "Daniel Raffel"}, "repository": "https://github.com/danielraffel/shipyard", "license": "MIT", "keywords": ["ci", "testing", "cross-platform", "validation"]}]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,9 +1,8 @@
 {
   "name": "shipyard",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "description": "Cross-platform CI coordination",
   "commands": "./commands",
-  "agents": "./agents",
   "skills": "./skills",
   "hooks": "./hooks/hooks.json"
 }


### PR DESCRIPTION
\`claude plugin install shipyard\` fails with:

\`\`\`
✘ Failed to install plugin "shipyard": ... Validation errors:
  agents: Invalid input
\`\`\`

The plugin schema doesn't accept a string path for \`agents\` the way it does for \`commands\` / \`skills\`. Verified against three other working plugins (pulp, juce-dev in generous-corp-marketplace, chainer) — **none** declare \`agents\`; all rely on Claude Code auto-discovering the \`agents/\` convention.

Shipyard had \`"agents": "./agents"\" pointing at \`agents/ci.md\`. The agent file stays where it is and is still picked up by Claude Code. Dropping the field unblocks install.

## Changes

- \`.claude-plugin/plugin.json\`: drop \`agents\` field; bump version 0.11.2 → 0.11.3
- \`.claude-plugin/marketplace.json\`: mirror plugin version bump, bump marketplace metadata 0.1.1 → 0.1.2 so clients see a new revision

## Validation

Plugin plus marketplace manifests now match the shape used by every other working Claude Code plugin in my ecosystem. Install should succeed on the next \`claude plugin marketplace add danielraffel/Shipyard\` + \`claude plugin install shipyard\`.

## Trailers

\`\`\`
Version-Bump: plugin=patch reason="manifest field removed to fix install validation"
Skill-Update: ci skip skill=ci reason="no skill content change"
\`\`\`