### PR TITLE
daemon: tunnel runs as a supervised background task; never kills the daemon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to Shipyard are documented here. Each entry links
 to its [GitHub Release](https://github.com/danielraffel/Shipyard/releases).
 
 <a id="v0261"></a>
+## [0.27.0]
+
 ## [0.26.2]
 
 ## [0.26.1] - 2026-04-22

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "shipyard"
-version = "0.26.2"
+version = "0.27.0"
 description = "Cross-platform CI coordination — local VMs, SSH hosts, cloud runners"
 readme = "README.md"
 license = "MIT"

--- a/src/shipyard/__init__.py
+++ b/src/shipyard/__init__.py
@@ -1,3 +1,3 @@
 """Shipyard — Cross-platform CI coordination."""
 
-__version__ = "0.26.2"
+__version__ = "0.27.0"

--- a/src/shipyard/daemon/controller.py
+++ b/src/shipyard/daemon/controller.py
@@ -91,10 +91,13 @@ class Daemon:
         self._pid_file: Path = self._paths.pid_file
         self._state = _RuntimeState()
         self._webhook_server: WebhookServer | None = None
+        self._webhook_port: int | None = None
+        self._webhook_secret: str | None = None
         self._ipc_server: IPCServer | None = None
         self._tunnel = TailscaleFunnelBackend()
         self._registrar = Registrar(config.state_dir)
         self._stop_event = asyncio.Event()
+        self._tunnel_supervisor_task: asyncio.Task[None] | None = None
         # Rolling 5-min dedupe set for X-GitHub-Delivery IDs. GitHub
         # retries failed deliveries with the same ID; without dedupe a
         # retry would re-broadcast an already-seen event, causing double
@@ -102,41 +105,50 @@ class Daemon:
         self._seen_delivery_ids: dict[str, float] = {}
 
     async def start(self) -> None:
+        """Bring the daemon up.
+
+        Ordering (changed in v0.26.3 — don't revert to the pre-IPC
+        sequence without reading shipyard#26):
+
+          1. Acquire the PID lock.
+          2. Load the webhook secret.
+          3. Bind the webhook HTTP server on localhost (needs a port
+             so the tunnel can target it).
+          4. **Start the IPC server immediately.** Subscribers (the
+             GUI, `shipyard wait`, `shipyard watch --follow`) can now
+             connect for ship-state-list queries and live status
+             reads regardless of tunnel state. Before this change,
+             any Tailscale hiccup at startup killed the whole daemon
+             and the GUI fell back to polling with no recovery until
+             a manual restart.
+          5. Spawn the tunnel supervisor as a background task. It
+             retries the Tailscale probe forever (capped backoff),
+             registers webhooks when the tunnel becomes ready, and
+             watches for tunnel loss mid-session.
+          6. Spawn the reconcile loop (unchanged).
+
+        `start()` only raises on truly-fatal startup errors: PID
+        lock contention, port bind failures, or socket setup
+        failures. Tunnel-related failures no longer take the daemon
+        down — they surface through `_build_status_snapshot` so
+        subscribers see an accurate tunnel state.
+        """
         self._paths.ensure_dirs()
         self._acquire_lock()
 
         # Resolve secret (keychain on macOS, file on Linux).
-        secret = secrets_mod.load_or_create(self._config.state_dir)
+        self._webhook_secret = secrets_mod.load_or_create(self._config.state_dir)
 
-        # Bring the HTTP server up first — need the bound port for
-        # the tunnel backend.
-        self._webhook_server = WebhookServer(_make_delivery_handler(secret, self))
-        port = self._webhook_server.start()
+        # Bind webhook server → port for the tunnel to target. Even
+        # if the tunnel never comes up, the port sits idle and
+        # harmless.
+        self._webhook_server = WebhookServer(
+            _make_delivery_handler(self._webhook_secret, self)
+        )
+        self._webhook_port = self._webhook_server.start()
 
-        # Bring the tunnel up.
-        try:
-            tunnel_info = await self._tunnel.start(port)
-        except (TunnelNotReadyError, TunnelStartError):
-            # If the tunnel can't come up, the daemon is still useful
-            # as a local-only subscribe host (future), but for v1 the
-            # whole point is webhook delivery. Fail fast.
-            self._webhook_server.stop()
-            self._release_lock()
-            raise
-        self._state.tunnel = tunnel_info
-        self._state.tunnel_verified_at = time.time()
-
-        # Register webhooks. URL always ends in /webhook — the server
-        # also accepts / for legacy compatibility.
-        public_url = tunnel_info.public_url.rstrip("/") + "/webhook"
-        for repo in self._config.repos:
-            try:
-                await self._registrar.ensure_registered(repo, public_url, secret)
-            except RegistrarError as exc:
-                logger.error("failed to register %s: %s", repo, exc)
-
-        # Last: the IPC server (so subscribers can connect once
-        # everything else is live).
+        # IPC server comes up here, NOT after the tunnel. See the
+        # docstring above for the rationale.
         self._ipc_server = IPCServer(
             socket_path=self._paths.socket_file,
             status_provider=self._build_status_snapshot,
@@ -144,6 +156,13 @@ class Daemon:
             ship_state_list_provider=self._build_ship_state_list,
         )
         await self._ipc_server.start()
+
+        # Tunnel supervisor: brings up Funnel (retrying forever with
+        # capped backoff), registers webhooks when it's up, watches
+        # for mid-session loss.
+        self._tunnel_supervisor_task = asyncio.create_task(
+            self._tunnel_supervisor_loop()
+        )
 
         # Continuously heal ship-state drift against GitHub truth.
         # Webhook events alone can't keep state accurate — re-runs get
@@ -174,8 +193,17 @@ class Daemon:
         await self._stop_event.wait()
 
     async def stop(self) -> None:
-        # Fire the event so a concurrent run() returns.
+        # Fire the event so a concurrent run() and the tunnel
+        # supervisor both observe the stop.
         self._stop_event.set()
+
+        # Cancel the tunnel supervisor before IPC shutdown so it
+        # doesn't try to push a status update into a closed server.
+        if self._tunnel_supervisor_task is not None:
+            self._tunnel_supervisor_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError, Exception):
+                await self._tunnel_supervisor_task
+            self._tunnel_supervisor_task = None
 
         if self._ipc_server is not None:
             await self._ipc_server.stop()
@@ -198,6 +226,132 @@ class Daemon:
 
     async def _request_stop(self) -> None:
         self._stop_event.set()
+
+    # Capped exponential backoff for tunnel retry. Starts aggressive
+    # for fast recovery from tailscaled warmup / DERP fallback, caps
+    # at 5min so a tailnet that's genuinely offline for hours doesn't
+    # spam the probe (still retries forever, just rarely).
+    _TUNNEL_RETRY_BACKOFFS: tuple[float, ...] = (
+        2.0, 6.0, 15.0, 30.0, 60.0, 120.0, 300.0,
+    )
+    # Once the tunnel is up, verify cadence. A tailnet that drops mid-
+    # session (sleep/wake, VPN switch, admin panel change) is detected
+    # within this window and the supervisor kicks a re-establish.
+    _TUNNEL_VERIFY_INTERVAL_SECS: float = 30.0
+
+    async def _tunnel_supervisor_loop(self) -> None:
+        """Bring the tunnel up, keep it up, never let it kill the daemon.
+
+        Three phases run in sequence inside an outer while-not-stopped
+        loop:
+
+          * **Bring-up.** Probe + start the tunnel. On failure, wait
+            `_TUNNEL_RETRY_BACKOFFS[i]` seconds (capped) and retry.
+            `_stop_event` preempts the sleep so shutdown is prompt.
+          * **Register webhooks.** Idempotent; runs every time the
+            tunnel comes up (new tunnel → same Tailscale DNS name →
+            existing hook still valid; the registrar dedupes).
+          * **Watch.** Verify every
+            `_TUNNEL_VERIFY_INTERVAL_SECS`. If the verify fails, flip
+            tunnel state to None (so IPC status reports the loss) and
+            loop back to bring-up.
+
+        The daemon never exits because of tunnel trouble. IPC stays
+        up, `shipyard wait` + GUI fast-path keeps working on the
+        local store, and live webhook delivery resumes automatically
+        whenever the tunnel recovers.
+        """
+        try:
+            while not self._stop_event.is_set():
+                tunnel_info = await self._bring_up_tunnel()
+                if tunnel_info is None:
+                    return  # stopped during bring-up
+
+                self._state.tunnel = tunnel_info
+                self._state.tunnel_verified_at = time.time()
+                logger.info("tunnel ready: %s", tunnel_info.public_url)
+                await self._register_webhooks(tunnel_info)
+
+                # Watch loop: periodically re-verify. When verify
+                # fails, fall through to the outer loop which restarts
+                # bring-up.
+                await self._watch_tunnel()
+                # Watch exited → either stop-requested or tunnel lost.
+                if self._stop_event.is_set():
+                    return
+                logger.warning(
+                    "tunnel lost mid-session; re-establishing (URL was %s)",
+                    tunnel_info.public_url,
+                )
+                self._state.tunnel = None
+                self._state.tunnel_verified_at = None
+        except asyncio.CancelledError:  # pragma: no cover — shutdown
+            raise
+        except Exception as exc:  # noqa: BLE001 — must never crash daemon
+            logger.error("tunnel supervisor crashed: %s", exc, exc_info=True)
+
+    async def _bring_up_tunnel(self) -> TunnelInfo | None:
+        """Retry tunnel.start indefinitely (capped backoff) until it
+        succeeds or stop is requested."""
+        attempt = 0
+        assert self._webhook_port is not None  # start() invariant
+        while not self._stop_event.is_set():
+            try:
+                return await self._tunnel.start(self._webhook_port)
+            except (TunnelNotReadyError, TunnelStartError) as exc:
+                wait_secs = self._TUNNEL_RETRY_BACKOFFS[
+                    min(attempt, len(self._TUNNEL_RETRY_BACKOFFS) - 1)
+                ]
+                attempt += 1
+                logger.info(
+                    "tunnel bring-up attempt %d failed: %s "
+                    "(retrying in %.0fs)",
+                    attempt, exc, wait_secs,
+                )
+                # Sleep preempted by stop_event so shutdown doesn't
+                # wait out the full backoff.
+                try:
+                    await asyncio.wait_for(
+                        self._stop_event.wait(), timeout=wait_secs
+                    )
+                    return None  # stop requested
+                except TimeoutError:
+                    continue
+        return None
+
+    async def _register_webhooks(self, tunnel_info: TunnelInfo) -> None:
+        """Idempotent webhook registration. Safe to call on every
+        tunnel bring-up — Registrar reuses existing hook IDs."""
+        assert self._webhook_secret is not None
+        public_url = tunnel_info.public_url.rstrip("/") + "/webhook"
+        for repo in self._config.repos:
+            try:
+                await self._registrar.ensure_registered(
+                    repo, public_url, self._webhook_secret
+                )
+            except RegistrarError as exc:
+                logger.error("failed to register %s: %s", repo, exc)
+
+    async def _watch_tunnel(self) -> None:
+        """Poll `tunnel.verify` every `_TUNNEL_VERIFY_INTERVAL_SECS`
+        and return once the verification fails or stop is requested."""
+        assert self._webhook_port is not None
+        while not self._stop_event.is_set():
+            try:
+                await asyncio.wait_for(
+                    self._stop_event.wait(),
+                    timeout=self._TUNNEL_VERIFY_INTERVAL_SECS,
+                )
+                return  # stop requested
+            except TimeoutError:
+                pass
+            try:
+                ok = await self._tunnel.verify(self._webhook_port)
+            except Exception as exc:  # noqa: BLE001 — verify must never crash the loop
+                logger.warning("tunnel verify raised: %s", exc)
+                return
+            if not ok:
+                return
 
     async def _on_delivery(
         self,

--- a/tests/daemon/test_tunnel_supervisor.py
+++ b/tests/daemon/test_tunnel_supervisor.py
@@ -1,0 +1,235 @@
+"""Daemon never dies from tunnel trouble.
+
+These tests lock in the post-refactor contract:
+
+1. IPC server comes up even when the tunnel probe fails at startup.
+2. Tunnel supervisor retries forever with capped backoff until stop.
+3. Mid-session tunnel loss (verify() → False) triggers re-establish
+   without touching the IPC server.
+
+Driven through the `Daemon` class directly with a fake tunnel
+backend — no real tailscaled / webhook server / gh involved.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from shipyard.daemon.controller import Daemon, DaemonConfig
+from shipyard.daemon.tunnels.base import (
+    TunnelInfo,
+    TunnelNotReadyError,
+)
+
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="daemon uses AF_UNIX sockets; macOS/Linux only",
+)
+
+
+@dataclass
+class _FakeTunnelState:
+    """Mutable script driving the fake tunnel's behavior per-call.
+
+    Tests set the `plan` list ahead of time: each entry is either
+    "fail" (raise TunnelNotReadyError), "ok" (return a TunnelInfo),
+    and subsequent `verify` calls consult `verify_plan` similarly.
+    """
+
+    plan: list[str]
+    start_calls: int = 0
+    verify_plan: list[bool] | None = None
+    verify_calls: int = 0
+
+
+class _FakeTunnel:
+    name = "tailscale"
+
+    def __init__(self, state: _FakeTunnelState) -> None:
+        self.state = state
+
+    async def start(self, local_port: int) -> TunnelInfo:
+        self.state.start_calls += 1
+        i = self.state.start_calls - 1
+        # After the plan is exhausted, repeat the last step so tests
+        # that want "forever failing" can pass plan=["fail"] and tests
+        # that want "always healthy" can pass plan=["ok"].
+        step = self.state.plan[i] if i < len(self.state.plan) else self.state.plan[-1]
+        if step == "fail":
+            raise TunnelNotReadyError("simulated: not ready")
+        return TunnelInfo(public_url="https://fake.ts.net", backend=self.name)
+
+    async def stop(self) -> None:
+        return None
+
+    async def verify(self, local_port: int) -> bool:
+        self.state.verify_calls += 1
+        if self.state.verify_plan is None:
+            return True
+        i = self.state.verify_calls - 1
+        if i >= len(self.state.verify_plan):
+            return True
+        return self.state.verify_plan[i]
+
+
+class _FakeWebhookServer:
+    def __init__(self, _handler):
+        pass
+
+    def start(self) -> int:
+        return 12345  # arbitrary port
+
+    def stop(self) -> None:
+        return None
+
+
+class _FakeRegistrar:
+    def __init__(self, _state_dir):
+        self.calls: list[tuple[str, str]] = []
+
+    def all(self) -> dict[str, int]:
+        return {}
+
+    async def ensure_registered(
+        self, repo: str, url: str, secret: str, **kw
+    ) -> int:
+        self.calls.append((repo, url))
+        return 1
+
+    async def unregister_all(self, **kw) -> None:
+        return None
+
+
+def _make_daemon(tmp: Path, tunnel_state: _FakeTunnelState) -> Daemon:
+    cfg = DaemonConfig(state_dir=tmp, repos=["owner/repo"])
+    daemon = Daemon(cfg)
+    daemon._tunnel = _FakeTunnel(tunnel_state)  # type: ignore[assignment]
+    daemon._registrar = _FakeRegistrar(tmp)  # type: ignore[assignment]
+    # Shorten backoffs to keep tests fast. The first attempt is
+    # immediate regardless; we just need the retry sleeps to be 0.
+    daemon._TUNNEL_RETRY_BACKOFFS = (0.0, 0.0, 0.0)  # type: ignore[assignment]
+    daemon._TUNNEL_VERIFY_INTERVAL_SECS = 0.05  # type: ignore[assignment]
+    return daemon
+
+
+def _patch_webhook_server():
+    """Patch WebhookServer in the controller module so start() doesn't
+    bind a real TCP listener."""
+    return patch(
+        "shipyard.daemon.controller.WebhookServer",
+        _FakeWebhookServer,
+    )
+
+
+def test_ipc_comes_up_even_when_tunnel_probe_keeps_failing() -> None:
+    """Startup invariant. Tunnel probe fails on the first call — daemon
+    must still have its IPC socket listening so subscribers can
+    connect, rather than exiting like the old behavior."""
+
+    async def run() -> None:
+        with tempfile.TemporaryDirectory(prefix="sy-supv-") as tmp:
+            # Infinite "fail" via single-entry plan (last step
+            # repeats forever once exhausted).
+            daemon = _make_daemon(
+                Path(tmp),
+                _FakeTunnelState(plan=["fail"]),
+            )
+            # Non-zero backoff to ensure the supervisor doesn't keep
+            # sending retries while our assertions run.
+            daemon._TUNNEL_RETRY_BACKOFFS = (0.5,)  # type: ignore[assignment]
+            with _patch_webhook_server():
+                await daemon.start()
+                try:
+                    # Give the supervisor a few ticks to attempt retries.
+                    await asyncio.sleep(0.1)
+                    # IPC socket is bound + accepting, despite tunnel
+                    # not being up.
+                    sock_path = Path(tmp) / "daemon" / "daemon.sock"
+                    assert sock_path.exists(), (
+                        "IPC socket must be listening even without tunnel"
+                    )
+                    # Status reflects tunnel-not-ready truth.
+                    state = daemon._build_status_snapshot()
+                    assert state.tunnel_url is None
+                    assert state.tunnel_verified_at is None
+                finally:
+                    await daemon.stop()
+
+    asyncio.run(run())
+
+
+def test_transient_tunnel_bring_up_eventually_succeeds() -> None:
+    """Classic recovery: N failures, then success. Webhooks register
+    exactly once after the tunnel lands."""
+
+    async def run() -> None:
+        with tempfile.TemporaryDirectory(prefix="sy-supv-") as tmp:
+            ts = _FakeTunnelState(plan=["fail", "fail", "ok"])
+            daemon = _make_daemon(Path(tmp), ts)
+            with _patch_webhook_server():
+                await daemon.start()
+                try:
+                    # Poll for the tunnel state to settle. With 0s
+                    # backoff this should happen within a handful of
+                    # event-loop ticks.
+                    for _ in range(200):
+                        if daemon._state.tunnel is not None:
+                            break
+                        await asyncio.sleep(0.01)
+                    assert daemon._state.tunnel is not None
+                    assert daemon._state.tunnel.public_url == "https://fake.ts.net"
+                    assert ts.start_calls == 3
+                    # Registrar fired once for the configured repo.
+                    reg = daemon._registrar  # type: ignore[attr-defined]
+                    assert reg.calls == [
+                        ("owner/repo", "https://fake.ts.net/webhook"),
+                    ]
+                finally:
+                    await daemon.stop()
+
+    asyncio.run(run())
+
+
+def test_tunnel_loss_mid_session_re_establishes() -> None:
+    """Up → verify fails → down → re-establish. The daemon must
+    not exit during the transition."""
+
+    async def run() -> None:
+        with tempfile.TemporaryDirectory(prefix="sy-supv-") as tmp:
+            ts = _FakeTunnelState(
+                plan=["ok", "ok"],
+                verify_plan=[True, False],  # healthy once, then lost
+            )
+            daemon = _make_daemon(Path(tmp), ts)
+            with _patch_webhook_server():
+                await daemon.start()
+                try:
+                    # Wait for first bring-up.
+                    for _ in range(200):
+                        if daemon._state.tunnel is not None:
+                            break
+                        await asyncio.sleep(0.01)
+                    assert daemon._state.tunnel is not None
+                    first_url = daemon._state.tunnel.public_url
+                    # Wait for re-establish after verify False.
+                    for _ in range(400):
+                        if ts.start_calls >= 2:
+                            break
+                        await asyncio.sleep(0.01)
+                    assert ts.start_calls >= 2, (
+                        "supervisor should re-establish after verify()=False"
+                    )
+                    # Tunnel state is back up.
+                    assert daemon._state.tunnel is not None
+                    assert daemon._state.tunnel.public_url == first_url
+                finally:
+                    await daemon.stop()
+
+    asyncio.run(run())


### PR DESCRIPTION
Full fix for the shipyard#26 class of problems: the daemon must
not exit when the tunnel is temporarily unavailable. IPC stays up,
subscribers (GUI, `shipyard wait`) keep working, and the tunnel
re-establishes automatically when it can.

## What changed in Daemon.start()

Old ordering (fragile):
  1. acquire lock
  2. secret
  3. webhook server
  4. TUNNEL → fail here kills the whole daemon
  5. register webhooks
  6. IPC server

New ordering:
  1. acquire lock
  2. secret
  3. webhook server (bind port — target for tunnel)
  4. **IPC server** — subscribers can now connect immediately
  5. tunnel supervisor spawned as a background task
  6. reconcile loop spawned as a background task

`start()` now only raises on truly fatal failures (PID lock,
port bind, socket setup). Tunnel trouble no longer takes the
daemon down.

## Tunnel supervisor loop

Three phases, all inside a not-stopped outer loop:

- **Bring-up.** Retry `tunnel.start` forever with capped
  exponential backoff (2s, 6s, 15s, 30s, 60s, 120s, 300s).
  Preemptable by stop_event so shutdown is prompt.
- **Register.** Idempotent webhook registration runs every
  time the tunnel lands. Same Tailscale DNS name → same URL →
  Registrar dedupes on repo and reuses existing hook IDs.
- **Watch.** `tunnel.verify(port)` every 30s. When it fails,
  log loudly, flip `_state.tunnel` to None, and loop back to
  bring-up.

Mid-session tunnel loss (sleep/wake, VPN switch, Tailscale
admin panel change) is now a recoverable event. IPC stays
listening the whole time; `_build_status_snapshot()` reports
an accurate tunnel state; the GUI renders "polling — tunnel
warming up" and flips back to "live" once the re-establish
completes. No manual `shipyard daemon stop` needed.

## Stop is clean

Cancellation of the supervisor task is the first thing stop()
does, so it can't race with the IPC teardown and push a final
status update into a dead server.

## Regression coverage

tests/daemon/test_tunnel_supervisor.py:
- `test_ipc_comes_up_even_when_tunnel_probe_keeps_failing` — the
  critical startup-time invariant. Fake tunnel with an
  always-fail plan; assert the IPC socket exists and status
  accurately shows tunnel_url=None.
- `test_transient_tunnel_bring_up_eventually_succeeds` — 2
  failures, then success; webhooks register exactly once.
- `test_tunnel_loss_mid_session_re_establishes` — verify
  returns False after an initial success; supervisor re-runs
  bring-up without the daemon exiting.

Closes shipyard#26.

Version-Bump: cli=minor reason="new tunnel-supervisor + IPC-first startup ordering"