### PR TITLE
install.sh + release.yml: gate bad binaries, surface taskgated SIGKILL (#219)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -299,6 +299,39 @@ jobs:
           # is registered with Apple server-side and matches the
           # binary's hash.
 
+      - name: End-to-end launch gate (macOS — #219)
+        # Runs the *signed + notarized* Mach-O as the CI runner would
+        # see it after an end-user install. Catches taskgated
+        # rejections (exit 137, "Code Signature Invalid") that
+        # `codesign --verify` and `spctl --assess` miss.
+        #
+        # install.sh's post-install smoke runs client-side on the
+        # end user's box; this runs server-side pre-upload, which is
+        # the only place we can block a broken binary from ever
+        # becoming a release asset.
+        #
+        # Tied to the notarize step's `needs`: if this job fails, the
+        # `release` job's `needs: build` dependency holds the tag from
+        # getting a release uploaded. Bad binaries never ship.
+        if: runner.os == 'macOS'
+        run: |
+          set -euo pipefail
+          BINARY="dist/${{ matrix.artifact }}"
+          echo "Running signed+notarized binary's --version to verify taskgated acceptance..."
+          # If taskgated will reject this binary, it'll do so here
+          # with exit 137 and zero output — the exact #219 shape.
+          if ! "$BINARY" --version >/dev/null 2>&1; then
+            echo "::error::Post-notarization launch gate FAILED for $BINARY"
+            echo "::error::This binary passes codesign --verify but taskgated rejects it at launch."
+            echo "::error::This is the #219 class of bug — fix before releasing."
+            echo "Attempting diagnostic capture:"
+            "$BINARY" --version || true
+            codesign -dvvv "$BINARY" 2>&1 | head -40 || true
+            spctl --assess --type execute -vv "$BINARY" 2>&1 || true
+            exit 1
+          fi
+          echo "✓ Binary launched cleanly under signed-and-notarized state."
+
       - name: Delete signing keychain (macOS)
         if: always() && steps.import_signing_identity.outputs.keychain != ''
         run: |

--- a/install.sh
+++ b/install.sh
@@ -113,7 +113,13 @@ fi
 
 echo "Downloading ${ARTIFACT} (${VERSION_LABEL})..."
 mkdir -p "${INSTALL_DIR}"
-curl -sL "${RELEASE_URL}" -o "${INSTALL_DIR}/shipyard"
+# SHIPYARD_SKIP_DOWNLOAD=1 preserves an already-present binary at
+# ${INSTALL_DIR}/shipyard. Used by the tests to exercise the
+# post-install smoke + remediation paths without hitting the
+# network or needing a real release asset.
+if [ "${SHIPYARD_SKIP_DOWNLOAD:-0}" != "1" ]; then
+    curl -sL "${RELEASE_URL}" -o "${INSTALL_DIR}/shipyard"
+fi
 chmod +x "${INSTALL_DIR}/shipyard"
 
 # macOS post-download signature handling.
@@ -166,6 +172,52 @@ fi
 # `sy` is the short-form alias that shipyard's packaging ships as an
 # entry point; mirror it with a symlink here so both names resolve.
 ln -sf "${INSTALL_DIR}/shipyard" "${INSTALL_DIR}/sy"
+
+# Post-install smoke test (#219).
+#
+# Bare Mach-O binaries on macOS can pass `codesign --verify` and
+# still SIGKILL at launch with "Taskgated Invalid Signature" —
+# notarization tickets can't be stapled to a Mach-O (only to .app
+# / .pkg / .dmg), so Gatekeeper falls back to an ONLINE check the
+# first time the binary runs. If that check hiccups (network, DNS,
+# Apple-side CDN), taskgated rejects launch and the user sees
+# exit 137 with zero output. Without this gate the installer
+# cheerfully reports "installed" and leaves the user with a dead
+# binary; that's exactly #219.
+#
+# If the smoke fails, try one recovery round (remove provenance
+# xattr + force a second launch) before giving up with a specific,
+# actionable error message. Skip entirely if SHIPYARD_SKIP_SMOKE=1
+# is set — useful for CI that's dispatching its own verification.
+if [ "${SKIP_SMOKE:-${SHIPYARD_SKIP_SMOKE:-0}}" != "1" ]; then
+    if ! "${INSTALL_DIR}/shipyard" --version >/dev/null 2>&1; then
+        # Recovery attempt: macOS occasionally caches an old
+        # taskgated rejection; stripping provenance + retrying gives
+        # the notarization check a second shot.
+        if [ "${OS}" = "macos" ]; then
+            xattr -d com.apple.provenance "${INSTALL_DIR}/shipyard" 2>/dev/null || true
+            sleep 1
+        fi
+        if ! "${INSTALL_DIR}/shipyard" --version >/dev/null 2>&1; then
+            echo "" >&2
+            echo "ERROR: shipyard was installed but failed its post-install smoke test." >&2
+            echo "" >&2
+            if [ "${OS}" = "macos" ]; then
+                echo "On macOS this usually means one of:" >&2
+                echo "  - Gatekeeper's first-launch online notarization check failed" >&2
+                echo "    (transient network / Apple CDN). Retry: ${INSTALL_DIR}/shipyard --version" >&2
+                echo "  - taskgated rejected the binary. Check the crash report under" >&2
+                echo "    ~/Library/Logs/DiagnosticReports/shipyard-*.ips for 'Code Signature Invalid'." >&2
+                echo "    If that's the signature, see https://github.com/danielraffel/Shipyard/issues/219" >&2
+                echo "    for status on the .dmg-stapling fix." >&2
+            else
+                echo "Run '${INSTALL_DIR}/shipyard --version' manually for a specific error." >&2
+            fi
+            echo "" >&2
+            exit 1
+        fi
+    fi
+fi
 
 echo ""
 echo "Installed shipyard to ${INSTALL_DIR}/shipyard"

--- a/tests/test_install_sh.py
+++ b/tests/test_install_sh.py
@@ -124,3 +124,112 @@ def test_install_dir_override_does_not_affect_version_resolution() -> None:
     )
     assert config["INSTALL_DIR"] == "/tmp/foo"
     assert config["API_PATH"] == "releases/tags/v0.22.1"
+
+
+# -- #219: post-install smoke + remediation -------------------------
+# install.sh now runs the freshly-installed binary's `--version` and
+# fails loud (exit 1, specific error messages) if it can't launch.
+# This is the first line of defense against the v0.42.0 taskgated
+# SIGKILL class of bug where `codesign --verify` passes but the
+# binary dies at runtime. Testability hook: SHIPYARD_SKIP_DOWNLOAD=1
+# reuses an existing binary at $INSTALL_DIR/shipyard so we can
+# inject a stub that succeeds or fails deterministically.
+
+def _install_with_stub(
+    tmp_path: Path,
+    *,
+    stub_behaviour: str,
+    extra_env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    """Drive install.sh against a tmp install dir with a stub binary
+    pre-planted at ``$INSTALL_DIR/shipyard``.
+
+    ``stub_behaviour`` is either ``"ok"`` (script exits 0 with a
+    version line) or ``"sigkill"`` (script exits 137 with no output,
+    simulating taskgated rejection).
+    """
+    install_dir = tmp_path / "bin"
+    install_dir.mkdir()
+    stub = install_dir / "shipyard"
+    if stub_behaviour == "ok":
+        stub.write_text("#!/bin/sh\necho shipyard 99.99.99\n")
+    elif stub_behaviour == "sigkill":
+        # kill -KILL $$ is the closest deterministic proxy for the
+        # real taskgated SIGKILL: no stdout, no stderr, exit 137.
+        stub.write_text("#!/bin/sh\nkill -KILL $$\n")
+    else:
+        raise ValueError(stub_behaviour)
+    stub.chmod(0o755)
+
+    env = {
+        **os.environ,
+        "SHIPYARD_INSTALL_DIR": str(install_dir),
+        "SHIPYARD_SKIP_DOWNLOAD": "1",
+    }
+    if extra_env:
+        env.update(extra_env)
+    return subprocess.run(
+        ["bash", str(INSTALL_SH)],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_post_install_smoke_passes_when_binary_launches(tmp_path: Path) -> None:
+    # Happy path: a binary that actually starts should produce an
+    # installer exit 0 with the usual success messages.
+    result = _install_with_stub(tmp_path, stub_behaviour="ok")
+    assert result.returncode == 0, (
+        f"installer failed: stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+    assert "Installed shipyard to" in result.stdout
+
+
+def test_post_install_smoke_fails_loud_on_sigkill(tmp_path: Path) -> None:
+    # The #219 failure mode: binary exists, is executable, passes
+    # codesign verify on macOS — but dies at launch. The installer
+    # MUST exit non-zero so downstream wrappers (pulp's
+    # install-shipyard.sh, Spectr's, etc.) can abort instead of
+    # claiming success and leaving the user with a dead binary.
+    result = _install_with_stub(tmp_path, stub_behaviour="sigkill")
+    assert result.returncode != 0, (
+        "smoke test failure must propagate exit code; got 0 with "
+        f"stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+    # Message must be on stderr (not swallowed by stdout redirection
+    # in wrapper scripts) and must name #219 so the user has a
+    # pointer to the tracking thread for the proper .dmg fix.
+    assert "smoke test" in result.stderr.lower()
+    assert "219" in result.stderr or "/issues/219" in result.stderr
+
+
+def test_post_install_smoke_can_be_disabled(tmp_path: Path) -> None:
+    # Escape hatch: CI or a wrapper that dispatches its own
+    # verification can opt out via SHIPYARD_SKIP_SMOKE=1 so a
+    # deliberately-broken stub doesn't prevent install-dir staging.
+    result = _install_with_stub(
+        tmp_path,
+        stub_behaviour="sigkill",
+        extra_env={"SHIPYARD_SKIP_SMOKE": "1"},
+    )
+    assert result.returncode == 0, (
+        f"SHIPYARD_SKIP_SMOKE=1 must bypass smoke gate; got exit "
+        f"{result.returncode} stderr={result.stderr!r}"
+    )
+
+
+def test_post_install_smoke_remediation_mentions_crash_report_on_macos(
+    tmp_path: Path,
+) -> None:
+    # macOS-only: the remediation block should point at the
+    # ~/Library/Logs/DiagnosticReports path so the user knows where
+    # to look for the taskgated crash signature, not just "retry".
+    # On Linux the hint is simpler so we conditionally assert.
+    if sys.platform != "darwin":
+        pytest.skip("macOS-specific remediation hint")
+    result = _install_with_stub(tmp_path, stub_behaviour="sigkill")
+    assert result.returncode != 0
+    assert "DiagnosticReports" in result.stderr
+    assert "Code Signature Invalid" in result.stderr

--- a/tests/test_install_sh.py
+++ b/tests/test_install_sh.py
@@ -198,11 +198,18 @@ def test_post_install_smoke_fails_loud_on_sigkill(tmp_path: Path) -> None:
         "smoke test failure must propagate exit code; got 0 with "
         f"stdout={result.stdout!r} stderr={result.stderr!r}"
     )
-    # Message must be on stderr (not swallowed by stdout redirection
-    # in wrapper scripts) and must name #219 so the user has a
-    # pointer to the tracking thread for the proper .dmg fix.
+    # Error message must be on stderr so wrapper scripts that redirect
+    # stdout don't swallow it.
     assert "smoke test" in result.stderr.lower()
-    assert "219" in result.stderr or "/issues/219" in result.stderr
+    # The #219 issue link is macOS-specific (taskgated doesn't exist
+    # on Linux, and the .dmg-stapling fix is macOS-only). On Linux
+    # the hint is generic "run the binary manually" — assert whichever
+    # the current OS should emit. `test_post_install_smoke_remediation
+    # _mentions_crash_report_on_macos` covers the macOS-specific text.
+    if sys.platform == "darwin":
+        assert "219" in result.stderr or "/issues/219" in result.stderr
+    else:
+        assert "run" in result.stderr.lower() and "manually" in result.stderr.lower()
 
 
 def test_post_install_smoke_can_be_disabled(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Closes the immediate breakage in #219. v0.42.0 shipped a binary that was signed + notarized and passed \`codesign --verify\` but taskgated SIGKILLed it at launch. Root cause: bare Mach-O binaries can't be stapled, so Gatekeeper falls back to an ONLINE notarization check on first launch, and the check failed for the user.

The proper fix is distributing as \`.dmg\` with a stapled ticket (tracked separately as task #52). This PR is the **guard rails + observability** so it can't happen silently again.

## Three-layer defense

### 1. CI gate in release.yml (the most important one)

After \`notarize\`, the macOS build job runs the signed binary's \`--version\` on the GH Actions runner. If taskgated rejects, the build fails, \`needs: build\` blocks the \`release\` job, and no asset is ever uploaded. **A broken binary can't become a release asset.**

### 2. install.sh post-install smoke

After install, run \`shipyard --version\`. On failure: one recovery attempt (strip \`com.apple.provenance\` xattr + retry), then exit 1 with a specific remediation message naming the crash-report path and linking to #219. Opt out with \`SHIPYARD_SKIP_SMOKE=1\`.

### 3. Tests

\`tests/test_install_sh.py\` drives install.sh with a deterministic SIGKILL stub (new \`SHIPYARD_SKIP_DOWNLOAD=1\` testability hook reuses an existing binary at \`\$INSTALL_DIR/shipyard\`). Covers:

- Happy path: clean stub binary → installer exit 0
- SIGKILL stub → installer exit 1 with \"smoke test\" + \"#219\" on stderr
- \`SHIPYARD_SKIP_SMOKE=1\` escape hatch → installer exit 0 despite SIGKILL stub
- macOS-specific remediation hint names the DiagnosticReports path + \"Code Signature Invalid\" signature

## Test plan

- [x] 14/14 tests pass locally (\`uv run pytest tests/test_install_sh.py -q\`)
- [x] Live-fire: SIGKILL stub installer exits 1 with the expected remediation message
- [x] Lint clean
- [ ] CI green (the end-to-end launch gate runs on the macOS build job — this very PR will exercise it against a bare push, not a notarized bundle, so the gate should be no-op outside tag builds)

## Related

- #216 — earlier macOS install-path issue (doctor-time check)
- #203 — install.sh preserve-notarization fix
- Task #52 (pending) — proper fix: .dmg distribution with stapled ticket