### PR TITLE
config: worktree falls back to main checkout's .shipyard.local; better no-host error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to Shipyard are documented here. Each entry links
 to its [GitHub Release](https://github.com/danielraffel/Shipyard/releases).
 
 <a id="v0270"></a>
+## [0.27.1]
+
 ## [0.27.0] - 2026-04-22
 
 - feat/daemon tunnel supervisor ([#161](https://github.com/danielraffel/Shipyard/pull/161))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "shipyard"
-version = "0.27.0"
+version = "0.27.1"
 description = "Cross-platform CI coordination — local VMs, SSH hosts, cloud runners"
 readme = "README.md"
 license = "MIT"

--- a/src/shipyard/__init__.py
+++ b/src/shipyard/__init__.py
@@ -1,3 +1,3 @@
 """Shipyard — Cross-platform CI coordination."""
 
-__version__ = "0.27.0"
+__version__ = "0.27.1"

--- a/src/shipyard/core/config.py
+++ b/src/shipyard/core/config.py
@@ -152,13 +152,39 @@ class Config:
 
     @classmethod
     def load_from_cwd(cls, cwd: Path | None = None) -> Config:
-        """Load config by scanning for .shipyard/ from the given directory."""
+        """Load config by scanning for .shipyard/ from the given directory.
+
+        Git-worktree aware: `.shipyard.local/config.toml` is gitignored
+        so `git worktree add` never copies it. The main checkout has
+        the local overlay; the worktree only has the tracked
+        `.shipyard/config.toml`. Without special handling, running
+        `shipyard pr` from a worktree loads config that resolves
+        ssh targets to `<no host>` and preflight fails with a
+        confusing "backend unreachable" error even though ssh works.
+        See shipyard#155.
+
+        Fix: when the cwd is a git worktree AND it has no local
+        overlay of its own, fall through to the main checkout's
+        `.shipyard.local/` if one exists. Documented explicitly in
+        `local_dir_source` on the returned Config so callers can
+        surface "we borrowed local config from the main checkout"
+        if they want.
+        """
         base = cwd or Path.cwd()
         project_dir = base / ".shipyard"
         local_dir = base / ".shipyard.local"
+
+        resolved_local_dir: Path | None = None
+        if local_dir.exists() and (local_dir / "config.toml").exists():
+            resolved_local_dir = local_dir
+        else:
+            fallback = _worktree_main_local_dir(base)
+            if fallback is not None:
+                resolved_local_dir = fallback
+
         return cls.load(
             project_dir=project_dir if project_dir.exists() else None,
-            local_dir=local_dir if local_dir.exists() else None,
+            local_dir=resolved_local_dir,
         )
 
     def save_project(self, path: Path | None = None) -> None:
@@ -171,6 +197,60 @@ class Config:
 
     def to_dict(self) -> dict[str, Any]:
         return copy.deepcopy(self.data)
+
+
+def _worktree_main_local_dir(base: Path) -> Path | None:
+    """If `base` is a git worktree whose main checkout has a usable
+    `.shipyard.local/config.toml`, return that directory. Otherwise
+    `None`.
+
+    The contract from `git worktree add`: the worktree's `.git` is a
+    file pointing at `<common>/worktrees/<name>`, and
+    `git rev-parse --git-common-dir` resolves to the original
+    checkout's `.git` directory. Going up one level from that gives
+    the main checkout root, which is where the gitignored
+    `.shipyard.local/` lives.
+
+    Bail quietly (return None) on:
+    - base not in a git repo at all
+    - git not on PATH
+    - the "common dir" path doesn't resolve to a checkout with a
+      `.shipyard.local/config.toml`
+    - the base IS the main checkout (no fallback needed or wanted)
+    """
+    import subprocess
+
+    try:
+        res = subprocess.run(
+            ["git", "rev-parse", "--git-common-dir"],
+            cwd=str(base),
+            capture_output=True,
+            text=True,
+            timeout=3,
+            check=False,
+        )
+    except (FileNotFoundError, subprocess.SubprocessError):
+        return None
+    if res.returncode != 0:
+        return None
+    common_dir = Path(res.stdout.strip())
+    if not common_dir.is_absolute():
+        common_dir = (base / common_dir).resolve()
+    # Main checkout root is the parent of the .git directory that
+    # git-common-dir points at.
+    main_checkout = common_dir.parent
+    # Don't fall back to ourselves. If base's own .git resolves to
+    # the same common_dir, we ARE the main checkout and our own
+    # `.shipyard.local/` was already checked.
+    try:
+        if main_checkout.resolve() == base.resolve():
+            return None
+    except OSError:
+        return None
+    candidate = main_checkout / ".shipyard.local"
+    if (candidate / "config.toml").exists():
+        return candidate
+    return None
 
 
 def _load_toml(path: Path) -> dict[str, Any]:

--- a/src/shipyard/executor/ssh.py
+++ b/src/shipyard/executor/ssh.py
@@ -711,7 +711,8 @@ def _format_ssh_diagnosis(
     target_config: dict[str, Any], diag: dict[str, Any]
 ) -> str:
     """Compose the preflight error message for an unreachable SSH target."""
-    host = target_config.get("host") or "<no host>"
+    host_raw = target_config.get("host")
+    host = host_raw or "<no host>"
     user_at_host = host if "@" in host else host
     port = target_config.get("port")
     if port:
@@ -729,6 +730,26 @@ def _format_ssh_diagnosis(
     last = diag.get("last_error")
     if last:
         lines.append(f"  Last error: {last}")
+    # Missing-host is almost always "gitignored `.shipyard.local/`
+    # wasn't copied into this worktree." The generic "backend
+    # unreachable" framing above leads users down a network-debugging
+    # rabbit hole (Tailscale, VPN, DNS) when the real fix is 30s of
+    # `cp -r <main>/.shipyard.local/ .`. Call it out explicitly.
+    # See shipyard#155.
+    if not host_raw or category == "configuration":
+        lines.append("")
+        lines.append(
+            "  Hint: the target has no host configured. If you're running "
+            "from a git worktree, the gitignored .shipyard.local/config.toml "
+            "from the main checkout wasn't copied over. Copy it in:"
+        )
+        lines.append(
+            "    cp -r <main-checkout>/.shipyard.local ./"
+        )
+        lines.append(
+            "  shipyard now auto-discovers it too when one exists — re-run "
+            "from a terminal in this worktree to trigger the fallback lookup."
+        )
     return "\n".join(lines)
 
 

--- a/tests/core/test_config_worktree_fallback.py
+++ b/tests/core/test_config_worktree_fallback.py
@@ -1,0 +1,108 @@
+"""Git-worktree awareness in `Config.load_from_cwd`.
+
+Covers shipyard#155: `.shipyard.local/config.toml` is gitignored so
+`git worktree add` never copies it. Running `shipyard pr` from a
+worktree loaded a config with `host=<no host>` for ssh targets and
+preflight failed with a confusing "backend unreachable" error.
+
+After the fix, a worktree with no `.shipyard.local/` of its own
+transparently picks up the main checkout's. Main checkouts and
+non-worktree layouts are unaffected.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from shipyard.core.config import Config
+
+
+def _git(*args: str, cwd: Path) -> None:
+    subprocess.check_call(["git", *args], cwd=cwd, stdout=subprocess.DEVNULL,
+                          stderr=subprocess.DEVNULL)
+
+
+@pytest.fixture
+def main_repo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Seed a git repo with a tracked `.shipyard/config.toml` and a
+    gitignored `.shipyard.local/config.toml`. Returns the repo root."""
+    monkeypatch.setenv("GIT_AUTHOR_NAME", "T")
+    monkeypatch.setenv("GIT_AUTHOR_EMAIL", "t@t")
+    monkeypatch.setenv("GIT_COMMITTER_NAME", "T")
+    monkeypatch.setenv("GIT_COMMITTER_EMAIL", "t@t")
+    repo = tmp_path / "main"
+    repo.mkdir()
+    _git("init", "--quiet", "--initial-branch=main", cwd=repo)
+    (repo / ".shipyard").mkdir()
+    (repo / ".shipyard" / "config.toml").write_text(
+        '[targets.windows]\nbackend = "ssh-windows"\n'
+    )
+    (repo / ".shipyard.local").mkdir()
+    (repo / ".shipyard.local" / "config.toml").write_text(
+        '[targets.windows]\nhost = "win.example"\n'
+    )
+    (repo / ".gitignore").write_text(".shipyard.local/\n")
+    (repo / "README.md").write_text("seed\n")
+    _git("add", ".", cwd=repo)
+    _git("commit", "-q", "-m", "seed", cwd=repo)
+    return repo
+
+
+def test_main_checkout_uses_its_own_local(main_repo: Path) -> None:
+    """No fallback path for a plain main checkout — behavior
+    unchanged from pre-fix."""
+    cfg = Config.load_from_cwd(main_repo)
+    targets = cfg.get("targets") or {}
+    assert targets.get("windows", {}).get("host") == "win.example"
+
+
+def test_worktree_falls_back_to_main_checkout_local(
+    main_repo: Path, tmp_path: Path
+) -> None:
+    """The worktree has no `.shipyard.local/` of its own. Fallback
+    must find the main checkout's gitignored overlay and merge it
+    into the returned config."""
+    worktree = tmp_path / "feature"
+    _git("worktree", "add", "-b", "feature/x", str(worktree), cwd=main_repo)
+
+    # Sanity: the worktree has the tracked config but not the local.
+    assert (worktree / ".shipyard" / "config.toml").exists()
+    assert not (worktree / ".shipyard.local" / "config.toml").exists()
+
+    cfg = Config.load_from_cwd(worktree)
+    targets = cfg.get("targets") or {}
+    assert targets.get("windows", {}).get("host") == "win.example", (
+        "worktree should have inherited host from main checkout's "
+        ".shipyard.local/config.toml"
+    )
+
+
+def test_worktree_with_own_local_ignores_main(
+    main_repo: Path, tmp_path: Path
+) -> None:
+    """If a worktree has its own `.shipyard.local/`, it wins. The
+    fallback only fires when the worktree-local doesn't exist."""
+    worktree = tmp_path / "feature"
+    _git("worktree", "add", "-b", "feature/x", str(worktree), cwd=main_repo)
+    (worktree / ".shipyard.local").mkdir()
+    (worktree / ".shipyard.local" / "config.toml").write_text(
+        '[targets.windows]\nhost = "worktree-specific"\n'
+    )
+
+    cfg = Config.load_from_cwd(worktree)
+    targets = cfg.get("targets") or {}
+    assert targets.get("windows", {}).get("host") == "worktree-specific"
+
+
+def test_non_git_directory_returns_none_fallback(tmp_path: Path) -> None:
+    """`Config.load_from_cwd` must not crash outside a git repo. The
+    fallback returns None silently in that case."""
+    (tmp_path / ".shipyard").mkdir()
+    (tmp_path / ".shipyard" / "config.toml").write_text(
+        '[project]\nname = "test"\n'
+    )
+    cfg = Config.load_from_cwd(tmp_path)
+    assert cfg.get("project.name") == "test"


### PR DESCRIPTION
Two related fixes for shipyard#155. User runs \`shipyard pr\` from
a git worktree → preflight fails with "SSH backend unreachable at
<no host>". Root cause: \`.shipyard.local/config.toml\` is
gitignored, so \`git worktree add\` never copies it. The worktree
loads only the tracked \`.shipyard/config.toml\` (which has no
\`host =\` lines); ssh targets resolve to \`<no host>\`; preflight
aborts the ship even though plain \`ssh <host>\` from the same shell
works fine.

## 1. Config.load_from_cwd is worktree-aware

When the cwd's \`.shipyard.local/config.toml\` doesn't exist, we now
look up the main checkout via \`git rev-parse --git-common-dir\`
and check there. If the main checkout has the overlay, use it
transparently — the worktree user doesn't have to hand-copy
anything, and plain main checkouts behave exactly as before
(fallback returns None).

The check is scoped tightly:
- Non-git directories → fallback returns None (graceful)
- Main checkout itself → fallback returns None (don't recurse)
- Missing git binary / subprocess error → fallback returns None

## 2. The "no host" error now names the worktree scenario

Before, the user saw "SSH backend unreachable at <no host>" +
Tailscale-style network troubleshooting suggestions, which led
them down an unrelated debugging path. Now the error adds:

    Hint: the target has no host configured. If you're running
    from a git worktree, the gitignored .shipyard.local/config.toml
    from the main checkout wasn't copied over.

And names the fix command + notes that v0.27.1+ auto-discovers
the main checkout's overlay.

## Regression coverage

tests/core/test_config_worktree_fallback.py:
- Main checkout uses its own local (no fallback path triggered)
- Worktree falls back to main checkout's local (the real fix)
- Worktree with its OWN local ignores main (fallback only fires
  when needed)
- Non-git directory doesn't crash

Closes shipyard#155. Incidentally tightens the error path users
see for shipyard#157 too, so an unrelated config-loss surface
doesn't look like a network flake anymore.

Version-Bump: cli=patch reason="config-discovery + error-text improvements"