### PR TITLE
queue: jitter concurrent-writer retry (#175) + doctor: rich bundle smoke (#181)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to Shipyard are documented here. Each entry links
 to its [GitHub Release](https://github.com/danielraffel/Shipyard/releases).
 
 <a id="v0400"></a>
+## [0.41.0]
+
 ## [0.40.0] - 2026-04-23
 
 - bundle: treat /-prefixed and UNC paths as absolute in upload (Codex P1 on #211) ([#213](https://github.com/danielraffel/Shipyard/pull/213))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "shipyard"
-version = "0.40.0"
+version = "0.41.0"
 description = "Cross-platform CI coordination — local VMs, SSH hosts, cloud runners"
 readme = "README.md"
 license = "MIT"

--- a/src/shipyard/__init__.py
+++ b/src/shipyard/__init__.py
@@ -1,3 +1,3 @@
 """Shipyard — Cross-platform CI coordination."""
 
-__version__ = "0.40.0"
+__version__ = "0.41.0"

--- a/src/shipyard/cli.py
+++ b/src/shipyard/cli.py
@@ -494,6 +494,9 @@ def doctor(ctx: Context, release_chain: bool, runners: bool) -> None:
     # downgrades the user to a pre-fix version. Surface this in
     # doctor so the user learns about it before it bites.
     core["shipyard-on-path"] = _check_shipyard_path_shadows()
+    # #181: catch a corrupt PyInstaller _unicode_data archive here
+    # rather than mid-render during `shipyard ship`.
+    core["rich-bundle"] = _check_rich_bundle_health()
     daemon_drift = _check_daemon_version_drift(ctx)
     if daemon_drift:
         core["daemon-version"] = daemon_drift
@@ -633,6 +636,53 @@ def _check_shipyard_path_shadows() -> dict[str, Any]:
         "version": f"v{_self_version} ({len(seen_bins)} binaries found)",
         "detail": detail,
     }
+
+
+def _check_rich_bundle_health() -> dict[str, Any]:
+    """Smoke-test the rich Unicode data loader against bundle corruption.
+
+    Closes #181 — a PyInstaller onefile bundle whose bundled
+    ``rich/_unicode_data`` archive entry got truncated (partial write,
+    on-disk corruption, XProtect rewrite) crashes ``shipyard ship``
+    mid-render with ``zlib.error: Error -3 … incorrect header check``
+    the first time Rich needs to compute the cell-width of a wide
+    char. That happens *inside the summary table renderer*, so the
+    user-visible failure is "PR opened, no evidence ever recorded,
+    ship silently abandoned."
+
+    This check force-loads the unicode-width table (via ``cell_len``
+    on a known wide char) so a corrupt bundle fails here, in
+    ``doctor``, with a "reinstall the binary" hint — rather than
+    later, during a real ship, with an unhelpful traceback.
+    """
+    try:
+        from rich.cells import cell_len
+
+        # The actual wide-char cell-len computation is what triggers
+        # the lazy ``_unicode_data`` archive read. Any value >= 1
+        # confirms the table loaded; the exact cell count doesn't
+        # matter for this health check.
+        width = cell_len("✓")
+        if width < 1:
+            return {
+                "ok": False,
+                "version": "rich.cells loaded but cell_len < 1",
+                "detail": "Unexpected rich.cells result; reinstall the binary.",
+            }
+    except Exception as exc:  # noqa: BLE001 — we want every failure shape
+        fingerprint = type(exc).__name__
+        hint = (
+            "Reinstall with: "
+            "curl -fsSL https://raw.githubusercontent.com/"
+            "danielraffel/Shipyard/main/install.sh | sh"
+        )
+        return {
+            "ok": False,
+            "version": f"rich bundle read failed ({fingerprint})",
+            "detail": f"{exc}\n  Fix: {hint}",
+        }
+
+    return {"ok": True, "version": "rich.cells + _unicode_data load OK"}
 
 
 def _check_daemon_version_drift(ctx: Context) -> dict[str, Any] | None:

--- a/src/shipyard/core/queue.py
+++ b/src/shipyard/core/queue.py
@@ -375,23 +375,32 @@ def _retry_replace_on_windows(src: Path, dst: Path) -> None:
     POSIX: first attempt always succeeds (atomic, no share modes).
     Windows: MoveFileEx can fail with WinError 5 (Access denied)
     while a peer writer is mid-rename or the target is briefly open.
-    We retry up to ~600 ms total — long enough to clear any real
-    contention, short enough that a genuinely permission-denied
-    target still surfaces.
+
+    Backoff is linear-ish (0.05s, 0.10s, …) with random jitter so
+    N concurrent writers don't retry in lockstep and collide on
+    every attempt — the #175 flake. Without jitter, three workers
+    that contended at t=0 will also contend at t=0.05s, t=0.15s,
+    etc., and the retry budget buys nothing. 18 attempts over ~8s
+    of wall time — long enough to outlast real CI-runner
+    contention, short enough that a genuinely denied target still
+    surfaces before the test timeout.
     """
     if sys.platform != "win32":
         src.replace(dst)
         return
+    import random as _random
     import time as _time
 
     last_exc: PermissionError | None = None
-    for attempt in range(12):
+    for attempt in range(18):
         try:
             src.replace(dst)
             return
         except PermissionError as exc:
             last_exc = exc
-            _time.sleep(0.05 * (attempt + 1))
+            base = 0.05 * (attempt + 1)
+            jitter = _random.uniform(0.0, base)
+            _time.sleep(base + jitter)
     assert last_exc is not None
     raise last_exc
 

--- a/tests/core/test_queue_atomic_writes.py
+++ b/tests/core/test_queue_atomic_writes.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import json
 import multiprocessing
 import os
+import sys
 import time
 from pathlib import Path
 
@@ -244,3 +245,104 @@ def test_save_writes_fsynced_before_rename(
     # must precede any rename of a queue tmp file.
     assert fsync_calls, "os.fsync was not called during _save()"
     assert rename_calls, "Path.replace was not called during _save()"
+
+
+# -- #175 retry jitter ----------------------------------------------
+# `_retry_replace_on_windows` was added in #105 but retried in
+# lockstep — 3 concurrent writers that contended at t=0 would
+# contend again at t=0.05s, t=0.15s, etc., because their retry
+# schedules were identical. The #174 CI Windows run hit the
+# residual flake anyway. Fix: random jitter breaks lockstep;
+# bumped to 18 attempts so the total budget outlasts real CI
+# contention (~8s max with jitter).
+
+def test_retry_replace_is_noop_on_posix(tmp_path: Path) -> None:
+    # POSIX path: a single atomic replace, no retry loop — and no
+    # random.uniform call, so we can assert no jitter side effect.
+    if sys.platform == "win32":
+        import pytest
+        pytest.skip("POSIX-only branch")
+
+    from shipyard.core.queue import _retry_replace_on_windows
+
+    src = tmp_path / "src.txt"
+    src.write_text("hello")
+    dst = tmp_path / "dst.txt"
+    _retry_replace_on_windows(src, dst)
+
+    assert not src.exists()
+    assert dst.read_text() == "hello"
+
+
+def test_retry_replace_uses_jittered_backoff(monkeypatch, tmp_path: Path) -> None:
+    # Windows path: every attempt must draw a random jitter value,
+    # and the sleep must include it. We patch sys.platform + replace
+    # to exercise the Windows branch deterministically on macOS.
+    import shipyard.core.queue as queue_mod
+
+    sleeps: list[float] = []
+    jitter_calls: list[tuple[float, float]] = []
+
+    attempts = {"n": 0}
+
+    def _fake_replace(self, _target):
+        # Fail the first 3 attempts with PermissionError, succeed
+        # on the fourth — exercises the retry loop without running
+        # the full 18-attempt budget.
+        attempts["n"] += 1
+        if attempts["n"] <= 3:
+            raise PermissionError(5, "Access denied")
+        return self
+
+    def _fake_sleep(s: float) -> None:
+        sleeps.append(s)
+
+    def _fake_uniform(a: float, b: float) -> float:
+        jitter_calls.append((a, b))
+        return (a + b) / 2.0
+
+    monkeypatch.setattr(queue_mod.sys, "platform", "win32")
+    monkeypatch.setattr(Path, "replace", _fake_replace)
+    import random as _random
+    import time as _time
+    monkeypatch.setattr(_time, "sleep", _fake_sleep)
+    monkeypatch.setattr(_random, "uniform", _fake_uniform)
+
+    src = tmp_path / "src.txt"
+    dst = tmp_path / "dst.txt"
+    queue_mod._retry_replace_on_windows(src, dst)
+
+    # Three failed attempts → three sleeps, three jitter draws.
+    assert len(sleeps) == 3
+    assert len(jitter_calls) == 3
+
+    # Jitter bounds grow with the attempt — base = 0.05 * (n+1).
+    # Verifies the jitter range isn't constant (which would preserve
+    # lockstep across concurrent callers).
+    assert jitter_calls[0][1] == pytest.approx(0.05)
+    assert jitter_calls[1][1] == pytest.approx(0.10)
+    assert jitter_calls[2][1] == pytest.approx(0.15)
+
+
+def test_retry_replace_surfaces_error_when_budget_exhausted(
+    monkeypatch, tmp_path: Path,
+) -> None:
+    # If all 18 attempts fail, the original PermissionError must
+    # propagate — a genuinely denied target shouldn't be swallowed
+    # by the retry loop.
+    import shipyard.core.queue as queue_mod
+
+    def _always_fail(self, _target):
+        raise PermissionError(5, "Access denied")
+
+    monkeypatch.setattr(queue_mod.sys, "platform", "win32")
+    monkeypatch.setattr(Path, "replace", _always_fail)
+    import time as _time
+    monkeypatch.setattr(_time, "sleep", lambda s: None)
+
+    src = tmp_path / "src.txt"
+    dst = tmp_path / "dst.txt"
+
+    import pytest
+    with pytest.raises(PermissionError, match="Access denied"):
+        queue_mod._retry_replace_on_windows(src, dst)

--- a/tests/test_doctor_rich_bundle.py
+++ b/tests/test_doctor_rich_bundle.py
@@ -1,0 +1,71 @@
+"""Tests for doctor's rich-bundle health smoke (#181).
+
+The PyInstaller onefile bundle embeds rich's ``_unicode_data``
+archive entry as a deflated blob. When that blob gets corrupted on
+disk (partial extract after an interrupted install, XProtect
+rewrite, Apple Silicon notarization race), the first ``cell_len``
+call on a wide char raises ``zlib.error: Error -3 ... incorrect
+header check`` — inside the summary-table renderer — and
+``shipyard ship`` silently abandons with the PR already opened.
+
+This check force-loads that table in doctor so the failure surfaces
+with a reinstall hint rather than during a real ship.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import patch
+
+from shipyard.cli import _check_rich_bundle_health
+
+
+def test_rich_bundle_healthy_returns_ok() -> None:
+    # Baseline: on any machine where rich is installed correctly,
+    # the smoke passes and doctor's Core section stays ready.
+    result: dict[str, Any] = _check_rich_bundle_health()
+    assert result["ok"] is True
+    assert "OK" in result["version"] or "ok" in result["version"].lower()
+
+
+def test_rich_bundle_zlib_corruption_surfaces_with_reinstall_hint() -> None:
+    # The #181 failure shape: rich.cells.cell_len raises zlib.error
+    # because the bundled _unicode_data archive entry is truncated.
+    import zlib
+
+    def _boom(_s: str) -> int:
+        raise zlib.error("Error -3 while decompressing data: incorrect header check")
+
+    with patch("rich.cells.cell_len", side_effect=_boom):
+        result = _check_rich_bundle_health()
+
+    assert result["ok"] is False
+    assert "error" in result["version"].lower() or "failed" in result["version"].lower()
+    # The reinstall hint must be in detail — that's the whole point
+    # of catching the failure in doctor rather than mid-ship.
+    assert "install.sh" in result["detail"]
+    # And the exception type must be named so a support thread can
+    # grep for "zlib" without asking the user to paste the traceback.
+    assert "error" in result["version"].lower()
+
+
+def test_rich_bundle_import_error_also_surfaces() -> None:
+    # A genuinely broken bundle might fail the import itself rather
+    # than the cell_len call. Doctor must report ok=False either way.
+    def _boom(_s: str) -> int:
+        raise ImportError("No module named 'rich._unicode_data._lookup'")
+
+    with patch("rich.cells.cell_len", side_effect=_boom):
+        result = _check_rich_bundle_health()
+
+    assert result["ok"] is False
+    assert "install.sh" in result["detail"]
+
+
+def test_rich_bundle_unexpected_result_is_not_silently_ok() -> None:
+    # Defense in depth: if cell_len returns something nonsensical
+    # (a mock or a corrupt fallback table), doctor should still flag
+    # rather than returning ok=True for a broken bundle.
+    with patch("rich.cells.cell_len", return_value=0):
+        result = _check_rich_bundle_health()
+    assert result["ok"] is False


### PR DESCRIPTION
## Summary

Two small, surgical fixes for a pair of sharp-edge issues that surfaced recently.

### #175 — Windows rename race in queue worker

The retry helper `_retry_replace_on_windows` was already in place (added in #105, 2026-04-20), which the issue didn't know about. But the test kept flaking on CI Windows because retries were **lockstep**: three concurrent writers that contended at t=0 retried at exactly t=0.05s, t=0.15s, … and contended again on every attempt. The retry budget bought nothing.

Fix: random jitter per attempt (`random.uniform(0, base)`), plus bumped attempts from 12 → 18 so the total budget outlasts real CI contention (~8s max with jitter).

### #181 — `shipyard ship` zlib.error inside rich summary render

A PyInstaller onefile bundle with a corrupt `rich/_unicode_data` archive entry (partial extract, XProtect rewrite, notarization race) crashes `shipyard ship` mid-render with `zlib.error: Error -3 ... incorrect header check` — *inside* the summary-table renderer. User-visible: PR opens, no evidence ever recorded, ship silently abandoned.

Fix: `doctor` now force-loads the wide-char cell-width table via `cell_len("✓")`. If the bundled `_unicode_data` entry is corrupt, the failure surfaces **here**, with an install.sh reinstall hint, rather than mid-ship.

### Out of scope

- `#77` (shipyard cloud handoff) — filed as a tracked task; multi-day scope.
- The issue's secondary suggestion on #181 (bundle mtime/size in `--version`) — skipped as scope creep; `doctor` is the right surface.

## Test plan

- [x] `uv run pytest tests/core/test_queue_atomic_writes.py tests/test_doctor_rich_bundle.py` — 15 passed locally
- [x] `uv run shipyard --json doctor` now emits `Core.rich-bundle` as a first-class check
- [ ] CI green across Linux / macOS / Windows