### PR TITLE
ship: reconcile must mirror healed status into evidence_snapshot (0.22.7)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "shipyard"
-version = "0.22.6"
+version = "0.22.7"
 description = "Cross-platform CI coordination — local VMs, SSH hosts, cloud runners"
 readme = "README.md"
 license = "MIT"

--- a/src/shipyard/__init__.py
+++ b/src/shipyard/__init__.py
@@ -1,3 +1,3 @@
 """Shipyard — Cross-platform CI coordination."""
 
-__version__ = "0.22.6"
+__version__ = "0.22.7"

--- a/src/shipyard/ship/reconcile.py
+++ b/src/shipyard/ship/reconcile.py
@@ -115,6 +115,7 @@ def reconcile_ship_state(
     """
     now = now or datetime.now(timezone.utc)
     new_runs: list[DispatchedRun] = []
+    new_evidence = dict(state.evidence_snapshot)
     changes: list[str] = []
     for run in state.dispatched_runs:
         match = _match_check(run, status_check_rollup)
@@ -124,15 +125,49 @@ def reconcile_ship_state(
         new_status = _conclusion_to_run_status(
             match.get("conclusion"), match.get("state")
         )
-        if not new_status or new_status == run.status:
+        if not new_status:
             new_runs.append(run)
             continue
-        changes.append(
-            f"target={run.target!r}: {run.status!r} → {new_status!r} "
-            f"(matched check {match.get('name')!r})"
-        )
-        new_runs.append(
-            replace(run, status=new_status, updated_at=now)
-        )
-    new_state = ShipState(**{**state.__dict__, "dispatched_runs": new_runs})
+        if new_status != run.status:
+            changes.append(
+                f"target={run.target!r}: {run.status!r} → {new_status!r} "
+                f"(matched check {match.get('name')!r})"
+            )
+            new_runs.append(
+                replace(run, status=new_status, updated_at=now)
+            )
+        else:
+            new_runs.append(run)
+        # Evidence snapshot is what the GUI actually renders (it
+        # overwrites dispatched_run status when present, see
+        # ShipStatePoller.swift:113). Mirror the healed run status
+        # into evidence so the GUI reflects GitHub truth. Only
+        # terminal statuses map cleanly — leave in_progress / pending
+        # alone so we don't stomp a running indicator with stale
+        # evidence.
+        evidence_value = _run_status_to_evidence(new_status)
+        if evidence_value is not None and new_evidence.get(run.target) != evidence_value:
+            changes.append(
+                f"evidence[{run.target!r}]: "
+                f"{new_evidence.get(run.target)!r} → {evidence_value!r}"
+            )
+            new_evidence[run.target] = evidence_value
+    new_state = ShipState(**{
+        **state.__dict__,
+        "dispatched_runs": new_runs,
+        "evidence_snapshot": new_evidence,
+    })
     return new_state, changes
+
+
+def _run_status_to_evidence(run_status: str) -> str | None:
+    """Project a DispatchedRun.status onto the evidence_snapshot
+    vocabulary used by the GUI (``pass`` / ``fail`` / ``reused``).
+
+    Non-terminal statuses return None so callers leave evidence alone.
+    """
+    if run_status == "completed":
+        return "pass"
+    if run_status in {"failed", "cancelled"}:
+        return "fail"
+    return None

--- a/tests/ship/test_reconcile.py
+++ b/tests/ship/test_reconcile.py
@@ -41,6 +41,10 @@ def _base_state() -> ShipState:
                 status="failed", started_at=ts, updated_at=ts,
             ),
         ],
+        # Pre-seed evidence to match the dispatched_run statuses so
+        # tests that expect "no change" aren't tripped by evidence
+        # bootstrap (which would otherwise go from unset → 'pass').
+        evidence_snapshot={"mac": "pass", "ubuntu": "pass", "windows": "fail"},
     )
 
 
@@ -63,11 +67,13 @@ def test_stale_failed_target_heals_to_completed_on_success() -> None:
         "ubuntu": "completed",
         "windows": "completed",
     }
-    # The only change should be windows — mac + ubuntu were already correct.
-    assert len(changes) == 1
-    assert "windows" in changes[0]
-    assert "failed" in changes[0]
-    assert "completed" in changes[0]
+    # Changes for windows only — dispatched_run.status flip AND the
+    # evidence_snapshot mirror. mac + ubuntu were already correct.
+    assert len(changes) == 2
+    assert any("windows" in c and "failed" in c and "completed" in c for c in changes)
+    assert any("evidence" in c.lower() and "windows" in c for c in changes)
+    # And the evidence_snapshot ended up in the healed state.
+    assert new_state.evidence_snapshot["windows"] == "pass"
 
 
 def test_no_matching_check_preserves_old_status() -> None:
@@ -131,6 +137,35 @@ def test_status_unchanged_emits_no_change() -> None:
     ]
     _, changes = reconcile_ship_state(state, rollup)
     # mac was already 'completed' locally — no change emitted.
+    assert changes == []
+
+
+def test_evidence_snapshot_mirrors_dispatched_run_heal() -> None:
+    """Regression for the pulp#619 bug: reconcile only updated
+    dispatched_runs but not evidence_snapshot. The GUI's
+    ShipStatePoller applies evidence_snapshot LAST (overwriting
+    dispatched_run-derived status), so healing dispatched_runs alone
+    still left the UI showing the old 'failed' pill. Fix: mirror
+    terminal statuses into evidence_snapshot too."""
+    state = _base_state()
+    # Seed stale evidence matching the stale dispatched_run state.
+    state.evidence_snapshot = {"mac": "pass", "ubuntu": "pass", "windows": "fail"}
+    rollup = [
+        {"name": "windows", "state": None, "conclusion": "SUCCESS"},
+    ]
+    new_state, changes = reconcile_ship_state(state, rollup)
+    assert new_state.evidence_snapshot["windows"] == "pass"
+    # Dispatched_run + evidence_snapshot BOTH updated → 2 change lines.
+    assert any("evidence" in c.lower() and "windows" in c for c in changes)
+
+
+def test_evidence_unchanged_when_status_unchanged() -> None:
+    state = _base_state()
+    state.evidence_snapshot = {"mac": "pass"}
+    rollup = [{"name": "mac", "state": None, "conclusion": "SUCCESS"}]
+    new_state, changes = reconcile_ship_state(state, rollup)
+    # mac was already completed + pass; no change expected.
+    assert new_state.evidence_snapshot == {"mac": "pass"}
     assert changes == []
 
 


### PR DESCRIPTION
Follow-up to #144. 0.22.6 reconcile healed dispatched_runs but left evidence_snapshot stale. The macOS GUI's ShipStatePoller applies evidence_snapshot last and overwrites Target.status, so users kept seeing the old 'failed' pill.

## Live verified
- pulp #619 had `evidence_snapshot.windows=fail` after dispatched_runs healed
- This PR's fix also updates evidence_snapshot
- Ran `shipyard ship-state reconcile 619` — evidence now `{mac: pass, ubuntu: pass, windows: pass}`
- Both pulp#618 + pulp#619 now fully consistent

## Tests
9 unit tests (2 new) covering evidence mirroring + no-op cases.

## Versions
CLI: 0.22.6 → 0.22.7