### PR TITLE
ssh-windows: persist raw bundle-apply stderr to disk (#200)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to Shipyard are documented here. Each entry links
 to its [GitHub Release](https://github.com/danielraffel/Shipyard/releases).
 
 <a id="v0340"></a>
+## [0.35.0]
+
 ## [0.34.0] - 2026-04-23
 
 - ci+release: --break-system-packages for Namespace macOS runners ([#191](https://github.com/danielraffel/Shipyard/pull/191))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "shipyard"
-version = "0.34.0"
+version = "0.35.0"
 description = "Cross-platform CI coordination — local VMs, SSH hosts, cloud runners"
 readme = "README.md"
 license = "MIT"

--- a/src/shipyard/__init__.py
+++ b/src/shipyard/__init__.py
@@ -1,3 +1,3 @@
 """Shipyard — Cross-platform CI coordination."""
 
-__version__ = "0.34.0"
+__version__ = "0.35.0"

--- a/src/shipyard/executor/ssh_windows.py
+++ b/src/shipyard/executor/ssh_windows.py
@@ -168,13 +168,21 @@ class SSHWindowsExecutor:
                         f"Bundle upload failed: {upload_result.message}",
                     )
 
-                # Apply bundle via PowerShell on the remote
+                # Apply bundle via PowerShell on the remote. Pass
+                # the per-target log_file through so the raw stderr
+                # (including any CLIXML envelope) gets persisted
+                # before decode, even if bundle apply fails before
+                # the streaming/validation layer would normally
+                # start writing the log. #200: without this, a
+                # bundle-apply-time CLIXML leak leaves zero
+                # diagnostic artifact on disk.
                 apply_result = _apply_bundle_windows(
                     host=host,
                     bundle_path=remote_bundle,
                     repo_path=remote_repo,
                     ssh_options=ssh_options,
                     timeout=int(target_config.get("bundle_apply_timeout_secs", 1800)),
+                    log_file=log_file,
                 )
                 if not apply_result.success:
                     return _error_result(
@@ -524,6 +532,7 @@ def _apply_bundle_windows(
     repo_path: str,
     ssh_options: list[str],
     timeout: int = 1800,
+    log_file: Path | None = None,
 ) -> _ApplyResult:
     """Apply a git bundle on a remote Windows host via PowerShell.
 
@@ -544,6 +553,16 @@ def _apply_bundle_windows(
     upload_bundle) so `git bundle verify` + `git fetch` on a large
     repo doesn't get killed on slow Windows disks. The previous
     120s was too tight for anything with real history.
+
+    On failure, the raw stderr (CLIXML envelope + exit code) is
+    written to a sibling log file — ``<log_file>.bundle-apply-stderr``
+    — before attempting decode. #200: the CLIXML decoder was
+    already wired in (#189) but real bundle-apply failures on pulp
+    surfaced only the sentinel ``#< CLIXML`` with no body or log
+    artifact to analyze. Persisting raw stderr gives every
+    future failure a self-describing forensic record regardless of
+    whether the decoder hits a complete envelope, a truncated one,
+    or something that isn't CLIXML at all.
     """
     # Expand a relative bundle path against $HOME inside PowerShell.
     # Detecting "relative" on the Windows side is simpler than on
@@ -578,15 +597,43 @@ def _apply_bundle_windows(
             timeout=timeout,
         )
         if result.returncode != 0:
+            raw_stderr = result.stderr or ""
+            # Persist raw stderr BEFORE decode (#200). The previous
+            # comment here claimed the envelope was saved by the
+            # streaming layer, but bundle-apply failures happen
+            # before streaming/validation starts — no streaming
+            # capture ever runs, the envelope was lost. Now we
+            # write it next to where the target log would be and
+            # reference it in the error message so the user has a
+            # concrete artifact to inspect.
+            stderr_log_path: Path | None = None
+            if log_file is not None:
+                try:
+                    stderr_log_path = Path(str(log_file) + ".bundle-apply-stderr")
+                    stderr_log_path.parent.mkdir(parents=True, exist_ok=True)
+                    stderr_log_path.write_text(
+                        f"=== exit_code={result.returncode} ===\n"
+                        f"=== stderr (bytes={len(raw_stderr)}) ===\n"
+                        f"{raw_stderr}\n"
+                        f"=== stdout (bytes={len(result.stdout or '')}) ===\n"
+                        f"{result.stdout or ''}\n",
+                    )
+                except OSError:
+                    # Persisting the log is best-effort — the primary
+                    # failure path must not be hidden by a log-write
+                    # error. Fall through to the original error
+                    # message without the log reference.
+                    stderr_log_path = None
+
             # PowerShell relays stderr as a CLIXML envelope (#188).
-            # Decoded text names the actual cause; raw envelope is
-            # still preserved in the per-target log via the streaming
-            # capture earlier in the pipeline.
-            detail = maybe_decode_clixml(result.stderr.strip())
-            return _ApplyResult(
-                success=False,
-                message=f"Remote bundle apply failed: {detail}",
-            )
+            # Decoded text names the actual cause when the envelope
+            # is complete; falls back to raw when it's truncated or
+            # malformed (see #200 for the real-world truncation case).
+            detail = maybe_decode_clixml(raw_stderr.strip())
+            message = f"Remote bundle apply failed: {detail}"
+            if stderr_log_path is not None:
+                message += f" (raw stderr: {stderr_log_path})"
+            return _ApplyResult(success=False, message=message)
         return _ApplyResult(success=True, message="Bundle applied")
 
     except subprocess.TimeoutExpired:

--- a/tests/executor/test_ssh_windows_bundle_apply_log.py
+++ b/tests/executor/test_ssh_windows_bundle_apply_log.py
@@ -1,0 +1,166 @@
+"""Bundle-apply failure persists raw PowerShell stderr to disk (#200).
+
+v0.34.0 (#189) wired a CLIXML decoder into the bundle-apply error
+path, but the decoder receives only whatever subprocess stderr
+contains. Real-world pulp failures today surfaced ``#< CLIXML`` with
+no body — the decoder has nothing to parse — and ``windows.log``
+doesn't exist yet at bundle-apply time, so there's zero forensic
+record.
+
+This test pins the post-fix contract: when ``_apply_bundle_windows``
+fails, the raw stderr is written to ``<log_file>.bundle-apply-stderr``
+next to the intended log file, regardless of whether the CLIXML
+decoder succeeds.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest  # noqa: TC002 — used at runtime via MonkeyPatch fixture
+
+from shipyard.executor.ssh_windows import _apply_bundle_windows
+
+
+class _FakeCompletedProcess:
+    def __init__(self, returncode: int, stderr: str = "", stdout: str = "") -> None:
+        self.returncode = returncode
+        self.stderr = stderr
+        self.stdout = stdout
+
+
+def test_bundle_apply_failure_writes_raw_stderr_log(tmp_path: Path) -> None:
+    log_file = tmp_path / "run-id" / "windows.log"
+    fake_stderr = "#< CLIXML\n<Objs><S S=\"Error\">bundle verify: not a valid bundle</S></Objs>"
+
+    with patch(
+        "shipyard.executor.ssh_windows.subprocess.run",
+        return_value=_FakeCompletedProcess(returncode=1, stderr=fake_stderr),
+    ):
+        result = _apply_bundle_windows(
+            host="win",
+            bundle_path="shipyard.bundle",
+            repo_path="~/repo",
+            ssh_options=[],
+            log_file=log_file,
+        )
+
+    assert result.success is False
+    # Raw stderr log lands right next to where windows.log would be.
+    sibling = Path(str(log_file) + ".bundle-apply-stderr")
+    assert sibling.exists(), "bundle-apply stderr log must be written on failure"
+    body = sibling.read_text()
+    assert "exit_code=1" in body
+    assert "#< CLIXML" in body
+    assert "bundle verify: not a valid bundle" in body
+    # And the ApplyResult message references the log path so the
+    # user can find it from the summary row.
+    assert str(sibling) in result.message
+
+
+def test_bundle_apply_failure_with_empty_envelope_still_logs_raw(
+    tmp_path: Path,
+) -> None:
+    """#200 specifically: a truncated envelope (sentinel-only, no
+    body) left the user with ``#< CLIXML`` and no log artifact at
+    all. The log write must still fire so next time we have bytes
+    to analyze."""
+    log_file = tmp_path / "run-id" / "windows.log"
+    fake_stderr = "#< CLIXML\n"  # sentinel only, no <Objs> body
+
+    with patch(
+        "shipyard.executor.ssh_windows.subprocess.run",
+        return_value=_FakeCompletedProcess(returncode=1, stderr=fake_stderr),
+    ):
+        result = _apply_bundle_windows(
+            host="win",
+            bundle_path="shipyard.bundle",
+            repo_path="~/repo",
+            ssh_options=[],
+            log_file=log_file,
+        )
+
+    sibling = Path(str(log_file) + ".bundle-apply-stderr")
+    assert sibling.exists()
+    assert "#< CLIXML" in sibling.read_text()
+    assert result.success is False
+
+
+def test_bundle_apply_success_does_not_write_log(tmp_path: Path) -> None:
+    log_file = tmp_path / "run-id" / "windows.log"
+
+    with patch(
+        "shipyard.executor.ssh_windows.subprocess.run",
+        return_value=_FakeCompletedProcess(returncode=0, stderr="", stdout="ok"),
+    ):
+        result = _apply_bundle_windows(
+            host="win",
+            bundle_path="shipyard.bundle",
+            repo_path="~/repo",
+            ssh_options=[],
+            log_file=log_file,
+        )
+
+    assert result.success is True
+    sibling = Path(str(log_file) + ".bundle-apply-stderr")
+    assert not sibling.exists(), "success path must not write a failure log"
+
+
+def test_bundle_apply_failure_without_log_file_still_returns_error(
+    tmp_path: Path,
+) -> None:
+    """Callers may pass log_file=None (e.g. in unit tests); the
+    error path must still return a clean ApplyResult, just without
+    the log reference."""
+    with patch(
+        "shipyard.executor.ssh_windows.subprocess.run",
+        return_value=_FakeCompletedProcess(returncode=1, stderr="boom"),
+    ):
+        result = _apply_bundle_windows(
+            host="win",
+            bundle_path="shipyard.bundle",
+            repo_path="~/repo",
+            ssh_options=[],
+            log_file=None,
+        )
+    assert result.success is False
+    assert "Remote bundle apply failed" in result.message
+    assert "raw stderr:" not in result.message
+
+
+def test_bundle_apply_log_write_failure_does_not_mask_original_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Best-effort logging: if the log write itself fails, the
+    primary ApplyResult must still carry the decoded message and
+    success=False. We simulate a filesystem-write OSError."""
+    # Point at a path whose parent creation will fail — null-byte
+    # in name triggers OSError on mkdir/write without any real IO.
+    log_file = tmp_path / "run-id" / "windows.log"
+
+    original_write_text = Path.write_text
+
+    def _raise(self: Path, *args, **kwargs) -> int:
+        if str(self).endswith(".bundle-apply-stderr"):
+            raise OSError("simulated: read-only filesystem")
+        return original_write_text(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "write_text", _raise)
+
+    with patch(
+        "shipyard.executor.ssh_windows.subprocess.run",
+        return_value=_FakeCompletedProcess(returncode=1, stderr="some stderr"),
+    ):
+        result = _apply_bundle_windows(
+            host="win",
+            bundle_path="shipyard.bundle",
+            repo_path="~/repo",
+            ssh_options=[],
+            log_file=log_file,
+        )
+
+    assert result.success is False
+    assert "Remote bundle apply failed" in result.message
+    # Log reference must NOT appear since the log write failed.
+    assert "raw stderr:" not in result.message

--- a/uv.lock
+++ b/uv.lock
@@ -455,7 +455,7 @@ wheels = [
 
 [[package]]
 name = "shipyard"
-version = "0.34.0"
+version = "0.35.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

- On \`_apply_bundle_windows\` failure, persist raw stderr + exit code + stdout to \`<log_file>.bundle-apply-stderr\` before calling the CLIXML decoder. Log path surfaces in the ApplyResult message so the user jumps straight there from the summary row.
- Log write is best-effort (OSError swallowed). Success path unchanged.
- 5 regression tests covering envelope-with-body, sentinel-only envelope, success path, \`log_file=None\`, and OSError in log write.

## Why

v0.34.0 (#189) wired the CLIXML decoder. But pulp users today see \`Bundle apply failed: Remote bundle apply failed: #< CLIXML\` on every ssh-windows ship — the envelope is either truncated, or non-CLIXML that the decoder falls back on. Either way, \`windows.log\` doesn't exist yet at bundle-apply time (remote logging starts only after apply succeeds), so there's zero forensic artifact.

This PR doesn't yet explain WHY the envelope arrives incomplete — that's the follow-up once we have bytes to analyze. The point is to make the raw transport stderr available on disk so the next repro is diagnosable instead of blind. #200 suggestion (1) from the issue.

## Test plan

- [x] \`pytest tests/executor/test_ssh_windows_bundle_apply_log.py\` — 5/5 pass.
- [x] \`ruff check\` clean.
- [ ] Post-merge + pulp bump: next pulp \`shipyard pr\` windows failure writes \`<log_file>.bundle-apply-stderr\` alongside the run dir. Contents tell us whether the envelope is truncated (no \`<Objs>\` body) or something the decoder doesn't currently handle.

## Follow-up (not in this PR)

- #200 suggestion (3): trace whether scp/sftp/PS-extraction is where the CLIXML comes from. Needs the log data this PR starts collecting.