### PR TITLE
config: compare main_checkout to repo toplevel, not cwd (#178)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to Shipyard are documented here. Each entry links
 to its [GitHub Release](https://github.com/danielraffel/Shipyard/releases).
 
 <a id="v0320"></a>
+## [0.33.0]
+
 ## [0.32.0] - 2026-04-22
 
 - daemon: 24h forced reconcile window closes aged-terminal blind spot (#176) ([#182](https://github.com/danielraffel/Shipyard/pull/182))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "shipyard"
-version = "0.32.0"
+version = "0.33.0"
 description = "Cross-platform CI coordination — local VMs, SSH hosts, cloud runners"
 readme = "README.md"
 license = "MIT"

--- a/src/shipyard/__init__.py
+++ b/src/shipyard/__init__.py
@@ -1,3 +1,3 @@
 """Shipyard — Cross-platform CI coordination."""
 
-__version__ = "0.32.0"
+__version__ = "0.33.0"

--- a/src/shipyard/core/config.py
+++ b/src/shipyard/core/config.py
@@ -200,53 +200,77 @@ class Config:
 
 
 def _worktree_main_local_dir(base: Path) -> Path | None:
-    """If `base` is a git worktree whose main checkout has a usable
-    `.shipyard.local/config.toml`, return that directory. Otherwise
-    `None`.
+    """If `base` is inside a *linked* git worktree whose main checkout
+    has a usable ``.shipyard.local/config.toml``, return that
+    directory. Otherwise ``None``.
 
-    The contract from `git worktree add`: the worktree's `.git` is a
-    file pointing at `<common>/worktrees/<name>`, and
-    `git rev-parse --git-common-dir` resolves to the original
-    checkout's `.git` directory. Going up one level from that gives
+    The contract from `git worktree add`: the linked worktree's
+    ``.git`` is a file pointing at ``<common>/worktrees/<name>``, and
+    ``git rev-parse --git-common-dir`` resolves to the original
+    checkout's ``.git`` directory. Going up one level from that gives
     the main checkout root, which is where the gitignored
-    `.shipyard.local/` lives.
+    ``.shipyard.local/`` lives.
 
     Bail quietly (return None) on:
     - base not in a git repo at all
     - git not on PATH
     - the "common dir" path doesn't resolve to a checkout with a
-      `.shipyard.local/config.toml`
-    - the base IS the main checkout (no fallback needed or wanted)
+      ``.shipyard.local/config.toml``
+    - the base IS (or is a subdir of) the main checkout (no fallback
+      needed — the main checkout's own ``.shipyard.local/`` was
+      already in the regular overlay search path)
+
+    The "subdir of the main checkout" case is #178: pre-fix, the
+    comparison was against ``base`` (cwd), not the repo toplevel, so
+    running shipyard from ``repo/src/`` falsely identified it as a
+    linked worktree and returned ``repo/.shipyard.local`` without
+    loading the matching ``repo/.shipyard/`` project overlay —
+    partial config, confusing downstream failures. Now we compare
+    against ``git rev-parse --show-toplevel`` so "inside the main
+    checkout" consistently returns None regardless of cwd depth.
     """
     import subprocess
 
-    try:
-        res = subprocess.run(
-            ["git", "rev-parse", "--git-common-dir"],
-            cwd=str(base),
-            capture_output=True,
-            text=True,
-            timeout=3,
-            check=False,
-        )
-    except (FileNotFoundError, subprocess.SubprocessError):
+    def _git(args: list[str]) -> str | None:
+        try:
+            res = subprocess.run(
+                ["git", *args],
+                cwd=str(base),
+                capture_output=True,
+                text=True,
+                timeout=3,
+                check=False,
+            )
+        except (FileNotFoundError, subprocess.SubprocessError):
+            return None
+        if res.returncode != 0:
+            return None
+        return res.stdout.strip()
+
+    common_dir_str = _git(["rev-parse", "--git-common-dir"])
+    if common_dir_str is None:
         return None
-    if res.returncode != 0:
-        return None
-    common_dir = Path(res.stdout.strip())
+    common_dir = Path(common_dir_str)
     if not common_dir.is_absolute():
         common_dir = (base / common_dir).resolve()
     # Main checkout root is the parent of the .git directory that
     # git-common-dir points at.
     main_checkout = common_dir.parent
-    # Don't fall back to ourselves. If base's own .git resolves to
-    # the same common_dir, we ARE the main checkout and our own
-    # `.shipyard.local/` was already checked.
+
+    # Compare against the *current checkout's* toplevel, not against
+    # cwd. In a regular repo run from a subdir, show-toplevel
+    # equals main_checkout and we correctly bail. In a linked
+    # worktree, show-toplevel is the worktree root and differs from
+    # main_checkout, so the fallback fires.
+    toplevel_str = _git(["rev-parse", "--show-toplevel"])
+    if toplevel_str is None:
+        return None
     try:
-        if main_checkout.resolve() == base.resolve():
-            return None
+        if Path(toplevel_str).resolve() == main_checkout.resolve():
+            return None  # we're in (or under) the main checkout
     except OSError:
         return None
+
     candidate = main_checkout / ".shipyard.local"
     if (candidate / "config.toml").exists():
         return candidate

--- a/tests/core/test_config_worktree_fallback.py
+++ b/tests/core/test_config_worktree_fallback.py
@@ -13,7 +13,7 @@ non-worktree layouts are unaffected.
 from __future__ import annotations
 
 import subprocess
-from pathlib import Path
+from pathlib import Path  # noqa: TC003 — used at runtime via pytest fixtures, not just annotations
 
 import pytest
 
@@ -106,3 +106,31 @@ def test_non_git_directory_returns_none_fallback(tmp_path: Path) -> None:
     )
     cfg = Config.load_from_cwd(tmp_path)
     assert cfg.get("project.name") == "test"
+
+
+def test_main_checkout_subdir_does_not_trigger_worktree_fallback(
+    main_repo: Path,
+) -> None:
+    """#178 regression. Running shipyard from a subdirectory of the
+    main checkout (e.g. ``repo/src/``) must *not* be mistaken for a
+    linked worktree. Pre-fix, ``_worktree_main_local_dir`` compared
+    ``main_checkout`` against the cwd; since ``repo/src`` != ``repo``,
+    it returned ``repo/.shipyard.local`` as a fallback without
+    loading ``repo/.shipyard/`` as the project overlay — a partial
+    config that surfaced as wrong ssh host or missing target.
+
+    Post-fix it compares against ``git rev-parse --show-toplevel``
+    (which is ``repo`` in both main-root and subdir cases), so the
+    subdir never trips the worktree branch.
+    """
+    from shipyard.core.config import _worktree_main_local_dir
+
+    subdir = main_repo / "src" / "nested"
+    subdir.mkdir(parents=True)
+
+    # With the fix: subdir is identified as "inside the main checkout"
+    # and no worktree fallback dir is returned.
+    assert _worktree_main_local_dir(subdir) is None, (
+        "subdir of the main checkout must not be treated as a "
+        "linked worktree; toplevel equals main_checkout"
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -455,7 +455,7 @@ wheels = [
 
 [[package]]
 name = "shipyard"
-version = "0.32.0"
+version = "0.33.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

- `_worktree_main_local_dir` now asks \`git rev-parse --show-toplevel\` for the *current checkout's* root and compares that to the \`main_checkout\` derived from \`--git-common-dir\`. In a regular repo run from a subdir, those match and the worktree fallback correctly bails. In a linked worktree, they differ and the fallback fires.
- Adds \`test_main_checkout_subdir_does_not_trigger_worktree_fallback\`.

## Why

Codex P2 on #162. Pre-fix comparison was against the cwd, so running shipyard from \`repo/src/\` (or any subdir) was misidentified as a linked worktree. \`Config.load_from_cwd\` then loaded \`repo/.shipyard.local\` as a fallback *without* the matching \`repo/.shipyard/\` project layer, yielding partial config and downstream "missing target" / "wrong host" failures.

Closes #178.

## Test plan

- [x] \`pytest tests/core/test_config_worktree_fallback.py\` — 5/5 pass (3 pre-existing + 1 new subdir regression + 1 non-git).
- [x] Lint clean.