### PR TITLE
plugin: user-visible banner for stale CLI via systemMessage

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
   "name": "shipyard",
   "owner": {"name": "Daniel Raffel"},
-  "metadata": {"description": "Cross-platform CI coordination", "version": "0.1.5"},
-  "plugins": [{"name": "shipyard", "source": "./", "description": "Cross-platform CI coordination — local VMs, SSH hosts, cloud runners", "version": "0.11.6", "author": {"name": "Daniel Raffel"}, "repository": "https://github.com/danielraffel/shipyard", "license": "MIT", "keywords": ["ci", "testing", "cross-platform", "validation"]}]
+  "metadata": {"description": "Cross-platform CI coordination", "version": "0.1.6"},
+  "plugins": [{"name": "shipyard", "source": "./", "description": "Cross-platform CI coordination — local VMs, SSH hosts, cloud runners", "version": "0.11.7", "author": {"name": "Daniel Raffel"}, "repository": "https://github.com/danielraffel/shipyard", "license": "MIT", "keywords": ["ci", "testing", "cross-platform", "validation"]}]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "shipyard",
-  "version": "0.11.6",
+  "version": "0.11.7",
   "description": "Cross-platform CI coordination",
   "min_shipyard_version": "0.22.1",
   "commands": "./commands",

--- a/commands/upgrade.md
+++ b/commands/upgrade.md
@@ -38,36 +38,27 @@ Accepts `v0.22.1`, `0.22.1`, or `latest`.
 
 ## Responding to the SessionStart staleness signal
 
-If the SessionStart hook detected a stale CLI you'll see a marker
-line like:
+The SessionStart hook now emits a JSON response with two fields
+when the CLI is stale:
 
-```
-[Shipyard] SHIPYARD_CLI_STALE installed=0.22.0 min_expected=0.22.1
-```
+- `systemMessage` — renders as a **user-visible banner** at session
+  start (independent of the agent). Example text:
+  *"Shipyard CLI is on 0.22.0; plugin expects ≥ 0.22.1. Run
+  /shipyard:upgrade to update."*
+- `hookSpecificOutput.additionalContext` — added to your context
+  so you can speak to it if the user asks.
 
-Claude Code injects this as session context *before* the user's
-first turn. Agents don't proactively act before a user message, so
-don't try to force an `AskUserQuestion` on your own. Instead:
+Behavior to follow:
 
-**In your reply to the user's first message**, include a single
-one-line advisory pointing them at `/shipyard:upgrade`, then
-proceed with whatever they actually asked. Example:
-
-> *(Note: shipyard CLI is 0.22.0; plugin expects ≥ 0.22.1 — run
-> `/shipyard:upgrade` when convenient.)*
->
-> [then answer the user's actual question]
-
-If the user responds with "yes, upgrade now", run the install
-command in this file and verify with `shipyard --version`.
-
-If the user says their install is project-pinned (e.g. pulp's
-`tools/install-shipyard.sh`), don't upgrade — instead persist the
-dismissal so the hook stops advising on future sessions (see
-below), and suggest bumping their pin file instead.
-
-If the user ignores the advisory, drop the topic. Don't re-mention
-it within the session unless they raise it.
+- **Do not proactively prompt** on your own. The banner already told
+  the user. If they don't ask about it, don't mention it.
+- **If the user responds to the banner** ("yes upgrade", "go ahead"),
+  run the install command in this file and verify with
+  `shipyard --version`.
+- **If the user says their install is project-pinned** (e.g. pulp's
+  `tools/install-shipyard.sh`), don't upgrade — persist the
+  dismissal (see below) so the banner stops on future sessions, and
+  suggest bumping their pin file instead.
 
 ### Persisting a "don't ask again" choice
 

--- a/hooks/check-cli.sh
+++ b/hooks/check-cli.sh
@@ -6,9 +6,10 @@
 #      (best-effort). The plugin is deferential — it only installs
 #      when something's actually missing.
 #   2. Staleness signal: if a shipyard binary IS on PATH but is older
-#      than this plugin build's `min_shipyard_version`, print a
-#      structured marker the agent picks up and turns into an
-#      AskUserQuestion prompt offering to run /shipyard:upgrade.
+#      than this plugin build's `min_shipyard_version`, emit a Claude
+#      Code SessionStart JSON response with `systemMessage` (renders
+#      as a user-visible banner at session start) and
+#      `hookSpecificOutput.additionalContext` (agent-facing).
 #   3. Honor a user's prior "don't ask again" choice via a dismiss
 #      file under the shipyard state dir. Re-prompts only when the
 #      plugin raises its min_shipyard_version past what was dismissed.
@@ -18,12 +19,6 @@
 # their CLI.
 
 set -u
-
-# ── Canary (temporary — remove after schema fix is verified) ────────
-# Confirms the plugin loader actually invokes this hook. Will be
-# removed in a follow-up PR once we've seen it fire.
-echo "HOOK_RAN at $(date) CLAUDE_PLUGIN_ROOT=${CLAUDE_PLUGIN_ROOT:-unset}" \
-  >> /tmp/shipyard-hook-ran.txt 2>/dev/null || true
 
 # ── State-dir resolution (matches shipyard/core/config.py) ──────────
 
@@ -98,31 +93,53 @@ if [ -f "$DISMISS_FILE" ]; then
   fi
 fi
 
-# ── Print the advisory marker the agent surfaces ────────────────────
+# ── Emit the SessionStart JSON response ─────────────────────────────
 #
-# This is advisory, not directive. Claude Code injects SessionStart hook
-# stdout into the session as context, but agents don't proactively act
-# before the user's first message — so the agent can't reliably fire an
-# AskUserQuestion on its own. What actually works: agent notes the
-# staleness in its first reply to the user's first message, and the
-# user initiates the upgrade via /shipyard:upgrade if they want it.
+# Plain-text stdout goes into the agent's context but agents often
+# treat it as ignorable ambient info. Using the structured JSON
+# response renders `systemMessage` as a user-visible banner at session
+# start (doesn't depend on the agent saying anything) and separately
+# populates `additionalContext` for when the user does ask the agent
+# about the upgrade.
 
-cat <<EOF
+if command -v python3 &>/dev/null; then
+  INSTALLED="$INSTALLED" MIN_VERSION="$MIN_VERSION" \
+    SHIPYARD_STATE_DIR="$SHIPYARD_STATE_DIR" DISMISS_FILE="$DISMISS_FILE" \
+    python3 <<'PY'
+import json, os
+installed = os.environ['INSTALLED']
+minv      = os.environ['MIN_VERSION']
+sdir      = os.environ['SHIPYARD_STATE_DIR']
+dfile     = os.environ['DISMISS_FILE']
+
+print(json.dumps({
+    "systemMessage": (
+        f"Shipyard CLI is on {installed}; plugin expects ≥ {minv}. "
+        f"Run /shipyard:upgrade to update."
+    ),
+    "hookSpecificOutput": {
+        "hookEventName": "SessionStart",
+        "additionalContext": (
+            f"The installed shipyard CLI is {installed} but this plugin "
+            f"expects >= {minv}. If the user asks about upgrading, suggest "
+            f"/shipyard:upgrade. If they say their install is project-pinned "
+            f"(e.g. pulp's tools/install-shipyard.sh) and want to silence "
+            f"this on future sessions, write the dismiss file:\n"
+            f'  mkdir -p "{sdir}"\n'
+            f'  printf \'%s\\n\' \'{{"dismissed_for_min":"{minv}"}}\' '
+            f'> "{dfile}"'
+        ),
+    },
+}))
+PY
+else
+  # Fallback: plain text for environments without python3. Renders as
+  # agent context only — agents may or may not surface it.
+  cat <<EOF
 
 [Shipyard] SHIPYARD_CLI_STALE installed=${INSTALLED} min_expected=${MIN_VERSION}
-[Shipyard] The plugin in this session expects shipyard ≥ ${MIN_VERSION};
-           you're on ${INSTALLED}. Recent releases include fixes that
-           affect plugin behavior (see GitHub releases).
-[Shipyard] Agent: when you reply to the user's first message, include a
-           single-line advisory like "(Note: shipyard CLI is ${INSTALLED};
-           plugin expects ≥ ${MIN_VERSION} — run /shipyard:upgrade when
-           convenient.)" then proceed with what they asked. Don't
-           interrupt their task or auto-run the upgrade. If the user
-           says they're project-pinned and want to silence this, persist
-           the dismiss by writing:
-             mkdir -p "${SHIPYARD_STATE_DIR}"
-             printf '%s\n' '{"dismissed_for_min":"${MIN_VERSION}"}' \\
-               > "${DISMISS_FILE}"
+[Shipyard] Run /shipyard:upgrade to update the CLI.
 
 EOF
+fi
 exit 0


### PR DESCRIPTION
## Why

Testing confirmed the prior staleness path was silently failing: the hook correctly fired (#137) and printed a plain-text marker, but the agent treated it as ambient context and didn't surface it when the user's first turn was a simple greeting. Users on stale CLIs got no indication.

## Fix

Switches the SessionStart hook to emit a structured JSON response with both surfaces Claude Code supports:

- **`systemMessage`** — renders as a user-visible banner at session start, regardless of agent behavior. Users see it the moment `claude` opens.
- **`hookSpecificOutput.additionalContext`** — agent-facing context for when the user asks about it; includes the dismiss-file command for project-pinned installs.

The banner text is intentionally short and actionable:

> *Shipyard CLI is on 0.22.0; plugin expects ≥ 0.22.1. Run /shipyard:upgrade to update.*

JSON is constructed via `python3` (already a shipyard dependency); falls back to plain-text marker if python3 isn't on PATH.

## Verification

- Local sanity: ran hook with a fake `plugin.json` setting `min_shipyard_version: "99.99.99"` against the installed `shipyard 0.22.1`. Hook emits valid JSON (verified with `python3 -m json.tool`) containing both fields with correct substitutions.
- Real-world test path: bump `min_shipyard_version` in an installed plugin to something above current CLI and open `claude`. Banner should render at session start.

## Also

Strips the `/tmp/shipyard-hook-ran.txt` canary from `check-cli.sh` — served its purpose confirming #137's schema fix.

## Versions

- plugin: 0.11.6 → 0.11.7
- marketplace: 0.1.5 → 0.1.6

## Follow-ups

#135 still tracks the richer "remind weekly" / "auto-upgrade" modes. Pulp likely has the same hooks.json schema bug — separate agent session.