### PR TITLE
chore: bump to 0.34.0 — rebuild release with PEP 668 fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "shipyard"
-version = "0.33.0"
+version = "0.34.0"
 description = "Cross-platform CI coordination — local VMs, SSH hosts, cloud runners"
 readme = "README.md"
 license = "MIT"

--- a/src/shipyard/__init__.py
+++ b/src/shipyard/__init__.py
@@ -1,3 +1,3 @@
 """Shipyard — Cross-platform CI coordination."""
 
-__version__ = "0.33.0"
+__version__ = "0.34.0"

--- a/uv.lock
+++ b/uv.lock
@@ -455,7 +455,7 @@ wheels = [
 
 [[package]]
 name = "shipyard"
-version = "0.33.0"
+version = "0.34.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Why

v0.32.0 and v0.33.0 tags auto-released successfully but their `release.yml` at those tag refs predates #191's \`--break-system-packages\` fix, so the macos-arm64 Build job failed on every dispatch with \`error: externally-managed-environment\`. Both tags exist with no release assets. Current \`gh release list\` latest: v0.31.0.

Re-dispatching the Release workflow on v0.32.0 / v0.33.0 won't help — \`workflow_dispatch --ref v0.XX.0\` uses the workflow file at *that* tag, which is stale. Cleanest cleanup is to bump to 0.34.0 so auto-release cuts a fresh tag pointing at a commit that contains the fix in its \`release.yml\`.

After this merges:
1. Auto-release creates v0.34.0 tag at HEAD.
2. Release workflow at v0.34.0 has \`--break-system-packages\` → macOS build succeeds.
3. Release assets publish to v0.34.0.
4. Users installing via \`curl … install.sh | bash\` jump v0.31.0 → v0.34.0 (skipping the two broken intermediate tags).

v0.32.0 and v0.33.0 stay as historical tag markers; no assets, not visible in \`gh release list\`, but removing them would break anyone pinned to them.

## What's in v0.34.0

Everything that landed since v0.31.0:
- #132 — \`install.sh\` SHIPYARD_VERSION + SHIPYARD_INSTALL_DIR env vars (unblocks pulp's version pin)
- #182 — daemon 24h forced-reconcile window (Codex P1)
- #183 — tunnel supervisor OSError handling + crash_attempt reset (Codex P2)
- #184 — signing identity by Team ID + detect-readiness step (Codex P1/P2)
- #185 — worktree detect uses toplevel not cwd (Codex P2)
- #187 — Namespace as default runner provider
- #189 — CLIXML decoder for ssh-windows errors (#188)
- #191 — \`--break-system-packages\` for Namespace macOS runners

## Test plan

- [ ] Post-merge: \`gh release list\` shows v0.34.0 as Latest with all 5 signed binaries uploaded within ~5 min of auto-release firing.