### PR TITLE
chore: bump to 0.36.0 — publish install.sh notarization-preserve fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "shipyard"
-version = "0.35.0"
+version = "0.36.0"
 description = "Cross-platform CI coordination — local VMs, SSH hosts, cloud runners"
 readme = "README.md"
 license = "MIT"

--- a/src/shipyard/__init__.py
+++ b/src/shipyard/__init__.py
@@ -1,3 +1,3 @@
 """Shipyard — Cross-platform CI coordination."""
 
-__version__ = "0.35.0"
+__version__ = "0.36.0"

--- a/uv.lock
+++ b/uv.lock
@@ -455,7 +455,7 @@ wheels = [
 
 [[package]]
 name = "shipyard"
-version = "0.35.0"
+version = "0.36.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Why

#203 merged the install.sh fix but didn't trigger auto-release (install.sh isn't in the CLI-surface path map). Without a new tag, the \`/releases/latest\` API still points to v0.35.0 and its bundled install.sh — so \`curl … install.sh | bash\` and \`gh release download\` consumers get the old ad-hoc-stripping behavior.

Bumping to 0.36.0 creates a fresh release tag with the fixed install.sh baked in.

## Contents

- v0.36.0 includes everything since v0.35.0:
  - #203: install.sh preserves Developer-ID notarization

## Test plan

- [ ] Post-merge: \`gh release list\` shows v0.36.0 as Latest with all 5 signed binaries.
- [ ] Re-running \`curl -fsSL …/install.sh | bash\` picks up the fix; resulting binary keeps \`TeamIdentifier=95CX6P84C4\` + \`flags=0x10000(runtime)\`.