### PR TITLE
ssh: probe retries with exponential backoff, DNS failures fast-fail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to Shipyard are documented here. Each entry links
 to its [GitHub Release](https://github.com/danielraffel/Shipyard/releases).
 
 <a id="v0250"></a>
+## [0.26.1]
+
 ## [0.25.0] - 2026-04-22
 
 - feat/ship state list ipc ([#154](https://github.com/danielraffel/Shipyard/pull/154))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "shipyard"
-version = "0.26.0"
+version = "0.26.1"
 description = "Cross-platform CI coordination — local VMs, SSH hosts, cloud runners"
 readme = "README.md"
 license = "MIT"

--- a/src/shipyard/__init__.py
+++ b/src/shipyard/__init__.py
@@ -1,3 +1,3 @@
 """Shipyard — Cross-platform CI coordination."""
 
-__version__ = "0.26.0"
+__version__ = "0.26.1"

--- a/src/shipyard/executor/ssh.py
+++ b/src/shipyard/executor/ssh.py
@@ -685,11 +685,17 @@ def _classify_probe_error(stderr: str, returncode: int) -> str:
         or "offending" in lowered
     ):
         return "host_key"
+    # DNS resolution failure: deterministic and fast, don't retry.
+    # A hostname that doesn't resolve once won't resolve on retry;
+    # retrying just slows down the "wrong host in config" path.
     if (
         "could not resolve hostname" in lowered
         or "name or service not known" in lowered
         or "nodename nor servname" in lowered  # macOS variant
-        or "no route to host" in lowered
+    ):
+        return "resolution"
+    if (
+        "no route to host" in lowered
         or "network is unreachable" in lowered
         or "connection refused" in lowered
     ):
@@ -730,11 +736,21 @@ def _format_ssh_diagnosis(
 
 PROBE_TIMEOUT_SECS = 10
 PROBE_CONNECT_TIMEOUT_SECS = 5
-# Transient categories retry once — Windows OpenSSH handshakes occasionally
-# exceed the 10s budget on first connect after idle. Non-transient categories
-# (auth, host_key, configuration) do NOT retry: retrying a wrong key is
-# pointless and slow.
+# Transient categories retry with backoff. Windows OpenSSH handshakes
+# occasionally exceed the 10s budget on first connect after idle, and
+# Tailscale WireGuard needs seconds to re-establish after a DERP
+# fallback or NAT-punch-through rebind. Non-transient categories
+# (auth, host_key, configuration) do NOT retry — retrying a wrong key
+# is pointless and slow.
 _TRANSIENT_CATEGORIES = frozenset({"timeout", "network"})
+
+# Sleep between attempts when the last result was transient. Tuned for
+# Tailscale: first retry almost-immediate (catches one-off race),
+# second allows a full DERP/NAT re-negotiation window. Total
+# worst-case probe cost for a genuinely-offline host: 10 + 2 + 10 + 6
+# + 10 = 38s, vs the old 20s — but we only pay that extra window
+# when the first attempt fails, and only on transient classifications.
+_PROBE_BACKOFFS_SECS = (2.0, 6.0)
 
 
 def _debug_probe_enabled() -> bool:
@@ -802,9 +818,13 @@ def run_probe(
             f"timeout={PROBE_TIMEOUT_SECS}s\n"
         )
 
+    import time as _time
+
     attempts = 0
     last_result: dict[str, Any] | None = None
-    for attempt in range(2):
+    # One initial attempt + one attempt per backoff window.
+    total_attempts = 1 + len(_PROBE_BACKOFFS_SECS)
+    for attempt in range(total_attempts):
         attempts = attempt + 1
         last_result = _single_probe_attempt(cmd)
         last_result["attempts"] = attempts
@@ -812,7 +832,11 @@ def run_probe(
             return last_result
         if last_result["category"] not in _TRANSIENT_CATEGORIES:
             return last_result
-        # Transient — retry once.
+        # Transient — back off before the next attempt. Skip sleep on
+        # the last iteration so we don't waste time after we've
+        # already decided to give up.
+        if attempt < total_attempts - 1:
+            _time.sleep(_PROBE_BACKOFFS_SECS[attempt])
     assert last_result is not None
     return last_result
 

--- a/tests/test_preflight_ssh_fail_fast.py
+++ b/tests/test_preflight_ssh_fail_fast.py
@@ -34,8 +34,8 @@ class TestSSHClassifier:
             ("Too many authentication failures", "auth"),
             ("Host key verification failed.", "host_key"),
             ("REMOTE HOST IDENTIFICATION HAS CHANGED!", "host_key"),
-            ("ssh: Could not resolve hostname bogus: Name or service not known", "network"),
-            ("ssh: Could not resolve hostname bogus: nodename nor servname provided", "network"),
+            ("ssh: Could not resolve hostname bogus: Name or service not known", "resolution"),
+            ("ssh: Could not resolve hostname bogus: nodename nor servname provided", "resolution"),
             ("ssh: connect to host bogus port 22: No route to host", "network"),
             ("ssh: connect to host 10.0.0.1 port 22: Connection refused", "network"),
             ("ssh: connect to host 10.0.0.1 port 22: Connection timed out", "timeout"),
@@ -54,7 +54,12 @@ class TestSSHProbeDiagnosis:
     def test_probe_honors_10s_budget(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """A hung ssh probe must surface within ~10s, not the full cmd timeout."""
+        """Each ssh probe attempt must use the 10s budget (not the full
+        validation timeout), and the overall probe must complete
+        promptly once every attempt has short-circuited via subprocess
+        timeout. #141: timeouts now retry with backoff (2s, 6s), so
+        three attempts happen before giving up; we suppress the
+        sleeps in-test so wall-clock still bounds quickly."""
         calls: list[int] = []
 
         def fake_run(cmd: list[str], **kw: Any) -> subprocess.CompletedProcess:
@@ -62,15 +67,19 @@ class TestSSHProbeDiagnosis:
             raise subprocess.TimeoutExpired(cmd=cmd, timeout=kw.get("timeout", 0))
 
         monkeypatch.setattr(subprocess, "run", fake_run)
+        # Suppress the inter-attempt backoff so wall-clock stays bounded.
+        from shipyard.executor import ssh as _ssh
+        monkeypatch.setattr(_ssh, "_PROBE_BACKOFFS_SECS", (0.0, 0.0))
+
         start = time.monotonic()
         diag = SSHExecutor().diagnose({"host": "bogus.invalid"})
         assert time.monotonic() - start < 2.0  # fake_run raises immediately
         assert diag["reachable"] is False
         assert diag["category"] == "timeout"
-        # #119: timeouts now retry once (transient category), so we see
-        # two 10s calls. The important invariant is that EVERY call uses
-        # the 10s probe budget, not the full validation timeout.
-        assert calls == [10, 10], (
+        # #141: timeouts retry twice (three attempts total), so we see
+        # three 10s calls. The important invariant is that EVERY call
+        # uses the 10s probe budget, not the full validation timeout.
+        assert calls == [10, 10, 10], (
             "probe must pass a 10s timeout to subprocess.run on each "
             "attempt, not the validation timeout"
         )

--- a/tests/test_ssh_probe_119.py
+++ b/tests/test_ssh_probe_119.py
@@ -102,9 +102,13 @@ class TestRunProbe:
         assert diag["attempts"] == 1, "auth is non-transient — must not retry"
         assert calls["n"] == 1
 
-    def test_timeout_is_retried_once(
+    def test_timeout_is_retried_with_backoff(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
+        """#141: transient timeouts retry with exponential backoff so a
+        Tailscale hiccup doesn't abort the ship. Three attempts total.
+        Test suppresses the real sleep windows to keep wall-clock
+        bounded; the production default is 2s + 6s between attempts."""
         calls = {"n": 0}
 
         def _timeout(cmd: list[str], **kw: Any) -> subprocess.CompletedProcess:
@@ -112,13 +116,15 @@ class TestRunProbe:
             raise subprocess.TimeoutExpired(cmd=cmd, timeout=kw.get("timeout", 0))
 
         monkeypatch.setattr(subprocess, "run", _timeout)
+        from shipyard.executor import ssh as _ssh
+        monkeypatch.setattr(_ssh, "_PROBE_BACKOFFS_SECS", (0.0, 0.0))
         diag = run_probe({"host": "win"}, remote_cmd=["echo", "ok"])
         assert diag["reachable"] is False
         assert diag["category"] == "timeout"
-        assert diag["attempts"] == 2
-        assert calls["n"] == 2
+        assert diag["attempts"] == 3
+        assert calls["n"] == 3
 
-    def test_network_error_is_retried_once(
+    def test_network_error_is_retried_with_backoff(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         calls = {"n": 0}
@@ -133,10 +139,12 @@ class TestRunProbe:
             )
 
         monkeypatch.setattr(subprocess, "run", _refused)
+        from shipyard.executor import ssh as _ssh
+        monkeypatch.setattr(_ssh, "_PROBE_BACKOFFS_SECS", (0.0, 0.0))
         diag = run_probe({"host": "win"}, remote_cmd=["echo", "ok"])
         assert diag["reachable"] is False
         assert diag["category"] == "network"
-        assert diag["attempts"] == 2
+        assert diag["attempts"] == 3
 
     def test_transient_retry_succeeds_on_second_attempt(
         self, monkeypatch: pytest.MonkeyPatch
@@ -205,7 +213,7 @@ class TestWindowsDiagnose:
         monkeypatch.setattr(subprocess, "run", _resolve_fail)
         win_diag = SSHWindowsExecutor().diagnose({"host": "win"})
         posix_diag = SSHExecutor().diagnose({"host": "win"})
-        assert win_diag["category"] == posix_diag["category"] == "network"
+        assert win_diag["category"] == posix_diag["category"] == "resolution"
 
     def test_windows_probe_uses_echo_not_powershell(
         self, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
Two related fixes that tighten the SSH probe's behavior on real
Tailscale networks.

## 1. Transient retries now use exponential backoff (#141)

Prior: `run_probe` retried transient failures (timeout/network)
exactly once, immediately. With Tailscale WireGuard sometimes
taking 10-20s to recover from a DERP fallback or NAT-punch-through
rebind, both back-to-back attempts could land inside the same
transient window and fail — aborting the entire ship.

Now: three attempts total, with 2s + 6s backoff between them. Total
worst-case probe cost on a transient failure rises from ~20s to ~36s,
but we only pay the extra window when the first attempt actually
fails — and only on transient classifications. Healthy hosts are
still sub-second.

User-reported symptom: "PR #654 created (coverage-gate union). Same
Windows SSH infra flake." — seen repeatedly on pulp PRs #609, #613,
#616, #654. The host was always reachable immediately after the
failure but within the 20s window.

## 2. DNS resolution failures get their own category

Prior: "could not resolve hostname" was bucketed under "network" and
retried. That's wasted time — hostname resolution is deterministic;
a name that doesn't resolve once won't resolve on retry. The
preflight fast-fail integration test even caught this regression
immediately: 16s instead of <15s budget on an unresolvable host.

Now: "resolution" is a first-class category, NOT in
_TRANSIENT_CATEGORIES, so DNS failures fail on the first attempt.
Fast-fail preserved for the "wrong host in config" path; backoff
only happens for actual transient network / timeout errors.

## Tests

- tests/test_ssh_probe_119.py: `_timeout_is_retried_with_backoff` +
  `_network_error_is_retried_with_backoff` assert 3 attempts, with
  a monkeypatched _PROBE_BACKOFFS_SECS = (0, 0) so wall-clock stays
  bounded. DNS-resolution-failure test asserts category == "resolution".
- tests/test_preflight_ssh_fail_fast.py: probe-budget test updated
  to suppress backoff sleeps; classifier test updated for the
  "resolution" category.

Closes #141.

Version-Bump: cli=patch reason="behavior-shaping fix for existing probe path"