### PR TITLE
ci+release: --break-system-packages for Namespace macOS runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install dependencies
-        run: pip install .[dev]
+        run: pip install --break-system-packages .[dev]
 
       - name: Run tests
         run: pytest
@@ -115,7 +115,7 @@ jobs:
         with:
           python-version: "3.12"
       - name: Install deps + pyinstaller
-        run: pip install .[dev] pyinstaller
+        run: pip install --break-system-packages .[dev] pyinstaller
       - name: Build --onefile binary
         run: pyinstaller --onefile --name shipyard src/shipyard/cli.py
       - name: --version sanity
@@ -160,7 +160,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install dependencies
-        run: pip install .[dev]
+        run: pip install --break-system-packages .[dev]
 
       - name: Run state-machine tests
         run: pytest -m state_machine -v

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,7 +85,16 @@ jobs:
           python-version: "3.13"
 
       - name: Install dependencies
-        run: pip install .[dev] pyinstaller
+        # `--break-system-packages` is required on Namespace macOS
+        # runners (PEP 668 externally-managed Python). GitHub-hosted
+        # runners accept the flag as a no-op. Without it, v0.32.0's
+        # macos-arm64 build job failed on
+        #   error: externally-managed-environment
+        # when the workflow moved from github-hosted default to
+        # Namespace default (#187). The runner is ephemeral so the
+        # "system-wide install" warning the flag bypasses is
+        # irrelevant.
+        run: pip install --break-system-packages .[dev] pyinstaller
 
       # Keychain setup MUST happen before the PyInstaller build so the
       # --codesign-identity flag can resolve and sign every embedded


### PR DESCRIPTION
## Summary

- Every \`pip install\` site in \`ci.yml\` and \`release.yml\` now passes \`--break-system-packages\`.
- No-op on GitHub-hosted runners and on Namespace Linux/Windows.
- Fixes v0.32.0 / v0.33.0 Release builds that failed on macos-arm64 with \`error: externally-managed-environment\` after #187 flipped the default runner provider to Namespace.

## Why

PEP 668 / Namespace macOS image. v0.30.0 and v0.31.0 built cleanly on github-hosted; the first post-#187 release (v0.32.0) hit this because Namespace's macOS runner has an externally-managed system Python. Every subsequent tag push was doomed to the same failure until fixed.

## Post-merge cleanup

Once this lands, manually dispatch \`release.yml\` on v0.32.0 and v0.33.0 tags so their release assets finally publish:

\`\`\`sh
gh workflow run release.yml --repo danielraffel/Shipyard --ref v0.32.0 -f runner_provider=namespace
gh workflow run release.yml --repo danielraffel/Shipyard --ref v0.33.0 -f runner_provider=namespace
\`\`\`

(Those tags already exist, auto-release fired successfully for both; only the build-+-publish part failed.)

## Test plan

- [x] \`actionlint\` clean on both workflows.
- [ ] Post-merge: next tagged release populates GitHub Releases page (currently stuck at v0.31.0).