### PR TITLE
fix: escape dynamic text before Rich markup interpolation (Codex on #170)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to Shipyard are documented here. Each entry links
 to its [GitHub Release](https://github.com/danielraffel/Shipyard/releases).
 
 <a id="v0290"></a>
+## [0.30.0]
+
 ## [0.29.0] - 2026-04-22
 
 - perf: defer rich import + bump PyInstaller Python to 3.13 (#28) ([#174](https://github.com/danielraffel/Shipyard/pull/174))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "shipyard"
-version = "0.29.0"
+version = "0.30.0"
 description = "Cross-platform CI coordination — local VMs, SSH hosts, cloud runners"
 readme = "README.md"
 license = "MIT"

--- a/src/shipyard/__init__.py
+++ b/src/shipyard/__init__.py
@@ -1,3 +1,3 @@
 """Shipyard — Cross-platform CI coordination."""
 
-__version__ = "0.29.0"
+__version__ = "0.30.0"

--- a/src/shipyard/output/human.py
+++ b/src/shipyard/output/human.py
@@ -122,7 +122,18 @@ def _render_target_errors(job: Job) -> None:
     Without this, the summary table collapses a bundle-upload failure
     or remote-apply failure into a bare "error" cell and the user has
     to `cat` the log file by hand to know what happened. See #169.
+
+    Backend error text is *uncontrolled* — it comes from raw exception
+    strings (``str(exc)``, SSH stderr, remote cmd stderr) and often
+    carries bracketed fragments like ``[Errno 2]`` or
+    ``[WinError 32]``. Rich's markup parser would otherwise treat
+    those as style tags and either render garbage or raise
+    ``MarkupError`` mid-flush, turning a target failure into a CLI
+    rendering crash. Pass every dynamic segment through
+    ``rich.markup.escape``. Codex-review catch post-#170.
     """
+    from rich.markup import escape
+
     for name in job.target_names:
         result = job.results.get(name)
         if result is None or result.passed:
@@ -137,9 +148,9 @@ def _render_target_errors(job: Job) -> None:
         first_line = msg.splitlines()[0].strip()
         if len(first_line) > 200:
             first_line = first_line[:200].rstrip() + "…"
-        console.print(f"  [red]✗ {name}:[/] {first_line}")
+        console.print(f"  [red]✗ {escape(name)}:[/] {escape(first_line)}")
         if result.log_path:
-            console.print(f"    [dim]log: {result.log_path}[/]")
+            console.print(f"    [dim]log: {escape(result.log_path)}[/]")
 
 
 def render_status(

--- a/tests/output/test_render_job_errors.py
+++ b/tests/output/test_render_job_errors.py
@@ -116,6 +116,36 @@ def test_failing_target_without_error_message_is_silent() -> None:
     assert "✗ mac" not in output
 
 
+def test_error_text_with_brackets_does_not_crash_markup() -> None:
+    """Codex-review P1 catch on #170: error messages like `[Errno 2]`
+    used to be interpolated into a markup-enabled `console.print`,
+    which would treat `[Errno 2]` as a style tag. Worst case: Rich
+    raises `MarkupError` mid-flush and the whole run summary fails
+    to render. Fix: every dynamic segment goes through
+    `rich.markup.escape`.
+
+    This test asserts the render *completes* (no exception) and that
+    the literal bracketed text appears in output as plain characters,
+    not as a style tag interpretation.
+    """
+    now = datetime.now(timezone.utc)
+    errored = TargetResult(
+        target_name="ubuntu",
+        platform="linux-arm64",
+        status=TargetStatus.ERROR,
+        backend="ssh",
+        started_at=now,
+        completed_at=now,
+        duration_secs=14.0,
+        log_path="/tmp/shipyard/logs/ubuntu[2].log",
+        error_message="Bundle apply failed: [Errno 2] No such file or directory",
+    )
+    output = _render(_job_with_results([errored]))
+    assert "[Errno 2]" in output
+    assert "Bundle apply failed" in output
+    assert "ubuntu[2].log" in output
+
+
 def test_reused_target_skipped() -> None:
     now = datetime.now(timezone.utc)
     reused = TargetResult(

--- a/uv.lock
+++ b/uv.lock
@@ -455,7 +455,7 @@ wheels = [
 
 [[package]]
 name = "shipyard"
-version = "0.29.0"
+version = "0.30.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

- `_render_target_errors` now passes `target_name`, trimmed `first_line` of `error_message`, and `log_path` through `rich.markup.escape` before building the markup-enabled `console.print` f-string.
- Adds a regression test with `error_message = \"Bundle apply failed: [Errno 2] No such file or directory\"` and `log_path = \"/tmp/.../ubuntu[2].log\"`; asserts the render completes and the literal brackets appear in output (vs Rich parsing `[Errno 2]` as a style tag).

## Why

Codex P1 catch on #170. Real error text from the ssh / ssh-windows backends routinely contains `[Errno N]`, `[WinError N]`, or framework names in brackets. My original #170 code dropped them into markup-enabled printing unescaped — best case garbled output, worst case `MarkupError` raised mid-flush, turning a target failure into a CLI rendering crash.

## Test plan

- [x] `pytest tests/output/ tests/ship/` — 9/9 output tests pass, including the new `test_error_text_with_brackets_does_not_crash_markup`.
- [x] Lint clean (`ruff check src/shipyard/output/human.py tests/output/test_render_job_errors.py`).