### PR TITLE
cli/watch: flag runs stuck in queued state past threshold (#190)

### DIFF
--- a/src/shipyard/cli.py
+++ b/src/shipyard/cli.py
@@ -3894,6 +3894,58 @@ def _run_elapsed_secs(run: DispatchedRun, now: datetime) -> int:
     return max(0, int((now - run.started_at).total_seconds()))
 
 
+# Statuses that mean "GitHub accepted the dispatch but no runner
+# picked it up yet." Used by `_is_stuck_queued` to annotate runs that
+# have been parked longer than ``_stuck_queued_threshold_secs()`` —
+# the scheduler-side stall pattern documented in #190.
+_QUEUED_STATUSES = frozenset({"queued", "pending", "waiting"})
+
+
+def _stuck_queued_threshold_secs() -> float:
+    """Threshold past which a `queued`-status run is flagged as stuck.
+
+    Tunable via ``SHIPYARD_STUCK_QUEUED_THRESHOLD_SECS``. Default 300s
+    (5 min) — generous enough that ordinary GitHub Actions queue
+    warm-up doesn't trigger it, tight enough to catch the 15-min+
+    stalls we saw on 2026-04-23 when Namespace's Windows profile
+    saturated (see #193 for the concrete incident, #190 for the
+    filed feature request).
+    """
+    import os
+
+    raw = os.environ.get("SHIPYARD_STUCK_QUEUED_THRESHOLD_SECS")
+    if raw:
+        try:
+            return max(0.0, float(raw))
+        except ValueError:
+            pass
+    return 300.0
+
+
+def _queued_for_secs(run: DispatchedRun, now: datetime) -> int | None:
+    """Seconds since dispatch iff the run is still in a queued-family
+    status. Returns None once the run has left the queue (any other
+    status)."""
+    if run.status.lower() not in _QUEUED_STATUSES:
+        return None
+    return _run_elapsed_secs(run, now)
+
+
+def _is_stuck_queued(run: DispatchedRun, now: datetime, threshold: float) -> bool:
+    qs = _queued_for_secs(run, now)
+    return qs is not None and qs >= threshold
+
+
+def _format_stuck_queued_duration(secs: int) -> str:
+    """Human-readable queue-time marker for the watch line."""
+    if secs < 60:
+        return f"{secs}s"
+    if secs < 3600:
+        return f"{secs // 60}m"
+    hours, rem = divmod(secs, 3600)
+    return f"{hours}h{rem // 60}m"
+
+
 def _progress_summary(state: ShipState) -> tuple[int, int, int]:
     total = len(state.dispatched_runs)
     complete = 0
@@ -3940,11 +3992,19 @@ def _emit_watch_event(ctx: Context, state: ShipState) -> None:
         if rec.sha == state.head_sha and rec.reused_from:
             reuse_map[target] = rec.reused_from
 
+    stuck_queued_threshold = _stuck_queued_threshold_secs()
     if ctx.json_mode:
         dispatched: list[dict[str, Any]] = []
         for run in state.dispatched_runs:
             entry = run.to_dict()
             entry["elapsed_seconds"] = _run_elapsed_secs(run, now)
+            # #190: surface queue-time on queued runs so machine
+            # consumers can flag scheduler-side stalls. `None` when
+            # the run has left the queue — stable schema.
+            entry["queued_for_secs"] = _queued_for_secs(run, now)
+            entry["stuck_queued"] = _is_stuck_queued(
+                run, now, stuck_queued_threshold,
+            )
             dispatched.append(entry)
         evidence_out: dict[str, dict[str, Any] | str] = {}
         for target, status in state.evidence_snapshot.items():
@@ -4029,6 +4089,18 @@ def _emit_watch_event(ctx: Context, state: ShipState) -> None:
         )
         if is_stale:
             line += "  " + _style("stale", "bold magenta", enabled=color)
+        # #190: annotate runs that have been parked in a queued-family
+        # status past the configured threshold. The `stale` marker
+        # above covers "run started but heartbeat went silent"; this
+        # one covers "run never got a runner at all" — different
+        # failure modes, different remediations.
+        if _is_stuck_queued(run, now, stuck_queued_threshold):
+            qs = _queued_for_secs(run, now) or 0
+            line += "  " + _style(
+                f"stuck-queued {_format_stuck_queued_duration(qs)}",
+                "bold yellow",
+                enabled=color,
+            )
         render_message(line)
 
 

--- a/tests/test_watch_stuck_queued.py
+++ b/tests/test_watch_stuck_queued.py
@@ -1,0 +1,101 @@
+"""Regression tests for #190 stuck-queued run annotation.
+
+When a dispatched run sits in a queued-family status past the
+configured threshold, `shipyard watch` now surfaces that as a
+`stuck-queued Nm` marker in human output and `stuck_queued: true`
++ `queued_for_secs: N` fields in JSON mode. Motivated by the
+2026-04-23 Namespace Windows saturation (#193) — jobs queued 30+
+min with no visible signal.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest  # noqa: TC002 — used at runtime via MonkeyPatch fixture
+
+from shipyard.cli import (
+    _format_stuck_queued_duration,
+    _is_stuck_queued,
+    _queued_for_secs,
+    _stuck_queued_threshold_secs,
+)
+from shipyard.core.ship_state import DispatchedRun
+
+
+def _run(status: str, age_secs: int) -> DispatchedRun:
+    now = datetime.now(timezone.utc)
+    started = now - timedelta(seconds=age_secs)
+    return DispatchedRun(
+        target="macos",
+        provider="namespace",
+        run_id="r1",
+        status=status,
+        started_at=started,
+        updated_at=started,
+    )
+
+
+def test_queued_for_secs_returns_age_for_queued_runs() -> None:
+    now = datetime.now(timezone.utc)
+    assert _queued_for_secs(_run("queued", 120), now) is not None
+    assert _queued_for_secs(_run("queued", 120), now) >= 119
+
+
+def test_queued_for_secs_returns_none_for_non_queued() -> None:
+    now = datetime.now(timezone.utc)
+    for status in ("in_progress", "completed", "success", "failed"):
+        assert _queued_for_secs(_run(status, 500), now) is None
+
+
+def test_is_stuck_queued_fires_past_threshold() -> None:
+    now = datetime.now(timezone.utc)
+    # 5-min-queued run is stuck at threshold 4m but not at 6m.
+    run = _run("queued", 300)
+    assert _is_stuck_queued(run, now, threshold=240.0) is True
+    assert _is_stuck_queued(run, now, threshold=360.0) is False
+
+
+def test_is_stuck_queued_does_not_fire_for_in_progress() -> None:
+    now = datetime.now(timezone.utc)
+    # Even a very old in-progress run is not "stuck queued" — only
+    # queued-family statuses qualify. Different failure mode from
+    # "heartbeat went silent" (which has its own `stale` marker).
+    run = _run("in_progress", 10_000)
+    assert _is_stuck_queued(run, now, threshold=60.0) is False
+
+
+def test_threshold_default_is_300s() -> None:
+    # Default derived from #190: long enough to not flag warm-up
+    # queue, tight enough to catch 15-30 min scheduler stalls.
+    assert _stuck_queued_threshold_secs() == 300.0
+
+
+def test_threshold_respects_env_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("SHIPYARD_STUCK_QUEUED_THRESHOLD_SECS", "60")
+    assert _stuck_queued_threshold_secs() == 60.0
+
+
+def test_threshold_ignores_malformed_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("SHIPYARD_STUCK_QUEUED_THRESHOLD_SECS", "not-a-number")
+    assert _stuck_queued_threshold_secs() == 300.0
+
+
+def test_format_duration_shapes() -> None:
+    assert _format_stuck_queued_duration(45) == "45s"
+    assert _format_stuck_queued_duration(125) == "2m"
+    assert _format_stuck_queued_duration(3900) == "1h5m"
+
+
+def test_waiting_and_pending_statuses_also_qualify() -> None:
+    # GitHub Actions uses "queued" but the underlying workflow run
+    # state model also emits "pending"/"waiting" in edge cases. All
+    # three should be treated the same by the stuck-queued check.
+    now = datetime.now(timezone.utc)
+    for status in ("queued", "pending", "waiting"):
+        assert _queued_for_secs(_run(status, 500), now) is not None
+        assert _is_stuck_queued(_run(status, 500), now, threshold=60.0) is True


### PR DESCRIPTION
## Summary

- \`shipyard watch\` now annotates runs whose status is in a queued-family state (\`queued\`/\`pending\`/\`waiting\`) past \`SHIPYARD_STUCK_QUEUED_THRESHOLD_SECS\` (default 300s).
- Human output: \`stuck-queued 12m\` bold-yellow marker next to the per-run line. Distinct from the existing \`stale\` marker (different failure mode — no runner picked up vs. heartbeat went silent).
- JSON mode: two additive stable-schema fields per dispatched run — \`queued_for_secs\` (int | null) and \`stuck_queued\` (bool).
- 9 regression tests.

## Why

Motivated by 2026-04-23 Namespace Windows saturation (#193) — jobs queued 15–30+ min with no signal beyond "why isn't my PR progressing?" Today every run parked past threshold surfaces it in-line.

## Scope

First slice of #190. The issue also proposed \`shipyard doctor --runs\` (one-shot diagnostic) and \`shipyard cloud unstick --apply\` (auto-cancel + redispatch on fallback provider). Those are larger surface changes — tracked as follow-ups. This PR is the \`watch\` annotation only, which is the highest-leverage/lowest-risk increment.

## Test plan

- [x] \`pytest tests/test_watch_stuck_queued.py\` — 9/9 pass.
- [x] ruff clean.
- [ ] Post-merge: hit a queued run and verify the marker shows in both human and JSON watch output.