### PR TITLE
chore: bump to 0.37.0 — publish stuck-queued watch annotation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "shipyard"
-version = "0.36.0"
+version = "0.37.0"
 description = "Cross-platform CI coordination — local VMs, SSH hosts, cloud runners"
 readme = "README.md"
 license = "MIT"

--- a/src/shipyard/__init__.py
+++ b/src/shipyard/__init__.py
@@ -1,3 +1,3 @@
 """Shipyard — Cross-platform CI coordination."""
 
-__version__ = "0.36.0"
+__version__ = "0.37.0"

--- a/uv.lock
+++ b/uv.lock
@@ -455,7 +455,7 @@ wheels = [
 
 [[package]]
 name = "shipyard"
-version = "0.36.0"
+version = "0.37.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Why

#206 added \`shipyard watch\` stuck-queued annotations but \`version_bump_check.py --mode=apply\` returned "no bump needed" at merge time. The change is user-visible (new output marker, new env var, new JSON schema fields), so it deserves a release.

Bumping manually to v0.37.0 so auto-release cuts the tag and users get the feature via \`install.sh\`.

## Side note

\`version_bump_check.py\` under-classified this change. Watch-output modifications in \`_emit_watch_event\` aren't matched as CLI-surface by the current path map. That's worth a separate small follow-up to tune the path map rules — not in scope for this PR.

## Test plan

- [ ] Post-merge: \`gh release list\` shows v0.37.0 as Latest with all 5 signed binaries.
- [ ] \`shipyard watch --json\` output includes \`queued_for_secs\` and \`stuck_queued\` fields per dispatched run.