### PR TITLE
daemon: retry Tailscale Funnel probe before giving up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to Shipyard are documented here. Each entry links
 to its [GitHub Release](https://github.com/danielraffel/Shipyard/releases).
 
 <a id="v0261"></a>
+## [0.26.2]
+
 ## [0.26.1] - 2026-04-22
 
 - fix/141 ssh probe backoff retry ([#158](https://github.com/danielraffel/Shipyard/pull/158))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "shipyard"
-version = "0.26.1"
+version = "0.26.2"
 description = "Cross-platform CI coordination — local VMs, SSH hosts, cloud runners"
 readme = "README.md"
 license = "MIT"

--- a/src/shipyard/__init__.py
+++ b/src/shipyard/__init__.py
@@ -1,3 +1,3 @@
 """Shipyard — Cross-platform CI coordination."""
 
-__version__ = "0.26.1"
+__version__ = "0.26.2"

--- a/src/shipyard/daemon/tunnels/tailscale.py
+++ b/src/shipyard/daemon/tunnels/tailscale.py
@@ -15,6 +15,29 @@ import asyncio
 from shipyard.daemon import tailscale as probe_mod
 from shipyard.daemon.tunnels.base import TunnelInfo, TunnelNotReadyError, TunnelStartError
 
+# tailscaled can return a partial / not-yet-populated status when it's
+# warming up, restoring a profile, rebuilding its cap map after a
+# control-plane reconnect, or mid-DERP-fallback. A single probe that
+# lands in that window returns `funnel_permitted=False` even on a node
+# that absolutely has Funnel in its ACLs. Retrying with short backoff
+# recovers in every case observed so far. Total worst-case wait before
+# giving up: ~20s, which is long enough to cross most tailscaled
+# transients but short enough that a genuinely-misconfigured tailnet
+# still fails fast.
+_PROBE_BACKOFFS_SECS: tuple[float, ...] = (2.0, 6.0, 12.0)
+
+
+async def _probe_with_retry() -> probe_mod.TailscaleStatus:
+    status = await asyncio.to_thread(probe_mod.probe)
+    if status.is_ready:
+        return status
+    for delay in _PROBE_BACKOFFS_SECS:
+        await asyncio.sleep(delay)
+        status = await asyncio.to_thread(probe_mod.probe)
+        if status.is_ready:
+            return status
+    return status
+
 
 class TailscaleFunnelBackend:
     name = "tailscale"
@@ -27,14 +50,14 @@ class TailscaleFunnelBackend:
         self._binary = probe_mod.resolve_binary()
         if self._binary is None:
             return False
-        status = await asyncio.to_thread(probe_mod.probe)
+        status = await _probe_with_retry()
         return status.is_ready
 
     async def start(self, local_port: int) -> TunnelInfo:
-        status = await asyncio.to_thread(probe_mod.probe)
+        status = await _probe_with_retry()
         if not status.is_ready or status.funnel_url is None:
             raise TunnelNotReadyError(
-                "Tailscale Funnel isn't ready: "
+                "Tailscale Funnel isn't ready after retries: "
                 f"backend={status.backend_state!r} "
                 f"funnel_permitted={status.funnel_permitted}"
             )

--- a/tests/daemon/test_tunnel_retry.py
+++ b/tests/daemon/test_tunnel_retry.py
@@ -1,0 +1,83 @@
+"""Transient-Funnel-unavailable retry for the Tailscale tunnel backend.
+
+tailscaled briefly reports `funnel_permitted=False` / empty
+BackendState when it's warming up, restoring a profile, or
+reconnecting to the control plane. A one-shot probe at daemon
+startup that lands in that window used to kill the daemon with
+"Tailscale Funnel isn't ready" and leave the GUI stuck in polling.
+These tests pin the retry-with-backoff recovery path.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from shipyard.daemon import tailscale as probe_mod
+from shipyard.daemon.tunnels import tailscale as tunnel_mod
+from shipyard.daemon.tunnels.base import TunnelNotReadyError
+
+
+def _status(*, ready: bool) -> probe_mod.TailscaleStatus:
+    return probe_mod.TailscaleStatus(
+        binary_path="/Applications/Tailscale.app/Contents/MacOS/Tailscale" if ready else None,
+        backend_state="Running" if ready else None,
+        dns_name="test.example.ts.net." if ready else None,
+        funnel_permitted=ready,
+    )
+
+
+def test_probe_retries_and_eventually_succeeds(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Two not-ready reads in a row, then a ready one. Caller should see ready."""
+    calls = iter([_status(ready=False), _status(ready=False), _status(ready=True)])
+
+    def fake_probe() -> probe_mod.TailscaleStatus:
+        return next(calls)
+
+    monkeypatch.setattr(probe_mod, "probe", fake_probe)
+    monkeypatch.setattr(tunnel_mod, "_PROBE_BACKOFFS_SECS", (0.0, 0.0, 0.0))
+
+    status = asyncio.run(tunnel_mod._probe_with_retry())
+    assert status.is_ready is True
+
+
+def test_probe_gives_up_after_all_retries(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Every probe returns not-ready → caller gets the last (not-ready)
+    status, `start` then raises TunnelNotReadyError."""
+    monkeypatch.setattr(probe_mod, "probe", lambda: _status(ready=False))
+    monkeypatch.setattr(tunnel_mod, "_PROBE_BACKOFFS_SECS", (0.0, 0.0, 0.0))
+
+    async def go() -> None:
+        backend = tunnel_mod.TailscaleFunnelBackend()
+        with pytest.raises(TunnelNotReadyError) as excinfo:
+            await backend.start(local_port=1234)
+        # Error message should flag that the retries ran (so a user
+        # reading the log knows we tried, not that we gave up
+        # immediately on one bad read).
+        assert "after retries" in str(excinfo.value)
+
+    asyncio.run(go())
+
+
+def test_probe_first_attempt_ready_skips_retry(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Happy path: one probe, one call, no sleeps."""
+    call_count = {"n": 0}
+
+    def fake_probe() -> probe_mod.TailscaleStatus:
+        call_count["n"] += 1
+        return _status(ready=True)
+
+    monkeypatch.setattr(probe_mod, "probe", fake_probe)
+
+    sleep_calls: list[float] = []
+
+    async def fake_sleep(d: float) -> None:
+        sleep_calls.append(d)
+
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+
+    status = asyncio.run(tunnel_mod._probe_with_retry())
+    assert status.is_ready is True
+    assert call_count["n"] == 1
+    assert sleep_calls == [], "no backoff should fire when first probe succeeds"


### PR DESCRIPTION
tailscaled can briefly return `funnel_permitted=False` / partial
BackendState while warming up, restoring a profile, reconnecting to
the control plane, or in a DERP fallback window. A single probe at
daemon startup that lands in that window used to kill the daemon
with "Tailscale Funnel isn't ready", and the GUI flipped to polling
with no automatic recovery.

Reproduced today: same node, same tailnet, same permissions. At
16:33 the probe returned funnel_permitted=False; ~90s later it
returned True cleanly. Nothing about the tailnet configuration had
changed.

Fix: retry the probe with 2s / 6s / 12s backoff before concluding
Funnel isn't available. Total worst-case wait ~20s before giving
up, which covers every tailscaled transient window I've observed
while still failing fast for genuinely-misconfigured tailnets
(where every probe returns the same not-ready signal from the
first attempt onward).

Follow-up in #26: even after this retry, the daemon still exits
when the probe ultimately fails. Better long-term design is to
start the IPC server immediately and run the tunnel probe as a
background task so the GUI's ship-state-list fast path keeps
working during tunnel warm-up. Not tackled here to keep this
change minimal.

Adds tests/daemon/test_tunnel_retry.py covering the three
scenarios: transient-then-ready, all-retries-fail, and
first-try-succeeds (no sleeps).

Version-Bump: cli=patch reason="targeted fix for transient tunnel probe"