### PR TITLE
doctor: surface macOS Gatekeeper / quarantine / codesign state (#216)

### DIFF
--- a/src/shipyard/cli.py
+++ b/src/shipyard/cli.py
@@ -497,6 +497,13 @@ def doctor(ctx: Context, release_chain: bool, runners: bool) -> None:
     # #181: catch a corrupt PyInstaller _unicode_data archive here
     # rather than mid-render during `shipyard ship`.
     core["rich-bundle"] = _check_rich_bundle_health()
+    # #216: surface macOS Gatekeeper / quarantine / codesign state so
+    # a binary in the silent-no-op failure mode is named rather than
+    # mysterious. None on non-macOS / non-frozen; omit that row so
+    # Linux + dev-env don't show a vacuous line.
+    gatekeeper_row = _check_macos_gatekeeper_health()
+    if gatekeeper_row is not None:
+        core["macos-gatekeeper"] = gatekeeper_row
     daemon_drift = _check_daemon_version_drift(ctx)
     if daemon_drift:
         core["daemon-version"] = daemon_drift
@@ -636,6 +643,103 @@ def _check_shipyard_path_shadows() -> dict[str, Any]:
         "version": f"v{_self_version} ({len(seen_bins)} binaries found)",
         "detail": detail,
     }
+
+
+def _check_macos_gatekeeper_health() -> dict[str, Any] | None:
+    """Surface a broken notarization state on macOS before it bites.
+
+    Closes #216 — the user-facing failure is "exit 137 once, then
+    exit 0 with zero output forever after." That shape is exactly
+    what happens when Gatekeeper rejects a PyInstaller bundle whose
+    Developer-ID signature got destroyed: macOS SIGKILLs on first
+    run and then caches the rejection so subsequent runs exit
+    silently. Root cause was ``install.sh``'s pre-v0.36.0
+    ``codesign --force --sign -`` ad-hoc resign (#203 fixed the
+    install side). This check catches users already in the broken
+    state or whose future install path regresses.
+
+    Three signals, any one of which flips ok=False:
+
+    1. ``com.apple.quarantine`` xattr present on the running binary
+       — Gatekeeper's first-run evaluation is still pending or
+       failed.
+    2. ``spctl --assess`` rejects the binary — active Gatekeeper
+       rejection. The definitive "your binary is broken" signal.
+    3. ``codesign --verify --deep`` fails — signing integrity is
+       broken independent of policy.
+
+    Returns None on non-macOS and when the running CLI isn't a
+    frozen bundle (e.g. ``uv run shipyard doctor`` during
+    development) — a passing row there would be false confidence
+    since the Python interpreter is well-signed regardless of how
+    the release binary fared.
+    """
+    if sys.platform != "darwin":
+        return None
+
+    frozen = getattr(sys, "frozen", False)
+    if not frozen:
+        return None
+
+    binary = Path(sys.executable)
+    if not binary.exists():
+        return None
+
+    problems: list[str] = []
+
+    try:
+        xattr_out = subprocess.run(
+            ["xattr", str(binary)],
+            capture_output=True, text=True, timeout=5,
+        )
+        if "com.apple.quarantine" in xattr_out.stdout:
+            import shlex as _shlex
+            problems.append(
+                "com.apple.quarantine xattr present — binary is in "
+                "Gatekeeper first-run evaluation state. Clear with: "
+                f"xattr -d com.apple.quarantine {_shlex.quote(str(binary))}"
+            )
+    except (subprocess.SubprocessError, FileNotFoundError):
+        pass
+
+    try:
+        spctl = subprocess.run(
+            ["spctl", "--assess", "--verbose=2", str(binary)],
+            capture_output=True, text=True, timeout=10,
+        )
+        if spctl.returncode != 0:
+            detail = (spctl.stderr.strip() or spctl.stdout.strip())[:200]
+            problems.append(
+                f"spctl rejection: {detail}. Reinstall v0.36.0+ "
+                "(install.sh now preserves Developer-ID notarization): "
+                "curl -fsSL https://raw.githubusercontent.com/"
+                "danielraffel/Shipyard/main/install.sh | sh"
+            )
+    except (subprocess.SubprocessError, FileNotFoundError):
+        pass
+
+    try:
+        verify = subprocess.run(
+            ["codesign", "--verify", "--deep", str(binary)],
+            capture_output=True, text=True, timeout=10,
+        )
+        if verify.returncode != 0:
+            detail = (verify.stderr.strip() or "verification failed")[:200]
+            problems.append(
+                f"codesign --verify failed: {detail}. Binary "
+                "signature is broken; reinstall from the release "
+                "artifact."
+            )
+    except (subprocess.SubprocessError, FileNotFoundError):
+        pass
+
+    if problems:
+        return {
+            "ok": False,
+            "version": "macOS Gatekeeper rejection risk",
+            "detail": "\n  ".join(problems),
+        }
+    return {"ok": True, "version": "Gatekeeper + codesign + xattr healthy"}
 
 
 def _check_rich_bundle_health() -> dict[str, Any]:

--- a/tests/test_doctor_gatekeeper.py
+++ b/tests/test_doctor_gatekeeper.py
@@ -1,0 +1,180 @@
+"""Tests for doctor's macOS Gatekeeper / quarantine / codesign smoke (#216).
+
+The #216 symptom — "exit 137 once, then exit 0 with zero output
+forever" — is macOS caching a Gatekeeper rejection of a binary
+whose Developer-ID signature got destroyed (pre-v0.36.0 install.sh
+ad-hoc resign). This check catches the broken state in doctor so
+the operator sees "spctl rejection: …" instead of silence.
+
+The check is macOS-only and only meaningful against a frozen
+PyInstaller bundle, so we mock sys.platform + sys.frozen to
+exercise the Windows/Linux and dev-env paths deterministically.
+"""
+
+from __future__ import annotations
+
+import sys
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import patch
+
+import pytest  # noqa: TC002 — used at runtime via MonkeyPatch fixture
+
+from shipyard.cli import _check_macos_gatekeeper_health
+
+
+def _ok_proc(returncode: int = 0, stdout: str = "", stderr: str = "") -> Any:
+    return SimpleNamespace(returncode=returncode, stdout=stdout, stderr=stderr)
+
+
+def test_skips_on_non_macos(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(sys, "platform", "linux")
+    assert _check_macos_gatekeeper_health() is None
+
+
+def test_skips_on_non_frozen_darwin(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Running from source: Python itself is always signed OK, so a
+    # passing row here would be false confidence about the release
+    # binary. Skip.
+    monkeypatch.setattr(sys, "platform", "darwin")
+    monkeypatch.setattr(sys, "frozen", False, raising=False)
+    assert _check_macos_gatekeeper_health() is None
+
+
+def _force_frozen_macos(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    """Pretend we're a frozen PyInstaller bundle on macOS.
+
+    `sys.executable` gets pointed at a real file under tmp_path so
+    the existence check passes; we don't care about its contents.
+    """
+    binary = tmp_path / "shipyard"
+    binary.write_bytes(b"stub")
+    monkeypatch.setattr(sys, "platform", "darwin")
+    monkeypatch.setattr(sys, "frozen", True, raising=False)
+    monkeypatch.setattr(sys, "executable", str(binary))
+
+
+def test_all_green_returns_ok(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    _force_frozen_macos(monkeypatch, tmp_path)
+
+    def fake_run(cmd, **kw):
+        # xattr: no quarantine. spctl + codesign: success.
+        return _ok_proc(returncode=0, stdout="", stderr="")
+
+    with patch("shipyard.cli.subprocess.run", side_effect=fake_run):
+        result = _check_macos_gatekeeper_health()
+
+    assert result is not None
+    assert result["ok"] is True
+
+
+def test_quarantine_xattr_flagged(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    _force_frozen_macos(monkeypatch, tmp_path)
+
+    calls = {"n": 0}
+
+    def fake_run(cmd, **kw):
+        calls["n"] += 1
+        # First call is xattr listing — include the quarantine flag.
+        if cmd[0] == "xattr":
+            return _ok_proc(stdout="com.apple.quarantine\n")
+        # spctl + codesign accept the binary.
+        return _ok_proc(returncode=0)
+
+    with patch("shipyard.cli.subprocess.run", side_effect=fake_run):
+        result = _check_macos_gatekeeper_health()
+
+    assert result is not None
+    assert result["ok"] is False
+    assert "quarantine" in result["detail"].lower()
+    # Fix instruction must name the actual xattr -d invocation.
+    assert "xattr -d com.apple.quarantine" in result["detail"]
+
+
+def test_spctl_rejection_flagged(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    _force_frozen_macos(monkeypatch, tmp_path)
+
+    def fake_run(cmd, **kw):
+        if cmd[0] == "spctl":
+            return _ok_proc(
+                returncode=3,
+                stderr="rejected (the code is valid but does not seem to be an app)",
+            )
+        return _ok_proc(returncode=0)
+
+    with patch("shipyard.cli.subprocess.run", side_effect=fake_run):
+        result = _check_macos_gatekeeper_health()
+
+    assert result is not None
+    assert result["ok"] is False
+    assert "spctl" in result["detail"].lower()
+    # Reinstall hint must point at install.sh so the operator gets
+    # the v0.36.0+ notarization-preserving path.
+    assert "install.sh" in result["detail"]
+
+
+def test_codesign_verify_failure_flagged(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    _force_frozen_macos(monkeypatch, tmp_path)
+
+    def fake_run(cmd, **kw):
+        if cmd[0] == "codesign":
+            return _ok_proc(returncode=1, stderr="code object is not signed at all")
+        return _ok_proc(returncode=0)
+
+    with patch("shipyard.cli.subprocess.run", side_effect=fake_run):
+        result = _check_macos_gatekeeper_health()
+
+    assert result is not None
+    assert result["ok"] is False
+    assert "codesign" in result["detail"].lower()
+
+
+def test_multiple_problems_all_surface(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    # The failure mode reported on #216 is the compounded case —
+    # quarantine xattr AND spctl rejection. Both must appear in the
+    # detail so the operator has the full picture.
+    _force_frozen_macos(monkeypatch, tmp_path)
+
+    def fake_run(cmd, **kw):
+        if cmd[0] == "xattr":
+            return _ok_proc(stdout="com.apple.quarantine\n")
+        if cmd[0] == "spctl":
+            return _ok_proc(returncode=3, stderr="rejected")
+        return _ok_proc(returncode=0)
+
+    with patch("shipyard.cli.subprocess.run", side_effect=fake_run):
+        result = _check_macos_gatekeeper_health()
+
+    assert result is not None
+    assert result["ok"] is False
+    assert "quarantine" in result["detail"].lower()
+    assert "spctl" in result["detail"].lower()
+
+
+def test_missing_tool_falls_through_without_raising(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    # A machine without xattr / spctl / codesign on PATH should not
+    # blow up doctor — those probes are individually try/excepted and
+    # either pass (no detected problems) or contribute nothing.
+    _force_frozen_macos(monkeypatch, tmp_path)
+
+    def fake_run(cmd, **kw):
+        raise FileNotFoundError(cmd[0])
+
+    with patch("shipyard.cli.subprocess.run", side_effect=fake_run):
+        result = _check_macos_gatekeeper_health()
+
+    # All three probes silently skipped → no problems detected → ok.
+    assert result is not None
+    assert result["ok"] is True


### PR DESCRIPTION
## Summary

Closes #216's diagnostic gap. The root-cause fix for the reported failure (\"exit 137 once, exit 0 with zero output after\") already landed in v0.36.0 (PR #203, \`install.sh\` preserves Developer-ID notarization). This adds **defense in depth** in \`shipyard doctor\` so any user already in the broken state — or whose future install regresses — sees an actionable name for the problem instead of silence.

## Why it matters

v0.29.0 binaries installed via pre-v0.36.0 \`install.sh\` got their Developer-ID signature destroyed by an unconditional \`codesign --force --sign -\` ad-hoc resign. After some time (XProtect scan, Gatekeeper first-run policy cache), macOS starts SIGKILLing the process — exit 137 first, then exit 0 with zero output as the rejection gets cached. The user has no way to tell this apart from \"shipyard is just broken.\"

## What ships

\`_check_macos_gatekeeper_health\` — three probes, any one ok=False flips the Core row:

1. **\`xattr\`** — detects \`com.apple.quarantine\` still stuck on the binary. Fix: \`xattr -d com.apple.quarantine <path>\`.
2. **\`spctl --assess --verbose=2\`** — Gatekeeper policy rejection. The definitive signal. Reinstall hint points at install.sh so the user lands on v0.36.0+.
3. **\`codesign --verify --deep\`** — signing integrity independent of policy.

Scope guards:
- Non-macOS → returns None, row omitted from Core.
- \`sys.frozen\` == False (source, \`uv run\`) → returns None. Python itself is always signed OK, so a passing row there would be false confidence about the release binary.
- Missing \`xattr\` / \`spctl\` / \`codesign\` on PATH → probe silently skipped, doesn't break doctor.

## Test plan

- [x] \`uv run pytest tests/test_doctor_gatekeeper.py -q\` → 8 passed
- [x] \`uvx ruff check src/shipyard/cli.py tests/test_doctor_gatekeeper.py\` → clean
- [ ] CI green on Linux / macOS / Windows