### PR TITLE
daemon: really fix spawn_detached for standalone binaries (0.22.2)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "shipyard"
-version = "0.22.1"
+version = "0.22.2"
 description = "Cross-platform CI coordination — local VMs, SSH hosts, cloud runners"
 readme = "README.md"
 license = "MIT"

--- a/src/shipyard/__init__.py
+++ b/src/shipyard/__init__.py
@@ -1,3 +1,3 @@
 """Shipyard — Cross-platform CI coordination."""
 
-__version__ = "0.22.1"
+__version__ = "0.22.2"

--- a/src/shipyard/daemon/runner.py
+++ b/src/shipyard/daemon/runner.py
@@ -72,6 +72,30 @@ def run_blocking(*, state_dir: Path, repos: list[str]) -> int:
     return 0
 
 
+def _spawn_argv() -> list[str]:
+    """Choose the argv prefix for spawning the daemon subprocess.
+
+    Two install shapes to handle:
+
+    * **pip / uv install** — ``sys.executable`` is a Python interpreter
+      (basename ``python`` / ``python3`` / ``pypy3``). Shipyard is
+      imported as a module; we invoke it via ``-m shipyard``.
+    * **Standalone binary** — shiv zipapp, PyInstaller bundle, etc.
+      (e.g. the ``install.sh`` drop-in at ``~/.local/bin/shipyard``).
+      ``sys.executable`` is the shipyard binary itself; passing ``-m``
+      makes Click error with ``No such option: -m`` and the daemon
+      never starts. Invoke the binary directly instead.
+
+    Detection is by basename — Python interpreters always contain
+    "python" (or "pypy"); the shipyard binary never does.
+    """
+    exe_name = os.path.basename(sys.executable).lower()
+    if "python" in exe_name or "pypy" in exe_name:
+        return [sys.executable, "-m", "shipyard", "daemon", "run"]
+    # Anything else is the shipyard binary itself.
+    return [sys.executable, "daemon", "run"]
+
+
 def spawn_detached(*, state_dir: Path, repos: list[str]) -> int:
     """Launch the daemon as a detached child process, return its PID.
 
@@ -88,7 +112,7 @@ def spawn_detached(*, state_dir: Path, repos: list[str]) -> int:
             existing_pid = 0
         if existing_pid > 0 and _pid_alive(existing_pid):
             return existing_pid
-    args = [sys.executable, "-m", "shipyard", "daemon", "run"]
+    args = _spawn_argv()
     for repo in repos:
         args.extend(["--repo", repo])
     # Close stdio so the detached process doesn't hold the parent

--- a/tests/daemon/test_runner.py
+++ b/tests/daemon/test_runner.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 import pytest
 
-from shipyard.daemon.runner import daemon_is_running, stop_running
+from shipyard.daemon.runner import _spawn_argv, daemon_is_running, stop_running
 
 # stop_running uses AF_UNIX sockets on the happy path. PID semantics
 # work on Windows but the full suite wasn't designed for it.
@@ -48,3 +48,42 @@ def test_stop_running_with_stale_pid_cleans_up(tmp_path: Path) -> None:
     assert stop_running(tmp_path) is False  # nothing was actually stopped
     # Stale file should be cleaned up.
     assert not (pid_dir / "daemon.pid").exists()
+
+
+# ── spawn_argv: standalone-binary vs pip-install detection ──────────
+
+
+@pytest.mark.parametrize(
+    ("executable_name", "expects_dash_m"),
+    [
+        ("python", True),
+        ("python3", True),
+        ("python3.12", True),
+        ("pypy3", True),
+        # Standalone binaries: shipyard / sy / anything non-python.
+        ("shipyard", False),
+        ("sy", False),
+        # PyInstaller-style onefile bundle often copies to a temp name.
+        ("shipyard-macos-arm64", False),
+    ],
+)
+def test_spawn_argv_detects_install_shape(
+    monkeypatch: pytest.MonkeyPatch,
+    executable_name: str,
+    expects_dash_m: bool,
+) -> None:
+    """Regression for the 0.22.x daemon.log spam:
+
+        Error: No such option: -m
+
+    Standalone-binary installs (shiv/zipapp) must NOT get ``-m shipyard``
+    in the argv — the CLI's Click root rejects it. Pip installs must.
+    """
+    monkeypatch.setattr("sys.executable", f"/fake/path/{executable_name}")
+    argv = _spawn_argv()
+    assert argv[0] == f"/fake/path/{executable_name}"
+    if expects_dash_m:
+        assert argv[1:4] == ["-m", "shipyard", "daemon"]
+    else:
+        assert "-m" not in argv
+        assert argv[1:3] == ["daemon", "run"]


### PR DESCRIPTION
## Why

PR #130 claimed to fix the \"No such option: -m\" daemon spawn failure for standalone-binary installs (shiv / zipapp / install.sh drop-ins). It bumped the version to 0.22.1 but **the runner.py code change the commit message promised was never actually included**.

Symptom on a 0.22.1 standalone install:

- macOS GUI shows \"Couldn't start Tailscale Funnel: shipyard CLI not found on PATH\" even though the CLI is clearly on PATH.
- `shipyard daemon start` reports success but `shipyard daemon status` says \"daemon is not running.\"
- `~/Library/Application Support/shipyard/daemon/daemon.log` fills with:
  ```
  Error: No such option: -m
  ```

Every GUI live-mode attempt silently fails and the user is forced to manually `shipyard daemon start` from a terminal — which *also* fails on a standalone binary because it hits the same bug path.

## Fix

Extracted `_spawn_argv()` that picks the right argv shape by inspecting `sys.executable`:

- Python interpreter (basename contains `python` or `pypy`) → `[sys.executable, \"-m\", \"shipyard\", \"daemon\", \"run\"]` (dev / pip / uv installs).
- Anything else (standalone shipyard binary, including the `sy` symlink and PyInstaller onefile builds) → `[sys.executable, \"daemon\", \"run\"]` — no `-m`.

## Tests

7 new parametrized tests in `tests/daemon/test_runner.py` cover both install shapes: `python`, `python3`, `python3.12`, `pypy3` → with `-m`; `shipyard`, `sy`, `shipyard-macos-arm64` → without. All 12 tests in the file pass locally.

## Verification after merge

Users on a standalone 0.22.1 binary update via:
```
curl -fsSL https://raw.githubusercontent.com/danielraffel/Shipyard/main/install.sh | bash
```
…land on 0.22.2. The macOS GUI's \"Auto\" live mode should now succeed in spawning the daemon without a terminal round-trip.

## Versions

- CLI: 0.22.1 → 0.22.2
- Plugin: unchanged (0.11.7)
- No SKILL.md touched.

## Follow-ups / out of scope

Architectural auto-reconcile (GUI detects tailscale coming / going, falls back to polling, returns to webhook when funnel recovers) tracked separately. This PR is specifically the spawn crash.