### PR TITLE
ship: run preflight before opening the PR (close shipyard#157)

### DIFF
--- a/src/shipyard/cli.py
+++ b/src/shipyard/cli.py
@@ -2823,7 +2823,47 @@ def ship(
     if _should_auto_create_base(base, auto_create_base):
         _maybe_auto_create_base_branch(ctx, base)
 
-    # Push branch
+    # ── Preflight BEFORE opening the PR ─────────────────────────
+    # shipyard#157: opening the PR and then aborting on a preflight
+    # failure (e.g. a flaky ssh probe, a worktree missing its
+    # .shipyard.local overlay) leaves the user with a stranded PR
+    # that was never dispatched, no CI runs kicked off, and no
+    # ship-state progress. Running preflight first means any
+    # reachability / config failure exits before we touch GitHub at
+    # all. If preflight passes, the PR creation + push below are
+    # safe to proceed.
+    #
+    # Preflight itself doesn't depend on the PR existing — it only
+    # needs the config, the target list, and the local repo layout.
+    config = ctx.config
+    target_names = list(config.targets.keys())
+    if not target_names:
+        render_error("No targets configured")
+        sys.exit(1)
+    dispatcher = _make_dispatcher(config)
+    try:
+        preflight = run_submission_preflight(
+            config,
+            target_names=target_names,
+            dispatcher=dispatcher,
+            allow_root_mismatch=allow_root_mismatch,
+            allow_unreachable_targets=allow_unreachable_targets,
+            skip_targets=skip_target,
+        )
+    except BackendUnreachableError as exc:
+        render_error(str(exc))
+        sys.exit(EXIT_BACKEND_UNREACHABLE)
+    except ValueError as exc:
+        render_error(str(exc))
+        sys.exit(1)
+
+    if not ctx.json_mode:
+        for warning in preflight.warnings:
+            render_message(warning, style="yellow")
+
+    # Push branch (only after preflight passed — no orphan PR if
+    # preflight later rejects something we'd otherwise have pushed
+    # a commit for).
     subprocess.run(["git", "push", "-u", "origin", branch], capture_output=True)
 
     # Find or create PR
@@ -2843,13 +2883,6 @@ def ship(
 
     if not pr_info:
         render_error("Failed to create or find PR")
-        sys.exit(1)
-
-    # Run validation
-    config = ctx.config
-    target_names = list(config.targets.keys())
-    if not target_names:
-        render_error("No targets configured")
         sys.exit(1)
 
     # ── Durable ship-state: detect or create ────────────────────
@@ -2928,27 +2961,9 @@ def ship(
         existing_state.touch()
         ship_state_store.save(existing_state)
 
-    dispatcher = _make_dispatcher(config)
-    try:
-        preflight = run_submission_preflight(
-            config,
-            target_names=target_names,
-            dispatcher=dispatcher,
-            allow_root_mismatch=allow_root_mismatch,
-            allow_unreachable_targets=allow_unreachable_targets,
-            skip_targets=skip_target,
-        )
-    except BackendUnreachableError as exc:
-        render_error(str(exc))
-        sys.exit(EXIT_BACKEND_UNREACHABLE)
-    except ValueError as exc:
-        render_error(str(exc))
-        sys.exit(1)
-
-    if not ctx.json_mode:
-        for warning in preflight.warnings:
-            render_message(f"warning: {warning}", style="bold yellow")
-
+    # Preflight already ran above (before PR creation, per
+    # shipyard#157). `preflight`, `dispatcher`, and `target_names`
+    # are in scope here.
     target_names = [n for n in target_names if n not in set(skip_target)]
     if not target_names:
         render_error("No targets remain after --skip-target filtering.")

--- a/tests/test_ship_preflight_before_pr.py
+++ b/tests/test_ship_preflight_before_pr.py
@@ -1,0 +1,124 @@
+"""Preflight runs BEFORE `gh pr create` — regression for shipyard#157.
+
+The old order was push → create_pr → preflight. If the ssh probe
+failed (flaky Tailscale, missing host config in a worktree), the PR
+was already open on GitHub with no ship-state, no dispatched runs,
+and no recovery path short of manually closing the PR. The new
+order runs preflight first: a probe failure exits cleanly and the
+user never sees a stranded PR.
+
+Drives `shipyard ship` through Click's CliRunner with every
+network operation mocked, then asserts that the preflight probe
+ran before any gh command would have.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from shipyard.cli import main
+from shipyard.preflight import BackendUnreachableError
+
+
+@pytest.fixture
+def mock_ship_env(monkeypatch: pytest.MonkeyPatch, tmp_path):
+    """Seed just enough of the shipyard environment to reach the
+    preflight call: fake git branch/sha, a project-dir config, and
+    a state_dir. Every subprocess and HTTP call we don't want to
+    run is patched off below."""
+    from shipyard.core.config import Config
+    from shipyard.core.ship_state import ShipStateStore
+
+    proj = tmp_path / ".shipyard"
+    proj.mkdir()
+    (proj / "config.toml").write_text(
+        '[project]\nname = "t"\n\n'
+        '[targets.ubuntu]\nbackend = "ssh"\nhost = "<no host>"\n'
+    )
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr("shipyard.cli._git_branch", lambda: "feat/x")
+    monkeypatch.setattr("shipyard.cli._git_sha", lambda: "deadbeefcafe")
+    monkeypatch.setattr(
+        "shipyard.cli._git_commit_subject", lambda _sha: "subject"
+    )
+    monkeypatch.setattr(
+        "shipyard.cli._detect_repo_slug_or_empty", lambda: "owner/repo"
+    )
+    monkeypatch.setattr(
+        "shipyard.cli._pr_url", lambda _repo, _n: "https://example/pr/1"
+    )
+    monkeypatch.setattr(
+        "shipyard.core.config.Config.load_from_cwd",
+        lambda cwd=None: Config(
+            data={
+                "project": {"name": "t"},
+                "targets": {
+                    "ubuntu": {
+                        "backend": "ssh",
+                        "host": "<no host>",
+                    },
+                },
+            },
+            global_dir=tmp_path / "_global",
+            project_dir=proj,
+        ),
+    )
+    # Fresh ship-state store so we can observe whether a state
+    # file got written (it shouldn't on preflight failure).
+    store = ShipStateStore(tmp_path / "ship")
+    return store, tmp_path
+
+
+def test_preflight_failure_does_not_create_pr(
+    mock_ship_env, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The critical #157 regression: a preflight failure must NOT
+    reach `create_pr` or `git push`. The user should see the
+    backend-unreachable error, exit code 3, and no leftover PR."""
+    store, tmp_path = mock_ship_env
+
+    # Preflight throws — simulates ssh probe failure / no host.
+    def fake_preflight(*args: Any, **kw: Any):
+        raise BackendUnreachableError(
+            "Target 'ubuntu' (ssh) is unreachable. "
+            "SSH backend unreachable at <no host>."
+        )
+
+    monkeypatch.setattr("shipyard.cli.run_submission_preflight", fake_preflight)
+
+    # Track whether GitHub would have been touched. These should
+    # NEVER fire if preflight runs first.
+    create_pr = MagicMock()
+    find_pr = MagicMock(return_value=None)
+    monkeypatch.setattr("shipyard.ship.pr.create_pr", create_pr)
+    monkeypatch.setattr("shipyard.ship.pr.find_pr_for_branch", find_pr)
+
+    # Track git-push invocations — also shouldn't fire.
+    push_calls = []
+
+    def fake_subprocess_run(*args: Any, **kw: Any):
+        cmd = args[0] if args else kw.get("args", [])
+        if isinstance(cmd, list) and len(cmd) >= 3 and cmd[:2] == ["git", "push"]:
+            push_calls.append(cmd)
+        return MagicMock(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr("subprocess.run", fake_subprocess_run)
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["ship"])
+    assert result.exit_code == 3, (
+        f"expected BackendUnreachable exit code 3, got {result.exit_code}\n"
+        f"output:\n{result.output}"
+    )
+    assert "unreachable" in result.output.lower()
+    # The real regression check: neither create_pr nor git push
+    # should have been reached.
+    create_pr.assert_not_called()
+    assert push_calls == [], (
+        "git push must not run before preflight passes — would leave "
+        f"a stranded PR. Got: {push_calls}"
+    )


### PR DESCRIPTION
User runs \`shipyard pr\`. Ship flow today pushed the branch,
called \`gh pr create\`, THEN ran the preflight ssh probe. If the
probe failed (flaky Tailscale DERP fallback, missing
\`.shipyard.local\` in a worktree, genuinely offline host), the
whole ship aborted with exit 3 — but the PR was already open on
GitHub, with no dispatched runs, no ship-state progress, and no
automatic recovery path. The user had to hand-close the PR or
kick \`shipyard ship\` again.

Reverse the order: preflight first, create_pr/push after. The
preflight call only needs config + target list + dispatcher, none
of which depend on the PR existing. If it fails, GitHub is never
touched; the user sees the error and fixes the underlying issue
(ssh config, Tailscale, target host) without cleanup.

\`git push\` also moves below preflight for the same reason —
pushing a branch that preflight would have rejected just wastes
a round-trip.

Closes shipyard#157. Pairs naturally with #155's worktree
\`.shipyard.local\` fallback (shipped v0.27.1): with both, a
worktree-related config miss gets auto-recovered, and if it
can't be auto-recovered, the user sees the clear error message
pointing at the fix rather than a stranded PR.

## Regression coverage

tests/test_ship_preflight_before_pr.py drives the full ship
command through Click's CliRunner with a preflight mock that
raises BackendUnreachableError. Asserts:
- exit code 3 (EXIT_BACKEND_UNREACHABLE)
- \`create_pr\` is never called
- \`git push\` never runs

Version-Bump: cli=patch reason="reorder preflight; no semantic API change"