### PR TITLE
plugin: reframe staleness as advisory (agents can't force AskUserQuestion)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
   "name": "shipyard",
   "owner": {"name": "Daniel Raffel"},
-  "metadata": {"description": "Cross-platform CI coordination", "version": "0.1.3"},
-  "plugins": [{"name": "shipyard", "source": "./", "description": "Cross-platform CI coordination — local VMs, SSH hosts, cloud runners", "version": "0.11.4", "author": {"name": "Daniel Raffel"}, "repository": "https://github.com/danielraffel/shipyard", "license": "MIT", "keywords": ["ci", "testing", "cross-platform", "validation"]}]
+  "metadata": {"description": "Cross-platform CI coordination", "version": "0.1.4"},
+  "plugins": [{"name": "shipyard", "source": "./", "description": "Cross-platform CI coordination — local VMs, SSH hosts, cloud runners", "version": "0.11.5", "author": {"name": "Daniel Raffel"}, "repository": "https://github.com/danielraffel/shipyard", "license": "MIT", "keywords": ["ci", "testing", "cross-platform", "validation"]}]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "shipyard",
-  "version": "0.11.4",
+  "version": "0.11.5",
   "description": "Cross-platform CI coordination",
   "min_shipyard_version": "0.22.1",
   "commands": "./commands",

--- a/commands/upgrade.md
+++ b/commands/upgrade.md
@@ -45,17 +45,29 @@ line like:
 [Shipyard] SHIPYARD_CLI_STALE installed=0.22.0 min_expected=0.22.1
 ```
 
-Don't silently run the upgrade. Use `AskUserQuestion` first with
-three options, recommending **Upgrade**:
+Claude Code injects this as session context *before* the user's
+first turn. Agents don't proactively act before a user message, so
+don't try to force an `AskUserQuestion` on your own. Instead:
 
-| Option | Action |
-|---|---|
-| **Upgrade the CLI now** (recommended) | Run the install command in this file; verify with `shipyard --version`. |
-| **Skip for this session** | Acknowledge; continue with existing CLI. Note any features that may not work. |
-| **My install is project-pinned (don't ask again)** | Defer to the project's own installer (e.g. pulp's `tools/install-shipyard.sh`). Also **persist the dismissal** so the hook stops prompting (see below). Suggest bumping their pin file instead. |
+**In your reply to the user's first message**, include a single
+one-line advisory pointing them at `/shipyard:upgrade`, then
+proceed with whatever they actually asked. Example:
 
-After any option, drop the topic — don't re-prompt within the
-session unless the user explicitly asks.
+> *(Note: shipyard CLI is 0.22.0; plugin expects ≥ 0.22.1 — run
+> `/shipyard:upgrade` when convenient.)*
+>
+> [then answer the user's actual question]
+
+If the user responds with "yes, upgrade now", run the install
+command in this file and verify with `shipyard --version`.
+
+If the user says their install is project-pinned (e.g. pulp's
+`tools/install-shipyard.sh`), don't upgrade — instead persist the
+dismissal so the hook stops advising on future sessions (see
+below), and suggest bumping their pin file instead.
+
+If the user ignores the advisory, drop the topic. Don't re-mention
+it within the session unless they raise it.
 
 ### Persisting a "don't ask again" choice
 

--- a/hooks/check-cli.sh
+++ b/hooks/check-cli.sh
@@ -92,7 +92,14 @@ if [ -f "$DISMISS_FILE" ]; then
   fi
 fi
 
-# ── Print the structured marker so the agent prompts ────────────────
+# ── Print the advisory marker the agent surfaces ────────────────────
+#
+# This is advisory, not directive. Claude Code injects SessionStart hook
+# stdout into the session as context, but agents don't proactively act
+# before the user's first message — so the agent can't reliably fire an
+# AskUserQuestion on its own. What actually works: agent notes the
+# staleness in its first reply to the user's first message, and the
+# user initiates the upgrade via /shipyard:upgrade if they want it.
 
 cat <<EOF
 
@@ -100,12 +107,13 @@ cat <<EOF
 [Shipyard] The plugin in this session expects shipyard ≥ ${MIN_VERSION};
            you're on ${INSTALLED}. Recent releases include fixes that
            affect plugin behavior (see GitHub releases).
-[Shipyard] Agent: use AskUserQuestion to offer three options,
-           recommending (1):
-             (1) Upgrade the CLI now via /shipyard:upgrade [recommended]
-             (2) Skip for this session
-             (3) Project-pinned — don't ask again
-           If the user picks (3), persist the dismiss by writing:
+[Shipyard] Agent: when you reply to the user's first message, include a
+           single-line advisory like "(Note: shipyard CLI is ${INSTALLED};
+           plugin expects ≥ ${MIN_VERSION} — run /shipyard:upgrade when
+           convenient.)" then proceed with what they asked. Don't
+           interrupt their task or auto-run the upgrade. If the user
+           says they're project-pinned and want to silence this, persist
+           the dismiss by writing:
              mkdir -p "${SHIPYARD_STATE_DIR}"
              printf '%s\n' '{"dismissed_for_min":"${MIN_VERSION}"}' \\
                > "${DISMISS_FILE}"


### PR DESCRIPTION
## Why

Follow-up to #134. Testing revealed the prior design didn't actually work: the SessionStart hook's marker said "Agent: use AskUserQuestion to offer three options", but Claude agents don't proactively invoke tools before the user's first message. When the user's first turn was `/shipyard:ci`, the agent responded to the command and silently ignored the staleness context.

## What changes

- `hooks/check-cli.sh` — the marker now tells the agent to **include a one-line advisory in its reply to the user's first message** pointing at `/shipyard:upgrade`, then proceed with whatever the user asked. No more "force AskUserQuestion" directive.
- `commands/upgrade.md` — same reframe; removes the three-option table in favor of an example first-turn advisory. Project-pin dismissal flow is preserved.

## What stays the same

- `min_shipyard_version` in `plugin.json` is still the comparison floor.
- Pure-shell version-compare via `sort -V`.
- `plugin-upgrade-dismissed.json` under `$SHIPYARD_STATE_DIR` still silences future sessions until the plugin bumps its min past what was dismissed.
- `/shipyard:upgrade` remains the explicit user-initiated upgrade path.

## Follow-up

#135 tracks the richer modes ("remind weekly", "auto-upgrade on detect") that *would* need an AskUserQuestion flow — but we'll need a user-initiated entry point (slash command or first-turn elicitation) to make those prompts actually fire.

## Versions

- plugin: 0.11.4 → 0.11.5
- marketplace metadata: 0.1.3 → 0.1.4

## Test plan

- [x] Local diff reads clean
- [ ] CI green
- [ ] Post-merge: refresh plugin in a test session; confirm the agent includes the advisory in its first reply when CLI < min