### PR TITLE
cloud: handoff subgroup — generalize runner re-routing to any GH Actions run (#77 MVP)

### DIFF
--- a/src/shipyard/cli.py
+++ b/src/shipyard/cli.py
@@ -2927,7 +2927,7 @@ def cloud_handoff_run(
     if result.returncode != 0:
         render_error(f"Could not fetch run {run_id}: {result.stderr.strip()}")
         sys.exit(1)
-    lines = [l for l in result.stdout.splitlines() if l.strip()]
+    lines = [line for line in result.stdout.splitlines() if line.strip()]
     if len(lines) < 4:
         render_error(f"Unexpected gh response for run {run_id}: {result.stdout!r}")
         sys.exit(1)

--- a/src/shipyard/cli.py
+++ b/src/shipyard/cli.py
@@ -2668,6 +2668,61 @@ def _find_matching_jobs(
     ]
 
 
+def _cancel_workflow_run(repo_slug: str, run_id: int) -> bool:
+    """Cancel a whole workflow run. Returns True on success.
+
+    Used by ``cloud handoff`` where the whole run needs to go away
+    (not just a single job, as in ``cloud retarget``). Requires
+    ``actions:write`` scope on the gh token.
+    """
+    try:
+        result = subprocess.run(
+            ["gh", "api", "-X", "POST",
+             f"repos/{repo_slug}/actions/runs/{run_id}/cancel"],
+            capture_output=True, text=True, timeout=15,
+        )
+    except (subprocess.SubprocessError, FileNotFoundError):
+        return False
+    return result.returncode == 0
+
+
+def _list_queued_runs(repo_slug: str, limit: int = 50) -> list[dict[str, Any]]:
+    """Return currently queued GitHub Actions runs for ``repo_slug``.
+
+    Queries ``/actions/runs?status=queued`` and returns the raw run
+    records (``databaseId``, ``name``, ``headBranch``, ``createdAt``,
+    ``workflowName``, ``url``). Empty list on any error — ``list-stuck``
+    is diagnostic and shouldn't hard-fail on a transient gh blip.
+    """
+    try:
+        result = subprocess.run(
+            [
+                "gh", "api",
+                f"repos/{repo_slug}/actions/runs?status=queued&per_page={limit}",
+                "--jq", (
+                    '.workflow_runs[] | {databaseId: .id, name: .name, '
+                    'headBranch: .head_branch, createdAt: .created_at, '
+                    'workflowName: .name, url: .html_url, path: .path}'
+                ),
+            ],
+            capture_output=True, text=True, timeout=15,
+        )
+    except (subprocess.SubprocessError, FileNotFoundError):
+        return []
+    if result.returncode != 0:
+        return []
+    out: list[dict[str, Any]] = []
+    for line in result.stdout.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            out.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+    return out
+
+
 def _cancel_workflow_job(repo_slug: str, job_id: int) -> bool:
     """Cancel a single job. Returns True on success, False on any failure."""
     try:
@@ -2679,6 +2734,304 @@ def _cancel_workflow_job(repo_slug: str, job_id: int) -> bool:
     except (subprocess.SubprocessError, FileNotFoundError):
         return False
     return result.returncode == 0
+
+
+@cloud.group("handoff")
+def cloud_handoff() -> None:
+    """Generalized in-flight runner handoff for any GH Actions workflow.
+
+    Sibling to ``cloud retarget`` (which is scoped to Shipyard-managed
+    ships). ``cloud handoff`` operates on arbitrary GH Actions runs by
+    run ID — useful when the consuming repo's GitHub-hosted macOS
+    queue is backed up 15+ minutes and you want to reroute to
+    Namespace or a self-hosted runner without tearing down any
+    per-PR state Shipyard owns.
+
+    See issue #77 for the feature scope.
+    """
+
+
+def _parse_threshold_secs(raw: str) -> float | None:
+    """Parse ``"10m"`` / ``"30s"`` / ``"600"`` into seconds.
+
+    Returns None on malformed input — callers surface that as a
+    user-facing error rather than a hard-coded default.
+    """
+    raw = raw.strip().lower()
+    if not raw:
+        return None
+    if raw.endswith("h") and raw[:-1].isdigit():
+        return float(raw[:-1]) * 3600.0
+    if raw.endswith("m") and raw[:-1].isdigit():
+        return float(raw[:-1]) * 60.0
+    if raw.endswith("s") and raw[:-1].isdigit():
+        return float(raw[:-1])
+    try:
+        return float(raw)
+    except ValueError:
+        return None
+
+
+@cloud_handoff.command("list-stuck")
+@click.option(
+    "--threshold",
+    default="10m",
+    show_default=True,
+    help=(
+        "Minimum queue age to surface. Accepts plain seconds or "
+        "a `Ns`/`Nm`/`Nh` suffix."
+    ),
+)
+@click.option(
+    "--repo",
+    default=None,
+    help="Owner/repo slug. Defaults to the current git repo.",
+)
+@click.pass_obj
+def cloud_handoff_list_stuck(
+    ctx: Context, threshold: str, repo: str | None,
+) -> None:
+    """List GH Actions runs currently queued past the threshold.
+
+    Diagnostic only — prints run ID, workflow, branch, and queued
+    age. Does not cancel or redispatch. Feed an interesting run ID
+    to ``cloud handoff run <id> --to <provider>`` to execute the
+    handoff.
+    """
+    threshold_secs = _parse_threshold_secs(threshold)
+    if threshold_secs is None:
+        render_error(f"Bad --threshold value: {threshold!r}")
+        sys.exit(1)
+
+    repo_slug = repo or _detect_repo_slug_or_empty()
+    if not repo_slug:
+        render_error(
+            "No repo detected. Pass --repo OWNER/REPO or run inside a git "
+            "clone with a tracked remote."
+        )
+        sys.exit(1)
+
+    runs = _list_queued_runs(repo_slug)
+    now = datetime.now(timezone.utc)
+    stuck: list[dict[str, Any]] = []
+    for run in runs:
+        created = run.get("createdAt")
+        if not created:
+            continue
+        try:
+            created_dt = datetime.fromisoformat(
+                created.replace("Z", "+00:00")
+            )
+        except ValueError:
+            continue
+        age_secs = (now - created_dt).total_seconds()
+        if age_secs < threshold_secs:
+            continue
+        stuck.append({
+            "run_id": run.get("databaseId"),
+            "workflow": run.get("workflowName"),
+            "branch": run.get("headBranch"),
+            "queued_for_secs": int(age_secs),
+            "url": run.get("url"),
+        })
+
+    if ctx.json_mode:
+        ctx.output(
+            "cloud.handoff",
+            {
+                "event": "list-stuck",
+                "repo": repo_slug,
+                "threshold_secs": threshold_secs,
+                "stuck": stuck,
+            },
+        )
+        return
+
+    if not stuck:
+        render_message(
+            f"No queued runs older than {threshold} on {repo_slug}.",
+            style="dim",
+        )
+        return
+
+    render_message(f"Stuck queued runs on {repo_slug} (>{threshold}):")
+    for row in stuck:
+        age_mins = row["queued_for_secs"] // 60
+        render_message(
+            f"  {row['run_id']}  {row['workflow']} @ {row['branch']}  "
+            f"queued {age_mins}m"
+        )
+
+
+@cloud_handoff.command("run")
+@click.argument("run_id", type=int)
+@click.option(
+    "--to",
+    "provider",
+    required=True,
+    help=(
+        "Target runner provider for the handoff (e.g. namespace, "
+        "github-hosted, local). Passed as `runner_provider=` to the "
+        "workflow_dispatch input."
+    ),
+)
+@click.option(
+    "--repo",
+    default=None,
+    help="Owner/repo slug. Defaults to the current git repo.",
+)
+@click.option(
+    "--dry-run/--apply",
+    "dry_run",
+    default=True,
+    help=(
+        "Dry-run by default. Shows what would be cancelled and "
+        "redispatched. --apply executes."
+    ),
+)
+@click.pass_obj
+def cloud_handoff_run(
+    ctx: Context, run_id: int, provider: str, repo: str | None, dry_run: bool,
+) -> None:
+    """Cancel a stuck GH Actions run and re-dispatch with a provider override.
+
+    Unlike ``cloud retarget`` (which operates on a Shipyard-managed PR
+    and targets a single job), this cancels the entire workflow run
+    and dispatches a fresh one against the same ref + workflow, with
+    ``runner_provider=<provider>`` threaded through. The workflow
+    must support that input (or the configured equivalent) — if it
+    doesn't, ``resolve_cloud_dispatch_plan`` raises and we refuse
+    rather than YAML-surgery the consumer's workflow file.
+    """
+    repo_slug = repo or _detect_repo_slug_or_empty()
+    if not repo_slug:
+        render_error(
+            "No repo detected. Pass --repo OWNER/REPO or run inside a git "
+            "clone with a tracked remote."
+        )
+        sys.exit(1)
+
+    try:
+        result = subprocess.run(
+            [
+                "gh", "api",
+                f"repos/{repo_slug}/actions/runs/{run_id}",
+                "--jq",
+                ".path, .head_branch, .name, .status",
+            ],
+            capture_output=True, text=True, timeout=15,
+        )
+    except (subprocess.SubprocessError, FileNotFoundError) as exc:
+        render_error(f"gh api failed: {exc}")
+        sys.exit(1)
+    if result.returncode != 0:
+        render_error(f"Could not fetch run {run_id}: {result.stderr.strip()}")
+        sys.exit(1)
+    lines = [l for l in result.stdout.splitlines() if l.strip()]
+    if len(lines) < 4:
+        render_error(f"Unexpected gh response for run {run_id}: {result.stdout!r}")
+        sys.exit(1)
+    workflow_path, head_branch, workflow_name, run_status = (
+        lines[0], lines[1], lines[2], lines[3],
+    )
+    workflow_file = workflow_path.rsplit("/", 1)[-1]
+
+    # Find the workflow key that matches this file so the dispatch
+    # plan resolver picks the right config overrides.
+    workflows = discover_workflows()
+    workflow_key: str | None = None
+    for key, wf in workflows.items():
+        if getattr(wf, "file", None) == workflow_file:
+            workflow_key = key
+            break
+    if workflow_key is None:
+        render_error(
+            f"Run {run_id} is for workflow '{workflow_file}' but "
+            "no matching key was found in .shipyard/config.toml. "
+            "Add a [cloud.workflows.<key>] entry that maps to it, or "
+            "use `shipyard cloud retarget` if this is a Shipyard-managed PR."
+        )
+        sys.exit(1)
+
+    try:
+        plan = resolve_cloud_dispatch_plan(
+            config=ctx.config,
+            workflows=workflows,
+            workflow_key=workflow_key,
+            ref=head_branch,
+            provider_override=provider,
+        )
+    except ValueError as exc:
+        render_error(
+            f"Workflow '{workflow_key}' can't be handed off: {exc}. "
+            "The workflow likely has no runner_provider input — add "
+            "one or use a config-driven override."
+        )
+        sys.exit(1)
+
+    payload: dict[str, Any] = {
+        "repo": repo_slug,
+        "run_id": run_id,
+        "workflow_key": workflow_key,
+        "workflow_file": workflow_file,
+        "workflow_name": workflow_name,
+        "ref": head_branch,
+        "status": run_status,
+        "new_provider": provider,
+        "dry_run": dry_run,
+    }
+
+    if not ctx.json_mode:
+        render_message(f"Handoff plan for run {run_id} ({repo_slug}):")
+        render_message(f"  workflow:    {workflow_name} ({workflow_file})")
+        render_message(f"  ref:         {head_branch}")
+        render_message(f"  status:      {run_status}")
+        render_message(f"  new provider: {provider}")
+
+    if dry_run:
+        if ctx.json_mode:
+            ctx.output("cloud.handoff", {"event": "plan", **payload})
+        else:
+            render_message(
+                "\nDry-run. Re-run with --apply to cancel + redispatch.",
+                style="dim",
+            )
+        return
+
+    if not _cancel_workflow_run(repo_slug, run_id):
+        render_error(
+            f"Could not cancel run {run_id}. Token may lack "
+            "`actions:write`. Cancel manually then re-run with --apply."
+        )
+        sys.exit(1)
+
+    try:
+        workflow_dispatch(
+            repository=plan.repository or repo_slug,
+            workflow_file=plan.workflow.file,
+            ref=plan.ref,
+            fields=plan.dispatch_fields,
+        )
+    except (subprocess.CalledProcessError, TimeoutError) as exc:
+        render_error(f"workflow_dispatch failed: {exc}")
+        sys.exit(1)
+
+    if ctx.json_mode:
+        ctx.output(
+            "cloud.handoff",
+            {
+                "event": "applied",
+                **payload,
+                "cancelled_run_id": run_id,
+                "new_dispatch": plan.to_dict(),
+            },
+        )
+    else:
+        render_message(
+            f"✓ Cancelled run {run_id}; dispatched fresh run with "
+            f"provider={provider}.",
+            style="bold green",
+        )
 
 
 @cloud.command("status")

--- a/tests/test_cli_cloud_handoff.py
+++ b/tests/test_cli_cloud_handoff.py
@@ -1,0 +1,291 @@
+"""Tests for ``shipyard cloud handoff`` (#77 MVP).
+
+Two subcommands:
+  - ``list-stuck``: diagnostic — print queued runs older than threshold
+  - ``run``: cancel a specific run + re-dispatch with provider override
+
+These tests mock gh + the dispatch plan resolver so they don't need
+network or a real consumer repo.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from click.testing import CliRunner
+
+from shipyard.cli import main
+
+
+def _assert_cli_ok(result: Any) -> None:
+    # Mirror the shape used in test_cli_cloud_retarget.py so the
+    # same Windows-flake escape hatch applies if CliRunner isolation
+    # ever trips this suite the same way (#198).
+    assert result.exit_code == 0, f"exit={result.exit_code} output={result.output!r}"
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason=(
+        "#198: Click CliRunner isolation flake on Windows across this "
+        "family of cloud-flow tests. Coverage preserved on Linux + macOS; "
+        "the test exercises gh API wiring with no Windows-specific behavior."
+    ),
+)
+class TestHandoffThresholdParser:
+    """_parse_threshold_secs handles the formats the --threshold flag
+    advertises: Ns, Nm, Nh, and bare seconds. Malformed returns None
+    so list-stuck can render a user-facing error rather than crashing.
+    """
+
+    def test_seconds_suffix(self) -> None:
+        from shipyard.cli import _parse_threshold_secs
+        assert _parse_threshold_secs("30s") == 30.0
+
+    def test_minutes_suffix(self) -> None:
+        from shipyard.cli import _parse_threshold_secs
+        assert _parse_threshold_secs("10m") == 600.0
+
+    def test_hours_suffix(self) -> None:
+        from shipyard.cli import _parse_threshold_secs
+        assert _parse_threshold_secs("2h") == 7200.0
+
+    def test_bare_seconds(self) -> None:
+        from shipyard.cli import _parse_threshold_secs
+        assert _parse_threshold_secs("600") == 600.0
+
+    def test_malformed_returns_none(self) -> None:
+        from shipyard.cli import _parse_threshold_secs
+        assert _parse_threshold_secs("forever") is None
+        assert _parse_threshold_secs("") is None
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason=(
+        "#198: Click CliRunner isolation flake on Windows across this "
+        "family of cloud-flow tests. Coverage preserved on Linux + macOS."
+    ),
+)
+class TestHandoffListStuck:
+    """``cloud handoff list-stuck`` surfaces runs older than threshold."""
+
+    def _patch(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        *,
+        queued_runs: list[dict[str, Any]],
+    ) -> None:
+        monkeypatch.setattr(
+            "shipyard.cli._detect_repo_slug_or_empty",
+            lambda: "owner/repo",
+        )
+        monkeypatch.setattr(
+            "shipyard.cli._list_queued_runs",
+            lambda repo, limit=50: queued_runs,
+        )
+
+    def test_no_stuck_runs_prints_clean_message(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from datetime import datetime, timedelta, timezone
+        # One run, 5 minutes old — below the 10m default threshold.
+        recent = (datetime.now(timezone.utc) - timedelta(minutes=5)).isoformat()
+        self._patch(monkeypatch, queued_runs=[{
+            "databaseId": 111, "name": "CI", "workflowName": "CI",
+            "headBranch": "main", "createdAt": recent,
+            "url": "https://example",
+        }])
+        runner = CliRunner()
+        result = runner.invoke(main, ["cloud", "handoff", "list-stuck"])
+        _assert_cli_ok(result)
+        assert "No queued runs" in result.output
+
+    def test_stuck_run_surfaces_with_age(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from datetime import datetime, timedelta, timezone
+        old = (datetime.now(timezone.utc) - timedelta(minutes=25)).isoformat()
+        self._patch(monkeypatch, queued_runs=[{
+            "databaseId": 222, "name": "CI", "workflowName": "CI",
+            "headBranch": "feat/x", "createdAt": old,
+            "url": "https://example/222",
+        }])
+        runner = CliRunner()
+        result = runner.invoke(main, ["cloud", "handoff", "list-stuck"])
+        _assert_cli_ok(result)
+        assert "222" in result.output
+        assert "feat/x" in result.output
+
+    def test_json_envelope_contains_stuck_list(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from datetime import datetime, timedelta, timezone
+        old = (datetime.now(timezone.utc) - timedelta(minutes=30)).isoformat()
+        self._patch(monkeypatch, queued_runs=[{
+            "databaseId": 333, "name": "CI", "workflowName": "CI",
+            "headBranch": "feat/y", "createdAt": old,
+            "url": "https://example/333",
+        }])
+        runner = CliRunner()
+        result = runner.invoke(
+            main, ["--json", "cloud", "handoff", "list-stuck"],
+        )
+        _assert_cli_ok(result)
+        parsed = json.loads(result.output)
+        assert parsed["command"] == "cloud.handoff"
+        assert parsed["event"] == "list-stuck"
+        assert parsed["repo"] == "owner/repo"
+        assert len(parsed["stuck"]) == 1
+        assert parsed["stuck"][0]["run_id"] == 333
+
+    def test_bad_threshold_surfaces_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._patch(monkeypatch, queued_runs=[])
+        runner = CliRunner()
+        result = runner.invoke(
+            main, ["cloud", "handoff", "list-stuck", "--threshold", "forever"],
+        )
+        assert result.exit_code != 0
+        assert "Bad --threshold" in result.output
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason=(
+        "#198: Click CliRunner isolation flake on Windows across this "
+        "family of cloud-flow tests. Coverage preserved on Linux + macOS."
+    ),
+)
+class TestHandoffRun:
+    """``cloud handoff run`` cancels + redispatches with provider override."""
+
+    def _patch(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        *,
+        workflow_file: str = "ci.yml",
+        workflow_key: str | None = "ci",
+    ) -> dict[str, Any]:
+        captured: dict[str, Any] = {
+            "cancelled_run": None,
+            "dispatched_with": None,
+        }
+
+        monkeypatch.setattr(
+            "shipyard.cli._detect_repo_slug_or_empty", lambda: "owner/repo",
+        )
+
+        def fake_run(cmd, **kw):
+            # The first gh api call is the run-details fetch.
+            return SimpleNamespace(
+                returncode=0,
+                stdout=(
+                    f".github/workflows/{workflow_file}\n"
+                    "feat/x\n"
+                    "CI\n"
+                    "queued\n"
+                ),
+                stderr="",
+            )
+
+        monkeypatch.setattr("shipyard.cli.subprocess.run", fake_run)
+
+        workflows = {}
+        if workflow_key is not None:
+            workflows[workflow_key] = SimpleNamespace(
+                file=workflow_file, key=workflow_key, name="CI",
+            )
+        monkeypatch.setattr("shipyard.cli.discover_workflows", lambda: workflows)
+
+        fake_plan = SimpleNamespace(
+            repository="owner/repo",
+            ref="feat/x",
+            workflow=SimpleNamespace(
+                file=workflow_file, key=workflow_key or "ci", name="CI",
+            ),
+            provider="namespace",
+            dispatch_fields={"runner_provider": "namespace"},
+            to_dict=lambda: {"provider": "namespace"},
+        )
+        monkeypatch.setattr(
+            "shipyard.cli.resolve_cloud_dispatch_plan",
+            lambda **kw: fake_plan,
+        )
+
+        def fake_cancel_run(repo, run_id):
+            captured["cancelled_run"] = run_id
+            return True
+
+        monkeypatch.setattr(
+            "shipyard.cli._cancel_workflow_run", fake_cancel_run,
+        )
+
+        def fake_dispatch(**kw):
+            captured["dispatched_with"] = kw
+
+        monkeypatch.setattr("shipyard.cli.workflow_dispatch", fake_dispatch)
+        return captured
+
+    def test_dry_run_does_not_cancel_or_dispatch(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        captured = self._patch(monkeypatch)
+        runner = CliRunner()
+        result = runner.invoke(
+            main, ["cloud", "handoff", "run", "555", "--to", "namespace"],
+        )
+        _assert_cli_ok(result)
+        assert "Dry-run" in result.output
+        assert captured["cancelled_run"] is None
+        assert captured["dispatched_with"] is None
+
+    def test_apply_cancels_and_dispatches(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        captured = self._patch(monkeypatch)
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["cloud", "handoff", "run", "555", "--to", "namespace", "--apply"],
+        )
+        _assert_cli_ok(result)
+        assert captured["cancelled_run"] == 555
+        assert captured["dispatched_with"] is not None
+        assert captured["dispatched_with"]["repository"] == "owner/repo"
+
+    def test_apply_json_envelope(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._patch(monkeypatch)
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                "--json", "cloud", "handoff", "run", "555",
+                "--to", "namespace", "--apply",
+            ],
+        )
+        _assert_cli_ok(result)
+        parsed = json.loads(result.output)
+        assert parsed["event"] == "applied"
+        assert parsed["cancelled_run_id"] == 555
+
+    def test_workflow_not_in_config_errors_out(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # The consumer's workflow file isn't mapped in
+        # .shipyard/config.toml — handoff can't pick the right
+        # provider override, so refuse rather than guess.
+        self._patch(monkeypatch, workflow_key=None)
+        runner = CliRunner()
+        result = runner.invoke(
+            main, ["cloud", "handoff", "run", "555", "--to", "namespace"],
+        )
+        assert result.exit_code != 0
+        assert "no matching key" in result.output.lower()


### PR DESCRIPTION
## Summary

MVP for #77. Adds \`shipyard cloud handoff\` — a sibling to \`cloud retarget\` that operates on **arbitrary GH Actions runs**, not just Shipyard-managed PRs. Solves the recurring pain of a stuck macOS queue where the fix is mechanical but the operator has to relearn each repo's runner-selection pattern every time.

## What ships in this PR (MVP)

\`\`\`
shipyard cloud handoff list-stuck [--threshold 10m] [--repo O/R]
    # Diagnostic: queued runs older than the threshold

shipyard cloud handoff run <run_id> --to <provider> [--apply]
    # Cancel the whole run + re-dispatch with runner_provider=<provider>.
    # Dry-run by default. Refuses if the workflow isn't mapped in
    # .shipyard/config.toml — no YAML surgery.
\`\`\`

## Why subgroup rather than options on \`cloud retarget\`

\`retarget\` is scoped to a PR + one target job — it cancels a single \`job_id\` and redispatches a fresh run against the PR's headRef. \`handoff\` cancels the whole run by \`run_id\` and doesn't touch ShipState (nothing to touch — the run is often outside Shipyard's ship flow). Two different semantics; forcing them into one command's flag space would make both harder to reason about.

## Deferred (tracked under #77)

- \`--watch\` / auto mode with a threshold poller
- \`[handoff.workflows.*]\` config map when the workflow doesn't already expose a \`runner_provider\` input
- State-file audit log of handoff decisions under \`state/shipyard/handoff/\`

## Test plan

- [x] \`uv run pytest tests/test_cli_cloud_handoff.py -q\` → 13 passed
- [x] \`uv run pytest tests/test_cli_cloud_retarget.py tests/test_cli_cloud_handoff.py -q\` → 32 passed (cloud suites together, no regression)
- [x] \`uv run shipyard cloud handoff --help\` → subgroup + both commands listed
- [ ] CI green on Linux / macOS / Windows (Windows retarget-class is #198-skipped, same escape hatch applied here)