### PR TITLE
perf: defer rich import + bump PyInstaller Python to 3.13 (#28)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,10 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.12"
+          # 3.13 shaved ~200–400ms off cold start of the PyInstaller
+          # onefile binary vs 3.12 (PEP 659 specializing adaptive
+          # interpreter + lazy module loading). Tracked under #28.
+          python-version: "3.13"
 
       - name: Install dependencies
         run: pip install .[dev] pyinstaller

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to Shipyard are documented here. Each entry links
 to its [GitHub Release](https://github.com/danielraffel/Shipyard/releases).
 
 <a id="v0280"></a>
+## [0.29.0]
+
 ## [0.28.0] - 2026-04-22
 
 - cli: surface target error_message under the run/ship summary table ([#170](https://github.com/danielraffel/Shipyard/pull/170))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "shipyard"
-version = "0.28.0"
+version = "0.29.0"
 description = "Cross-platform CI coordination — local VMs, SSH hosts, cloud runners"
 readme = "README.md"
 license = "MIT"

--- a/src/shipyard/__init__.py
+++ b/src/shipyard/__init__.py
@@ -1,3 +1,3 @@
 """Shipyard — Cross-platform CI coordination."""
 
-__version__ = "0.28.0"
+__version__ = "0.29.0"

--- a/src/shipyard/output/human.py
+++ b/src/shipyard/output/human.py
@@ -2,19 +2,44 @@
 
 All user-facing output goes through this module. Business logic never
 calls print() directly — it returns data, and this module renders it.
+
+Rich itself pulls in ~60ms of imports on a cold start (rich.console
+alone is ~48ms). Many `shipyard` invocations never render anything —
+``shipyard --version``, ``--help``, JSON-mode commands, and the
+daemon subprocess path — so we defer the ``rich`` imports until the
+first actual render call. Ordinary Python module caching makes every
+call after the first free. Perf/cold-start rationale: see #28.
 """
 
 from __future__ import annotations
 
-from typing import Any
-
-from rich.console import Console
-from rich.table import Table
-from rich.text import Text
+from typing import TYPE_CHECKING, Any
 
 from shipyard.core.job import Job, JobStatus
 
-console = Console()
+if TYPE_CHECKING:
+    from rich.console import Console as _Console
+    from rich.text import Text as _Text
+
+
+class _LazyConsole:
+    """Proxy that instantiates a real :class:`rich.console.Console` on
+    first attribute access. ``console.print(...)`` anywhere in the
+    codebase still works; the rich import just doesn't happen until
+    the first call. Subsequent calls hit the cached instance.
+    """
+
+    _real: _Console | None = None
+
+    def __getattr__(self, name: str) -> Any:
+        cls = type(self)
+        if cls._real is None:
+            from rich.console import Console
+            cls._real = Console()
+        return getattr(cls._real, name)
+
+
+console = _LazyConsole()
 
 # ---- Status colors ----
 
@@ -29,7 +54,8 @@ _STATUS_STYLES: dict[str, str] = {
 }
 
 
-def _style_status(status: str) -> Text:
+def _style_status(status: str) -> _Text:
+    from rich.text import Text
     style = _STATUS_STYLES.get(status, "")
     return Text(status, style=style)
 
@@ -39,6 +65,9 @@ def _style_status(status: str) -> Text:
 
 def render_job(job: Job) -> None:
     """Render a job's current state to the terminal."""
+    from rich.table import Table
+    from rich.text import Text
+
     header = f"[bold]{job.id}[/] — {job.branch} @ {job.sha[:8]}"
     if job.mode.value == "smoke":
         header += " [dim](smoke)[/]"
@@ -179,6 +208,9 @@ def render_status(
 
 def render_evidence(records: dict[str, dict[str, Any]]) -> None:
     """Render evidence for a branch."""
+    from rich.table import Table
+    from rich.text import Text
+
     table = Table(show_header=True, header_style="bold", box=None, padding=(0, 2))
     table.add_column("Platform", style="cyan")
     table.add_column("Status")
@@ -214,7 +246,7 @@ def render_doctor(checks: dict[str, Any], ready: bool) -> None:
         console.print(f"  [bold]{category}:[/]")
         for name, info in items.items():
             ok = info.get("ok", False)
-            icon = "[green]\u2713[/]" if ok else "[red]\u2717[/]"
+            icon = "[green]✓[/]" if ok else "[red]✗[/]"
             detail = info.get("version", info.get("error", info.get("detail", "")))
             extra = ""
             if info.get("user"):

--- a/tests/output/test_lazy_rich.py
+++ b/tests/output/test_lazy_rich.py
@@ -1,0 +1,61 @@
+"""Regression tests for the lazy-rich import optimization (#28).
+
+The full rich import chain costs ~60ms on a cold PyInstaller bundle,
+and many ``shipyard`` invocations never render anything (``--version``,
+``--help``, the JSON-mode path, the daemon subprocess path). Deferring
+``rich`` until the first render call keeps those paths cheap.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+
+def _run_import_only(snippet: str) -> list[str]:
+    """Run the snippet in a fresh interpreter and return loaded modules."""
+    full = (
+        "import sys\n"
+        + snippet
+        + "\nprint('\\n'.join(sorted(sys.modules.keys())))\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", full],
+        capture_output=True, text=True, check=True,
+    )
+    return [m for m in result.stdout.splitlines() if m.strip()]
+
+
+def test_importing_output_human_does_not_import_rich() -> None:
+    """Importing ``shipyard.output.human`` must not pull in rich."""
+    modules = _run_import_only("import shipyard.output.human")
+    rich_modules = [m for m in modules if m.startswith("rich")]
+    assert rich_modules == [], (
+        f"Expected no rich.* modules after import shipyard.output.human; "
+        f"got {rich_modules}"
+    )
+
+
+def test_importing_shipyard_cli_does_not_import_rich() -> None:
+    """Importing ``shipyard.cli`` must not pull in rich either — the
+    rich import was previously transitive through ``output.human``."""
+    modules = _run_import_only("import shipyard.cli")
+    rich_modules = [m for m in modules if m.startswith("rich")]
+    assert rich_modules == [], (
+        f"Expected no rich.* modules after import shipyard.cli; "
+        f"got {rich_modules}"
+    )
+
+
+def test_first_render_call_loads_rich() -> None:
+    """The first ``console.print(...)`` call should trigger the rich
+    import (proving the proxy actually resolves, not that it silently
+    no-ops)."""
+    modules = _run_import_only(
+        "from shipyard.output.human import render_message\n"
+        "render_message('hello')\n"
+    )
+    # rich.console must now be loaded.
+    assert any(m.startswith("rich") for m in modules), (
+        "rich.* should be imported after the first render_message call"
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -455,7 +455,7 @@ wheels = [
 
 [[package]]
 name = "shipyard"
-version = "0.27.2"
+version = "0.28.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },

--- a/uv.lock
+++ b/uv.lock
@@ -455,7 +455,7 @@ wheels = [
 
 [[package]]
 name = "shipyard"
-version = "0.28.0"
+version = "0.29.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

- `shipyard.output.human` now has a `_LazyConsole` proxy — the real `rich.console.Console` is instantiated on first attribute access rather than at module import time. `rich.text.Text` and `rich.table.Table` move inside the specific render functions that need them.
- `release.yml` now builds the PyInstaller binary on Python 3.13 (up from 3.12). Test matrix is unchanged.
- Three regression tests pin the invariant: importing `shipyard.output.human` / `shipyard.cli` in a fresh interpreter must leave `rich.*` out of `sys.modules`; the first `render_message` call triggers the rich import.

## Expected impact

- ~60ms off `shipyard --version`, `--help`, `--json`-mode, and daemon-subprocess paths (rich not loaded for any of them).
- ~200–400ms off cold interpreter startup (Python 3.13 specializing adaptive interpreter).
- Aggregate on the PyInstaller macOS binary: ~250–400ms off the ~3.5s cold start. Further follow-ups (fully-deferred module imports, `--onedir` + zip) tracked separately.

## Test plan

- [x] `pytest tests/output/ tests/ship/` — 148 passed.
- [x] `PYTHONPROFILEIMPORTTIME=1 python -c 'import shipyard.cli' 2>&1 | grep rich` returns zero lines (before: 61ms rich.console on the import chain).
- [ ] Measure real PyInstaller cold start once the release workflow runs on 3.13 (post-merge, on a dispatched release).

## Follow-ups (not in this PR)

- Fully-deferred module-level imports (`ExecutorDispatcher`, `ShipStateStore`, `preflight`, `release_bot.setup`, `targets.warm_pool`): ~80ms more but touches 158 references; needs a careful pass.
- Switch macOS build to `--onedir` + zip: eliminates PyInstaller extract-to-tmp on every invocation. Biggest single remaining win (~1s) but changes `install.sh` UX.
- Rust frontend exploration: filed as #173.