### PR TITLE
version-bump: make Version-Bump trailer authoritative, not just ceiling-raising

### DIFF
--- a/scripts/version_bump_check.py
+++ b/scripts/version_bump_check.py
@@ -505,26 +505,40 @@ def assess_surfaces(
         override = surface_trailer_override(trailers, cfg.trailer_version_bump, s.name)
         final = heur
         skip_requested = (override == "skip")
+        explicit_level = override in LEVELS
 
         if skip_requested:
             final = "none"
-        elif override in LEVELS:
-            # Only raise, never lower. And only if the surface was actually touched.
-            if heur != "none" and LEVELS.index(override) > LEVELS.index(heur):
+        elif explicit_level:
+            # An explicit `Version-Bump: <surface>=<level> reason="..."`
+            # trailer is authoritative: the author has stated the
+            # level AND accepted accountability via the reason. Use it
+            # exactly. This is *not* "can only raise" — patch can
+            # override a minor heuristic when the author judges that
+            # a large-surface-area change is still semver-patch
+            # (e.g. a bug fix that touches many files). The reason
+            # string carries the justification; a reviewer can still
+            # push back in PR review. Bailing to heuristic silently
+            # when the author asked for a lower level defeats the
+            # entire point of the trailer.
+            if heur != "none":
                 final = override
-            elif heur != "none":
-                final = heur
             else:
-                # Surface not touched; ignore the override to avoid
-                # rubber-stamping unrelated bumps.
+                # Surface not touched by paths — ignore the override
+                # to avoid rubber-stamping unrelated bumps.
                 final = "none"
 
         # Promote via conventional-commit subjects on commits that touched
         # THIS surface — never from commits that only touched unrelated
-        # paths. A plugin-only `feat:` cannot raise the SDK ceiling. An
-        # explicit `Version-Bump: <surface>=skip` on the tip commit is
-        # authoritative and is NOT raised back up by conv-commit subjects.
-        if heur != "none" and not skip_requested:
+        # paths. A plugin-only `feat:` cannot raise the SDK ceiling.
+        #
+        # Skipped when:
+        #   * `skip` trailer is set (authoritative)
+        #   * an explicit level trailer is set (also authoritative —
+        #     otherwise `feat:` in a commit subject would silently
+        #     raise an author-declared `=patch` back to `=minor`,
+        #     defeating the override's purpose).
+        if heur != "none" and not skip_requested and not explicit_level:
             conv_ceiling = "none"
             for sha, subject, body in git_log_subjects_and_bodies(base, head):
                 if is_revert_commit(subject, {}):

--- a/skills/ci/SKILL.md
+++ b/skills/ci/SKILL.md
@@ -670,6 +670,8 @@ A doc-sync gate enforces that `docs/ship-state-machine.md` moves whenever `src/s
 | Auto-release  | `Release: skip reason="..."`                                 |
 | Lane policy   | `Lane-Policy: <target>=required\|advisory` (escalate/demote for this PR only) |
 
+**`Version-Bump` is authoritative when set.** The override wins against both the path-based heuristic and the conventional-commit subject ceiling. If you want a bug fix to ship as `cli=patch` even though it touches many public-API files, write `Version-Bump: cli=patch reason="bug fix"` — the trailer is the author's explicit accountability, and the reason string is reviewable. Two escape hatches stay in place: `skip` zeroes the level, and an override on a surface that wasn't actually touched is ignored (no rubber-stamping unrelated bumps).
+
 **Gotcha:** anything under `.github/workflows/**`, `.claude-plugin/**`, `commands/**`, `agents/**`, `hooks/**`, `scripts/release.sh`, `src/shipyard/cli/**`, `src/shipyard/runners/**`, or `src/shipyard/config/**` triggers the `ci` skill's path map (`scripts/skill_path_map.json`). Update this SKILL.md in the same PR — or use the `Skill-Update: skip` trailer with a real reason.
 
 **Manual release fallback:** `./scripts/release.sh` still exists for emergencies but is no longer the happy path. Normal releases flow through `shipyard pr` → merge → auto-release workflow.

--- a/tests/test_version_bump_override_precedence.py
+++ b/tests/test_version_bump_override_precedence.py
@@ -1,0 +1,233 @@
+"""Tests for `scripts/version_bump_check.py::assess_surfaces` override
+precedence.
+
+Before this fix, the override policy was "can raise, never lower" —
+an explicit `Version-Bump: cli=patch` trailer would be silently
+dropped when the heuristic chose minor (because the public-API path
+cli.py was touched). That defeated the entire point of the trailer:
+the author had taken explicit accountability with a reason string,
+but their stated intent lost to pattern-matching.
+
+New contract: the trailer is authoritative. If an author writes
+`Version-Bump: cli=<level> reason="..."`, that `<level>` wins
+against both the heuristic and the conventional-commit ceiling.
+Two escape hatches remain:
+
+  * ``skip`` still zeroes out the level (unchanged).
+  * If the surface wasn't touched at all, the override is ignored
+    (prevents rubber-stamping a bump on an unrelated surface).
+
+Regression fixture: shipyard PR #151 should have been v0.23.1
+(patch bug fix) but shipped as v0.24.0 because the heuristic beat
+the trailer.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "scripts"
+
+
+def _load_module():
+    if str(SCRIPTS_DIR) not in sys.path:
+        sys.path.insert(0, str(SCRIPTS_DIR))
+    import version_bump_check  # type: ignore[import-not-found]
+
+    return version_bump_check
+
+
+def _git(*args: str, cwd: Path) -> None:
+    subprocess.check_call(["git", *args], cwd=cwd)
+
+
+def _init_repo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("GIT_AUTHOR_NAME", "T")
+    monkeypatch.setenv("GIT_AUTHOR_EMAIL", "t@t")
+    monkeypatch.setenv("GIT_COMMITTER_NAME", "T")
+    monkeypatch.setenv("GIT_COMMITTER_EMAIL", "t@t")
+    _git("init", "--quiet", "--initial-branch=main", cwd=tmp_path)
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "cli.py").write_text("# v1\n")
+    (tmp_path / "pyproject.toml").write_text('version = "0.1.0"\n')
+    _git("add", ".", cwd=tmp_path)
+    _git("commit", "-q", "-m", "seed", cwd=tmp_path)
+    return tmp_path
+
+
+def _make_cli_surface(mod):
+    return mod.Surface(
+        name="cli",
+        label="Test CLI",
+        version_files=[mod.VersionFile(path="pyproject.toml", kind="pyproject_version")],
+        trigger_paths=["src/**"],
+        public_api_paths=["src/cli.py"],  # touching cli.py → heuristic=minor
+        internal_only_paths=[],
+        changelog=None,
+        auto_apply_patch=True,
+    )
+
+
+def _make_config(mod, surface):
+    return mod.Config(
+        surfaces=[surface],
+        generated_globs=[],
+        trailer_version_bump="version-bump",
+    )
+
+
+def _change_cli_and_commit(repo: Path, *, commit_msg: str) -> None:
+    (repo / "src" / "cli.py").write_text("# v2\nnew_func = 1\n")
+    _git("add", ".", cwd=repo)
+    _git("commit", "-q", "-m", commit_msg, cwd=repo)
+
+
+def test_explicit_patch_override_beats_minor_heuristic(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Regression for shipyard #151 behavior:
+    `Version-Bump: cli=patch` must produce final=patch even when the
+    heuristic says minor (public-API path touched)."""
+    mod = _load_module()
+    repo = _init_repo(tmp_path, monkeypatch)
+    surface = _make_cli_surface(mod)
+    cfg = _make_config(mod, surface)
+
+    _change_cli_and_commit(
+        repo,
+        commit_msg='bug: real fix\n\n'
+                   'Version-Bump: cli=patch reason="bug fix"',
+    )
+
+    changed = ["src/cli.py"]
+    verdicts = mod.assess_surfaces(cfg, changed, "HEAD~1", "HEAD", repo)
+
+    assert len(verdicts) == 1
+    v = verdicts[0]
+    assert v.heuristic == "minor"
+    assert v.trailer_override == "patch"
+    assert v.final_level == "patch", (
+        f"Expected final=patch (author override), got final={v.final_level}. "
+        "The heuristic won over an explicit trailer — the trailer is meant "
+        "to be authoritative when the author accepts accountability via "
+        "the reason string."
+    )
+
+
+def test_explicit_minor_override_still_works_when_heuristic_is_minor(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No-op case: override=minor + heuristic=minor → final=minor."""
+    mod = _load_module()
+    repo = _init_repo(tmp_path, monkeypatch)
+    surface = _make_cli_surface(mod)
+    cfg = _make_config(mod, surface)
+
+    _change_cli_and_commit(
+        repo,
+        commit_msg='feat: x\n\nVersion-Bump: cli=minor reason="feature"',
+    )
+
+    changed = ["src/cli.py"]
+    verdicts = mod.assess_surfaces(cfg, changed, "HEAD~1", "HEAD", repo)
+    assert verdicts[0].final_level == "minor"
+
+
+def test_explicit_major_override_raises_from_heuristic_minor(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Raising case still works: override=major, heuristic=minor →
+    final=major (the author wants a bigger bump than the heuristic
+    chose)."""
+    mod = _load_module()
+    repo = _init_repo(tmp_path, monkeypatch)
+    surface = _make_cli_surface(mod)
+    cfg = _make_config(mod, surface)
+
+    _change_cli_and_commit(
+        repo,
+        commit_msg='feat!: breaking\n\n'
+                   'Version-Bump: cli=major reason="breaking change"',
+    )
+
+    changed = ["src/cli.py"]
+    verdicts = mod.assess_surfaces(cfg, changed, "HEAD~1", "HEAD", repo)
+    assert verdicts[0].final_level == "major"
+
+
+def test_skip_override_zeros_out_final(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`skip` remains authoritative: final=none."""
+    mod = _load_module()
+    repo = _init_repo(tmp_path, monkeypatch)
+    surface = _make_cli_surface(mod)
+    cfg = _make_config(mod, surface)
+
+    _change_cli_and_commit(
+        repo,
+        commit_msg='chore: x\n\nVersion-Bump: cli=skip reason="trivial"',
+    )
+
+    changed = ["src/cli.py"]
+    verdicts = mod.assess_surfaces(cfg, changed, "HEAD~1", "HEAD", repo)
+    assert verdicts[0].final_level == "none"
+
+
+def test_override_ignored_when_surface_not_touched(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Rubber-stamp protection: if paths in this surface weren't
+    touched at all, the override is ignored so a user can't bump an
+    unrelated surface."""
+    mod = _load_module()
+    repo = _init_repo(tmp_path, monkeypatch)
+    surface = _make_cli_surface(mod)
+    cfg = _make_config(mod, surface)
+
+    # Commit that touches a path OUTSIDE trigger_paths.
+    (repo / "docs.md").write_text("hello\n")
+    _git("add", ".", cwd=repo)
+    _git(
+        "commit", "-q", "-m",
+        'docs: notes\n\nVersion-Bump: cli=minor reason="noop"',
+        cwd=repo,
+    )
+
+    changed = ["docs.md"]
+    verdicts = mod.assess_surfaces(cfg, changed, "HEAD~1", "HEAD", repo)
+    assert verdicts[0].final_level == "none"
+
+
+def test_conv_commit_feat_does_not_raise_over_explicit_patch_override(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Conv-commit-subject ceiling (``feat:`` → minor) must not
+    silently raise an author-declared ``=patch`` back up to minor.
+
+    Previously the code applied conv-commit promotion whenever the
+    heuristic was non-none — bypassing the override entirely. That
+    reduced the trailer to "can raise, never lower" even though
+    skip-vs-level was meant to be a meaningful choice."""
+    mod = _load_module()
+    repo = _init_repo(tmp_path, monkeypatch)
+    surface = _make_cli_surface(mod)
+    cfg = _make_config(mod, surface)
+
+    _change_cli_and_commit(
+        repo,
+        commit_msg='feat: looks-like-a-feature\n\n'
+                   'Version-Bump: cli=patch reason="really a patch"',
+    )
+
+    changed = ["src/cli.py"]
+    verdicts = mod.assess_surfaces(cfg, changed, "HEAD~1", "HEAD", repo)
+    assert verdicts[0].final_level == "patch", (
+        "Conv-commit-subject-based promotion ignored the explicit "
+        "trailer and raised patch → minor. The trailer must win."
+    )


### PR DESCRIPTION
The prior policy was "override can raise, never lower": a public-API
path change would set heuristic=minor, and an explicit
`Version-Bump: cli=patch reason="bug fix"` trailer on the tip commit
was silently dropped in favor of the heuristic. The conv-commit
subject ceiling (feat: → minor) also bypassed the override
unconditionally.

That defeated the trailer's whole point: the author is taking
explicit accountability with a reason string the reviewer can push
back on. Preferring pattern-match over stated intent + reason is
the wrong default.

New contract (scripts/version_bump_check.py::assess_surfaces):

- `Version-Bump: <surface>=<level> reason="..."` → final = <level>
  exactly, regardless of heuristic or conv-commit ceiling, when the
  surface was touched.
- `Version-Bump: <surface>=skip reason="..."` → final = none
  (unchanged).
- Override on a surface with no touched paths → ignored (unchanged;
  prevents rubber-stamping bumps on unrelated surfaces).
- Conv-commit subject ceiling only raises `final` when no explicit
  level trailer is set — feat: can no longer silently raise a
  declared =patch back up to minor.

Observed in the wild: shipyard#151 was authored with
`Version-Bump: cli=patch` (a bug fix to pr_text) but shipped as
v0.24.0 because cli.py is public-API and triggered heuristic=minor.
With this change, the same commit would have landed as v0.23.1.

Regression coverage:
- tests/test_version_bump_override_precedence.py (new, 6 cases):
  patch-beats-minor, minor-stays-minor, major-raises, skip-zeros,
  override-ignored-when-surface-untouched, feat:-conv-does-not-
  raise-over-patch.
- skills/ci/SKILL.md: added one paragraph spelling out the
  authoritative semantics so the next author doesn't re-discover
  this.

Version-Bump: cli=patch reason="bug fix to version-bump override precedence"