### PR TITLE
ship: drop Shipyard branding + 'Ship' term from auto-opened PR bodies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "shipyard"
-version = "0.22.2"
+version = "0.22.3"
 description = "Cross-platform CI coordination — local VMs, SSH hosts, cloud runners"
 readme = "README.md"
 license = "MIT"

--- a/src/shipyard/__init__.py
+++ b/src/shipyard/__init__.py
@@ -1,3 +1,3 @@
 """Shipyard — Cross-platform CI coordination."""
 
-__version__ = "0.22.2"
+__version__ = "0.22.3"

--- a/src/shipyard/cli.py
+++ b/src/shipyard/cli.py
@@ -4810,11 +4810,10 @@ def _compose_pr_body(config: Config) -> str:
     out separately so the reviewer can audit why the default policy
     was flipped on this PR.
     """
-    lines: list[str] = ["Automated by Shipyard."]
+    lines: list[str] = []
     policy = _resolve_lane_policy_for_ship(config)
     advisory = sorted(policy.advisory_targets)
     if advisory:
-        lines.append("")
         lines.append("## Advisory lanes")
         lines.append(
             "The following lanes are **advisory** — their status is "

--- a/src/shipyard/ship/merge.py
+++ b/src/shipyard/ship/merge.py
@@ -205,7 +205,7 @@ def ship(
         pr = find_pr_for_branch(branch)
         if pr is None:
             title = _default_pr_title(branch)
-            body = f"Ship {branch} @ {sha[:8]}\n\nAutomated by Shipyard."
+            body = f"Branch `{branch}` @ `{sha[:8]}`."
             pr = create_pr(branch, base, title, body)
     except GhError as e:
         return ShipResult(success=False, error=f"PR creation failed: {e}")


### PR DESCRIPTION
## Why

Consumer-visible: pulp/pull/614 shows \"Automated by Shipyard.\" in its PR body. Every repo using shipyard's auto-PR flow inherits the same string. Violates two standing rules:

- **No Shipyard branding in consumer-facing files** — this is a PR body reviewers read.
- **\"Ship\" is internal terminology** — these are pull requests, not ships.

## What changes

- `src/shipyard/ship/merge.py:208` — body was `f\"Ship {branch} @ {sha[:8]}\\n\\nAutomated by Shipyard.\"` → now `f\"Branch \\`{branch}\\` @ \\`{sha[:8]}\\`.\"` (hits both violations in one line).
- `src/shipyard/cli.py:4813` — `_compose_pr_body()` no longer seeds the body with \"Automated by Shipyard.\" If advisory lanes are present, that section becomes the first content. If not, body is empty — which `gh pr create` accepts fine.

No tests reference these strings. Verified with `grep -rn \"Automated by Shipyard\" src/ tests/` — clean.

## Tests

Ran `tests/ship/` and `tests/test_cli*.py` — 223 tests pass.

## Versions

- CLI: 0.22.2 → 0.22.3

Auto-release will tag + publish binaries on merge.