### PR TITLE
fix(plugin): wrap hooks.json under 'hooks' key — was silently ignored

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
   "name": "shipyard",
   "owner": {"name": "Daniel Raffel"},
-  "metadata": {"description": "Cross-platform CI coordination", "version": "0.1.4"},
-  "plugins": [{"name": "shipyard", "source": "./", "description": "Cross-platform CI coordination — local VMs, SSH hosts, cloud runners", "version": "0.11.5", "author": {"name": "Daniel Raffel"}, "repository": "https://github.com/danielraffel/shipyard", "license": "MIT", "keywords": ["ci", "testing", "cross-platform", "validation"]}]
+  "metadata": {"description": "Cross-platform CI coordination", "version": "0.1.5"},
+  "plugins": [{"name": "shipyard", "source": "./", "description": "Cross-platform CI coordination — local VMs, SSH hosts, cloud runners", "version": "0.11.6", "author": {"name": "Daniel Raffel"}, "repository": "https://github.com/danielraffel/shipyard", "license": "MIT", "keywords": ["ci", "testing", "cross-platform", "validation"]}]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "shipyard",
-  "version": "0.11.5",
+  "version": "0.11.6",
   "description": "Cross-platform CI coordination",
   "min_shipyard_version": "0.22.1",
   "commands": "./commands",

--- a/hooks/check-cli.sh
+++ b/hooks/check-cli.sh
@@ -19,6 +19,12 @@
 
 set -u
 
+# ── Canary (temporary — remove after schema fix is verified) ────────
+# Confirms the plugin loader actually invokes this hook. Will be
+# removed in a follow-up PR once we've seen it fire.
+echo "HOOK_RAN at $(date) CLAUDE_PLUGIN_ROOT=${CLAUDE_PLUGIN_ROOT:-unset}" \
+  >> /tmp/shipyard-hook-ran.txt 2>/dev/null || true
+
 # ── State-dir resolution (matches shipyard/core/config.py) ──────────
 
 case "$(uname -s)" in

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,26 +1,28 @@
 {
-  "SessionStart": [
-    {
-      "matcher": "*",
-      "hooks": [
-        {
-          "type": "command",
-          "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/check-cli.sh",
-          "timeout": 5
-        }
-      ]
-    }
-  ],
-  "PostToolUse": [
-    {
-      "matcher": "Edit|Write",
-      "hooks": [
-        {
-          "type": "command",
-          "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/version-skill-hint.sh",
-          "timeout": 3000
-        }
-      ]
-    }
-  ]
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/check-cli.sh",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/version-skill-hint.sh",
+            "timeout": 3000
+          }
+        ]
+      }
+    ]
+  }
 }


### PR DESCRIPTION
## Root cause

The SessionStart hook added in #134 and reframed in #136 was **never actually firing**. Canary testing confirmed zero hook invocations across multiple interactive sessions with the plugin installed.

Reason: our `hooks/hooks.json` used a flat schema with event names at the top level:

```json
{"SessionStart": [...], "PostToolUse": [...]}
```

Claude Code's plugin-loader schema requires event names nested under a top-level `"hooks"` object:

```json
{"hooks": {"SessionStart": [...], "PostToolUse": [...]}}
```

Every known-working plugin installed in the user's environment (ralph-loop, ralph-wiggum, prompt-repeater) uses the nested form. The flat form is `settings.json`'s hooks schema — a different format that Claude Code accepts in settings but not in plugin manifests.

As a result: `/shipyard:ci` commands worked (different loader), but **every hook in the plugin was silently dropped**, including the SessionStart CLI-install bootstrap, the staleness check, and the version-skill hint on Edit/Write.

## What changes

- `hooks/hooks.json` — wraps the existing `SessionStart` + `PostToolUse` blocks under a top-level `"hooks"` key. No other logic change.
- `hooks/check-cli.sh` — adds a temporary canary line that appends to `/tmp/shipyard-hook-ran.txt` on every invocation. Will be removed in a follow-up PR once the fix is verified.

## Verification plan

Post-merge:
1. `claude plugin marketplace remove shipyard && claude plugin marketplace add danielraffel/Shipyard && claude plugin install shipyard`
2. Open `claude` interactively, exit immediately
3. Check `/tmp/shipyard-hook-ran.txt` — should contain a `HOOK_RAN at ...` entry
4. Confirm the agent's first-reply advisory appears when starting a fresh session with a stale CLI
5. File follow-up PR removing the canary

## Versions

- plugin: 0.11.5 → 0.11.6
- marketplace: 0.1.4 → 0.1.5

## Related

- #134 (original staleness detection — broken by this schema bug)
- #136 (advisory reframe — correct design, never got a chance to run)
- #135 (future enhancements, deferred)
- pulp `tools/hooks/hooks.json` likely has the same bug; file a companion issue upstream