### PR TITLE
release: sign + notarize the macOS CLI binary (opt-in via secrets)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,6 +81,75 @@ jobs:
       - name: Build binary
         run: pyinstaller --onefile --name ${{ matrix.artifact }} src/shipyard/cli.py
 
+      # macOS 26.3+ enforces code-signing strictly; ad-hoc-signed
+      # binaries with `com.apple.provenance`/`quarantine` xattrs (which
+      # every GitHub-downloaded file carries) SIGKILL with "Taskgated
+      # Invalid Signature". Sign with Developer ID + notarize so the
+      # binary runs cleanly on a fresh install without the `install.sh`
+      # xattr-strip dance having to be the only backstop.
+      #
+      # No Info.plist → we can't `stapler staple` a bare Mach-O, so
+      # Gatekeeper verifies notarization online at first launch. That
+      # requires network, which every CI user has. Accepted tradeoff
+      # vs wrapping the CLI in a .app bundle we don't otherwise need.
+      #
+      # Skipped when the signing secrets aren't present (forks, PRs
+      # from outside contributors) — the install.sh fallback still
+      # handles those.
+      - name: Sign + notarize macOS binary
+        if: startsWith(matrix.target, 'macos-') && env.APPLE_ID != ''
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          TEAM_ID: ${{ secrets.TEAM_ID }}
+          APP_SPECIFIC_PASSWORD: ${{ secrets.APP_SPECIFIC_PASSWORD }}
+          SIGNING_CERT_P12_BASE64: ${{ secrets.SIGNING_CERT_P12_BASE64 }}
+          SIGNING_CERT_PASSWORD: ${{ secrets.SIGNING_CERT_PASSWORD }}
+        run: |
+          set -euo pipefail
+          BINARY="dist/${{ matrix.artifact }}"
+
+          # Import the Developer ID certificate into a temporary keychain
+          # so the job is self-contained and cleans up automatically.
+          KEYCHAIN="$RUNNER_TEMP/shipyard-sign.keychain-db"
+          KEYCHAIN_PASSWORD="$(openssl rand -hex 32)"
+          CERT_PATH="$RUNNER_TEMP/developer-id.p12"
+
+          echo "$SIGNING_CERT_P12_BASE64" | base64 -d > "$CERT_PATH"
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          security import "$CERT_PATH" -P "$SIGNING_CERT_PASSWORD" \
+            -A -t cert -f pkcs12 -k "$KEYCHAIN"
+          security list-keychains -d user -s "$KEYCHAIN" \
+            $(security list-keychains -d user | sed -e 's/"//g')
+          security set-key-partition-list -S apple-tool:,apple: \
+            -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+
+          # Sign with hardened-runtime + secure timestamp.
+          codesign --force --options runtime --timestamp \
+            --sign "Developer ID Application: Daniel Raffel (${TEAM_ID})" \
+            "$BINARY"
+          codesign -dv --verbose=4 "$BINARY"
+
+          # Notarize. --wait blocks up to 30min; in practice the bare
+          # Mach-O notarizes in <60s. submit needs a zip or dmg, so
+          # wrap first.
+          NOTARIZE_ZIP="$RUNNER_TEMP/${{ matrix.artifact }}.zip"
+          /usr/bin/ditto -c -k --keepParent "$BINARY" "$NOTARIZE_ZIP"
+          xcrun notarytool submit "$NOTARIZE_ZIP" \
+            --apple-id "$APPLE_ID" \
+            --team-id "$TEAM_ID" \
+            --password "$APP_SPECIFIC_PASSWORD" \
+            --wait
+
+          # Can't staple a bare Mach-O. Gatekeeper checks online at
+          # first launch instead (requires network). No additional
+          # action needed here; the notarization ticket is registered
+          # with Apple server-side and matches the binary's hash.
+
+          # Cleanup: delete the temp keychain.
+          security delete-keychain "$KEYCHAIN"
+
       - name: Upload artifact
         uses: actions/upload-artifact@v5
         with:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -61,6 +61,28 @@ gh workflow run release.yml --ref v<x.y.z>
 
 Run that after the auto-tag appears. The release workflow will pick up the existing tag and publish the binaries. (Pulp's first auto-released tag, `v0.4.0`, used this fallback before its `RELEASE_BOT_TOKEN` was provisioned.)
 
+## Optional: sign + notarize the macOS CLI binary
+
+macOS 26.3+ refuses to execute ad-hoc-signed binaries that carry the `com.apple.provenance` xattr GitHub stamps on every release download — the OS SIGKILLs with "Taskgated Invalid Signature" and the user sees a bare `zsh: killed` with no context.
+
+`install.sh` works around this locally by stripping the xattr and re-applying an ad-hoc signature. Anyone installing via `gh release download` or a manual browser click still hits the crash. The proper fix is Developer-ID-signed + Apple-notarized binaries produced by the release workflow itself.
+
+Five secrets on the repo (all `gh secret set NAME`):
+
+| Secret | What |
+|---|---|
+| `APPLE_ID` | Apple ID email (same one used for Developer ID certificate) |
+| `TEAM_ID` | 10-char Team ID from [developer.apple.com/account](https://developer.apple.com/account) |
+| `APP_SPECIFIC_PASSWORD` | App-specific password generated at [appleid.apple.com](https://appleid.apple.com) → Sign-In and Security → App-Specific Passwords |
+| `SIGNING_CERT_P12_BASE64` | `base64 -i DeveloperID.p12` of your exported Developer ID Application cert + private key |
+| `SIGNING_CERT_PASSWORD` | Export password for the .p12 |
+
+When all five are set, the release workflow's macOS matrix jobs run `codesign --sign "Developer ID Application: … (TEAM_ID)"` + `xcrun notarytool submit --wait` on the PyInstaller output before uploading. Users downloading a signed binary get clean execution on macOS 26.3+ with no xattr dance.
+
+When the secrets aren't set, the sign+notarize step no-ops and the workflow continues to publish ad-hoc-signed binaries (the current default). Forks and pull requests from external contributors aren't blocked.
+
+A bare Mach-O can't be `stapler staple`'d — Gatekeeper verifies notarization online at first launch instead. That requires network, which every CI / user machine has. Accepted tradeoff vs wrapping the CLI in a no-op `.app` bundle just for stapling.
+
 ## Default path: automatic on merge
 
 Normal releases are automatic. You don't call any script.


### PR DESCRIPTION
macOS 26.3+ enforces strict code-signing; ad-hoc binaries downloaded from GitHub get SIGKILL'd. install.sh has a local workaround, but only covers curl|bash installs — `gh release download` / browser-click still crashes.

Workflow change: after PyInstaller builds the macOS binary, codesign with Developer ID + notarize via `xcrun notarytool`. Gated on `APPLE_ID` secret presence — no-ops on forks / PRs without it, so nothing breaks if secrets aren't provisioned.

Required secrets documented in RELEASING.md: APPLE_ID, TEAM_ID, APP_SPECIFIC_PASSWORD, SIGNING_CERT_P12_BASE64, SIGNING_CERT_PASSWORD.

Closes task #25.