### PR TITLE
ssh-windows: prepend UTF-8 code-page prelude to PS commands (#208)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "shipyard"
-version = "0.37.0"
+version = "0.38.0"
 description = "Cross-platform CI coordination — local VMs, SSH hosts, cloud runners"
 readme = "README.md"
 license = "MIT"

--- a/src/shipyard/__init__.py
+++ b/src/shipyard/__init__.py
@@ -1,3 +1,3 @@
 """Shipyard — Cross-platform CI coordination."""
 
-__version__ = "0.37.0"
+__version__ = "0.38.0"

--- a/src/shipyard/executor/ssh_windows.py
+++ b/src/shipyard/executor/ssh_windows.py
@@ -577,6 +577,9 @@ def _apply_bundle_windows(
     )
 
     ps_cmd = (
+        # UTF-8 prelude (#208): also affects git bundle verify /
+        # git fetch output and any non-ASCII bundle path.
+        f"{_WINDOWS_UTF8_PRELUDE}"
         f"$Bundle = {resolved}; "
         f"cd '{safe_repo}'; "
         f"git bundle verify $Bundle; "
@@ -754,6 +757,42 @@ def _append_log(log_file: Path, text: str) -> None:
         pass
 
 
+# Prelude prepended to every PowerShell command shipyard dispatches to
+# a Windows host. Forces UTF-8 across the Win32 console round-trip so
+# non-ASCII argv (em-dashes, emoji, accented test names) survive the
+# trip through any child process.
+#
+# Three settings cover three different encoding paths:
+#
+#   `chcp.com 65001`          → sets the Win32 console code page.
+#                                Child processes' CRT and Win32 APIs
+#                                (GetConsoleCP, GetConsoleOutputCP)
+#                                pick this up. Without it, Namespace's
+#                                Windows image defaults to CP-1252 and
+#                                UTF-8 argv → CP-1252 → mojibake.
+#   `[Console]::OutputEncoding`→ how PowerShell decodes child-process
+#                                stdout back into strings.
+#   `$OutputEncoding`          → how PowerShell sends pipeline data
+#                                TO a child process's stdin.
+#
+# All three are session-scoped — set once at the top of the PS
+# script, they apply to everything that session spawns, and die when
+# the session does. No leak, no global mutation.
+#
+# Zero-cost on hosts already at 65001 (GitHub-hosted Windows runners
+# default to it); the setters are idempotent. See #208 for the
+# concrete incident: pulp's ctest hit 46 spurious failures on
+# Namespace Windows because em-dash test names got mangled.
+#
+# ``| Out-Null`` suppresses `chcp`'s "Active code page: 65001"
+# confirmation line so it doesn't pollute the validation log.
+_WINDOWS_UTF8_PRELUDE = (
+    "[Console]::OutputEncoding = [System.Text.Encoding]::UTF8; "
+    "$OutputEncoding = [System.Text.Encoding]::UTF8; "
+    "chcp.com 65001 | Out-Null; "
+)
+
+
 def _build_remote_command(
     sha: str,
     remote_repo: str,
@@ -803,6 +842,7 @@ def _build_remote_command(
     safe_repo = _ps_single_quote(remote_repo)
     safe_sha = _ps_single_quote(sha)
     return (
+        f"{_WINDOWS_UTF8_PRELUDE}"
         f"{toolchain_env_exports(toolchain)}; "
         f"cd '{safe_repo}'; "
         f"git checkout --force '{safe_sha}'; "

--- a/tests/executor/test_ssh_windows_utf8_prelude.py
+++ b/tests/executor/test_ssh_windows_utf8_prelude.py
@@ -1,0 +1,81 @@
+"""Regression tests for the UTF-8 code-page prelude in ssh-windows
+PowerShell commands (#208).
+
+Pulp hit 46 spurious ctest failures on Namespace Windows because the
+host defaulted to CP-1252 and em-dash test names got mangled through
+the argv round-trip. Shipyard owns the command wrapping, so the fix
+belongs here — prepend a three-line UTF-8 setter to every PS command
+we dispatch.
+"""
+
+from __future__ import annotations
+
+from shipyard.executor.ssh_windows import (
+    _WINDOWS_UTF8_PRELUDE,
+    _build_remote_command,
+)
+
+
+def test_prelude_contains_all_three_encoding_settings() -> None:
+    # Three settings cover three different encoding paths. Any one
+    # missing leaves a window for mojibake — assert all three by
+    # exact substring.
+    assert "chcp.com 65001" in _WINDOWS_UTF8_PRELUDE
+    assert "[Console]::OutputEncoding = [System.Text.Encoding]::UTF8" in _WINDOWS_UTF8_PRELUDE
+    assert "$OutputEncoding = [System.Text.Encoding]::UTF8" in _WINDOWS_UTF8_PRELUDE
+
+
+def test_prelude_runs_before_user_commands_in_build_remote_command() -> None:
+    cmd = _build_remote_command(
+        sha="abc123",
+        remote_repo="C:/repo",
+        validation_config={"command": "ctest --output-on-failure"},
+    )
+    assert cmd is not None
+    # Prelude must be the FIRST thing in the command — any user code
+    # that runs before the prelude would still see CP-1252.
+    assert cmd.startswith(_WINDOWS_UTF8_PRELUDE), (
+        f"prelude must prefix the PS command; got: {cmd[:200]!r}"
+    )
+    # And the user command itself must still land intact downstream.
+    assert "ctest --output-on-failure" in cmd
+    assert "git checkout --force 'abc123'" in cmd
+
+
+def test_prelude_prepended_to_staged_validation() -> None:
+    # The multi-stage path (build / test / lint) also goes through
+    # _build_remote_command; make sure the prelude isn't bypassed
+    # when the user supplies stages instead of a single command.
+    cmd = _build_remote_command(
+        sha="feedface",
+        remote_repo="C:/repo",
+        validation_config={
+            "build": "cmake --build build",
+            "test": "ctest --output-on-failure",
+        },
+    )
+    assert cmd is not None
+    assert cmd.startswith(_WINDOWS_UTF8_PRELUDE)
+    assert "cmake --build build" in cmd
+    assert "ctest --output-on-failure" in cmd
+
+
+def test_prelude_order_matters() -> None:
+    # chcp.com AFTER the PowerShell encoding setters ensures the
+    # console CP change doesn't reset what PowerShell is already
+    # using for its I/O. Assert the order so a future refactor
+    # doesn't silently shuffle it.
+    prelude = _WINDOWS_UTF8_PRELUDE
+    console_idx = prelude.index("[Console]::OutputEncoding")
+    output_idx = prelude.index("$OutputEncoding")
+    chcp_idx = prelude.index("chcp.com")
+    assert console_idx < chcp_idx, "console encoding must be set before chcp"
+    assert output_idx < chcp_idx, "$OutputEncoding must be set before chcp"
+
+
+def test_prelude_suppresses_chcp_confirmation_output() -> None:
+    # `chcp.com 65001` normally prints "Active code page: 65001"
+    # which would pollute the validation log. `| Out-Null`
+    # suppresses it. Without this the log would carry one extra
+    # decoration line per run.
+    assert "| Out-Null" in _WINDOWS_UTF8_PRELUDE

--- a/uv.lock
+++ b/uv.lock
@@ -455,7 +455,7 @@ wheels = [
 
 [[package]]
 name = "shipyard"
-version = "0.37.0"
+version = "0.38.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Every PowerShell command shipyard dispatches via \`ssh_windows\` now starts with a three-line UTF-8 prelude:

\`\`\`powershell
[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
\$OutputEncoding           = [System.Text.Encoding]::UTF8
chcp.com 65001 | Out-Null
\`\`\`

Applied at \`_build_remote_command\` (validation path, where ctest lives) and \`_apply_bundle_windows\` (bundle verify + fetch). Session-scoped; zero-cost on hosts already at 65001; \`| Out-Null\` keeps chcp's banner out of validation logs.

## Why

Pulp hit **46 spurious ctest failures** on Namespace Windows today: em-dash in test names → CP-1252 mangling → filter matched zero. Pulp's workaround (PR #697: prepend \`chcp.com 65001\` in their build.yml) fixed them, but every Shipyard consumer would rediscover this trap. Since Shipyard already wraps every Windows command, UTF-8 enforcement belongs here.

## Test plan

- [x] \`pytest tests/executor/test_ssh_windows_*\` — 28/28 pass (5 new + 23 existing).
- [x] ruff clean.
- [ ] Post-merge + pulp bump: em-dash test names should survive the argv round-trip on Namespace Windows. Pulp's PR #697 \`chcp\`-prepend can be reverted once consumers are on the Shipyard version containing this fix.

Closes #208.