### PR TITLE
ssh-windows: decode PowerShell CLIXML error envelope (#188)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to Shipyard are documented here. Each entry links
 to its [GitHub Release](https://github.com/danielraffel/Shipyard/releases).
 
 <a id="v0300"></a>
+## [0.31.0]
+
 ## [0.30.0] - 2026-04-22
 
 - fix: escape dynamic text before Rich markup interpolation (Codex on #170) ([#180](https://github.com/danielraffel/Shipyard/pull/180))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "shipyard"
-version = "0.30.0"
+version = "0.31.0"
 description = "Cross-platform CI coordination — local VMs, SSH hosts, cloud runners"
 readme = "README.md"
 license = "MIT"

--- a/src/shipyard/__init__.py
+++ b/src/shipyard/__init__.py
@@ -1,3 +1,3 @@
 """Shipyard — Cross-platform CI coordination."""
 
-__version__ = "0.30.0"
+__version__ = "0.31.0"

--- a/src/shipyard/executor/clixml.py
+++ b/src/shipyard/executor/clixml.py
@@ -1,0 +1,173 @@
+"""Decode PowerShell CLIXML error envelopes surfaced by remote
+Windows commands over SSH.
+
+When a Windows PowerShell session writes to any non-stdout stream
+(``Write-Error``, uncaught exceptions, ``Write-Warning``, etc.) and
+the stream is relayed back to the SSH client, the receiving side
+sees a payload that starts with the literal bytes ``#< CLIXML``
+followed by a PowerShell CLIXML (Common Language Infrastructure
+XML) document. The actual human-readable diagnostic — "file in
+use," "git exit 1," "missing dependency," etc. — is buried inside
+``<S S="Error">…</S>`` elements in that XML, not in plain text.
+
+Pre-decoder, shipyard's summary row looked like::
+
+    ✗ windows: Bundle apply failed: Remote bundle apply failed: #< CLIXML
+
+Which is exactly as useful as the bare ``windows  error  ssh-windows``
+row we fixed in v0.28.0. This module closes that gap (#188): if the
+stderr buffer starts with the CLIXML sentinel, we extract the error
+and warning stream text, decode PowerShell's ``_x000D_``/``_x000A_``
+escape sequences back to CR/LF, and hand the caller plain text that
+names the actual failure.
+
+Malformed or partially-transferred envelopes fall through to the
+original raw text — the pre-decoder behaviour — so we never make a
+failure case worse.
+"""
+
+from __future__ import annotations
+
+import re
+from xml.etree import ElementTree as ET
+
+# PowerShell's CLIXML stream-header sentinel. Case-insensitive; older
+# hosts sometimes send the header with a different whitespace between
+# `#<` and `CLIXML`. Any stderr buffer whose first non-whitespace
+# characters match this gets routed through `_decode`.
+_CLIXML_SENTINEL = "#< CLIXML"
+
+# Powershell serializes the XML 1.0 "restricted" character set by
+# encoding forbidden code points as ``_xHHHH_`` (four-digit hex).
+# Most commonly ``_x000D_`` / ``_x000A_`` / ``_x0009_`` for CR / LF /
+# tab in multi-line error messages. Decode them back so the printed
+# text preserves readable line breaks.
+_ESCAPE_RE = re.compile(r"_x([0-9A-Fa-f]{4})_")
+
+# Cap the decoded payload so a multi-kilobyte traceback doesn't
+# balloon the terminal when surfaced beneath the summary table. The
+# per-target log file still carries the full envelope.
+_MAX_DECODED_CHARS = 800
+
+
+def is_clixml(text: str) -> bool:
+    """True iff ``text`` starts with a CLIXML envelope header."""
+    return text.lstrip().startswith(_CLIXML_SENTINEL)
+
+
+def maybe_decode_clixml(text: str) -> str:
+    """Best-effort: if ``text`` looks like a CLIXML envelope, return
+    the decoded human-readable error. Otherwise return ``text`` as-is.
+
+    Never raises — malformed CLIXML falls back to the original text
+    so callers' existing error surfaces keep working on partial or
+    non-standard envelopes.
+    """
+    if not is_clixml(text):
+        return text
+    try:
+        decoded = _decode(text)
+    except (ET.ParseError, ValueError):
+        return text
+    return decoded or text
+
+
+def _decode(text: str) -> str:
+    # Strip everything up to and including the sentinel; the rest
+    # should be a well-formed XML document.
+    idx = text.find(_CLIXML_SENTINEL)
+    xml_blob = text[idx + len(_CLIXML_SENTINEL):].lstrip()
+
+    # The stream can contain multiple concatenated ``<Objs>…</Objs>``
+    # documents back-to-back (one per stderr flush). Parse each
+    # independently so a malformed trailing doc doesn't throw away
+    # an earlier well-formed one.
+    messages: list[str] = []
+    for obj_doc in _split_objs(xml_blob):
+        messages.extend(_extract_messages(obj_doc))
+    if not messages:
+        return ""
+
+    # Preserve order, dedupe consecutive exact-same lines (PowerShell
+    # tends to emit both a short ``Message`` and a longer
+    # ``FullyQualifiedErrorId`` derived from the same exception).
+    deduped: list[str] = []
+    for m in messages:
+        stripped = m.strip()
+        if not stripped:
+            continue
+        if deduped and deduped[-1] == stripped:
+            continue
+        deduped.append(stripped)
+
+    joined = "\n".join(deduped)
+    if len(joined) > _MAX_DECODED_CHARS:
+        # Keep the tail — last errors in a multi-line cascade are
+        # almost always the proximate cause.
+        joined = "…" + joined[-(_MAX_DECODED_CHARS - 1):]
+    return joined
+
+
+def _split_objs(xml_blob: str) -> list[str]:
+    """Split a concatenation of ``<Objs>…</Objs>`` documents into a
+    list of individual XML strings. Returns ``[xml_blob]`` unchanged
+    when only one document is present; empty list when the blob is
+    empty or shaped wrong for recovery."""
+    out: list[str] = []
+    start = 0
+    while start < len(xml_blob):
+        open_idx = xml_blob.find("<Objs", start)
+        if open_idx < 0:
+            break
+        close_idx = xml_blob.find("</Objs>", open_idx)
+        if close_idx < 0:
+            break
+        end = close_idx + len("</Objs>")
+        out.append(xml_blob[open_idx:end])
+        start = end
+    return out
+
+
+def _extract_messages(obj_doc: str) -> list[str]:
+    """Pull the human-readable text out of a single ``<Objs>``
+    document. Looks at both ``<S S="...">`` stream records (the
+    common case: ``Write-Error`` / ``Write-Warning`` output) and
+    nested ``<Obj>`` records with ``<S N="Message">`` /
+    ``<S N="Exception">`` properties (full ``ErrorRecord``
+    serializations)."""
+    root = ET.fromstring(obj_doc)
+
+    # PowerShell CLIXML uses a default namespace on ``<Objs>``. ElementTree
+    # preserves that as ``{ns}tag`` when walking, so match on local
+    # names without hardcoding the namespace URI.
+    results: list[str] = []
+    for elem in root.iter():
+        tag = _local_name(elem.tag)
+        if tag == "S":
+            # Stream record: S="Error" / S="Warning" / S="Verbose" /
+            # etc. Or property record: N="Message" / N="Exception".
+            stream = elem.get("S", "")
+            prop_name = elem.get("N", "")
+            if (
+                stream in {"Error", "Warning"}
+                or prop_name in {"Message", "Exception", "FullyQualifiedErrorId"}
+            ):
+                results.append(_decode_escapes(elem.text or ""))
+    return results
+
+
+def _local_name(tag: str) -> str:
+    # Strip ``{ns}`` prefix from ``ElementTree.Element.tag``.
+    if "}" in tag:
+        return tag.split("}", 1)[1]
+    return tag
+
+
+def _decode_escapes(raw: str) -> str:
+    """Decode PowerShell's ``_xHHHH_`` escapes back to real chars."""
+    def _sub(m: re.Match[str]) -> str:
+        try:
+            return chr(int(m.group(1), 16))
+        except ValueError:
+            return m.group(0)
+    return _ESCAPE_RE.sub(_sub, raw)

--- a/src/shipyard/executor/ssh_windows.py
+++ b/src/shipyard/executor/ssh_windows.py
@@ -27,6 +27,7 @@ from typing import Any
 
 from shipyard.bundle.git_bundle import create_bundle, upload_bundle
 from shipyard.core.job import TargetResult, TargetStatus
+from shipyard.executor.clixml import maybe_decode_clixml
 from shipyard.executor.contract import evaluate_contract, required_markers
 from shipyard.executor.streaming import ProgressCallback, run_streaming_command
 from shipyard.executor.windows_toolchain import (
@@ -577,9 +578,14 @@ def _apply_bundle_windows(
             timeout=timeout,
         )
         if result.returncode != 0:
+            # PowerShell relays stderr as a CLIXML envelope (#188).
+            # Decoded text names the actual cause; raw envelope is
+            # still preserved in the per-target log via the streaming
+            # capture earlier in the pipeline.
+            detail = maybe_decode_clixml(result.stderr.strip())
             return _ApplyResult(
                 success=False,
-                message=f"Remote bundle apply failed: {result.stderr.strip()}",
+                message=f"Remote bundle apply failed: {detail}",
             )
         return _ApplyResult(success=True, message="Bundle applied")
 
@@ -793,7 +799,12 @@ def _error_result(
 
 
 def _extract_ssh_error(output: str) -> str | None:
-    for line in reversed(output.splitlines()):
+    # PowerShell wraps any stderr stream in a CLIXML envelope; the
+    # actual message lives inside. Decode before falling through to
+    # the bare-last-line heuristic so ssh_windows errors read the
+    # same as ssh ones under the summary table. See #188.
+    decoded = maybe_decode_clixml(output)
+    for line in reversed(decoded.splitlines()):
         if line.strip():
             return line.strip()
     return None

--- a/tests/executor/test_clixml.py
+++ b/tests/executor/test_clixml.py
@@ -1,0 +1,152 @@
+"""CLIXML decoder regression tests (#188).
+
+Pre-fix, ssh-windows backend errors surfaced as literal
+``#< CLIXML <Objs>…</Objs>`` under the summary table — gibberish.
+These tests pin the decoder to the real shapes PowerShell emits:
+
+- plain ``<S S="Error">`` stream records (Write-Error output)
+- mixed Error + Warning streams
+- nested ``<Obj>`` with ``<S N="Message">`` (full ErrorRecord)
+- concatenated back-to-back envelopes from multiple stderr flushes
+- ``_xHHHH_`` character-escape decoding for CR/LF
+- malformed payload → fall through to raw (never raise)
+"""
+
+from __future__ import annotations
+
+from shipyard.executor.clixml import is_clixml, maybe_decode_clixml
+
+
+def test_plain_text_passes_through_unchanged() -> None:
+    assert maybe_decode_clixml("just a regular error\nline 2") == (
+        "just a regular error\nline 2"
+    )
+    assert is_clixml("just a regular error") is False
+
+
+def test_write_error_stream_decoded() -> None:
+    envelope = (
+        '#< CLIXML\r\n'
+        '<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/'
+        'powershell/2004/04">'
+        '<S S="Error">intentional failure_x000D__x000A_</S>'
+        '</Objs>'
+    )
+    out = maybe_decode_clixml(envelope)
+    assert "intentional failure" in out
+    assert "#< CLIXML" not in out
+    assert "<Objs" not in out
+
+
+def test_error_and_warning_both_extracted() -> None:
+    envelope = (
+        '#< CLIXML\n'
+        '<Objs xmlns="http://schemas.microsoft.com/powershell/2004/04">'
+        '<S S="Warning">slow disk detected</S>'
+        '<S S="Error">git exit 1: refusing to fetch</S>'
+        '</Objs>'
+    )
+    out = maybe_decode_clixml(envelope)
+    assert "slow disk detected" in out
+    assert "git exit 1: refusing to fetch" in out
+
+
+def test_error_record_message_property_extracted() -> None:
+    # ErrorRecord serializations nest a <Props> block with a
+    # <S N="Message"> giving the exception text. Real-world example
+    # shape: System.IO.IOException with "file in use" message.
+    envelope = (
+        '#< CLIXML\n'
+        '<Objs xmlns="http://schemas.microsoft.com/powershell/2004/04">'
+        '<Obj>'
+        '<Props>'
+        '<S N="Message">The process cannot access the file because it '
+        'is being used by another process.</S>'
+        '<S N="FullyQualifiedErrorId">System.IO.IOException</S>'
+        '</Props>'
+        '</Obj>'
+        '</Objs>'
+    )
+    out = maybe_decode_clixml(envelope)
+    assert "being used by another process" in out
+
+
+def test_concatenated_envelopes_both_decoded() -> None:
+    # PowerShell can flush stderr multiple times; receiver sees two
+    # back-to-back envelopes. Decoder must pick up both.
+    envelope = (
+        '#< CLIXML\n'
+        '<Objs xmlns="http://schemas.microsoft.com/powershell/2004/04">'
+        '<S S="Error">first error</S>'
+        '</Objs>'
+        '<Objs xmlns="http://schemas.microsoft.com/powershell/2004/04">'
+        '<S S="Error">second error</S>'
+        '</Objs>'
+    )
+    out = maybe_decode_clixml(envelope)
+    assert "first error" in out
+    assert "second error" in out
+
+
+def test_xhhhh_escape_sequences_decoded() -> None:  # noqa: N802 — mirror the PowerShell CLIXML escape form
+    # PowerShell encodes CR/LF/tab as _x000D_/_x000A_/_x0009_ because
+    # the naïve XML 1.0 character set doesn't allow them in content.
+    envelope = (
+        '#< CLIXML\n'
+        '<Objs xmlns="http://schemas.microsoft.com/powershell/2004/04">'
+        '<S S="Error">line1_x000D__x000A_line2</S>'
+        '</Objs>'
+    )
+    out = maybe_decode_clixml(envelope)
+    assert "line1" in out
+    assert "line2" in out
+    # Escapes must not leak through literally.
+    assert "_x000D_" not in out
+    assert "_x000A_" not in out
+
+
+def test_malformed_xml_falls_back_to_raw() -> None:
+    envelope = '#< CLIXML\n<Objs>unclosed'
+    # Must not raise; must return the raw envelope unchanged so the
+    # caller's original "at least show something" behaviour holds.
+    out = maybe_decode_clixml(envelope)
+    assert out == envelope
+
+
+def test_empty_envelope_falls_back_to_raw() -> None:
+    envelope = '#< CLIXML\n'
+    out = maybe_decode_clixml(envelope)
+    # No Objs document, nothing to decode → return unchanged.
+    assert out == envelope
+
+
+def test_envelope_with_leading_whitespace_still_detected() -> None:
+    # Sometimes the stream begins with a newline or extra space
+    # before the sentinel.
+    envelope = (
+        '\n   #< CLIXML\n'
+        '<Objs xmlns="http://schemas.microsoft.com/powershell/2004/04">'
+        '<S S="Error">wrapped</S>'
+        '</Objs>'
+    )
+    assert is_clixml(envelope)
+    out = maybe_decode_clixml(envelope)
+    assert "wrapped" in out
+    assert "<Objs" not in out
+
+
+def test_very_long_output_truncated_from_head() -> None:
+    # 5000-char error chain; output must keep the tail (the proximate
+    # cause) and drop the head with an ellipsis marker.
+    long_text = " ".join(f"line{i}" for i in range(1000))
+    envelope = (
+        '#< CLIXML\n'
+        '<Objs xmlns="http://schemas.microsoft.com/powershell/2004/04">'
+        f'<S S="Error">{long_text}</S>'
+        '</Objs>'
+    )
+    out = maybe_decode_clixml(envelope)
+    assert len(out) <= 900  # _MAX_DECODED_CHARS + ellipsis margin
+    assert out.startswith("…")
+    # The very last line must still be in the output.
+    assert "line999" in out

--- a/uv.lock
+++ b/uv.lock
@@ -455,7 +455,7 @@ wheels = [
 
 [[package]]
 name = "shipyard"
-version = "0.30.0"
+version = "0.31.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

- New \`shipyard.executor.clixml\` module with \`is_clixml\` + \`maybe_decode_clixml\`. Detects the \`#< CLIXML\` sentinel, parses the XML payload, walks \`<S S="Error">\` / \`<S S="Warning">\` stream records + nested \`<Obj>\` / \`<S N="Message">\` ErrorRecord properties, decodes \`_xHHHH_\` escape sequences, dedupes + concatenates, caps at 800 chars.
- Wired into \`ssh_windows.py\` at both the bundle-apply error path and the validate-phase stderr extractor.
- Malformed XML / partial envelopes fall back to the raw input — worst case matches pre-decoder behavior.
- 10 new regression tests covering plain text, Error+Warning streams, ErrorRecord properties, concatenated envelopes, escape sequences, malformed/empty/wrapped envelopes, and truncation.

## Why

v0.28.0 surfaces Windows errors but as raw \`#< CLIXML <Objs>…</Objs>\` — user sees gibberish instead of the actual cause (file-in-use, exit 1, missing dep). With the decoder, \`shipyard ship\` against \`ssh-windows\` prints the plain-text error underneath the summary table the same way it does for \`ssh\`.

Unblocks pulp's \`win\` host triage — with raw CLIXML we can't distinguish a transient transport blip from a real file-lock issue.

## Test plan

- [x] \`pytest tests/executor/test_clixml.py\` — 10/10 pass.
- [x] \`pytest tests/executor/\` — 55/55 pass (no regressions in ssh or streaming).
- [x] \`ruff check\` clean.
- [ ] Post-merge: next pulp ship against \`win\` should print the actual error underneath the \`windows  error  ssh-windows\` row. If the decoded message names a real file-in-use / exit-N condition, file a pulp-side issue; if it's a transport blip, already diagnosed.

## Cheap manual repro (if running locally)

On any Windows PowerShell remote target, schedule a \`Write-Error "intentional failure"\` + non-zero exit. Before: \`windows error ssh-windows\` row with \`#< CLIXML …\`. After: same row with \`intentional failure\` on the indented line.

Closes #188.