### PR TITLE
preflight: annotate target-unreachable errors with daemon version skew (#197)

### DIFF
--- a/src/shipyard/preflight.py
+++ b/src/shipyard/preflight.py
@@ -156,6 +156,7 @@ def run_submission_preflight(
         target_states[target_name] = probe_result
 
     if unreachable:
+        skew_note = _daemon_version_skew_note(config)
         if allow_unreachable_targets:
             # Loud warning: the user asked for this escape hatch, but
             # they probably didn't realize they were buying a
@@ -173,9 +174,11 @@ def run_submission_preflight(
             for u in unreachable:
                 detail = u.message or f"Target '{u.target_name}' is unreachable"
                 warnings.append(f"  - {detail}")
+            if skew_note:
+                warnings.append(skew_note)
         else:
             raise BackendUnreachableError(
-                _format_unreachable_error(unreachable)
+                _format_unreachable_error(unreachable, skew_note=skew_note)
             )
 
     return PreflightResult(
@@ -187,7 +190,11 @@ def run_submission_preflight(
     )
 
 
-def _format_unreachable_error(unreachable: list[TargetPreflight]) -> str:
+def _format_unreachable_error(
+    unreachable: list[TargetPreflight],
+    *,
+    skew_note: str | None = None,
+) -> str:
     """Compose the multi-line error that fires on fail-fast."""
     lines: list[str] = []
     for u in unreachable:
@@ -198,6 +205,16 @@ def _format_unreachable_error(unreachable: list[TargetPreflight]) -> str:
                 lines.append(f"  {detail_line}")
         if u.failure_category:
             lines.append(f"  category: {u.failure_category}")
+
+    # #197: when the daemon is on a stale version, preflight errors are
+    # a common symptom (probe logic changes, IPC format drift, etc.).
+    # Surface the skew as a likely-root-cause note so users don't
+    # chase phantom SSH / network bugs when the fix is "restart the
+    # daemon." Non-blocking annotation — the user can still read the
+    # primary error and decide.
+    if skew_note:
+        lines.append("")
+        lines.append(skew_note)
 
     lines.append("")
     lines.append("Options:")
@@ -212,6 +229,50 @@ def _format_unreachable_error(unreachable: list[TargetPreflight]) -> str:
         "(LANE WILL BE SKIPPED, NOT VALIDATED)"
     )
     return "\n".join(lines)
+
+
+def _daemon_version_skew_note(config: Config) -> str | None:
+    """If a daemon is running and its version differs from the CLI's,
+    return a multi-line annotation callers can append to a preflight
+    error. Returns ``None`` otherwise (daemon absent, version matches,
+    or any query error).
+
+    Deliberately fail-quiet: a flaky daemon-status probe must not
+    turn a real preflight error into a confusing aggregate error.
+    """
+    try:
+        from shipyard import __version__ as cli_version
+        from shipyard.daemon.controller import read_daemon_status
+
+        status = read_daemon_status(config.state_dir)
+    except Exception:  # noqa: BLE001 — best-effort annotation
+        return None
+    if status is None:
+        return None  # daemon not running — no skew to warn about
+
+    daemon_version = status.get("shipyard_version")
+    if not isinstance(daemon_version, str) or not daemon_version:
+        # Daemon pre-v0.26.0 doesn't advertise its version. That IS
+        # the skew signal — the current CLI is newer than any version
+        # that would populate this field.
+        return (
+            "Note: a running daemon was detected but it predates v0.26.0 "
+            "and doesn't advertise its version. This daemon's probe logic "
+            "may be incompatible with the current CLI — run "
+            "`shipyard daemon stop && shipyard daemon start` to refresh."
+        )
+    if daemon_version == cli_version:
+        return None
+
+    return (
+        f"Note: the running daemon is v{daemon_version} but this CLI is "
+        f"v{cli_version}. Version skew can surface as phantom SSH "
+        f"timeouts / unreachable errors because probe logic and IPC "
+        f"formats change across versions. If the target reads as "
+        f"reachable from `ssh <host>` directly, try "
+        f"`shipyard daemon stop && shipyard daemon start` to sync the "
+        f"daemon to the current binary before debugging further."
+    )
 
 
 def _probe_target_path(

--- a/tests/test_preflight_daemon_skew.py
+++ b/tests/test_preflight_daemon_skew.py
@@ -1,0 +1,92 @@
+"""Preflight error annotation when daemon version is skewed (#197).
+
+Before this, a CLI upgrade with a still-running older daemon produced
+phantom "SSH target is unreachable (timeout)" errors during
+`shipyard run/ship/pr` preflight. The user had no signal that the
+real cause was daemon staleness — they'd spend time chasing
+`~/.ssh/config` or network issues. These tests pin the annotation:
+
+1. Daemon running at matching version → no note added.
+2. Daemon running at different version → skew note in the error.
+3. Daemon not running → no note (daemon-less is supported).
+4. Daemon pre-v0.26.0 (no `shipyard_version` field) → skew note
+   because that absence IS the skew signal.
+"""
+
+from __future__ import annotations
+
+import pytest  # noqa: TC002 — used at runtime via MonkeyPatch fixtures, not only annotations
+
+from shipyard.preflight import _daemon_version_skew_note
+
+
+class _FakeConfig:
+    """Minimal stand-in for ``shipyard.core.config.Config`` —
+    ``_daemon_version_skew_note`` only reads ``state_dir``."""
+
+    def __init__(self, state_dir: str = "/tmp/sy-test") -> None:
+        self.state_dir = state_dir
+
+
+def test_matching_version_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    import shipyard
+
+    monkeypatch.setattr(shipyard, "__version__", "0.34.0")
+    monkeypatch.setattr(
+        "shipyard.daemon.controller.read_daemon_status",
+        lambda _: {"shipyard_version": "0.34.0"},
+    )
+    assert _daemon_version_skew_note(_FakeConfig()) is None
+
+
+def test_mismatched_version_returns_note(monkeypatch: pytest.MonkeyPatch) -> None:
+    import shipyard
+
+    monkeypatch.setattr(shipyard, "__version__", "0.34.0")
+    monkeypatch.setattr(
+        "shipyard.daemon.controller.read_daemon_status",
+        lambda _: {"shipyard_version": "0.29.0"},
+    )
+    note = _daemon_version_skew_note(_FakeConfig())
+    assert note is not None
+    assert "v0.29.0" in note
+    assert "v0.34.0" in note
+    assert "shipyard daemon stop" in note
+
+
+def test_daemon_not_running_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "shipyard.daemon.controller.read_daemon_status",
+        lambda _: None,
+    )
+    assert _daemon_version_skew_note(_FakeConfig()) is None
+
+
+def test_pre_0_26_daemon_missing_version_field_flags_skew(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Daemons before v0.26.0 don't populate `shipyard_version`. That
+    # absence is itself the skew signal.
+    monkeypatch.setattr(
+        "shipyard.daemon.controller.read_daemon_status",
+        lambda _: {"some_other_field": "hello"},
+    )
+    note = _daemon_version_skew_note(_FakeConfig())
+    assert note is not None
+    assert "pre" in note.lower() or "predates" in note.lower()
+    assert "shipyard daemon stop" in note
+
+
+def test_read_daemon_status_exception_returns_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Fail-quiet contract: a flaky daemon-status probe must never
+    turn a real preflight error into an aggregate error."""
+
+    def _raiser(_: object) -> dict:
+        raise RuntimeError("simulated: daemon socket wedged")
+
+    monkeypatch.setattr(
+        "shipyard.daemon.controller.read_daemon_status", _raiser
+    )
+    assert _daemon_version_skew_note(_FakeConfig()) is None


### PR DESCRIPTION
## Summary

- \`src/shipyard/preflight.py\` grows a \`_daemon_version_skew_note()\` helper that returns a multi-line annotation if the running daemon's \`shipyard_version\` differs from the CLI's, \`None\` otherwise.
- The annotation is appended to the \`BackendUnreachableError\` message (fail-fast path) and to the \`--allow-unreachable-targets\` warnings list (soften path). Same signal in both.
- Fail-quiet: any error reading daemon status returns \`None\` — a flaky IPC probe must never turn a real preflight error into an aggregate error.
- 5 new tests covering matching version, mismatched version, daemon absent, pre-v0.26.0 daemon (no \`shipyard_version\` field = skew signal), and exception fail-quiet.

## Why Option 2, not Option 1

Per the #197 discussion, chose the softer "annotate the hypothesis" approach over Option 1's "hard-fail on version mismatch." Option 1 rejected because (a) it blocks users who are intentionally running an older daemon, and (b) daemon-skew isn't the only path to a spurious SSH timeout — we don't want to mis-attribute every preflight error to version skew.

Option 2 lets the user see the primary SSH diagnostic and the version-skew hypothesis side by side, and decide. The hint is actionable (\`shipyard daemon stop && shipyard daemon start\`) and fixes the skew case 100%.

## Test plan

- [x] \`pytest tests/test_preflight_daemon_skew.py tests/test_preflight.py\` — 10/10 pass.
- [x] \`ruff check\` clean.
- [ ] Manual: run daemon at older version, bump CLI, trigger \`shipyard pr\` against an SSH target — error now ends with the skew note.

Closes #197.