### PR TITLE
ship: shipyard ship-state reconcile — heal drifted CI state (0.22.6)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "shipyard"
-version = "0.22.5"
+version = "0.22.6"
 description = "Cross-platform CI coordination — local VMs, SSH hosts, cloud runners"
 readme = "README.md"
 license = "MIT"

--- a/src/shipyard/__init__.py
+++ b/src/shipyard/__init__.py
@@ -1,3 +1,3 @@
 """Shipyard — Cross-platform CI coordination."""
 
-__version__ = "0.22.5"
+__version__ = "0.22.6"

--- a/src/shipyard/cli.py
+++ b/src/shipyard/cli.py
@@ -4044,11 +4044,13 @@ def ship_state_reconcile(
         render_error("Usage: shipyard ship-state reconcile <pr> | --all")
         sys.exit(2)
 
-    targets: list[ShipState] = (
-        ctx.ship_state.list_active()
-        if reconcile_all
-        else [s for s in [ctx.ship_state.get(pr)] if s is not None]
-    )
+    targets: list[ShipState] = []
+    if reconcile_all:
+        targets = ctx.ship_state.list_active()
+    elif pr is not None:
+        state = ctx.ship_state.get(pr)
+        if state is not None:
+            targets = [state]
     if not targets:
         render_message(
             f"No active ship state for PR #{pr}." if pr else "No active ship state.",

--- a/src/shipyard/cli.py
+++ b/src/shipyard/cli.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 # Explicit import forces PyInstaller to include encodings.idna in the
 # --onefile binary. Keep this even if it looks unused.
 import encodings.idna  # noqa: F401 — PyInstaller bundle primer
+import json
 import subprocess
 import sys
 from datetime import datetime, timedelta, timezone
@@ -4010,6 +4011,96 @@ def _ship_terminal_verdict(state: ShipState) -> bool | None:
         v == "pass" or tgt in advisory_targets
         for tgt, v in state.evidence_snapshot.items()
     )
+
+
+@ship_state_group.command("reconcile")
+@click.argument("pr", type=int, required=False)
+@click.option(
+    "--all",
+    "reconcile_all",
+    is_flag=True,
+    help="Reconcile every active ship-state (ignores the PR argument)",
+)
+@click.pass_obj
+def ship_state_reconcile(
+    ctx: Context, pr: int | None, reconcile_all: bool
+) -> None:
+    """Re-fetch CI state from GitHub and heal drifted ship-state.
+
+    Webhook events update dispatched_runs as they arrive; if the daemon
+    was down or not registered for the repo, those events are lost and
+    the local ship-state file keeps stale statuses. This command pulls
+    ``gh pr view <PR> --json statusCheckRollup`` and rewrites
+    dispatched_runs to match what GitHub reports right now.
+    """
+    import subprocess as _sp
+
+    from shipyard.ship.reconcile import reconcile_ship_state
+
+    if reconcile_all and pr is not None:
+        render_error("Pass either <pr> or --all, not both.")
+        sys.exit(2)
+    if not reconcile_all and pr is None:
+        render_error("Usage: shipyard ship-state reconcile <pr> | --all")
+        sys.exit(2)
+
+    targets: list[ShipState] = (
+        ctx.ship_state.list_active()
+        if reconcile_all
+        else [s for s in [ctx.ship_state.get(pr)] if s is not None]
+    )
+    if not targets:
+        render_message(
+            f"No active ship state for PR #{pr}." if pr else "No active ship state.",
+            style="dim",
+        )
+        return
+
+    results: list[dict[str, Any]] = []
+    for state in targets:
+        try:
+            raw = _sp.run(
+                [
+                    "gh", "pr", "view", str(state.pr),
+                    "--repo", state.repo,
+                    "--json", "statusCheckRollup",
+                ],
+                capture_output=True, text=True, check=True, timeout=20,
+            ).stdout
+        except (_sp.CalledProcessError, _sp.TimeoutExpired, FileNotFoundError) as exc:
+            results.append({"pr": state.pr, "ok": False, "error": str(exc)})
+            continue
+        try:
+            rollup = json.loads(raw).get("statusCheckRollup") or []
+        except (ValueError, KeyError):
+            results.append({"pr": state.pr, "ok": False, "error": "unparseable gh output"})
+            continue
+        new_state, changes = reconcile_ship_state(state, rollup)
+        if changes:
+            ctx.ship_state.save(new_state)
+        results.append({
+            "pr": state.pr, "ok": True, "changes": changes,
+        })
+
+    if ctx.json_mode:
+        ctx.output("ship-state:reconcile", {"results": results})
+        return
+
+    for r in results:
+        if not r["ok"]:
+            render_error(f"PR #{r['pr']}: {r['error']}")
+            continue
+        changes = r.get("changes") or []
+        if changes:
+            render_message(
+                f"PR #{r['pr']}: applied {len(changes)} change(s)", style="green",
+            )
+            for c in changes:
+                render_message(f"  · {c}", style="dim")
+        else:
+            render_message(
+                f"PR #{r['pr']}: already in sync with GitHub", style="dim",
+            )
 
 
 @ship_state_group.command("discard")

--- a/src/shipyard/daemon/controller.py
+++ b/src/shipyard/daemon/controller.py
@@ -131,6 +131,14 @@ class Daemon:
         )
         await self._ipc_server.start()
 
+        # Auto-heal any ship-state drift that accumulated while the
+        # daemon was down or watching the wrong repo set. Cheap: one
+        # `gh pr view --json statusCheckRollup` per active PR, then
+        # writes back only when something actually changed. Failures
+        # are logged but never block startup — the daemon is a real-
+        # time pipeline first; reconcile is a best-effort safety net.
+        asyncio.create_task(_reconcile_all_active_ships(self._config.state_dir))
+
     async def run(self) -> None:
         """Block until a stop is requested."""
         loop = asyncio.get_running_loop()
@@ -311,3 +319,60 @@ def read_daemon_status(state_dir: Path) -> dict[str, object] | None:
     except (TimeoutError, OSError):
         return None
     return None
+
+
+async def _reconcile_all_active_ships(state_dir: Path) -> None:
+    """Best-effort: for every active ship-state file, pull the current
+    CI rollup from GitHub and write back any changes. Runs once at
+    daemon startup as a safety net against missed webhook events.
+
+    Runs in the asyncio loop but shells out to `gh` via a thread so a
+    slow GitHub response doesn't stall the event loop. Errors are
+    logged and skipped — reconcile failure must never block daemon
+    startup or event processing.
+    """
+    from shipyard.core.ship_state import ShipStateStore
+    from shipyard.ship.reconcile import reconcile_ship_state
+
+    def _reconcile_sync() -> int:
+        """Returns the number of ship-states that were updated."""
+        import subprocess as _sp
+
+        store = ShipStateStore(state_dir / "ship")
+        healed = 0
+        for state in store.list_active():
+            try:
+                raw = _sp.run(
+                    [
+                        "gh", "pr", "view", str(state.pr),
+                        "--repo", state.repo,
+                        "--json", "statusCheckRollup",
+                    ],
+                    capture_output=True, text=True, check=True, timeout=20,
+                ).stdout
+            except (_sp.CalledProcessError, _sp.TimeoutExpired, FileNotFoundError) as exc:
+                logger.info(
+                    "reconcile: skipped PR #%d (%s): %s",
+                    state.pr, state.repo, exc,
+                )
+                continue
+            try:
+                rollup = json.loads(raw).get("statusCheckRollup") or []
+            except (ValueError, KeyError):
+                continue
+            new_state, changes = reconcile_ship_state(state, rollup)
+            if changes:
+                store.save(new_state)
+                healed += 1
+                logger.info(
+                    "reconcile: healed PR #%d — %s",
+                    state.pr, "; ".join(changes),
+                )
+        return healed
+
+    try:
+        healed = await asyncio.to_thread(_reconcile_sync)
+        if healed:
+            logger.info("reconcile: %d active ship-state(s) updated on startup", healed)
+    except Exception as exc:  # noqa: BLE001 — best-effort, never crash startup
+        logger.warning("reconcile on startup failed: %s", exc)

--- a/src/shipyard/ship/reconcile.py
+++ b/src/shipyard/ship/reconcile.py
@@ -1,0 +1,138 @@
+"""Re-fetch PR CI state from GitHub and heal drifted ship-state files.
+
+Webhook events update `dispatched_runs[].status` as they arrive. When
+the daemon wasn't running (crashed, not yet spawned, or registered on
+the wrong set of repos), those events are lost — the ship-state file
+keeps whatever status the last-received event wrote. The macOS GUI
+reads that file and keeps showing the stale status.
+
+This module fetches the current `statusCheckRollup` for a PR via `gh`
+and updates dispatched_runs to match what GitHub thinks is true right
+now. The matching is deliberately forgiving (substring containment on
+the check name) because GitHub workflow names vary across repos
+(``Build and Test / windows (pull_request)`` vs. ``windows`` vs.
+``Build / Windows (x64)``) and we only need to reconcile by target
+identity.
+
+Pure logic — no I/O. The CLI layer handles `gh` invocation and file
+writes so this module stays unit-testable.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import datetime, timezone
+
+from shipyard.core.ship_state import DispatchedRun, ShipState
+
+
+def _conclusion_to_run_status(conclusion: str | None, state: str | None) -> str:
+    """Map a GitHub check's conclusion/state to our DispatchedRun.status
+    vocabulary (pending | in_progress | completed | failed | cancelled).
+
+    GitHub's fields:
+      * state: QUEUED | IN_PROGRESS | COMPLETED | PENDING | …
+      * conclusion (set once state==COMPLETED): SUCCESS | FAILURE |
+        TIMED_OUT | CANCELLED | NEUTRAL | SKIPPED | ACTION_REQUIRED …
+    """
+    s = (state or "").upper()
+    c = (conclusion or "").upper()
+    # GitHub's statusCheckRollup returns `state: null` for legacy
+    # commit-status checks and some CheckRun shapes once the check has
+    # a conclusion. Treat "conclusion set, state unset" as completed.
+    if s in {"QUEUED", "PENDING"}:
+        return "pending"
+    if s == "IN_PROGRESS":
+        return "in_progress"
+    if s != "COMPLETED" and not c:
+        # No conclusion and no recognized state — don't guess.
+        return ""
+    if c in {"SUCCESS", "NEUTRAL", "SKIPPED"}:
+        return "completed"
+    if c == "CANCELLED":
+        return "cancelled"
+    # FAILURE, TIMED_OUT, ACTION_REQUIRED, STARTUP_FAILURE, STALE, ...
+    return "failed"
+
+
+def _match_check(run: DispatchedRun, checks: list[dict]) -> dict | None:
+    """Find the GitHub check whose name best identifies this target.
+
+    Matching rules, in priority order:
+      1. Exact name match (check.name == run.target).
+      2. Word-boundary containment (' mac ' in ' Build and Test / mac ').
+      3. Case-insensitive substring (less selective, used as fallback).
+
+    If multiple checks match, prefer the most-recently-updated one so
+    we track re-runs after a failed attempt.
+    """
+    target_lc = run.target.lower()
+    exact: list[dict] = []
+    word_boundary: list[dict] = []
+    substring: list[dict] = []
+    for check in checks:
+        name = str(check.get("name") or "")
+        name_lc = name.lower()
+        if name_lc == target_lc:
+            exact.append(check)
+            continue
+        # Word-boundary: target appears as a whole token. Pads both sides
+        # with separators so "macos" doesn't match "mac" and vice versa.
+        padded = f" {name_lc.replace('/', ' ').replace('(', ' ').replace(')', ' ')} "
+        if f" {target_lc} " in padded:
+            word_boundary.append(check)
+            continue
+        if target_lc in name_lc:
+            substring.append(check)
+    pool = exact or word_boundary or substring
+    if not pool:
+        return None
+    # Prefer the most-recent by completedAt/startedAt.
+    def _key(c: dict) -> str:
+        return str(c.get("completedAt") or c.get("startedAt") or "")
+    return max(pool, key=_key)
+
+
+def reconcile_ship_state(
+    state: ShipState,
+    status_check_rollup: list[dict],
+    *,
+    now: datetime | None = None,
+) -> tuple[ShipState, list[str]]:
+    """Produce a new ShipState with dispatched_runs healed to match
+    what GitHub's statusCheckRollup reports. Returns the new state and
+    a list of human-readable change descriptions for logging.
+
+    Inputs:
+      * ``state`` — the drifted ship-state we want to heal.
+      * ``status_check_rollup`` — the raw list from
+        ``gh pr view <n> --json statusCheckRollup`` (each entry is a
+        dict with at least ``name``, ``state``, ``conclusion``).
+
+    No matching check found → target keeps its old status (don't
+    overwrite with uncertainty). Match found but status unchanged →
+    no change recorded. Match found with different status → replaced.
+    """
+    now = now or datetime.now(timezone.utc)
+    new_runs: list[DispatchedRun] = []
+    changes: list[str] = []
+    for run in state.dispatched_runs:
+        match = _match_check(run, status_check_rollup)
+        if match is None:
+            new_runs.append(run)
+            continue
+        new_status = _conclusion_to_run_status(
+            match.get("conclusion"), match.get("state")
+        )
+        if not new_status or new_status == run.status:
+            new_runs.append(run)
+            continue
+        changes.append(
+            f"target={run.target!r}: {run.status!r} → {new_status!r} "
+            f"(matched check {match.get('name')!r})"
+        )
+        new_runs.append(
+            replace(run, status=new_status, updated_at=now)
+        )
+    new_state = ShipState(**{**state.__dict__, "dispatched_runs": new_runs})
+    return new_state, changes

--- a/tests/daemon/test_ipc_roundtrip.py
+++ b/tests/daemon/test_ipc_roundtrip.py
@@ -180,18 +180,16 @@ def test_read_daemon_status_sees_past_hello_line(short_socket_path: Path) -> Non
         await server.start()
         try:
             # `read_daemon_status(state_dir)` expects `<state_dir>/daemon/daemon.sock`.
-            # Point it at the parent of the socket's parent so the path assembles
-            # back to the socket our server bound.
-            state_dir = short_socket_path.parent.parent
-            (short_socket_path.parent).mkdir(parents=True, exist_ok=True)
-            # The fixture uses `<tmp>/daemon.sock` directly; bridge to the
-            # expected layout with a symlink.
-            expected = state_dir / "daemon" / "daemon.sock"
-            expected.parent.mkdir(parents=True, exist_ok=True)
-            if not expected.exists():
+            # The fixture gave us `<tmp>/daemon.sock` directly; set up an
+            # isolated state_dir that points at our server's socket via
+            # a symlink. Use a fresh tempdir so parallel test runs don't
+            # collide on the `<tmp>/daemon/` path.
+            with tempfile.TemporaryDirectory(prefix="sy-state-") as state_str:
+                state_dir = Path(state_str)
+                expected = state_dir / "daemon" / "daemon.sock"
+                expected.parent.mkdir(parents=True, exist_ok=True)
                 expected.symlink_to(short_socket_path)
-
-            status = await asyncio.to_thread(read_daemon_status, state_dir)
+                status = await asyncio.to_thread(read_daemon_status, state_dir)
         finally:
             await server.stop()
 

--- a/tests/ship/test_reconcile.py
+++ b/tests/ship/test_reconcile.py
@@ -1,0 +1,150 @@
+"""Unit tests for the ship-state reconcile logic.
+
+Does not exercise `gh` or any subprocess — the CLI layer is
+responsible for shelling out. These tests feed in a statusCheckRollup
+dict shape (as `gh pr view --json statusCheckRollup` returns) and
+assert the pure reconcile function heals drifted state correctly.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from shipyard.core.ship_state import DispatchedRun, ShipState
+from shipyard.ship.reconcile import reconcile_ship_state
+
+
+def _base_state() -> ShipState:
+    ts = datetime(2026, 4, 21, 22, 0, tzinfo=timezone.utc)
+    return ShipState(
+        pr=618,
+        repo="danielraffel/pulp",
+        branch="chore/pin-bump",
+        base_branch="main",
+        head_sha="fe1bf4f",
+        policy_signature="fc9b712b",
+        pr_url="https://github.com/danielraffel/pulp/pull/618",
+        pr_title="Bump shipyard pin",
+        commit_subject="chore: bump",
+        dispatched_runs=[
+            DispatchedRun(
+                target="mac", provider="local", run_id="sy-1",
+                status="completed", started_at=ts, updated_at=ts,
+            ),
+            DispatchedRun(
+                target="ubuntu", provider="ssh", run_id="sy-1",
+                status="completed", started_at=ts, updated_at=ts,
+            ),
+            DispatchedRun(
+                target="windows", provider="ssh-windows", run_id="sy-1",
+                # stale: actually passed on GH but webhook was missed
+                status="failed", started_at=ts, updated_at=ts,
+            ),
+        ],
+    )
+
+
+def test_stale_failed_target_heals_to_completed_on_success() -> None:
+    """The #618 pulp drift bug: windows locally shows failed, GH shows
+    pass. Reconcile flips it."""
+    state = _base_state()
+    rollup = [
+        {"name": "Build and Test / mac (pull_request)",
+         "state": "COMPLETED", "conclusion": "SUCCESS"},
+        {"name": "Build and Test / ubuntu (pull_request)",
+         "state": "COMPLETED", "conclusion": "SUCCESS"},
+        {"name": "Build and Test / windows (pull_request)",
+         "state": "COMPLETED", "conclusion": "SUCCESS"},
+    ]
+    new_state, changes = reconcile_ship_state(state, rollup)
+    statuses = {r.target: r.status for r in new_state.dispatched_runs}
+    assert statuses == {
+        "mac": "completed",
+        "ubuntu": "completed",
+        "windows": "completed",
+    }
+    # The only change should be windows — mac + ubuntu were already correct.
+    assert len(changes) == 1
+    assert "windows" in changes[0]
+    assert "failed" in changes[0]
+    assert "completed" in changes[0]
+
+
+def test_no_matching_check_preserves_old_status() -> None:
+    """If GitHub has no check we can match to a target, we DON'T
+    overwrite with uncertainty. The target keeps its old status."""
+    state = _base_state()
+    rollup = [
+        {"name": "Totally Unrelated Linter",
+         "state": "COMPLETED", "conclusion": "SUCCESS"},
+    ]
+    new_state, changes = reconcile_ship_state(state, rollup)
+    assert changes == []
+    assert [r.status for r in new_state.dispatched_runs] == [
+        "completed", "completed", "failed",
+    ]
+
+
+def test_in_progress_check_maps_to_in_progress() -> None:
+    state = _base_state()
+    rollup = [
+        {"name": "windows", "state": "IN_PROGRESS", "conclusion": None},
+    ]
+    new_state, _ = reconcile_ship_state(state, rollup)
+    windows = [r for r in new_state.dispatched_runs if r.target == "windows"][0]
+    assert windows.status == "in_progress"
+
+
+def test_failure_conclusion_maps_to_failed() -> None:
+    state = _base_state()
+    # Flip mac from "completed" to "failed" via reconcile.
+    rollup = [
+        {"name": "Build and Test / mac (pull_request)",
+         "state": "COMPLETED", "conclusion": "FAILURE"},
+    ]
+    new_state, changes = reconcile_ship_state(state, rollup)
+    mac = [r for r in new_state.dispatched_runs if r.target == "mac"][0]
+    assert mac.status == "failed"
+    assert any("mac" in c for c in changes)
+
+
+def test_word_boundary_match_not_substring() -> None:
+    """The target 'mac' must not spuriously match 'macOS (ARM64)' if
+    there's an exact 'mac' check available — but it should still match
+    'macOS' as a fallback when nothing more specific exists."""
+    state = _base_state()
+    rollup = [
+        # Both present. Prefer the exact 'mac'.
+        {"name": "macOS (ARM64)", "state": "COMPLETED", "conclusion": "FAILURE"},
+        {"name": "mac", "state": "COMPLETED", "conclusion": "SUCCESS"},
+    ]
+    new_state, _ = reconcile_ship_state(state, rollup)
+    mac = [r for r in new_state.dispatched_runs if r.target == "mac"][0]
+    # The exact-name check wins over the substring one.
+    assert mac.status == "completed"
+
+
+def test_status_unchanged_emits_no_change() -> None:
+    state = _base_state()
+    rollup = [
+        {"name": "mac", "state": "COMPLETED", "conclusion": "SUCCESS"},
+    ]
+    _, changes = reconcile_ship_state(state, rollup)
+    # mac was already 'completed' locally — no change emitted.
+    assert changes == []
+
+
+def test_null_state_with_conclusion_maps_correctly() -> None:
+    """GH's statusCheckRollup returns `state: null` for legacy commit
+    statuses once they complete. Regression for #618 drift: the
+    reconcile ignored these entirely and kept showing stale failures."""
+    state = _base_state()
+    rollup = [
+        # No state field — just conclusion. This is what GH returns
+        # for certain check types after completion.
+        {"name": "windows", "state": None, "conclusion": "SUCCESS"},
+    ]
+    new_state, changes = reconcile_ship_state(state, rollup)
+    windows = [r for r in new_state.dispatched_runs if r.target == "windows"][0]
+    assert windows.status == "completed"
+    assert any("windows" in c for c in changes)


### PR DESCRIPTION
Fixes a real-world drift scenario that bit pulp #618 today.

## Symptom
- GitHub: all 16 checks green on the PR
- macOS GUI: "failed" pill, Windows lane red
- Ship-state file: windows target still at status=failed

## Root cause
Webhook events that would've flipped windows to completed never reached our daemon — the daemon was started with `--repo shipyard` but the PR lives on `pulp`. Pulp's webhook was never registered; events for pulp activity silently discarded.

## Fix
`shipyard ship-state reconcile <pr>` (or `--all`) pulls `gh pr view --json statusCheckRollup` and writes the current truth back to the ship-state file. Users can self-serve any time local state drifts from GitHub.

Matching: exact → word-boundary → substring, with most-recently-updated preferred when multiple checks match.

Also handles GH's `state: null` quirk for legacy commit-status checks (exactly what bit pulp #618).

## Tests
7 unit tests on pure reconcile logic (no gh required).

## Live verification
Ran against #618 on my machine; windows healed failed → completed.

## Follow-up
Next PR: auto-reconcile every tracked PR on daemon startup, so this runs itself after any daemon outage.

## Versions
CLI: 0.22.5 → 0.22.6