### PR TITLE
feat(plugin): add /shipyard:upgrade command for explicit CLI upgrades

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
   "name": "shipyard",
   "owner": {"name": "Daniel Raffel"},
-  "metadata": {"description": "Cross-platform CI coordination", "version": "0.1.2"},
-  "plugins": [{"name": "shipyard", "source": "./", "description": "Cross-platform CI coordination — local VMs, SSH hosts, cloud runners", "version": "0.11.3", "author": {"name": "Daniel Raffel"}, "repository": "https://github.com/danielraffel/shipyard", "license": "MIT", "keywords": ["ci", "testing", "cross-platform", "validation"]}]
+  "metadata": {"description": "Cross-platform CI coordination", "version": "0.1.3"},
+  "plugins": [{"name": "shipyard", "source": "./", "description": "Cross-platform CI coordination — local VMs, SSH hosts, cloud runners", "version": "0.11.4", "author": {"name": "Daniel Raffel"}, "repository": "https://github.com/danielraffel/shipyard", "license": "MIT", "keywords": ["ci", "testing", "cross-platform", "validation"]}]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "shipyard",
-  "version": "0.11.3",
+  "version": "0.11.4",
   "description": "Cross-platform CI coordination",
   "commands": "./commands",
   "skills": "./skills",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,6 +2,7 @@
   "name": "shipyard",
   "version": "0.11.4",
   "description": "Cross-platform CI coordination",
+  "min_shipyard_version": "0.22.1",
   "commands": "./commands",
   "skills": "./skills",
   "hooks": "./hooks/hooks.json"

--- a/commands/upgrade.md
+++ b/commands/upgrade.md
@@ -1,0 +1,66 @@
+---
+name: upgrade
+description: Upgrade the Shipyard CLI to the latest (or a specific) version
+---
+
+Upgrade the `shipyard` CLI binary in place. Uses the same installer
+the Claude Code plugin's SessionStart hook calls — drops the new
+binary at `~/.local/bin/shipyard` (the canonical location), no
+other files touched.
+
+## Default: latest release
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/danielraffel/Shipyard/main/install.sh | bash
+shipyard --version
+```
+
+## Pin a specific version
+
+If the user asks for a specific version (e.g. "downgrade to 0.21.2",
+"stay on 0.22.0 for now"), pass `SHIPYARD_VERSION`:
+
+```bash
+SHIPYARD_VERSION="v0.22.1" bash <(curl -fsSL https://raw.githubusercontent.com/danielraffel/Shipyard/main/install.sh)
+shipyard --version
+```
+
+Accepts `v0.22.1`, `0.22.1`, or `latest`.
+
+## When to reach for this
+
+- The user asks for "upgrade", "update shipyard", "get the latest
+  CLI", "install the new version".
+- Plugin features depend on a newer CLI (e.g. a new command or
+  schema field) and the user is running an older binary.
+- After a release that fixes a bug affecting the current session
+  (e.g. the 0.22.1 daemon-spawn fix).
+
+## When NOT to auto-run this
+
+- **Project-pinned installs.** If a project pins a specific CLI
+  version via its own installer (e.g. pulp's `tools/install-shipyard.sh`
+  reading `tools/shipyard.toml`), defer to the pin — upgrading the
+  CLI bypasses the project's intentional pin and can break
+  reproducibility. Warn the user and suggest bumping the pin file
+  instead.
+- **Unattended agent sessions.** Upgrading a running CLI mid-session
+  can produce surprising mismatches with the plugin. Prefer: finish
+  the current task, then upgrade.
+
+## After upgrade
+
+```bash
+shipyard --version    # confirm the new version
+shipyard doctor       # re-run the environment check
+```
+
+If the user has the macOS menu-bar app running in live mode,
+restart the daemon so it picks up the new binary:
+
+```bash
+shipyard daemon stop
+# Auto/On mode in the GUI will spawn the new one automatically,
+# or manually:
+shipyard daemon start
+```

--- a/commands/upgrade.md
+++ b/commands/upgrade.md
@@ -36,6 +36,51 @@ Accepts `v0.22.1`, `0.22.1`, or `latest`.
 - After a release that fixes a bug affecting the current session
   (e.g. the 0.22.1 daemon-spawn fix).
 
+## Responding to the SessionStart staleness signal
+
+If the SessionStart hook detected a stale CLI you'll see a marker
+line like:
+
+```
+[Shipyard] SHIPYARD_CLI_STALE installed=0.22.0 min_expected=0.22.1
+```
+
+Don't silently run the upgrade. Use `AskUserQuestion` first with
+three options, recommending **Upgrade**:
+
+| Option | Action |
+|---|---|
+| **Upgrade the CLI now** (recommended) | Run the install command in this file; verify with `shipyard --version`. |
+| **Skip for this session** | Acknowledge; continue with existing CLI. Note any features that may not work. |
+| **My install is project-pinned (don't ask again)** | Defer to the project's own installer (e.g. pulp's `tools/install-shipyard.sh`). Also **persist the dismissal** so the hook stops prompting (see below). Suggest bumping their pin file instead. |
+
+After any option, drop the topic — don't re-prompt within the
+session unless the user explicitly asks.
+
+### Persisting a "don't ask again" choice
+
+When the user picks option 3, write a tiny JSON file under the
+shipyard state dir so the hook stays silent on future sessions
+(until the plugin raises its `min_shipyard_version` past what was
+dismissed — a new release that matters, new decision).
+
+The hook prints the exact paths in its marker; use those. On macOS
+that's `~/Library/Application Support/shipyard/plugin-upgrade-dismissed.json`;
+on Linux, `${XDG_STATE_HOME:-~/.local/state}/shipyard/plugin-upgrade-dismissed.json`.
+
+```bash
+# macOS example:
+mkdir -p "$HOME/Library/Application Support/shipyard"
+printf '%s\n' '{"dismissed_for_min":"0.22.1"}' \
+  > "$HOME/Library/Application Support/shipyard/plugin-upgrade-dismissed.json"
+```
+
+The `dismissed_for_min` value should match the `min_expected` from
+the staleness marker. Next session the hook reads the file; if the
+current plugin's `min_shipyard_version` is ≤ the dismissed version,
+it stays silent. If a newer plugin release bumps the minimum past
+that, the hook prompts again — by design.
+
 ## When NOT to auto-run this
 
 - **Project-pinned installs.** If a project pins a specific CLI

--- a/hooks/check-cli.sh
+++ b/hooks/check-cli.sh
@@ -1,31 +1,114 @@
 #!/bin/bash
-# Check if the shipyard CLI binary is installed.
-# If not, download and install it automatically.
-# Runs as a SessionStart hook from the Claude Code plugin.
+# SessionStart hook for the Claude Code plugin.
+#
+# Three jobs:
+#   1. Bootstrap: if no `shipyard` binary is on PATH, curl install.sh
+#      (best-effort). The plugin is deferential — it only installs
+#      when something's actually missing.
+#   2. Staleness signal: if a shipyard binary IS on PATH but is older
+#      than this plugin build's `min_shipyard_version`, print a
+#      structured marker the agent picks up and turns into an
+#      AskUserQuestion prompt offering to run /shipyard:upgrade.
+#   3. Honor a user's prior "don't ask again" choice via a dismiss
+#      file under the shipyard state dir. Re-prompts only when the
+#      plugin raises its min_shipyard_version past what was dismissed.
+#
+# We never auto-upgrade. Project pinners (e.g. pulp with
+# tools/shipyard.toml) rely on the plugin not surprise-upgrading
+# their CLI.
 
-if command -v shipyard &>/dev/null; then
+set -u
+
+# ── State-dir resolution (matches shipyard/core/config.py) ──────────
+
+case "$(uname -s)" in
+    Darwin)  SHIPYARD_STATE_DIR="$HOME/Library/Application Support/shipyard" ;;
+    Linux)   SHIPYARD_STATE_DIR="${XDG_STATE_HOME:-$HOME/.local/state}/shipyard" ;;
+    *)       SHIPYARD_STATE_DIR="$HOME/.shipyard" ;;  # fallback for Windows / weird hosts
+esac
+DISMISS_FILE="$SHIPYARD_STATE_DIR/plugin-upgrade-dismissed.json"
+
+# ── Bootstrap ───────────────────────────────────────────────────────
+
+if ! command -v shipyard &>/dev/null; then
+  echo ""
+  echo "[Shipyard] CLI binary not found. Installing..."
+  echo ""
+  curl -fsSL https://raw.githubusercontent.com/danielraffel/Shipyard/main/install.sh | sh
+  if command -v shipyard &>/dev/null; then
+    echo ""
+    echo "[Shipyard] Installed successfully: $(shipyard --version)"
+  elif [ -f "$HOME/.local/bin/shipyard" ]; then
+    echo ""
+    echo "[Shipyard] Installed to ~/.local/bin/shipyard"
+    echo "[Shipyard] Add to PATH: export PATH=\"\$HOME/.local/bin:\$PATH\""
+  else
+    echo ""
+    echo "[Shipyard] Installation may have failed. Try manually:"
+    echo "  curl -fsSL https://raw.githubusercontent.com/danielraffel/Shipyard/main/install.sh | sh"
+  fi
   exit 0
 fi
 
-echo ""
-echo "[Shipyard] CLI binary not found. Installing..."
-echo ""
+# ── Staleness check ─────────────────────────────────────────────────
 
-# Download and run the install script
-curl -fsSL https://raw.githubusercontent.com/danielraffel/Shipyard/main/install.sh | sh
-
-# Verify it worked
-if command -v shipyard &>/dev/null; then
-  echo ""
-  echo "[Shipyard] Installed successfully: $(shipyard --version)"
-elif [ -f "$HOME/.local/bin/shipyard" ]; then
-  echo ""
-  echo "[Shipyard] Installed to ~/.local/bin/shipyard"
-  echo "[Shipyard] Add to PATH: export PATH=\"\$HOME/.local/bin:\$PATH\""
-else
-  echo ""
-  echo "[Shipyard] Installation may have failed. Try manually:"
-  echo "  curl -fsSL https://raw.githubusercontent.com/danielraffel/Shipyard/main/install.sh | sh"
+PLUGIN_JSON="${CLAUDE_PLUGIN_ROOT:-}/.claude-plugin/plugin.json"
+if [ -z "${CLAUDE_PLUGIN_ROOT:-}" ] || [ ! -f "$PLUGIN_JSON" ]; then
+  exit 0
 fi
 
+MIN_VERSION=$(sed -n 's/^[[:space:]]*"min_shipyard_version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$PLUGIN_JSON" | head -1)
+if [ -z "$MIN_VERSION" ]; then
+  exit 0
+fi
+
+INSTALLED=$(shipyard --version 2>/dev/null | awk 'NF{print $NF}' | head -1 | sed 's/^v//')
+if [ -z "$INSTALLED" ]; then
+  exit 0
+fi
+
+MIN_CMP="${MIN_VERSION#v}"
+
+# Pure-shell version compare via sort -V. If MIN_CMP sorts first or
+# is equal to INSTALLED, installed is >= min (no action).
+version_gte() {
+    # $1 >= $2 ?
+    [ "$1" = "$2" ] && return 0
+    [ "$(printf '%s\n%s\n' "$1" "$2" | sort -V | head -1)" = "$2" ]
+}
+
+if version_gte "$INSTALLED" "$MIN_CMP"; then
+  exit 0
+fi
+
+# ── Honor a prior "don't ask again" dismissal ───────────────────────
+
+if [ -f "$DISMISS_FILE" ]; then
+  DISMISSED_MIN=$(sed -n 's/.*"dismissed_for_min"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$DISMISS_FILE" | head -1)
+  DISMISSED_CMP="${DISMISSED_MIN#v}"
+  if [ -n "$DISMISSED_CMP" ] && version_gte "$DISMISSED_CMP" "$MIN_CMP"; then
+    # User already dismissed this (or a later) min version. Stay silent.
+    exit 0
+  fi
+fi
+
+# ── Print the structured marker so the agent prompts ────────────────
+
+cat <<EOF
+
+[Shipyard] SHIPYARD_CLI_STALE installed=${INSTALLED} min_expected=${MIN_VERSION}
+[Shipyard] The plugin in this session expects shipyard ≥ ${MIN_VERSION};
+           you're on ${INSTALLED}. Recent releases include fixes that
+           affect plugin behavior (see GitHub releases).
+[Shipyard] Agent: use AskUserQuestion to offer three options,
+           recommending (1):
+             (1) Upgrade the CLI now via /shipyard:upgrade [recommended]
+             (2) Skip for this session
+             (3) Project-pinned — don't ask again
+           If the user picks (3), persist the dismiss by writing:
+             mkdir -p "${SHIPYARD_STATE_DIR}"
+             printf '%s\n' '{"dismissed_for_min":"${MIN_VERSION}"}' \\
+               > "${DISMISS_FILE}"
+
+EOF
 exit 0


### PR DESCRIPTION
Adds \`/shipyard:upgrade\` as the explicit opt-in for upgrading the Shipyard CLI binary from inside Claude Code.

## Why

The plugin's SessionStart hook is deliberately deferential — installs the CLI only when one isn't on PATH. That's the right default so plugin installs don't silently clobber a project-pinned binary (e.g. a pulp install pinned at v0.22.0 shouldn't get auto-upgraded to v0.22.1 just because Claude Code saw a new plugin). But it means users on an older CLI see no obvious path to "get the latest" from inside Claude Code.

\`/shipyard:upgrade\` fills that gap as an explicit, user-requested action.

## What it does

Invokes the same \`install.sh\` the SessionStart hook would. Lands at \`~/.local/bin/shipyard\` (canonical location). Supports \`SHIPYARD_VERSION\` for pinning to a specific release.

The command definition teaches the agent:

- **When to run it**: user says "upgrade shipyard", "update to latest", "install the new version"; plugin features depend on a newer CLI; a bug-fix release affects the current session.
- **When NOT to auto-run**: project has a pinned install (e.g. pulp's \`tools/shipyard.toml\`) — upgrading bypasses the pin. Defer to the project's own installer.
- **After**: re-run doctor, restart the daemon if it was running.

## Version bump

Plugin: 0.11.3 → 0.11.4. Marketplace: 0.1.2 → 0.1.3.

Trailers:
\`\`\`
Version-Bump: plugin=patch reason="new /shipyard:upgrade command"
Skill-Update: skip skill=ci reason="new command, no ci skill content change"
\`\`\`