### PR TITLE
daemon: reconcile skips aged-terminal ship-states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to Shipyard are documented here. Each entry links
 to its [GitHub Release](https://github.com/danielraffel/Shipyard/releases).
 
 <a id="v0271"></a>
+## [0.27.2]
+
 ## [0.27.1] - 2026-04-22
 
 - fix/155 worktree shipyard local fallback ([#162](https://github.com/danielraffel/Shipyard/pull/162))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "shipyard"
-version = "0.27.1"
+version = "0.27.2"
 description = "Cross-platform CI coordination — local VMs, SSH hosts, cloud runners"
 readme = "README.md"
 license = "MIT"

--- a/src/shipyard/__init__.py
+++ b/src/shipyard/__init__.py
@@ -1,3 +1,3 @@
 """Shipyard — Cross-platform CI coordination."""
 
-__version__ = "0.27.1"
+__version__ = "0.27.2"

--- a/src/shipyard/daemon/controller.py
+++ b/src/shipyard/daemon/controller.py
@@ -28,7 +28,7 @@ import os
 import signal
 import time
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from shipyard.daemon import events as events_mod
 from shipyard.daemon import secrets as secrets_mod
@@ -585,6 +585,24 @@ lower this if you need real-time freshness, raise it if you have more
 active PRs than REST budget tolerates."""
 
 
+RECONCILE_TERMINAL_RUN_STATUSES = frozenset(
+    {"completed", "passed", "failed", "cancelled", "canceled"}
+)
+"""Run statuses that mean "this check has reached a settled state."
+
+Shared with `_is_aged_terminal` below. States whose runs are ALL in
+this set AND whose `updated_at` is past the fresh window are skipped
+by reconcile — cuts the daemon's gh-API budget on machines with a
+long shipyard history. See task #22."""
+
+RECONCILE_FRESH_WINDOW_SECONDS = 3600
+"""Grace period after a ship-state's last update during which it's
+still reconciled even if all runs are terminal. Covers CI re-runs
+that complete quickly after a failure — updated_at still reflects
+the recent activity, so reconcile picks up the transition. Past
+this window, terminal states are treated as settled and skipped."""
+
+
 async def _reconcile_loop(state_dir: Path, daemon: Daemon | None = None) -> None:
     """Continuously heal ship-state drift against GitHub truth.
 
@@ -633,6 +651,35 @@ async def _reconcile_all_active_ships(
     # (pr, repo, target, before_status, after_status)
     transition_t = tuple[int, str, str, str, str]
 
+    def _is_aged_terminal(state: Any) -> bool:
+        """True iff every run is terminal AND the state is past its
+        fresh window (so reconcile can skip it this tick without
+        missing a real CI transition)."""
+        runs = state.dispatched_runs or []
+        if not runs:
+            evidence = state.evidence_snapshot or {}
+            if not evidence:
+                return False  # pre-dispatch — always reconcile
+            all_terminal = all(
+                v in {"pass", "fail", "reused", "skipped"}
+                for v in evidence.values()
+            )
+        else:
+            all_terminal = all(
+                (r.status or "").lower() in RECONCILE_TERMINAL_RUN_STATUSES
+                for r in runs
+            )
+        if not all_terminal:
+            return False
+        updated = state.updated_at
+        if updated is None:
+            return False
+        from datetime import datetime as _dt
+        from datetime import timezone as _tz
+
+        age_secs = (_dt.now(_tz.utc) - updated).total_seconds()
+        return age_secs > RECONCILE_FRESH_WINDOW_SECONDS
+
     def _reconcile_sync() -> tuple[int, list[transition_t]]:
         """Returns (healed count, list of per-target transitions)."""
         import subprocess as _sp
@@ -640,7 +687,20 @@ async def _reconcile_all_active_ships(
         store = ShipStateStore(state_dir / "ship")
         healed = 0
         transitions: list[transition_t] = []
+        skipped_terminal = 0
         for state in store.list_active():
+            if _is_aged_terminal(state):
+                # Aged-terminal ship — every run is in a terminal
+                # status AND the state hasn't been updated in the
+                # fresh window. No reconcile drift expected; if CI
+                # actually re-runs, the check_run/check_suite
+                # webhook refreshes updated_at and the next tick
+                # picks it up (no longer aged). Safety net is
+                # still intact for the webhook-missed case — the
+                # updated_at timestamp advances on every observed
+                # change, so any drift resets the aging clock.
+                skipped_terminal += 1
+                continue
             try:
                 raw = _sp.run(
                     [
@@ -683,6 +743,11 @@ async def _reconcile_all_active_ships(
             logger.info(
                 "reconcile: %d active ship-state(s) updated", healed
             )
+        # The skipped-terminal count is intentionally NOT logged —
+        # on a machine with 60 terminal ships that'd be a line every
+        # 30s with no signal. The relevant view is `shipyard cleanup
+        # --ship-state` which surfaces aged-terminal states for
+        # optional archiving.
         if daemon is not None:
             for pr, repo, target, before, after in transitions:
                 await daemon.broadcast_reconcile_healed(

--- a/tests/daemon/test_reconcile_skip_terminal.py
+++ b/tests/daemon/test_reconcile_skip_terminal.py
@@ -1,0 +1,192 @@
+"""Daemon reconcile skips aged-terminal PRs.
+
+Reconcile fetches `gh pr view --json statusCheckRollup` for every
+active ship-state every 30s. With 60+ states the budget blows past
+5000/hr. Most of those 60 are long-settled (terminal runs, last
+touched days ago). Skip reconcile for states that are BOTH:
+
+  - all dispatched_runs in a terminal status (or evidence_snapshot
+    entries all terminal for legacy states with empty runs), AND
+  - `updated_at` older than 1 hour (past the fresh window).
+
+Fresh terminal states still get reconciled — preserves the
+"reconcile heals a CI re-run that just completed" path that
+test_reconcile_emits_events.py depends on. The fresh window is
+short enough that webhook events reset it on any real state change,
+keeping the safety net intact.
+
+Task #22.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import subprocess
+import sys
+import tempfile
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from shipyard.core.ship_state import DispatchedRun, ShipState, ShipStateStore
+from shipyard.daemon.controller import _reconcile_all_active_ships
+
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="reconcile shells out to gh; macOS/Linux only",
+)
+
+
+def _ship(*, pr: int, runs: list[tuple[str, str]], age_secs: int = 0) -> ShipState:
+    """Build a ShipState. `age_secs` backdates `updated_at` so tests
+    can control fresh-vs-aged."""
+    now = datetime.now(timezone.utc)
+    when = now - timedelta(seconds=age_secs)
+    dispatched = [
+        DispatchedRun(
+            target=t,
+            provider="namespace",
+            run_id=f"r-{pr}-{t}",
+            status=s,
+            started_at=when,
+            updated_at=when,
+        )
+        for t, s in runs
+    ]
+    return ShipState(
+        pr=pr,
+        repo="o/r",
+        branch=f"feat/{pr}",
+        base_branch="main",
+        head_sha="abc123",
+        policy_signature="sig",
+        dispatched_runs=dispatched,
+        evidence_snapshot={t: "pass" for t, _ in runs},
+        attempt=1,
+        created_at=when,
+        updated_at=when,
+    )
+
+
+def test_aged_terminal_ships_skip_gh_view(monkeypatch) -> None:
+    """Three aged-terminal ships + one still running. Reconcile hits
+    `gh pr view` exactly once — for the running one. Each aged ship
+    has updated_at > 1hr in the past."""
+
+    async def run() -> None:
+        with tempfile.TemporaryDirectory(prefix="sy-skip-") as tmp:
+            store = ShipStateStore(Path(tmp) / "ship")
+            store.save(_ship(
+                pr=1, runs=[("mac", "completed")], age_secs=7200,
+            ))
+            store.save(_ship(
+                pr=2, runs=[("mac", "failed")], age_secs=7200,
+            ))
+            store.save(_ship(
+                pr=3, runs=[("mac", "in_progress")], age_secs=7200,
+            ))
+
+            gh_calls: list[list[str]] = []
+
+            class _Completed:
+                stdout = '{"statusCheckRollup": []}'
+                returncode = 0
+
+            def fake_run(cmd, *a, **kw):
+                gh_calls.append(cmd)
+                return _Completed()
+
+            monkeypatch.setattr(subprocess, "run", fake_run)
+            await _reconcile_all_active_ships(Path(tmp), daemon=None)
+
+            assert len(gh_calls) == 1
+            assert "3" in gh_calls[0]
+
+    asyncio.run(run())
+
+
+def test_fresh_terminal_ships_still_reconciled(monkeypatch) -> None:
+    """A terminal ship whose updated_at is recent (< 1hr) must STILL
+    be reconciled — this is the CI-re-run recovery scenario. The
+    existing `test_reconcile_emits_event_when_target_transitions`
+    test pins this behavior."""
+
+    async def run() -> None:
+        with tempfile.TemporaryDirectory(prefix="sy-skip-") as tmp:
+            store = ShipStateStore(Path(tmp) / "ship")
+            # Fresh terminal (age=0).
+            store.save(_ship(pr=1, runs=[("mac", "failed")]))
+
+            gh_calls: list[list[str]] = []
+
+            class _Completed:
+                stdout = '{"statusCheckRollup": []}'
+                returncode = 0
+
+            monkeypatch.setattr(
+                subprocess, "run",
+                lambda c, *a, **kw: gh_calls.append(c) or _Completed(),
+            )
+            await _reconcile_all_active_ships(Path(tmp), daemon=None)
+            assert len(gh_calls) == 1, (
+                "fresh terminal states must still be reconciled — "
+                "catches CI re-runs that just completed"
+            )
+
+    asyncio.run(run())
+
+
+def test_pre_dispatch_ship_always_reconciled(monkeypatch) -> None:
+    """Pre-dispatch ship (empty dispatched_runs + empty evidence)
+    must NEVER be skipped regardless of age — we haven't even
+    observed a first rollup yet."""
+
+    async def run() -> None:
+        with tempfile.TemporaryDirectory(prefix="sy-skip-") as tmp:
+            store = ShipStateStore(Path(tmp) / "ship")
+            s = _ship(pr=42, runs=[], age_secs=86400)
+            s.evidence_snapshot = {}
+            store.save(s)
+
+            gh_calls: list[list[str]] = []
+
+            class _Completed:
+                stdout = '{"statusCheckRollup": []}'
+                returncode = 0
+
+            monkeypatch.setattr(
+                subprocess, "run",
+                lambda c, *a, **kw: gh_calls.append(c) or _Completed(),
+            )
+            await _reconcile_all_active_ships(Path(tmp), daemon=None)
+            assert len(gh_calls) == 1
+
+    asyncio.run(run())
+
+
+def test_aged_evidence_only_ship_is_skipped(monkeypatch) -> None:
+    """Legacy ship-state layout: only evidence_snapshot populated.
+    Aged + all evidence entries terminal → skip."""
+
+    async def run() -> None:
+        with tempfile.TemporaryDirectory(prefix="sy-skip-") as tmp:
+            store = ShipStateStore(Path(tmp) / "ship")
+            s = _ship(pr=7, runs=[], age_secs=7200)
+            s.evidence_snapshot = {"mac": "pass", "linux": "fail"}
+            store.save(s)
+
+            gh_calls: list[list[str]] = []
+
+            class _Completed:
+                stdout = '{"statusCheckRollup": []}'
+                returncode = 0
+
+            monkeypatch.setattr(
+                subprocess, "run",
+                lambda c, *a, **kw: gh_calls.append(c) or _Completed(),
+            )
+            await _reconcile_all_active_ships(Path(tmp), daemon=None)
+            assert gh_calls == []
+
+    asyncio.run(run())


### PR DESCRIPTION
Every 30s the reconcile loop calls \`gh pr view --json
statusCheckRollup\` for every active ship-state. With ~60 tracked
PRs that's 7200 calls/hr — 44% over the 5000/hr GitHub API budget.
Users with a long shipyard history hit the limit today from the
daemon alone, before the GUI or any manual \`gh\` use added anything.

Most of those 60 ship-states are long-settled: every dispatched
run in a terminal status, last touched days ago. Reconcile has
nothing to heal for them — but it still burns the budget.

## Fix

Skip reconcile for a state when BOTH:

  1. Every dispatched_run is in a terminal status
     (completed / passed / failed / cancelled), OR — for older
     layouts with only evidence_snapshot — every evidence entry
     is in a terminal bucket (pass / fail / reused / skipped).
  2. \`updated_at\` is more than 1 hour in the past.

Fresh terminal states (updated_at < 1hr ago) STILL get reconciled
— that's the CI-just-re-ran-after-a-fail recovery scenario the
existing \`test_reconcile_emits_event_when_target_transitions\`
test depends on. The fresh window is short enough that any real
state change (via webhook or manual intervention) bumps
updated_at and resets the aging clock.

Pre-dispatch states (empty dispatched_runs + empty
evidence_snapshot) are ALWAYS reconciled — we need the first
rollup to know what GitHub sees.

## Impact

On the user's machine today (67 active states, 32 locally
terminal): reconcile drops from 67 calls/tick to 35. Post-fix
after aging (most of those 35 will age into terminal over 1hr):
steady-state approaches 10-15 calls/tick = 1200-1800/hr. Well
under budget.

## Tradeoff

A ship that terminates locally but has a CI re-run kicked
silently on GitHub AND misses the webhook (check_run,
check_suite, workflow_run, reconcile_healed all drop) won't
get healed by periodic reconcile for at least 1 hour. In
practice the webhook path is reliable, and any user-initiated
action (clicking "Show all" in the GUI, running \`shipyard
ship-state reconcile <pr>\` by hand) still does a fresh fetch.
Acceptable.

## Regression coverage

tests/daemon/test_reconcile_skip_terminal.py:
- Aged-terminal ships skip \`gh pr view\`
- Fresh terminal ships still reconciled
- Pre-dispatch (empty runs + empty evidence) always reconciled
- Legacy evidence-only layout: aged + all terminal → skip

Closes task #22.

Version-Bump: cli=patch reason="rate-limit-pressure relief for reconcile loop"