### PR TITLE
daemon: bundle encodings.idna + verify child alive after spawn (0.22.4)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "shipyard"
-version = "0.22.3"
+version = "0.22.4"
 description = "Cross-platform CI coordination — local VMs, SSH hosts, cloud runners"
 readme = "README.md"
 license = "MIT"

--- a/src/shipyard/__init__.py
+++ b/src/shipyard/__init__.py
@@ -1,3 +1,3 @@
 """Shipyard — Cross-platform CI coordination."""
 
-__version__ = "0.22.3"
+__version__ = "0.22.4"

--- a/src/shipyard/cli.py
+++ b/src/shipyard/cli.py
@@ -6,6 +6,16 @@ output is the default.
 
 from __future__ import annotations
 
+# PyInstaller only bundles stdlib modules it can detect via static
+# import analysis. Python's http.server -> socket.getfqdn() pulls in
+# the IDNA codec lazily when the server binds to a hostname; if that
+# codec isn't in the bundle the shipyard daemon crashes on start with
+#   LookupError: unknown encoding: idna
+# and the binary exits before writing any useful error to stderr.
+# Explicit import forces PyInstaller to include encodings.idna in the
+# --onefile binary. Keep this even if it looks unused.
+import encodings.idna  # noqa: F401 — PyInstaller bundle primer
+
 import subprocess
 import sys
 from datetime import datetime, timedelta, timezone
@@ -6241,12 +6251,30 @@ def daemon_start(ctx: Context, repos: tuple[str, ...], detach: bool) -> None:
     """Start the webhook daemon."""
     import os as _os
 
-    from shipyard.daemon.runner import run_blocking, spawn_detached
+    from shipyard.daemon.runner import (
+        DaemonSpawnFailedError,
+        run_blocking,
+        spawn_detached,
+    )
 
     repo_list = _resolve_repo_list(ctx, repos)
     state_dir = ctx.config.state_dir
     if detach:
-        pid = spawn_detached(state_dir=state_dir, repos=repo_list)
+        try:
+            pid = spawn_detached(state_dir=state_dir, repos=repo_list)
+        except DaemonSpawnFailedError as exc:
+            # The child died before the verification window expired.
+            # Don't lie about it ("daemon started") — surface the log
+            # tail so users see the real error (PyInstaller bundling,
+            # port in use, tunnel permission denied, etc.).
+            if ctx.json_mode:
+                ctx.output(
+                    "daemon:start",
+                    {"ok": False, "error": str(exc), "repos": repo_list},
+                )
+            else:
+                render_message(str(exc), style="red")
+            sys.exit(3)
         if ctx.json_mode:
             ctx.output("daemon:start", {"pid": pid, "repos": repo_list})
         else:

--- a/src/shipyard/cli.py
+++ b/src/shipyard/cli.py
@@ -15,7 +15,6 @@ from __future__ import annotations
 # Explicit import forces PyInstaller to include encodings.idna in the
 # --onefile binary. Keep this even if it looks unused.
 import encodings.idna  # noqa: F401 — PyInstaller bundle primer
-
 import subprocess
 import sys
 from datetime import datetime, timedelta, timezone

--- a/src/shipyard/daemon/runner.py
+++ b/src/shipyard/daemon/runner.py
@@ -135,15 +135,54 @@ def spawn_detached(*, state_dir: Path, repos: list[str]) -> int:
     finally:
         os.close(log_fd)
     # Poll briefly for the PID file so callers can report accurately.
+    # Then verify the child is *still alive* — a PyInstaller-bundled
+    # standalone binary can crash 100ms into startup with a
+    # LookupError and write its PID before exiting, leaving callers
+    # with a stale PID that no longer maps to a process. Fixed in
+    # 0.22.4 after the encodings.idna bundling bug surfaced.
     deadline = time.time() + 3.0
+    pid_from_file: int | None = None
     while time.time() < deadline:
         if pid_file.exists():
             try:
-                return int(pid_file.read_text(encoding="utf-8").strip())
+                pid_from_file = int(pid_file.read_text(encoding="utf-8").strip())
             except (OSError, ValueError):
                 break
+            break
         time.sleep(0.05)
-    return proc.pid
+    final_pid = pid_from_file if pid_from_file is not None else proc.pid
+    # Settle window: give the child a bit to die if it's going to.
+    time.sleep(0.3)
+    if not _pid_alive(final_pid):
+        # Harvest the tail of the log so the caller can surface a
+        # useful error instead of a lie ("daemon started").
+        tail = _read_log_tail(log_path)
+        raise DaemonSpawnFailedError(
+            f"daemon exited immediately after spawn (pid {final_pid}). "
+            f"Tail of {log_path}:\n{tail}"
+        )
+    return final_pid
+
+
+class DaemonSpawnFailedError(RuntimeError):
+    """Raised when spawn_detached starts a daemon that dies before
+    the verification window expires. Callers should surface the
+    log tail in the exception message rather than claim success."""
+
+
+def _read_log_tail(log_path: Path, *, bytes_to_read: int = 2048) -> str:
+    """Return the last few KB of the daemon log as text. Best-effort —
+    returns an empty string if the file doesn't exist or can't be read.
+    """
+    try:
+        with open(log_path, "rb") as handle:
+            handle.seek(0, os.SEEK_END)
+            size = handle.tell()
+            handle.seek(max(0, size - bytes_to_read))
+            data = handle.read()
+        return data.decode("utf-8", errors="replace")
+    except OSError:
+        return ""
 
 
 def stop_running(state_dir: Path) -> bool:


### PR DESCRIPTION
Fixes two compounding silent-failure bugs that left the daemon non-functional on standalone binary installs. See commit message for the full story.

## What users experienced before
- daemon started (pid 46615); registering 2 repo(s). prints "daemon started (pid N); registering 2 repo(s)."
- `shipyard daemon status` prints "daemon is not running." 0.5s later
- `~/Library/Application Support/shipyard/daemon/daemon.log` fills with `LookupError: unknown encoding: idna` tracebacks
- macOS GUI shows "Live · via Tailscale Funnel" with cached data from before the crash

## Fix
- `src/shipyard/cli.py`: `import encodings.idna` at module top so PyInstaller bundles it. One-liner, static-analysis-friendly.
- `src/shipyard/daemon/runner.py`: `spawn_detached` now settles 300ms after writing PID, verifies process is alive, raises `DaemonSpawnFailedError` with log tail if not. CLI catches this, renders the real error, exits 3.
- 12 existing daemon-runner tests still pass.

## Versions
- CLI: 0.22.3 → 0.22.4

Auto-release will tag + publish binaries on merge.