### PR TITLE
pr: use the feature commit (not the bump commit) for PR title + body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to Shipyard are documented here. Each entry links
 to its [GitHub Release](https://github.com/danielraffel/Shipyard/releases).
 
 <a id="v0229"></a>
+## [0.24.0]
+
 ## [0.22.9] - 2026-04-21
 
 - ship: quality PR titles + bodies from commit subject/body (0.22.9) ([#148](https://github.com/danielraffel/Shipyard/pull/148))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "shipyard"
-version = "0.23.0"
+version = "0.24.0"
 description = "Cross-platform CI coordination — local VMs, SSH hosts, cloud runners"
 readme = "README.md"
 license = "MIT"

--- a/src/shipyard/__init__.py
+++ b/src/shipyard/__init__.py
@@ -1,3 +1,3 @@
 """Shipyard — Cross-platform CI coordination."""
 
-__version__ = "0.23.0"
+__version__ = "0.24.0"

--- a/src/shipyard/cli.py
+++ b/src/shipyard/cli.py
@@ -4350,7 +4350,7 @@ def pr(
                 "commit.gpgsign=false",
                 "commit",
                 "-m",
-                "chore: bump versions\n\nAutomated by `shipyard pr`.",
+                "chore: bump versions",
                 "--only",
                 "--",
                 *bumped_files,

--- a/src/shipyard/ship/pr_text.py
+++ b/src/shipyard/ship/pr_text.py
@@ -11,10 +11,14 @@ Principles (see memory ``feedback_no_branding`` + ``feedback_no_ship_in_user_tex
   leak into artifacts reviewers read.
 * Never append "Automated by Shipyard." — the reviewer doesn't need
   to know what tool opened the PR.
-* Pull title + body from the HEAD commit message, which the author
-  already wrote for human consumption.
-* Fall back to a prettified branch name when the commit subject
-  isn't recoverable (shallow clone, detached HEAD, git failure).
+* Pull title + body from the most recent *meaningful* commit, not
+  the tip. `shipyard pr` always tags on a ``chore: bump versions``
+  commit at the tip so version bumps get stamped into git; that
+  commit's subject and body are mechanical filler and must never
+  surface as the PR's title/body. Walk back past them to the
+  feature commit the author actually wrote.
+* Fall back to a prettified branch name when no meaningful commit
+  is recoverable (shallow clone, detached HEAD, git failure).
 
 Kept in a dedicated module so both the ``shipyard pr`` path in
 ``cli.py`` and the ``shipyard ship`` path in ``ship/merge.py`` share
@@ -32,23 +36,35 @@ if TYPE_CHECKING:
     from shipyard.ship.lane_policy import LanePolicy
 
 
+# Subjects that are known to be mechanical/bot commits `shipyard pr`
+# (or similar tooling) tags on. When the tip commit starts with any
+# of these prefixes, we walk back to find the real author commit.
+_MECHANICAL_SUBJECT_PREFIXES = (
+    "chore: bump versions",
+    "chore(plugin): bump",
+    "chore(release):",
+    "chore: regenerate changelog",
+    "docs: regenerate changelog",
+)
+
+# Depth cap on the walk. Branches with more than a handful of
+# consecutive mechanical commits aren't a real scenario; if every
+# commit in the range is mechanical, fall back to the branch name.
+_MEANINGFUL_COMMIT_WALK_DEPTH = 20
+
+
 def compose_pr_title(branch: str) -> str:
     """Return a PR title for ``branch``.
 
-    Prefers the HEAD commit's subject line (usually the most
-    descriptive single sentence available). Falls back to a
-    prettified branch name when git can't answer.
+    Prefers the most recent *meaningful* commit's subject line.
+    Falls back to a prettified branch name when git can't answer
+    or every recent commit is mechanical.
     """
-    try:
-        result = subprocess.run(
-            ["git", "log", "-1", "--format=%s", "HEAD"],
-            capture_output=True, text=True, check=True, timeout=5,
-        )
-        subject = result.stdout.strip()
+    ref = _meaningful_commit_ref()
+    if ref is not None:
+        subject = _commit_field(ref, "%s")
         if subject:
             return subject
-    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, OSError):
-        pass
     return _branch_fallback(branch)
 
 
@@ -60,10 +76,12 @@ def compose_pr_body(
     """Return a PR body for a freshly-opened PR.
 
     Body shape:
-      1. HEAD commit's body text (everything after the subject line),
-         if present. Authors routinely explain the 'why' in the
-         commit body — surfacing it in the PR makes the PR self-
-         contained without a second click.
+      1. Most recent *meaningful* commit's body text (everything
+         after the subject line), if present. Authors routinely
+         explain the 'why' in the commit body — surfacing it in the
+         PR makes the PR self-contained without a second click.
+         Mechanical tip commits (``chore: bump versions``) are
+         skipped so their empty body doesn't stomp the feature body.
       2. Advisory-lanes section, if the resolved lane policy marks
          any lanes advisory. Reviewers need to know a red advisory
          lane didn't block merge. Lane overrides via Lane-Policy
@@ -74,9 +92,11 @@ def compose_pr_body(
     Passing neither yields a body with only the commit body.
     """
     lines: list[str] = []
-    commit_body = _head_commit_body()
-    if commit_body:
-        lines.append(commit_body)
+    ref = _meaningful_commit_ref()
+    if ref is not None:
+        commit_body = _commit_field(ref, "%b")
+        if commit_body:
+            lines.append(commit_body)
 
     resolved_policy = policy or _resolve_policy_or_none(config)
     if resolved_policy is not None:
@@ -100,10 +120,36 @@ def compose_pr_body(
     return "\n".join(lines)
 
 
-def _head_commit_body() -> str:
+def _meaningful_commit_ref() -> str | None:
+    """Walk back from HEAD, returning the first commit ref whose
+    subject is not a known mechanical bump/release filler.
+
+    Returns ``None`` when every commit in the walk window is
+    mechanical, when git fails, or when the repo has no commits.
+    """
+    for depth in range(_MEANINGFUL_COMMIT_WALK_DEPTH):
+        ref = "HEAD" if depth == 0 else f"HEAD~{depth}"
+        subject = _commit_field(ref, "%s")
+        if not subject:
+            # Either git failed or we walked past the branch root.
+            return None
+        if not _is_mechanical_subject(subject):
+            return ref
+    return None
+
+
+def _is_mechanical_subject(subject: str) -> bool:
+    lowered = subject.strip().lower()
+    return any(
+        lowered.startswith(prefix.lower())
+        for prefix in _MECHANICAL_SUBJECT_PREFIXES
+    )
+
+
+def _commit_field(ref: str, fmt: str) -> str:
     try:
         result = subprocess.run(
-            ["git", "log", "-1", "--format=%b", "HEAD"],
+            ["git", "log", "-1", f"--format={fmt}", ref],
             capture_output=True, text=True, check=True, timeout=5,
         )
         return result.stdout.strip()

--- a/tests/ship/test_pr_text.py
+++ b/tests/ship/test_pr_text.py
@@ -26,11 +26,50 @@ from unittest.mock import patch
 from shipyard.ship.pr_text import compose_pr_body, compose_pr_title
 
 
-def _mock_git_run(subject: str = "", body: str = ""):
-    """Return a fake subprocess.run that matches on ``--format=`` arg."""
+def _mock_git_run(subject: str = "work", body: str = ""):
+    """Return a fake subprocess.run that matches on ``--format=`` arg.
+
+    A non-empty default subject reflects real git: any commit that
+    exists returns a subject for ``--format=%s``. Tests that want to
+    simulate "git failed / walked past root" should explicitly pass
+    ``subject=""`` to match the walker's termination signal.
+    """
     def fake(cmd, *args, **kwargs):
         if "--format=%s" in cmd:
             return subprocess.CompletedProcess(cmd, 0, stdout=subject + "\n", stderr="")
+        if "--format=%b" in cmd:
+            return subprocess.CompletedProcess(cmd, 0, stdout=body + "\n", stderr="")
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+    return fake
+
+
+def _mock_git_refs(subjects: list[str], bodies: list[str] | None = None):
+    """Return a fake subprocess.run that serves different subjects per
+    HEAD / HEAD~1 / HEAD~2 ref.
+
+    ``subjects[i]`` is the subject returned for ``HEAD~i`` (or HEAD
+    when ``i == 0``). Same shape for ``bodies`` — defaults to empty
+    strings. Once the list is exhausted, empty string is returned,
+    which the walker treats as "walked past root".
+    """
+    bodies = bodies if bodies is not None else [""] * len(subjects)
+
+    def _ref_depth(cmd: list[str]) -> int:
+        # Cmd looks like: ["git", "log", "-1", "--format=...", "HEAD"]
+        # or "HEAD~N". Last element is the ref.
+        ref = cmd[-1]
+        if ref == "HEAD":
+            return 0
+        if ref.startswith("HEAD~"):
+            return int(ref[len("HEAD~"):])
+        return 0
+
+    def fake(cmd, *args, **kwargs):
+        depth = _ref_depth(cmd)
+        subj = subjects[depth] if depth < len(subjects) else ""
+        body = bodies[depth] if depth < len(bodies) else ""
+        if "--format=%s" in cmd:
+            return subprocess.CompletedProcess(cmd, 0, stdout=subj + "\n", stderr="")
         if "--format=%b" in cmd:
             return subprocess.CompletedProcess(cmd, 0, stdout=body + "\n", stderr="")
         return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
@@ -145,3 +184,79 @@ def test_body_advisory_section_alone_when_no_commit_body() -> None:
     # Starts with the heading — no blank-line-before-content.
     assert body.startswith("## Advisory lanes")
     assert "`windows`" in body
+
+
+# ── walker: skip mechanical `chore: bump versions` tip ──────────────
+
+
+def test_title_walks_past_chore_bump_versions_tip() -> None:
+    """Regression for the pulp#624 / shipyard#150 observed behavior:
+    `shipyard pr` creates a ``chore: bump versions`` commit at the
+    tip, and the PR title was reading from THAT commit. The walker
+    must skip back to the feature commit."""
+    subjects = [
+        "chore: bump versions",
+        "wait: new shipyard wait primitive — release / pr / run",
+    ]
+    with patch("subprocess.run", _mock_git_refs(subjects)):
+        title = compose_pr_title("feat/wait-primitive")
+    assert title == "wait: new shipyard wait primitive — release / pr / run"
+
+
+def test_body_walks_past_chore_bump_versions_tip() -> None:
+    """Same pattern for the body — the feature commit's body
+    (the 'why') must surface, not the bump commit's empty body."""
+    subjects = [
+        "chore: bump versions",
+        "wait: new shipyard wait primitive",
+    ]
+    bodies = [
+        "",
+        "Adds a daemon-backed wait for release / pr / run conditions.",
+    ]
+    with patch("subprocess.run", _mock_git_refs(subjects, bodies)):
+        body = compose_pr_body()
+    assert "daemon-backed wait" in body
+    assert "Automated by" not in body
+    assert "shipyard pr" not in body
+
+
+def test_body_never_uses_automated_by_from_bump_commit() -> None:
+    """Defense in depth: even if an older shipyard left `Automated by
+    shipyard pr.` in a bump commit's body, the walker's subject-based
+    skip means we never read from that commit's body at all."""
+    subjects = [
+        "chore: bump versions",
+        "fix: real feature",
+    ]
+    bodies = [
+        "Automated by `shipyard pr`.",
+        "Real commit body.",
+    ]
+    with patch("subprocess.run", _mock_git_refs(subjects, bodies)):
+        body = compose_pr_body()
+    assert body == "Real commit body."
+    assert "Automated by" not in body
+
+
+def test_title_walks_past_multiple_mechanical_commits() -> None:
+    """Walker tolerates a stack of mechanical commits (e.g. a bump
+    commit plus a regenerated-changelog commit)."""
+    subjects = [
+        "chore: bump versions",
+        "docs: regenerate changelog for v0.23.0 [skip ci]",
+        "feat: the real work",
+    ]
+    with patch("subprocess.run", _mock_git_refs(subjects)):
+        title = compose_pr_title("feat/work")
+    assert title == "feat: the real work"
+
+
+def test_title_falls_back_to_branch_when_every_commit_is_mechanical() -> None:
+    """Degenerate case — if every commit in the walk window is a
+    mechanical bump, degrade to the branch-name fallback rather than
+    leaking the bump subject as the title."""
+    subjects = ["chore: bump versions"] * 3 + [""]  # walked past root
+    with patch("subprocess.run", _mock_git_refs(subjects)):
+        title = compose_pr_title("feature/new-thing")
+    assert title == "New thing"


### PR DESCRIPTION
`shipyard pr` always tags on a `chore: bump versions` commit at the
tip before handoff so the version bump gets stamped into git. That
commit's subject + body were being picked up as the PR title + body,
producing:

    title: chore: bump versions
    body:  Automated by `shipyard pr`.

Two root-cause fixes:

1. Drop the `Automated by shipyard pr.` body from the bump commit in
   cli.py. It was tool-identity noise (feedback_no_branding) and was
   the literal source of the branded PR body.

2. Teach compose_pr_title / compose_pr_body (ship/pr_text.py) to walk
   back from HEAD past known-mechanical commit subjects (chore: bump
   versions, chore(plugin): bump, chore(release): …, docs: regenerate
   changelog) up to a depth of 20, returning the first meaningful
   commit's subject + body. Falls back to the branch-name
   prettification when every commit in the window is mechanical.

Regression tests cover: skip single bump tip, skip stacked
mechanical commits, degrade to branch fallback when everything is
mechanical, and a defense-in-depth check that even if an older
shipyard left `Automated by shipyard pr.` in a bump body, the
walker never reads it because the subject match eliminates the
commit upstream.

Observed in the wild on pulp#624 and shipyard#150; v0.22.9's
pr_text rewrite was correct in intent but missed this specific
path where the bump commit becomes the tip.

Version-Bump: cli=patch reason="bug fix for PR title + body when bump commit is the tip"