### PR TITLE
ssh-windows: fix bundle-open path mismatch + pre-sentinel stderr decode (#210)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to Shipyard are documented here. Each entry links
 to its [GitHub Release](https://github.com/danielraffel/Shipyard/releases).
 
 <a id="v0380"></a>
+## [0.39.0]
+
 ## [0.38.0] - 2026-04-23
 
 - ssh-windows: prepend UTF-8 code-page prelude to PS commands (#208) ([#209](https://github.com/danielraffel/Shipyard/pull/209))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "shipyard"
-version = "0.38.0"
+version = "0.39.0"
 description = "Cross-platform CI coordination — local VMs, SSH hosts, cloud runners"
 readme = "README.md"
 license = "MIT"

--- a/src/shipyard/__init__.py
+++ b/src/shipyard/__init__.py
@@ -1,3 +1,3 @@
 """Shipyard — Cross-platform CI coordination."""
 
-__version__ = "0.38.0"
+__version__ = "0.39.0"

--- a/src/shipyard/bundle/git_bundle.py
+++ b/src/shipyard/bundle/git_bundle.py
@@ -141,14 +141,41 @@ def upload_bundle(
     )
 
     if is_windows:
-        # PowerShell binary-safe stdin → file:
-        # $input is the automatic pipeline variable for stdin bytes.
-        # [System.IO.File]::WriteAllBytes reads from stdin via
-        # [Console]::OpenStandardInput().
+        # PowerShell binary-safe stdin → file.
+        #
+        # #210: resolve relative `remote_path` against `$HOME` inside
+        # the PS script before creating the file. Otherwise the file
+        # lands in whatever directory OpenSSH's server spawned the
+        # shell in (SSHD default = $HOME, but various configs
+        # deviate) and the apply step — which Join-Paths against
+        # $HOME explicitly — then fails with "could not open" because
+        # the two sides disagree on what the "relative" base is.
+        # Anchoring at $HOME on both sides makes the bundle location
+        # deterministic regardless of SSHD config.
+        #
+        # We detect "relative" cheaply on the Python side: no drive
+        # letter (`X:`) and no leading backslash. The PS-side
+        # `[System.IO.Path]::IsPathRooted` would be more correct but
+        # requires more plumbing.
+        is_rooted = (
+            len(remote_path) >= 2 and remote_path[1] == ":"
+        ) or remote_path.startswith("\\")
+        if is_rooted:
+            resolved_dest = f"'{remote_path}'"
+        else:
+            # PS single-quote string → no escape needed for ordinary
+            # filenames; reject anything with a quote just in case a
+            # caller's path is adversarial.
+            if "'" in remote_path:
+                return BundleResult(
+                    success=False,
+                    message=f"Refusing single-quoted remote_path: {remote_path!r}",
+                )
+            resolved_dest = f"(Join-Path $HOME '{remote_path}')"
         ps_script = (
-            f"$bytes = [System.IO.Stream]::Null;"
+            f"$Dest = {resolved_dest};"
             f"$stdin = [Console]::OpenStandardInput();"
-            f"$fs = [System.IO.File]::Create('{remote_path}');"
+            f"$fs = [System.IO.File]::Create($Dest);"
             f"$stdin.CopyTo($fs);"
             f"$fs.Close();"
             f"$stdin.Close()"

--- a/src/shipyard/executor/clixml.py
+++ b/src/shipyard/executor/clixml.py
@@ -62,14 +62,64 @@ def maybe_decode_clixml(text: str) -> str:
     Never raises — malformed CLIXML falls back to the original text
     so callers' existing error surfaces keep working on partial or
     non-standard envelopes.
+
+    Text that appears *before* the CLIXML sentinel is also surfaced
+    (#210). PowerShell's progress-stream CLIXML can arrive AFTER
+    unrelated stderr lines written by child processes (git, cmake,
+    ctest, etc.) — those pre-sentinel bytes used to be dropped
+    because the decoder started at the sentinel. Now they're
+    prefixed to the decoded envelope (or returned alone if the
+    envelope body is empty), so "error: could not open '...'"
+    style messages survive even when wrapped in a later CLIXML
+    progress object.
     """
-    if not is_clixml(text):
+    # Fast path: no sentinel anywhere → plain text, nothing to do.
+    # If the sentinel IS present (whether at the start or mid-string
+    # after pre-sentinel stderr), fall through to _split_and_decode.
+    if not is_clixml(text) and _CLIXML_SENTINEL not in text:
         return text
     try:
-        decoded = _decode(text)
+        prefix, decoded = _split_and_decode(text)
     except (ET.ParseError, ValueError):
         return text
-    return decoded or text
+    # Join pre-sentinel text and decoded body; either can be empty.
+    parts = [p for p in (prefix.strip(), decoded.strip()) if p]
+    joined = "\n".join(parts)
+    return joined or text
+
+
+def _split_and_decode(text: str) -> tuple[str, str]:
+    """Return ``(pre_sentinel_text, decoded_envelope)``.
+
+    Split on the first occurrence of ``#< CLIXML``; decode everything
+    after as one-or-more ``<Objs>…</Objs>`` documents. Pre-sentinel
+    text is returned verbatim. Either half may be empty.
+    """
+    idx = text.find(_CLIXML_SENTINEL)
+    if idx < 0:
+        return (text, "")
+    prefix = text[:idx]
+    xml_blob = text[idx + len(_CLIXML_SENTINEL):].lstrip()
+
+    messages: list[str] = []
+    for obj_doc in _split_objs(xml_blob):
+        messages.extend(_extract_messages(obj_doc))
+    if not messages:
+        return (prefix, "")
+
+    deduped: list[str] = []
+    for m in messages:
+        stripped = m.strip()
+        if not stripped:
+            continue
+        if deduped and deduped[-1] == stripped:
+            continue
+        deduped.append(stripped)
+
+    joined = "\n".join(deduped)
+    if len(joined) > _MAX_DECODED_CHARS:
+        joined = "…" + joined[-(_MAX_DECODED_CHARS - 1):]
+    return (prefix, joined)
 
 
 def _decode(text: str) -> str:

--- a/src/shipyard/executor/ssh_windows.py
+++ b/src/shipyard/executor/ssh_windows.py
@@ -581,6 +581,19 @@ def _apply_bundle_windows(
         # git fetch output and any non-ASCII bundle path.
         f"{_WINDOWS_UTF8_PRELUDE}"
         f"$Bundle = {resolved}; "
+        # #210: pre-verify the bundle exists at the resolved path
+        # before handing it to git. If the upload landed the file
+        # somewhere else (SSH session working-dir drift, relative-
+        # path mismatch, etc.), `git bundle verify` produces
+        # "error: could not open '...'" which arrives on stderr
+        # BEFORE PowerShell's CLIXML envelope starts, so the decoder
+        # has nothing to extract and the user saw only `#< CLIXML`.
+        # Pre-check surfaces a clean diagnostic naming the exact
+        # expected path.
+        f"if (-not (Test-Path -LiteralPath $Bundle)) {{ "
+        f"Write-Error \"shipyard: bundle file not found at $Bundle \"\""
+        f"(expected after scp/ssh upload; check upload step logs)\"; "
+        f"exit 1 }}; "
         f"cd '{safe_repo}'; "
         f"git bundle verify $Bundle; "
         f"if ($LASTEXITCODE -ne 0) {{ exit 1 }}; "

--- a/tests/executor/test_210_bundle_path_fixes.py
+++ b/tests/executor/test_210_bundle_path_fixes.py
@@ -1,0 +1,172 @@
+"""Regression tests for #210 — three coordinated fixes:
+
+1. Bundle upload resolves relative remote_path against ``$HOME``
+   inside PowerShell, so the file always lands at a deterministic
+   path regardless of SSHD's default working directory.
+2. ``_apply_bundle_windows`` pre-verifies the bundle exists via
+   ``Test-Path`` before handing it to git, so a path mismatch
+   surfaces with a named path instead of git's "could not open"
+   leaking out as pre-CLIXML stderr.
+3. ``maybe_decode_clixml`` also surfaces stderr that appears
+   BEFORE the CLIXML sentinel (the exact byte layout from the
+   incident report).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from shipyard.bundle.git_bundle import upload_bundle
+from shipyard.executor.clixml import maybe_decode_clixml
+from shipyard.executor.ssh_windows import _WINDOWS_UTF8_PRELUDE
+
+
+class _FakeCompletedProcess:
+    def __init__(self, returncode: int = 0) -> None:
+        self.returncode = returncode
+        self.stderr = ""
+        self.stdout = ""
+
+
+def _get_ps_script(tmp_path) -> str:
+    """Drive a Windows-targeted upload and return the PowerShell
+    script that was encoded into the ssh argv."""
+    bundle = tmp_path / "shipyard.bundle"
+    bundle.write_bytes(b"fake")
+
+    captured: dict[str, str] = {}
+
+    def fake_run(cmd, **kw):
+        # Decode the -EncodedCommand payload on the fly.
+        import base64
+        idx = cmd.index("-EncodedCommand")
+        payload = cmd[idx + 1]
+        captured["script"] = base64.b64decode(payload).decode("utf-16-le")
+        return _FakeCompletedProcess(returncode=0)
+
+    with patch("shipyard.bundle.git_bundle.subprocess.run", side_effect=fake_run):
+        result = upload_bundle(
+            bundle_path=bundle,
+            host="win",
+            remote_path="shipyard.bundle",  # relative
+            is_windows=True,
+        )
+    assert result.success, result.message
+    return captured["script"]
+
+
+def test_upload_relative_remote_path_resolved_via_join_path_home(tmp_path) -> None:
+    # Fix (1): the PS script must resolve relative remote_path
+    # against $HOME so the file lands at a deterministic location
+    # regardless of SSHD's cwd.
+    script = _get_ps_script(tmp_path)
+    assert "(Join-Path $HOME 'shipyard.bundle')" in script
+    # And no hardcoded relative path — the earlier implementation
+    # would interpolate 'shipyard.bundle' directly as a
+    # `[System.IO.File]::Create` arg.
+    assert "[System.IO.File]::Create('shipyard.bundle')" not in script
+
+
+def test_upload_absolute_remote_path_used_as_is(tmp_path) -> None:
+    bundle = tmp_path / "shipyard.bundle"
+    bundle.write_bytes(b"fake")
+    captured: dict[str, str] = {}
+
+    def fake_run(cmd, **kw):
+        import base64
+        idx = cmd.index("-EncodedCommand")
+        captured["script"] = base64.b64decode(cmd[idx + 1]).decode("utf-16-le")
+        return _FakeCompletedProcess(returncode=0)
+
+    with patch("shipyard.bundle.git_bundle.subprocess.run", side_effect=fake_run):
+        result = upload_bundle(
+            bundle_path=bundle,
+            host="win",
+            remote_path=r"C:\shipyard.bundle",  # absolute
+            is_windows=True,
+        )
+    assert result.success
+    assert "'C:\\shipyard.bundle'" in captured["script"]
+    # Absolute path must NOT be double-wrapped in Join-Path.
+    assert "Join-Path" not in captured["script"]
+
+
+def test_apply_bundle_contains_test_path_preverify() -> None:
+    # Fix (2): the apply PS command must include a Test-Path pre-
+    # verification before `git bundle verify`.
+    from shipyard.executor.ssh_windows import _apply_bundle_windows
+
+    captured: dict[str, list[str]] = {}
+
+    def fake_run(cmd, **kw):
+        captured["cmd"] = cmd
+        return _FakeCompletedProcess(returncode=0)
+
+    with patch("shipyard.executor.ssh_windows.subprocess.run", side_effect=fake_run):
+        _apply_bundle_windows(
+            host="win",
+            bundle_path="shipyard.bundle",
+            repo_path="~/repo",
+            ssh_options=[],
+        )
+
+    import base64
+    idx = captured["cmd"].index("-EncodedCommand")
+    script = base64.b64decode(captured["cmd"][idx + 1]).decode("utf-16-le")
+    assert "Test-Path -LiteralPath $Bundle" in script
+    assert "bundle file not found" in script
+    # Sanity: the UTF-8 prelude from #208 is still there.
+    assert _WINDOWS_UTF8_PRELUDE in script
+
+
+def test_decoder_surfaces_pre_sentinel_stderr() -> None:
+    # Fix (3): the exact byte layout from the #210 forensic capture.
+    # `error:` appears BEFORE the CLIXML sentinel, envelope body is
+    # a harmless PowerShell progress object. Pre-fix, decoder
+    # returned the raw string (fallback). Post-fix, the error line
+    # survives as the prefix.
+    envelope = (
+        "error: could not open 'C:/Users/alice/shipyard.bundle'\n"
+        "#< CLIXML\n"
+        '<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/'
+        'powershell/2004/04">'
+        '<Obj S="progress" RefId="0"><TN RefId="0"><T>PSCustomObject</T></TN>'
+        '<MS><PR N="Record"><AV>Preparing modules</AV></PR></MS></Obj>'
+        "</Objs>"
+    )
+    decoded = maybe_decode_clixml(envelope)
+    assert "could not open" in decoded
+    assert "#< CLIXML" not in decoded
+    assert "<Objs" not in decoded
+
+
+def test_decoder_handles_pre_sentinel_only_no_body() -> None:
+    # If pre-sentinel text exists but envelope has no extractable
+    # messages (e.g. progress-only), the prefix still surfaces.
+    envelope = (
+        "error: something bad happened\n"
+        "#< CLIXML\n"
+        '<Objs><Obj S="progress"><TN><T>X</T></TN></Obj></Objs>'
+    )
+    decoded = maybe_decode_clixml(envelope)
+    assert "error: something bad happened" in decoded
+
+
+def test_decoder_pre_sentinel_plus_error_stream_joins_both() -> None:
+    # Both pre-sentinel text AND an Error stream in the envelope
+    # should survive the trip.
+    envelope = (
+        "error: outer context\n"
+        "#< CLIXML\n"
+        '<Objs xmlns="http://schemas.microsoft.com/powershell/2004/04">'
+        '<S S="Error">inner PS error</S>'
+        "</Objs>"
+    )
+    decoded = maybe_decode_clixml(envelope)
+    assert "error: outer context" in decoded
+    assert "inner PS error" in decoded
+
+
+def test_decoder_no_sentinel_unchanged() -> None:
+    # Legacy happy path preserved.
+    assert maybe_decode_clixml("just a regular error") == "just a regular error"


### PR DESCRIPTION
## Summary

Three coordinated fixes for the "could not open 'C:/Users/<user>/shipyard.bundle'" failure pulp hit today:

1. **Upload** resolves relative \`remote_path\` against \`\$HOME\` in PowerShell, matching what the apply step does. Removes the SSHD-cwd-dependent behavior that caused the two sides to disagree.
2. **Apply** pre-verifies the bundle via \`Test-Path -LiteralPath\` before \`git bundle verify\`, so any remaining path mismatch surfaces as a named-path error instead of git's pre-sentinel "could not open" bleeding through.
3. **Decoder** surfaces text that appears BEFORE the CLIXML sentinel too — the exact byte layout from the #210 forensic capture had the error pre-sentinel and the envelope was a PowerShell progress object with nothing to extract.

## Why

#201's raw-stderr forensics caught real bytes. Diagnosis: upload writes relative path (lands in sshd-cwd), apply reads \`\$HOME\\shipyard.bundle\` — mismatch when sshd-cwd != \$HOME. Combined with the decoder-starts-at-sentinel assumption, users saw only \`#< CLIXML\` with no signal.

(1) fixes root cause. (2) makes any future mismatch self-diagnosing. (3) generalizes beyond this specific bug.

## Test plan

- [x] \`pytest tests/executor/\` — 27/27 pass on the ssh_windows + clixml + bundle-log + utf8-prelude test surface.
- [x] ruff clean.
- [ ] Post-merge + pulp bump: pulp PR #694 ship attempt should succeed. If it still fails, the new Test-Path diagnostic will name the exact path that's missing.

Closes #210.