### PR TITLE
daemon: widen tunnel-supervisor retry surface + restart on unexpected (#179)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to Shipyard are documented here. Each entry links
 to its [GitHub Release](https://github.com/danielraffel/Shipyard/releases).
 
 <a id="v0300"></a>
+## [0.31.0]
+
 ## [0.30.0] - 2026-04-22
 
 - fix: escape dynamic text before Rich markup interpolation (Codex on #170) ([#180](https://github.com/danielraffel/Shipyard/pull/180))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "shipyard"
-version = "0.30.0"
+version = "0.31.0"
 description = "Cross-platform CI coordination — local VMs, SSH hosts, cloud runners"
 readme = "README.md"
 license = "MIT"

--- a/src/shipyard/__init__.py
+++ b/src/shipyard/__init__.py
@@ -1,3 +1,3 @@
 """Shipyard — Cross-platform CI coordination."""
 
-__version__ = "0.30.0"
+__version__ = "0.31.0"

--- a/src/shipyard/daemon/controller.py
+++ b/src/shipyard/daemon/controller.py
@@ -267,6 +267,16 @@ class Daemon:
         # Tunnel error (#179). We now log and *restart* the inner
         # loop after a short backoff so the supervisor genuinely
         # never gives up short of `_stop_event`.
+        #
+        # ``crash_attempt`` escalates the restart backoff on
+        # consecutive crashes, but resets to 0 whenever the tunnel
+        # successfully comes up (see #183): without that, a few
+        # isolated one-off failures accumulated forever and pinned
+        # future restarts to the 300s max, so later transient issues
+        # took much longer to self-heal than intended. Resetting on
+        # successful bring-up scopes the backoff to "how bad is *this*
+        # crash streak," not "how many crashes has this daemon ever
+        # seen across its lifetime."
         crash_attempt = 0
         while not self._stop_event.is_set():
             try:
@@ -278,6 +288,10 @@ class Daemon:
                     self._state.tunnel = tunnel_info
                     self._state.tunnel_verified_at = time.time()
                     logger.info("tunnel ready: %s", tunnel_info.public_url)
+                    # Fresh recovery — stop compounding backoff from
+                    # pre-recovery crashes. If we crash again later,
+                    # backoff starts over at the first bucket.
+                    crash_attempt = 0
                     await self._register_webhooks(tunnel_info)
 
                     # Watch loop: periodically re-verify. When verify

--- a/src/shipyard/daemon/controller.py
+++ b/src/shipyard/daemon/controller.py
@@ -261,52 +261,95 @@ class Daemon:
         local store, and live webhook delivery resumes automatically
         whenever the tunnel recovers.
         """
-        try:
-            while not self._stop_event.is_set():
-                tunnel_info = await self._bring_up_tunnel()
-                if tunnel_info is None:
-                    return  # stopped during bring-up
+        # The outer `except Exception` used to log-and-return, which
+        # ended the supervisor task after the first unexpected
+        # exception. That silently broke self-healing on any non-
+        # Tunnel error (#179). We now log and *restart* the inner
+        # loop after a short backoff so the supervisor genuinely
+        # never gives up short of `_stop_event`.
+        crash_attempt = 0
+        while not self._stop_event.is_set():
+            try:
+                while not self._stop_event.is_set():
+                    tunnel_info = await self._bring_up_tunnel()
+                    if tunnel_info is None:
+                        return  # stopped during bring-up
 
-                self._state.tunnel = tunnel_info
-                self._state.tunnel_verified_at = time.time()
-                logger.info("tunnel ready: %s", tunnel_info.public_url)
-                await self._register_webhooks(tunnel_info)
+                    self._state.tunnel = tunnel_info
+                    self._state.tunnel_verified_at = time.time()
+                    logger.info("tunnel ready: %s", tunnel_info.public_url)
+                    await self._register_webhooks(tunnel_info)
 
-                # Watch loop: periodically re-verify. When verify
-                # fails, fall through to the outer loop which restarts
-                # bring-up.
-                await self._watch_tunnel()
-                # Watch exited → either stop-requested or tunnel lost.
-                if self._stop_event.is_set():
-                    return
-                logger.warning(
-                    "tunnel lost mid-session; re-establishing (URL was %s)",
-                    tunnel_info.public_url,
+                    # Watch loop: periodically re-verify. When verify
+                    # fails, fall through to the outer loop which
+                    # restarts bring-up.
+                    await self._watch_tunnel()
+                    if self._stop_event.is_set():
+                        return
+                    logger.warning(
+                        "tunnel lost mid-session; re-establishing "
+                        "(URL was %s)",
+                        tunnel_info.public_url,
+                    )
+                    self._state.tunnel = None
+                    self._state.tunnel_verified_at = None
+                return
+            except asyncio.CancelledError:  # pragma: no cover — shutdown
+                raise
+            except Exception as exc:  # noqa: BLE001 — keep supervisor alive
+                wait_secs = self._TUNNEL_RETRY_BACKOFFS[
+                    min(crash_attempt, len(self._TUNNEL_RETRY_BACKOFFS) - 1)
+                ]
+                crash_attempt += 1
+                logger.error(
+                    "tunnel supervisor hit unexpected exception (%s): %s "
+                    "— restarting loop in %.0fs",
+                    type(exc).__name__, exc, wait_secs,
+                    exc_info=True,
                 )
-                self._state.tunnel = None
-                self._state.tunnel_verified_at = None
-        except asyncio.CancelledError:  # pragma: no cover — shutdown
-            raise
-        except Exception as exc:  # noqa: BLE001 — must never crash daemon
-            logger.error("tunnel supervisor crashed: %s", exc, exc_info=True)
+                try:
+                    await asyncio.wait_for(
+                        self._stop_event.wait(), timeout=wait_secs
+                    )
+                    return  # stop requested during backoff
+                except TimeoutError:
+                    continue
 
     async def _bring_up_tunnel(self) -> TunnelInfo | None:
         """Retry tunnel.start indefinitely (capped backoff) until it
-        succeeds or stop is requested."""
+        succeeds or stop is requested.
+
+        Transient-failure surface has to be wider than the Tunnel-
+        specific error classes. `TailscaleFunnelBackend.start` shells
+        out via ``asyncio.create_subprocess_exec``, which can raise
+        bare ``OSError`` (e.g. `ENOENT` when the `tailscale` binary is
+        momentarily gone during a package update), ``FileNotFoundError``
+        (same condition, different Python surface), or
+        ``asyncio.TimeoutError`` if probing stalls. Before #179 those
+        escaped straight into the supervisor's outer ``except Exception``
+        and ended the supervisor task after a single log line — the
+        daemon kept running but never attempted tunnel recovery again,
+        silently breaking self-healing. We retry all three.
+        """
         attempt = 0
         assert self._webhook_port is not None  # start() invariant
         while not self._stop_event.is_set():
             try:
                 return await self._tunnel.start(self._webhook_port)
-            except (TunnelNotReadyError, TunnelStartError) as exc:
+            except (
+                TunnelNotReadyError,
+                TunnelStartError,
+                OSError,
+                asyncio.TimeoutError,
+            ) as exc:
                 wait_secs = self._TUNNEL_RETRY_BACKOFFS[
                     min(attempt, len(self._TUNNEL_RETRY_BACKOFFS) - 1)
                 ]
                 attempt += 1
                 logger.info(
-                    "tunnel bring-up attempt %d failed: %s "
+                    "tunnel bring-up attempt %d failed (%s): %s "
                     "(retrying in %.0fs)",
-                    attempt, exc, wait_secs,
+                    attempt, type(exc).__name__, exc, wait_secs,
                 )
                 # Sleep preempted by stop_event so shutdown doesn't
                 # wait out the full backoff.

--- a/tests/daemon/test_tunnel_supervisor.py
+++ b/tests/daemon/test_tunnel_supervisor.py
@@ -273,6 +273,52 @@ def test_runtime_error_restarts_supervisor_loop_not_kills_it() -> None:
     asyncio.run(run())
 
 
+def test_crash_backoff_resets_after_successful_bring_up() -> None:
+    """#183 regression. ``crash_attempt`` must reset to 0 after a
+    successful tunnel bring-up so consecutive unrelated crashes
+    over a daemon's lifetime don't pin later restarts to the max
+    backoff. Plan: runtime-error → ok → (verify fails → reloop) →
+    runtime-error → ok. If the counter reset, BOTH crashes back off
+    at bucket[0]; if it didn't, the second uses bucket[1+].
+
+    We make bucket[0] small (0.2s) and bucket[1+] large (10s) so
+    the total elapsed wall time distinguishes the two cases
+    decisively.
+    """
+
+    async def run() -> None:
+        with tempfile.TemporaryDirectory(prefix="sy-reset-") as tmp:
+            ts = _FakeTunnelState(
+                plan=["runtime", "ok", "runtime", "ok"],
+                verify_plan=[False],  # first verify fails → reloop
+            )
+            daemon = _make_daemon(Path(tmp), ts)
+            daemon._TUNNEL_RETRY_BACKOFFS = (0.2, 10.0, 10.0)  # type: ignore[assignment]
+            daemon._TUNNEL_VERIFY_INTERVAL_SECS = 0.01  # type: ignore[assignment]
+            with _patch_webhook_server():
+                start = asyncio.get_event_loop().time()
+                await daemon.start()
+                try:
+                    for _ in range(400):
+                        if ts.start_calls >= 4:
+                            break
+                        await asyncio.sleep(0.05)
+                    elapsed = asyncio.get_event_loop().time() - start
+                    assert ts.start_calls >= 4, (
+                        f"expected two full crash-recover cycles; "
+                        f"got start_calls={ts.start_calls}"
+                    )
+                    assert elapsed < 3.0, (
+                        f"crash backoff didn't reset after recovery — "
+                        f"second crash waited bucket[1+] (10s) instead "
+                        f"of bucket[0] (0.2s); elapsed={elapsed:.1f}s"
+                    )
+                finally:
+                    await daemon.stop()
+
+    asyncio.run(run())
+
+
 def test_tunnel_loss_mid_session_re_establishes() -> None:
     """Up → verify fails → down → re-establish. The daemon must
     not exit during the transition."""

--- a/tests/daemon/test_tunnel_supervisor.py
+++ b/tests/daemon/test_tunnel_supervisor.py
@@ -64,6 +64,17 @@ class _FakeTunnel:
         step = self.state.plan[i] if i < len(self.state.plan) else self.state.plan[-1]
         if step == "fail":
             raise TunnelNotReadyError("simulated: not ready")
+        if step == "oserror":
+            # Surfaces as e.g. ENOENT from create_subprocess_exec when
+            # the tailscale binary is momentarily gone during a
+            # package update. Before #179 this escaped the retry
+            # block, hit the outer except Exception, and killed the
+            # supervisor silently.
+            raise OSError("simulated: tailscale binary not found")
+        if step == "runtime":
+            # Catch-all unexpected error. Must not kill the
+            # supervisor; outer loop re-enters after a backoff.
+            raise RuntimeError("simulated: unexpected failure")
         return TunnelInfo(public_url="https://fake.ts.net", backend=self.name)
 
     async def stop(self) -> None:
@@ -191,6 +202,71 @@ def test_transient_tunnel_bring_up_eventually_succeeds() -> None:
                     assert reg.calls == [
                         ("owner/repo", "https://fake.ts.net/webhook"),
                     ]
+                finally:
+                    await daemon.stop()
+
+    asyncio.run(run())
+
+
+def test_oserror_during_bring_up_is_retried_not_fatal() -> None:
+    """#179 regression. Before the fix, an `OSError` from
+    `create_subprocess_exec` (e.g. `ENOENT` when the `tailscale`
+    binary is momentarily gone during a package update) escaped
+    `_bring_up_tunnel`'s narrow except clause, hit the supervisor's
+    outer `except Exception`, and ended the supervisor task after
+    one log line. The daemon kept running but would never attempt
+    tunnel recovery again, silently breaking self-healing. This
+    test plans an OSError on attempt 1 then success on attempt 2
+    and asserts the tunnel eventually lands."""
+
+    async def run() -> None:
+        with tempfile.TemporaryDirectory(prefix="sy-supv-") as tmp:
+            ts = _FakeTunnelState(plan=["oserror", "ok"])
+            daemon = _make_daemon(Path(tmp), ts)
+            with _patch_webhook_server():
+                await daemon.start()
+                try:
+                    for _ in range(300):
+                        if daemon._state.tunnel is not None:
+                            break
+                        await asyncio.sleep(0.01)
+                    assert daemon._state.tunnel is not None, (
+                        "supervisor must retry past OSError and bring "
+                        "the tunnel up on the next attempt"
+                    )
+                    assert ts.start_calls == 2
+                finally:
+                    await daemon.stop()
+
+    asyncio.run(run())
+
+
+def test_runtime_error_restarts_supervisor_loop_not_kills_it() -> None:
+    """Hardening for #179. If a genuinely unexpected exception
+    escapes `_bring_up_tunnel` (anything not in the transient list),
+    the supervisor now catches it at the outer level, logs it,
+    sleeps a backoff, and re-enters the inner loop. The task
+    survives so eventual recovery is still possible. Pre-fix
+    behavior: log once and exit the task forever."""
+
+    async def run() -> None:
+        with tempfile.TemporaryDirectory(prefix="sy-supv-") as tmp:
+            ts = _FakeTunnelState(plan=["runtime", "ok"])
+            daemon = _make_daemon(Path(tmp), ts)
+            with _patch_webhook_server():
+                await daemon.start()
+                try:
+                    for _ in range(300):
+                        if daemon._state.tunnel is not None:
+                            break
+                        await asyncio.sleep(0.01)
+                    assert daemon._state.tunnel is not None, (
+                        "supervisor's outer handler must restart the "
+                        "inner loop, not kill the task"
+                    )
+                    # start_calls == 2 proves the loop re-entered
+                    # after the RuntimeError rather than dying.
+                    assert ts.start_calls == 2
                 finally:
                     await daemon.stop()
 

--- a/uv.lock
+++ b/uv.lock
@@ -455,7 +455,7 @@ wheels = [
 
 [[package]]
 name = "shipyard"
-version = "0.30.0"
+version = "0.31.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

- `_bring_up_tunnel` retries `OSError`, `FileNotFoundError`, and `asyncio.TimeoutError` alongside the existing `TunnelNotReadyError`/`TunnelStartError`. Same capped-backoff loop.
- `_tunnel_supervisor_loop` outer `except Exception` now logs + backs off + re-enters the inner loop instead of returning. Supervisor genuinely never gives up short of `_stop_event`.
- Two new tests (`test_oserror_during_bring_up_is_retried_not_fatal`, `test_runtime_error_restarts_supervisor_loop_not_kills_it`) drive fake-tunnel plans with `oserror` and `runtime` steps and assert the tunnel lands on retry.

## Why

Codex P2 on #161. `TailscaleFunnelBackend.start()` shells out via `create_subprocess_exec`. An ENOENT during a `tailscale` package update (or any bare `OSError`) used to escape the narrow retry clause, hit the outer `except Exception`, and silently end the supervisor task. Daemon kept running, but never retried the tunnel again — self-healing broken until the next daemon restart.

Closes #179.

## Test plan

- [x] `pytest tests/daemon/test_tunnel_supervisor.py tests/daemon/test_tunnel_retry.py` — 8/8 pass.
- [x] Lint clean.