### PR TITLE
ship: quality PR titles + bodies from commit subject/body (0.22.9)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "shipyard"
-version = "0.22.8"
+version = "0.22.9"
 description = "Cross-platform CI coordination — local VMs, SSH hosts, cloud runners"
 readme = "README.md"
 license = "MIT"

--- a/src/shipyard/__init__.py
+++ b/src/shipyard/__init__.py
@@ -1,3 +1,3 @@
 """Shipyard — Cross-platform CI coordination."""
 
-__version__ = "0.22.8"
+__version__ = "0.22.9"

--- a/src/shipyard/cli.py
+++ b/src/shipyard/cli.py
@@ -2773,8 +2773,11 @@ def ship(
         if not ctx.json_mode:
             render_message(f"Found existing PR #{pr_info.number}")
     else:
-        pr_body = _compose_pr_body(ctx.config)
-        pr_info = create_pr(branch, base, f"Ship {branch}", pr_body)
+        from shipyard.ship.pr_text import compose_pr_body, compose_pr_title
+
+        pr_title = compose_pr_title(branch)
+        pr_body = compose_pr_body(config=ctx.config)
+        pr_info = create_pr(branch, base, pr_title, pr_body)
         if not ctx.json_mode:
             render_message(f"Created PR #{pr_info.number}")
 
@@ -4903,32 +4906,12 @@ def _update_ship_state_from_job(
 
 
 def _compose_pr_body(config: Config) -> str:
-    """Build the PR body for a freshly-opened ship, including advisory
-    lane annotations.
+    """Legacy entry point preserved for any callers importing this
+    name from cli.py. New code should import directly from
+    ``shipyard.ship.pr_text``."""
+    from shipyard.ship.pr_text import compose_pr_body
 
-    When the resolved lane policy marks one or more lanes advisory,
-    list them in the body so reviewers aren't surprised that a red
-    advisory lane still landed. Trailer-based overrides are called
-    out separately so the reviewer can audit why the default policy
-    was flipped on this PR.
-    """
-    lines: list[str] = []
-    policy = _resolve_lane_policy_for_ship(config)
-    advisory = sorted(policy.advisory_targets)
-    if advisory:
-        lines.append("## Advisory lanes")
-        lines.append(
-            "The following lanes are **advisory** — their status is "
-            "informational and does not block merge:"
-        )
-        for target in advisory:
-            suffix = (
-                " (overridden via Lane-Policy trailer)"
-                if target in policy.overrides_from_trailer
-                else ""
-            )
-            lines.append(f"- `{target}`{suffix}")
-    return "\n".join(lines)
+    return compose_pr_body(config=config)
 
 
 def _resolve_lane_policy_for_ship(config: Config) -> LanePolicy:

--- a/src/shipyard/ship/merge.py
+++ b/src/shipyard/ship/merge.py
@@ -200,12 +200,16 @@ def ship(
             error="No required platforms configured in merge.require_platforms",
         )
 
-    # Find or create PR
+    # Find or create PR. Use the shared compose_pr_* helpers so the
+    # ship/merge path and the `shipyard pr` path produce identically-
+    # styled PRs — no drift between them.
     try:
         pr = find_pr_for_branch(branch)
         if pr is None:
-            title = _default_pr_title(branch)
-            body = f"Branch `{branch}` @ `{sha[:8]}`."
+            from shipyard.ship.pr_text import compose_pr_body, compose_pr_title
+
+            title = compose_pr_title(branch)
+            body = compose_pr_body(config=config)
             pr = create_pr(branch, base, title, body)
     except GhError as e:
         return ShipResult(success=False, error=f"PR creation failed: {e}")

--- a/src/shipyard/ship/pr_text.py
+++ b/src/shipyard/ship/pr_text.py
@@ -1,0 +1,132 @@
+"""Compose PR titles + bodies for auto-opened PRs.
+
+Goal: an auto-opened PR should be indistinguishable in quality from
+a human-written one. That means the title should describe **what**
+changed (not 'Ship feature/foo'), and the body should carry the
+context the author already wrote in the commit message.
+
+Principles (see memory ``feedback_no_branding`` + ``feedback_no_ship_in_user_text``):
+
+* Never prefix the title with "Ship" — that's an internal vocabulary
+  leak into artifacts reviewers read.
+* Never append "Automated by Shipyard." — the reviewer doesn't need
+  to know what tool opened the PR.
+* Pull title + body from the HEAD commit message, which the author
+  already wrote for human consumption.
+* Fall back to a prettified branch name when the commit subject
+  isn't recoverable (shallow clone, detached HEAD, git failure).
+
+Kept in a dedicated module so both the ``shipyard pr`` path in
+``cli.py`` and the ``shipyard ship`` path in ``ship/merge.py`` share
+the same implementation — drift between the two was the root cause
+of pulp#621 (empty body) and pulp#616 (branding trailer still there).
+"""
+
+from __future__ import annotations
+
+import subprocess
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from shipyard.core.config import Config
+    from shipyard.ship.lane_policy import LanePolicy
+
+
+def compose_pr_title(branch: str) -> str:
+    """Return a PR title for ``branch``.
+
+    Prefers the HEAD commit's subject line (usually the most
+    descriptive single sentence available). Falls back to a
+    prettified branch name when git can't answer.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "log", "-1", "--format=%s", "HEAD"],
+            capture_output=True, text=True, check=True, timeout=5,
+        )
+        subject = result.stdout.strip()
+        if subject:
+            return subject
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, OSError):
+        pass
+    return _branch_fallback(branch)
+
+
+def compose_pr_body(
+    *,
+    config: Config | None = None,
+    policy: LanePolicy | None = None,
+) -> str:
+    """Return a PR body for a freshly-opened PR.
+
+    Body shape:
+      1. HEAD commit's body text (everything after the subject line),
+         if present. Authors routinely explain the 'why' in the
+         commit body — surfacing it in the PR makes the PR self-
+         contained without a second click.
+      2. Advisory-lanes section, if the resolved lane policy marks
+         any lanes advisory. Reviewers need to know a red advisory
+         lane didn't block merge. Lane overrides via Lane-Policy
+         trailer are called out so reviewers can audit why the
+         default policy was flipped.
+
+    Either ``config`` OR a pre-resolved ``policy`` may be passed.
+    Passing neither yields a body with only the commit body.
+    """
+    lines: list[str] = []
+    commit_body = _head_commit_body()
+    if commit_body:
+        lines.append(commit_body)
+
+    resolved_policy = policy or _resolve_policy_or_none(config)
+    if resolved_policy is not None:
+        advisory = sorted(resolved_policy.advisory_targets)
+        if advisory:
+            if lines:
+                lines.append("")
+            lines.append("## Advisory lanes")
+            lines.append(
+                "The following lanes are **advisory** — their status is "
+                "informational and does not block merge:"
+            )
+            for target in advisory:
+                suffix = (
+                    " (overridden via Lane-Policy trailer)"
+                    if target in resolved_policy.overrides_from_trailer
+                    else ""
+                )
+                lines.append(f"- `{target}`{suffix}")
+
+    return "\n".join(lines)
+
+
+def _head_commit_body() -> str:
+    try:
+        result = subprocess.run(
+            ["git", "log", "-1", "--format=%b", "HEAD"],
+            capture_output=True, text=True, check=True, timeout=5,
+        )
+        return result.stdout.strip()
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, OSError):
+        return ""
+
+
+def _branch_fallback(branch: str) -> str:
+    """feature/foo-bar → 'Foo bar'. Last-resort title for when git
+    won't cooperate."""
+    name = branch.split("/")[-1]
+    name = name.replace("-", " ").replace("_", " ")
+    return name.capitalize() or branch
+
+
+def _resolve_policy_or_none(config: Config | None) -> LanePolicy | None:
+    """Resolve the lane policy without forcing a hard dep on it when
+    callers don't care about advisory lanes."""
+    if config is None:
+        return None
+    from shipyard.ship.lane_policy import resolve_lane_policy
+
+    return resolve_lane_policy(
+        config,
+        known_targets=list((config.targets or {}).keys()),
+    )

--- a/tests/ship/test_pr_text.py
+++ b/tests/ship/test_pr_text.py
@@ -1,0 +1,147 @@
+"""Tests for PR title + body composition.
+
+These tests drive the pure-logic helpers (no real git, no real PR
+creation). Git invocations are mocked via monkeypatching
+``subprocess.run``; lane policy is passed in directly rather than
+resolved from config.
+
+Coverage checklist (explicit anti-regression for the pulp#616 /
+pulp#621 class of bugs):
+
+  * Title never starts with "Ship "
+  * Body never contains "Automated by Shipyard"
+  * Empty commit message falls back to branch-derived title, NOT
+    empty string
+  * Body carries commit-body text when present (reviewers get
+    context without clicking through to the commit)
+  * Advisory-lanes section renders when applicable
+"""
+
+from __future__ import annotations
+
+import subprocess
+from dataclasses import dataclass, field
+from unittest.mock import patch
+
+from shipyard.ship.pr_text import compose_pr_body, compose_pr_title
+
+
+def _mock_git_run(subject: str = "", body: str = ""):
+    """Return a fake subprocess.run that matches on ``--format=`` arg."""
+    def fake(cmd, *args, **kwargs):
+        if "--format=%s" in cmd:
+            return subprocess.CompletedProcess(cmd, 0, stdout=subject + "\n", stderr="")
+        if "--format=%b" in cmd:
+            return subprocess.CompletedProcess(cmd, 0, stdout=body + "\n", stderr="")
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+    return fake
+
+
+@dataclass
+class _FakePolicy:
+    advisory_targets: set[str] = field(default_factory=set)
+    overrides_from_trailer: set[str] = field(default_factory=set)
+
+
+# ── compose_pr_title ────────────────────────────────────────────────
+
+
+def test_title_uses_commit_subject_when_present() -> None:
+    with patch("subprocess.run", _mock_git_run(
+        subject="fix(cache): stop evicting warm entries on startup",
+    )):
+        title = compose_pr_title("fix/cache-startup")
+    assert title == "fix(cache): stop evicting warm entries on startup"
+
+
+def test_title_never_prefixes_with_ship() -> None:
+    """Regression for the pulp#621 pattern: prior code used
+    f'Ship {branch}' and every auto-opened PR title leaked internal
+    vocabulary."""
+    with patch("subprocess.run", _mock_git_run(
+        subject="refactor: extract connection pool",
+    )):
+        title = compose_pr_title("feature/connection-pool")
+    assert not title.startswith("Ship ")
+    assert "Ship " not in title
+
+
+def test_title_falls_back_to_prettified_branch_when_git_empty() -> None:
+    with patch("subprocess.run", _mock_git_run(subject="")):
+        title = compose_pr_title("feature/foo-bar-baz")
+    assert title == "Foo bar baz"
+    assert not title.startswith("Ship ")
+
+
+def test_title_falls_back_when_git_errors() -> None:
+    def raise_git(*a, **kw):
+        raise subprocess.CalledProcessError(returncode=128, cmd=a)
+    with patch("subprocess.run", raise_git):
+        title = compose_pr_title("fix/deep-foo")
+    assert title == "Deep foo"
+
+
+# ── compose_pr_body ─────────────────────────────────────────────────
+
+
+def test_body_uses_commit_body_when_present() -> None:
+    commit_body = (
+        "The cache's eviction timer fires before the warm pool probe "
+        "has a chance to run, so cold-start requests hit an empty cache.\n"
+        "\n"
+        "Fixes #123."
+    )
+    with patch("subprocess.run", _mock_git_run(body=commit_body)):
+        body = compose_pr_body()
+    assert body == commit_body
+    assert "Automated by Shipyard" not in body
+
+
+def test_body_never_contains_shipyard_branding() -> None:
+    """Regression for pulp#606 / pulp#616: the body used to trail
+    with 'Automated by Shipyard.' which leaks tool identity into
+    reviewer-visible text."""
+    with patch("subprocess.run", _mock_git_run(
+        subject="anything",
+        body="a body",
+    )):
+        body = compose_pr_body()
+    assert "Automated by Shipyard" not in body
+    assert "Shipyard." not in body
+    assert "shipyard pr" not in body
+
+
+def test_body_empty_string_when_no_commit_body_and_no_advisory() -> None:
+    """Regression for pulp#621: an empty lane policy + empty commit
+    body used to yield `""` which renders as an unhelpful blank PR
+    description. This asserts the *contract* — empty is correct
+    when there's nothing to say — but real-world PRs should always
+    have a commit body to draw from."""
+    with patch("subprocess.run", _mock_git_run(body="")):
+        body = compose_pr_body()
+    assert body == ""
+
+
+def test_body_appends_advisory_lanes_section() -> None:
+    policy = _FakePolicy(
+        advisory_targets={"windows", "freebsd"},
+        overrides_from_trailer={"windows"},
+    )
+    with patch("subprocess.run", _mock_git_run(body="The main reason.")):
+        body = compose_pr_body(policy=policy)
+    assert "The main reason." in body
+    assert "## Advisory lanes" in body
+    # Both advisory targets appear, windows with the trailer note.
+    assert "`windows` (overridden via Lane-Policy trailer)" in body
+    assert "`freebsd`" in body
+    # Blank line separates commit body from advisory section.
+    assert "The main reason.\n\n## Advisory lanes" in body
+
+
+def test_body_advisory_section_alone_when_no_commit_body() -> None:
+    policy = _FakePolicy(advisory_targets={"windows"})
+    with patch("subprocess.run", _mock_git_run(body="")):
+        body = compose_pr_body(policy=policy)
+    # Starts with the heading — no blank-line-before-content.
+    assert body.startswith("## Advisory lanes")
+    assert "`windows`" in body


### PR DESCRIPTION
## Problem

Every auto-opened PR from `shipyard pr` / `shipyard ship` produces garbage reviewer-facing text:

- **Title:** `Ship fix/coverage-lcov-pipeline-full-surface` — leaks internal 'Ship' vocabulary, adds zero context.
- **Body:** either `Automated by Shipyard.` (pulp#606, pulp#616) or empty string (pulp#621). Reviewer has no idea what the PR does without clicking through to the commits.

## Root cause

Two drifted code paths rolled their own title/body strings (`cli.py`'s `shipyard pr` and `ship/merge.py`'s merge flow). Neither pulled from the actual commit the user already wrote.

## Fix

New shared module `shipyard.ship.pr_text` with `compose_pr_title()` + `compose_pr_body()`:

- Title = HEAD commit subject (reviewer-quality). Falls back to prettified branch name if git fails. Never prefixed with 'Ship'.
- Body = HEAD commit body + optional advisory-lanes section. Never appends 'Automated by Shipyard'.

Both call sites (`cli.py:2778` and `merge.py:209`) now use these helpers — no more drift surface.

## Tests

9 unit tests with git mocked via `subprocess.run` patching. Covers:
- Title uses commit subject when present
- Title never prefixes with 'Ship' (explicit regression)
- Title falls back to prettified branch on empty git + on git errors
- Body carries commit body verbatim
- Body never contains Shipyard branding (explicit regression)
- Empty contract holds when nothing to say
- Advisory lanes section renders correctly, alone and combined

## Versions
CLI: 0.22.8 → 0.22.9

Auto-release will tag + publish on merge.