### PR TITLE
install: strip xattrs + re-ad-hoc-sign on macOS

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -47,6 +47,27 @@ mkdir -p "${INSTALL_DIR}"
 curl -sL "${RELEASE_URL}" -o "${INSTALL_DIR}/shipyard"
 chmod +x "${INSTALL_DIR}/shipyard"
 
+# macOS 26.3+ hardened Gatekeeper SIGKILLs ad-hoc-signed binaries that
+# carry the `com.apple.provenance` / `com.apple.quarantine` xattrs from
+# a GitHub Release download. PyInstaller produces ad-hoc-signed Mach-O,
+# so a fresh install silently crashes with "killed" on every run and
+# the user has to dig through ~/Library/Logs/DiagnosticReports to see
+# the real reason ("Taskgated Invalid Signature" / SIGKILL Code
+# Signature Invalid).
+#
+# Fix: strip the download xattrs + re-apply an ad-hoc signature on the
+# user's machine. The re-sign produces a trust-anchored signature
+# because it's local (no download-origin tracking). This is the same
+# two-command dance every PyInstaller / binary-distribution project
+# on macOS ends up running; folding it into the installer saves every
+# user from hitting it.
+if [ "${OS}" = "macos" ]; then
+    xattr -cr "${INSTALL_DIR}/shipyard" 2>/dev/null || true
+    if command -v codesign >/dev/null 2>&1; then
+        codesign --force --sign - "${INSTALL_DIR}/shipyard" 2>/dev/null || true
+    fi
+fi
+
 # Create sy symlink
 ln -sf "${INSTALL_DIR}/shipyard" "${INSTALL_DIR}/sy"
 


### PR DESCRIPTION
macOS 26.3+ hardened Gatekeeper SIGKILLs ad-hoc-signed binaries
that carry the com.apple.provenance / com.apple.quarantine xattrs
GitHub stamps on every download. PyInstaller's output is ad-hoc
signed, so every fresh shipyard install silently crashes on every
invocation (user sees just "killed" with no explanation — the
real reason ("Taskgated Invalid Signature" / SIGKILL Code
Signature Invalid) is only visible in the crash report in
~/Library/Logs/DiagnosticReports).

Fix: on macOS, strip the download xattrs + re-apply an ad-hoc
signature locally. The re-sign produces a trust-anchored
signature because it's performed on the user's machine (no
download-origin tracking), which Gatekeeper accepts.

Both commands are no-ops if xattr or codesign aren't available
(embedded runtimes, unusual systems), and || true keeps the
installer from erroring out if they fail — worst case the user
hits the original crash and the fix is "run codesign manually",
which we can document separately.

Reproduced on macOS 26.3.1 with shipyard v0.26.1. The proper
long-term fix is Developer ID signing + notarization of the
shipyard CLI binary in the release workflow, tracked separately.

Version-Bump: cli=patch reason="installer-side fix; CLI code unchanged"