### PR TITLE
chore: bump CLI 0.42.0 → 0.43.0 — releases #219 install-smoke + CI launch gate

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "shipyard"
-version = "0.42.0"
+version = "0.43.0"
 description = "Cross-platform CI coordination — local VMs, SSH hosts, cloud runners"
 readme = "README.md"
 license = "MIT"

--- a/src/shipyard/__init__.py
+++ b/src/shipyard/__init__.py
@@ -1,3 +1,3 @@
 """Shipyard — Cross-platform CI coordination."""
 
-__version__ = "0.42.0"
+__version__ = "0.43.0"


### PR DESCRIPTION
## Why

v0.42.0 was the broken release (#219 — taskgated SIGKILL at launch despite valid codesign). PR #220 landed three-layer defense:

- **release.yml launch gate** — catches taskgated-rejected binaries before they become release assets
- **install.sh smoke + remediation** — exits 1 with actionable error instead of handing users a dead binary
- **Tests** — 14 cases with SIGKILL-emitting stub so the gate can't silently regress

**This bump is meaningful**: v0.43.0's build will be the first to go through the new CI launch gate. If the signed binary fails to launch under taskgated, the build fails here — no broken asset ever ships. That's exactly the protection #219 called for.

If CI green → v0.43.0 published → pulp + spectr pin bumps can target this.

No code changes beyond the two version fields.