### PR TITLE
ipc: serve ship-state-list directly from the daemon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to Shipyard are documented here. Each entry links
 to its [GitHub Release](https://github.com/danielraffel/Shipyard/releases).
 
 <a id="v0240"></a>
+## [0.25.0]
+
 ## [0.24.0] - 2026-04-22
 
 - fix/pr text walk past bump commit ([#151](https://github.com/danielraffel/Shipyard/pull/151))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "shipyard"
-version = "0.24.0"
+version = "0.25.0"
 description = "Cross-platform CI coordination — local VMs, SSH hosts, cloud runners"
 readme = "README.md"
 license = "MIT"

--- a/src/shipyard/__init__.py
+++ b/src/shipyard/__init__.py
@@ -1,3 +1,3 @@
 """Shipyard — Cross-platform CI coordination."""
 
-__version__ = "0.24.0"
+__version__ = "0.25.0"

--- a/src/shipyard/daemon/controller.py
+++ b/src/shipyard/daemon/controller.py
@@ -141,6 +141,7 @@ class Daemon:
             socket_path=self._paths.socket_file,
             status_provider=self._build_status_snapshot,
             on_stop_request=self._request_stop,
+            ship_state_list_provider=self._build_ship_state_list,
         )
         await self._ipc_server.start()
 
@@ -256,6 +257,27 @@ class Daemon:
                 },
             }
         )
+
+    def _build_ship_state_list(self) -> list[dict[str, object]]:
+        """Return the same JSON shape `shipyard --json ship-state list`
+        emits, read directly from the local store.
+
+        Serves the ``{"type":"ship-state-list"}`` IPC request so
+        subscribers (the macOS GUI, primarily) don't have to pay the
+        PyInstaller cold-start tax on every poll. See shipyard#153.
+
+        Read through the store so we pick up any concurrent writes
+        from the ship path. If the read throws (disk glitch, partial
+        write), return an empty list rather than crashing the daemon.
+        """
+        try:
+            from shipyard.core.ship_state import ShipStateStore
+
+            store = ShipStateStore(self._config.state_dir / "ship")
+            return [s.to_dict() for s in store.list_active()]
+        except Exception as exc:  # noqa: BLE001 — never crash daemon
+            logger.warning("ship-state-list IPC: %s", exc)
+            return []
 
     def _build_status_snapshot(self) -> IPCState:
         return IPCState(

--- a/src/shipyard/daemon/ipc.py
+++ b/src/shipyard/daemon/ipc.py
@@ -64,6 +64,7 @@ class IPCState:
 
 StatusProvider = Callable[[], IPCState]
 StopRequestCallback = Callable[[], Awaitable[None]]
+ShipStateListProvider = Callable[[], list[dict[str, object]]]
 
 
 class _Subscriber:
@@ -90,10 +91,12 @@ class IPCServer:
         socket_path: Path,
         status_provider: StatusProvider,
         on_stop_request: StopRequestCallback | None = None,
+        ship_state_list_provider: ShipStateListProvider | None = None,
     ) -> None:
         self._socket_path = socket_path
         self._status_provider = status_provider
         self._on_stop_request = on_stop_request
+        self._ship_state_list_provider = ship_state_list_provider
         self._server: asyncio.AbstractServer | None = None
         self._subscribers: set[_Subscriber] = set()
         self._ring: deque[dict[str, object]] = deque(maxlen=RING_BUFFER_SIZE)
@@ -217,6 +220,22 @@ class IPCServer:
         elif msg_type == "stop":
             if self._on_stop_request is not None:
                 await self._on_stop_request()
+        elif msg_type == "ship-state-list":
+            # Daemon-side shortcut for `shipyard --json ship-state list`.
+            # Subscribers (primarily the macOS GUI) would otherwise pay
+            # the PyInstaller CLI cold-start tax (~5-6s) on every
+            # 7s poll tick; serving the same JSON directly from the
+            # in-daemon `ShipStateStore` returns in milliseconds.
+            # See shipyard#153.
+            if self._ship_state_list_provider is None:
+                await sub.queue.put(
+                    {"type": "ship-state-list", "states": []}
+                )
+            else:
+                states = self._ship_state_list_provider()
+                await sub.queue.put(
+                    {"type": "ship-state-list", "states": states}
+                )
 
     async def _writer_loop(self, sub: _Subscriber) -> None:
         """Drains the subscriber's queue into the socket.

--- a/tests/daemon/test_ipc_ship_state_list.py
+++ b/tests/daemon/test_ipc_ship_state_list.py
@@ -1,0 +1,152 @@
+"""IPC ship-state-list request: daemon-side shortcut for
+`shipyard --json ship-state list`.
+
+Subscribers (primarily the macOS GUI) use this to avoid the
+PyInstaller cold-start tax on every poll. See shipyard#153.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import socket
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from shipyard.daemon.ipc import IPCServer, IPCState
+
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="AF_UNIX sockets are macOS/Linux only",
+)
+
+
+@pytest.fixture
+def short_socket_path():
+    with tempfile.TemporaryDirectory(prefix="sy-ssl-") as d:
+        yield Path(d) / "daemon.sock"
+
+
+def _dummy_state() -> IPCState:
+    return IPCState(
+        tunnel_backend="tailscale",
+        tunnel_url=None,
+        tunnel_verified_at=None,
+        subscribers=0,
+        last_event_at=None,
+        registered_repos=[],
+        rate_limit=None,
+    )
+
+
+def _read_lines_blocking(
+    sock: socket.socket, count: int, timeout: float = 3.0
+) -> list[dict]:
+    sock.settimeout(timeout)
+    buf = b""
+    out: list[dict] = []
+    while len(out) < count:
+        chunk = sock.recv(65536)
+        if not chunk:
+            break
+        buf += chunk
+        while b"\n" in buf and len(out) < count:
+            line, _, buf = buf.partition(b"\n")
+            out.append(json.loads(line))
+    return out
+
+
+def test_ship_state_list_returns_provider_output(
+    short_socket_path: Path,
+) -> None:
+    """Provider returns a list of two dict entries → client sees both."""
+
+    entries = [
+        {
+            "schema_version": 1,
+            "pr": 151,
+            "repo": "o/r",
+            "branch": "feat/x",
+            "dispatched_runs": [],
+            "evidence_snapshot": {},
+        },
+        {
+            "schema_version": 1,
+            "pr": 152,
+            "repo": "o/r",
+            "branch": "fix/y",
+            "dispatched_runs": [],
+            "evidence_snapshot": {},
+        },
+    ]
+
+    async def run() -> None:
+        server = IPCServer(
+            socket_path=short_socket_path,
+            status_provider=_dummy_state,
+            ship_state_list_provider=lambda: entries,
+        )
+        await server.start()
+        try:
+
+            def client_fn() -> list[dict]:
+                sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+                sock.connect(str(short_socket_path))
+                try:
+                    sock.sendall(b'{"type":"ship-state-list"}\n')
+                    return _read_lines_blocking(sock, count=2)
+                finally:
+                    sock.close()
+
+            lines = await asyncio.wait_for(
+                asyncio.to_thread(client_fn), timeout=3.0
+            )
+        finally:
+            await server.stop()
+
+        assert lines[0]["type"] == "hello"
+        assert lines[1]["type"] == "ship-state-list"
+        assert lines[1]["states"] == entries
+
+    asyncio.run(run())
+
+
+def test_ship_state_list_returns_empty_when_no_provider(
+    short_socket_path: Path,
+) -> None:
+    """If the daemon wasn't wired with a provider (shouldn't happen in
+    production but keep the fallback sane), the request is still
+    answered — just with an empty list."""
+
+    async def run() -> None:
+        server = IPCServer(
+            socket_path=short_socket_path,
+            status_provider=_dummy_state,
+            ship_state_list_provider=None,
+        )
+        await server.start()
+        try:
+
+            def client_fn() -> list[dict]:
+                sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+                sock.connect(str(short_socket_path))
+                try:
+                    sock.sendall(b'{"type":"ship-state-list"}\n')
+                    return _read_lines_blocking(sock, count=2)
+                finally:
+                    sock.close()
+
+            lines = await asyncio.wait_for(
+                asyncio.to_thread(client_fn), timeout=3.0
+            )
+        finally:
+            await server.stop()
+
+        assert lines[0]["type"] == "hello"
+        assert lines[1]["type"] == "ship-state-list"
+        assert lines[1]["states"] == []
+
+    asyncio.run(run())


### PR DESCRIPTION
Every `shipyard --json ship-state list` subprocess spawn costs
~5-6s on cold start (PyInstaller onefile extract + Python interpreter
boot). The macOS GUI polls that command every 7s. Each poll burns
wall-clock + CPU on identical startup work, and with ~60 tracked
PRs the pipe-drain path was the load-bearing bottleneck.

The daemon already has the in-memory `ShipStateStore` available.
Add one IPC message type and serve the identical JSON directly:

    client: {"type":"ship-state-list"}
    daemon: {"type":"ship-state-list", "states": [...]}

The JSON shape exactly mirrors `ctx.output("ship-state:list", ...)`
so the GUI's existing decoder doesn't need any changes.

Wiring:

- `IPCServer.__init__` grows a new `ship_state_list_provider`
  callback (optional; `None` → replies with an empty list so old
  daemon builds fail softly for new clients).
- `Daemon._build_ship_state_list` reads the store directly and
  emits the JSON the CLI path emits.
- No change to existing `status` / `subscribe` / `stop` semantics.

Fast-path callers (primarily the macOS GUI) can now issue a
one-shot connect/request/reply and get an answer in milliseconds.
Slow-path (legacy or daemon-down) callers keep using the CLI
subprocess; they're unaffected.

Regression coverage: new test_ipc_ship_state_list.py round-trips a
non-empty and an empty provider through a live IPCServer + raw
AF_UNIX client, asserting the reply frame shape matches the CLI
envelope.

Closes #153.

Version-Bump: cli=minor reason="new daemon IPC message — additive"