### PR TITLE
ci+release: default runner provider via repo variable (prefer Namespace)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,18 @@ jobs:
       windows: ${{ steps.resolve.outputs.windows }}
     steps:
       - id: resolve
+        # Runner provider resolution, in priority order:
+        #   1. workflow_dispatch input (explicit override per-run).
+        #   2. repo variable `DEFAULT_RUNNER_PROVIDER` — set once,
+        #      applies to every PR/push. Configure with
+        #      `gh variable set DEFAULT_RUNNER_PROVIDER --body namespace`.
+        #   3. Hardcoded fallback `github-hosted` — safe default for
+        #      forks and first-time setup where the variable isn't set.
+        # See RELEASING.md § "Preferred runner provider" for the
+        # rationale (GitHub-hosted macOS queues were blocking this
+        # repo for 10+ minutes during a typical workday).
         run: |
-          PROVIDER="${{ inputs.runner_provider || 'github-hosted' }}"
+          PROVIDER="${{ inputs.runner_provider || vars.DEFAULT_RUNNER_PROVIDER || 'github-hosted' }}"
           if [ "$PROVIDER" = "namespace" ]; then
             echo "linux=\"namespace-profile-generouscorp\"" >> "$GITHUB_OUTPUT"
             echo "macos=\"macos-15\"" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,8 +28,14 @@ jobs:
       windows: ${{ steps.resolve.outputs.windows }}
     steps:
       - id: resolve
+        # Same resolution order as ci.yml: workflow_dispatch input
+        # > repo variable `DEFAULT_RUNNER_PROVIDER` > hardcoded
+        # `github-hosted`. Set the variable once:
+        #   gh variable set DEFAULT_RUNNER_PROVIDER --body namespace
+        # and every tag-triggered release build lands on Namespace
+        # without workflow edits. See RELEASING.md.
         run: |
-          PROVIDER="${{ inputs.runner_provider || 'github-hosted' }}"
+          PROVIDER="${{ inputs.runner_provider || vars.DEFAULT_RUNNER_PROVIDER || 'github-hosted' }}"
           if [ "$PROVIDER" = "namespace" ]; then
             echo "linux=\"namespace-profile-generouscorp\"" >> "$GITHUB_OUTPUT"
             echo "linux_arm=\"namespace-profile-generouscorp\"" >> "$GITHUB_OUTPUT"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -94,6 +94,27 @@ When the secrets aren't set, the sign+notarize step no-ops and the workflow cont
 
 A bare Mach-O can't be `stapler staple`'d — Gatekeeper verifies notarization online at first launch instead. That requires network, which every CI / user machine has. Accepted tradeoff vs wrapping the CLI in a no-op `.app` bundle just for stapling.
 
+## Preferred runner provider
+
+Shipyard's own CI defaults to the runner provider configured in the repo variable `DEFAULT_RUNNER_PROVIDER`. Set it once:
+
+```sh
+gh variable set DEFAULT_RUNNER_PROVIDER --repo danielraffel/Shipyard --body namespace
+```
+
+Every subsequent PR push, tag push, and scheduled release picks that up without workflow edits. Per-run overrides still work via `gh workflow run ci.yml --ref <branch> -f runner_provider=github-hosted`.
+
+**Why Namespace is the preferred default:** GitHub-hosted `macos-15` queues routinely stall shipyard PRs for 10+ minutes during business hours. Namespace's cloud pool (profiles `namespace-profile-generouscorp`, `-macos`, `-windows`) has near-zero queue time and faster macOS ARM machines. The trade-off is per-minute cost — Namespace is not free like GitHub-hosted on public repos — but for an active project the wall-clock-time savings are worth it.
+
+**When to flip back to `github-hosted`:**
+- Forks / external contributors whose repos don't have the variable set will naturally fall through to `github-hosted` (safe default, no paid surface exposed).
+- If Namespace has an outage: `gh variable delete DEFAULT_RUNNER_PROVIDER` restores `github-hosted` for all future runs without a workflow PR.
+
+The resolution order in `ci.yml` / `release.yml` is:
+1. `workflow_dispatch` input (per-run override).
+2. `vars.DEFAULT_RUNNER_PROVIDER` (repo-wide default).
+3. Hardcoded fallback `github-hosted`.
+
 ## Default path: automatic on merge
 
 Normal releases are automatic. You don't call any script.


### PR DESCRIPTION
## Summary

- \`ci.yml\` and \`release.yml\`'s \`resolve-runners\` step now reads \`vars.DEFAULT_RUNNER_PROVIDER\` before falling through to the hardcoded \`github-hosted\`.
- Resolution priority: \`workflow_dispatch\` input → \`vars.DEFAULT_RUNNER_PROVIDER\` → \`github-hosted\`.
- Repo variable \`DEFAULT_RUNNER_PROVIDER=namespace\` set outside this PR — effective immediately after merge.
- RELEASING.md grows a "Preferred runner provider" section documenting the three-tier priority + how to flip back.

## Why

GitHub-hosted \`macos-15\` queues were stalling shipyard PRs 10+ minutes today. Namespace's cloud pool (\`namespace-profile-generouscorp*\`) has near-zero queue and faster macOS ARM machines. Setting the default at the variable layer (vs. editing workflow defaults) means we can flip providers repo-wide with one \`gh variable set\` instead of a workflow PR, and external fork PRs still land safely on \`github-hosted\` because vars don't propagate across fork boundaries.

## Test plan

- [x] \`actionlint\` clean (pre-existing shellcheck style warnings only).
- [ ] Post-merge: next PR push should land on a Namespace runner by default (verify via the \`runs-on\` value in the run logs).