### PR TITLE
feat: scripts/release-macos-local.sh — Option B local build+sign+test (#219)

### DIFF
--- a/scripts/release-macos-local.sh
+++ b/scripts/release-macos-local.sh
@@ -1,0 +1,219 @@
+#!/usr/bin/env bash
+# Build, sign, notarize, AND TEST the macOS shipyard binary on this Mac.
+#
+# Motivation (#219): CI-signed + Apple-notarized binaries shipped in
+# v0.42.0 and v0.43.0 both SIGKILL'd with "Taskgated Invalid Signature"
+# on the primary maintainer's Mac — even though they passed CI's own
+# launch gate on a GH Actions macOS-15 runner. That strongly suggests
+# the problem is either (a) CI's signing pipeline producing a ticket
+# that's subtly different from what Apple returns for the same cert
+# locally, or (b) a per-Mac Gatekeeper/taskgated state that won't
+# accept tickets from a specific CI environment.
+#
+# This script is "Option B" from the #219 discussion: take signing
+# completely off CI and put it on the Mac that's actually going to
+# run the binary. The build is deterministic in the sense that the
+# PyInstaller flags match CI's exactly — only the environment is
+# different. If the locally-built+signed binary launches cleanly
+# here, that's definitive proof CI signing was broken.
+#
+# Even more important per user instruction: THIS SCRIPT TESTS THE
+# BINARY AFTER NOTARIZATION AND BEFORE UPLOAD. No asset uploads if
+# `--version` doesn't print. That's the whole point — if CI did
+# this we'd have caught v0.42.0 before it shipped.
+#
+# Usage:
+#   ./scripts/release-macos-local.sh [--tag vX.Y.Z] [--upload] [--arch arm64|x64]
+#
+# Env vars required for notarization:
+#   SHIPYARD_NOTARIZE_APPLE_ID           (Apple ID email)
+#   SHIPYARD_NOTARIZE_TEAM_ID            (Developer Team ID, e.g. 95CX6P84C4)
+#   SHIPYARD_NOTARIZE_APP_PASSWORD       (app-specific password from appleid.apple.com)
+#   SHIPYARD_SIGNING_IDENTITY            (SHA-1 fingerprint OR subject CN of Developer-ID cert)
+#
+# Flags:
+#   --tag vX.Y.Z   Assume the current commit is tagged vX.Y.Z.
+#                  Defaults to `git describe --tags`.
+#   --upload       Upload the signed+tested asset to the GitHub release
+#                  for --tag. Without this, the script only builds and
+#                  verifies — useful for diagnosing without shipping.
+#   --arch         Build for arm64 (default) or x64. The host CPU is
+#                  what you'll actually get; x64 needs Rosetta or a
+#                  different host.
+#
+# Exit codes:
+#   0   Build + sign + notarize + local-launch test all passed.
+#       Asset was uploaded if --upload was passed.
+#   1   One of the steps failed. Diagnostics on stderr.
+#   2   Missing required env var.
+#   3   --version smoke test FAILED on this Mac. Do NOT ship this binary.
+
+set -euo pipefail
+
+ARCH="arm64"
+TAG=""
+DO_UPLOAD=0
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --tag) TAG="$2"; shift 2 ;;
+        --arch) ARCH="$2"; shift 2 ;;
+        --upload) DO_UPLOAD=1; shift ;;
+        -h|--help)
+            sed -n '/^# Usage:/,/^$/p' "$0" | sed 's/^# //; s/^#//'
+            exit 0
+            ;;
+        *) echo "Unknown flag: $1" >&2; exit 1 ;;
+    esac
+done
+
+if [ -z "$TAG" ]; then
+    TAG=$(git describe --tags --exact-match 2>/dev/null || true)
+    if [ -z "$TAG" ]; then
+        echo "ERROR: --tag required (current commit is not a tagged release)" >&2
+        echo "       Pass --tag vX.Y.Z explicitly, or tag the commit first." >&2
+        exit 2
+    fi
+fi
+
+# Every env var must be set for notarization. We bail out BEFORE
+# the expensive build step rather than letting the user burn 60s
+# on PyInstaller only to discover they forgot a secret.
+for var in SHIPYARD_NOTARIZE_APPLE_ID SHIPYARD_NOTARIZE_TEAM_ID \
+           SHIPYARD_NOTARIZE_APP_PASSWORD SHIPYARD_SIGNING_IDENTITY; do
+    if [ -z "${!var:-}" ]; then
+        echo "ERROR: $var is not set in the environment." >&2
+        echo "       See scripts/release-macos-local.sh header for the full list." >&2
+        exit 2
+    fi
+done
+
+ARTIFACT="shipyard-macos-${ARCH}"
+DIST_BINARY="dist/${ARTIFACT}"
+
+echo ""
+echo "═══ Local macOS release build: ${TAG} (${ARCH}) ═══"
+echo ""
+
+# ── Build ──────────────────────────────────────────────────────────
+# Mirror CI's invocation from .github/workflows/release.yml line 251
+# so the resulting binary is byte-identical to what CI would produce
+# on the same commit (modulo signing timestamp). If this binary
+# launches but the CI-signed one doesn't, the delta is signing.
+echo "Step 1/5: PyInstaller build..."
+if ! command -v pyinstaller >/dev/null 2>&1; then
+    echo "ERROR: pyinstaller not on PATH. pip install pyinstaller." >&2
+    exit 1
+fi
+rm -rf dist/ build/ "${ARTIFACT}".spec
+pyinstaller --onefile \
+    --name "$ARTIFACT" \
+    --codesign-identity "$SHIPYARD_SIGNING_IDENTITY" \
+    src/shipyard/cli.py >/dev/null
+
+if [ ! -f "$DIST_BINARY" ]; then
+    echo "ERROR: PyInstaller did not produce $DIST_BINARY" >&2
+    exit 1
+fi
+
+# ── Re-sign with hardened runtime + timestamp ──────────────────────
+echo "Step 2/5: Re-sign with hardened runtime + secure timestamp..."
+codesign --force --options runtime --timestamp \
+    --sign "$SHIPYARD_SIGNING_IDENTITY" \
+    "$DIST_BINARY"
+codesign -dv --verbose=4 "$DIST_BINARY" 2>&1 | grep -E "Authority|TeamIdentifier|Timestamp" | head -5
+
+# ── Notarize ───────────────────────────────────────────────────────
+echo "Step 3/5: Submit to Apple notarization service (this takes ~30-90s)..."
+NOTARIZE_ZIP="$(mktemp -d)/${ARTIFACT}.zip"
+/usr/bin/ditto -c -k --keepParent "$DIST_BINARY" "$NOTARIZE_ZIP"
+
+# Capture notarytool output so we can grep for the submission id on
+# failure — Apple's rejection reasons are only findable via
+# `notarytool log <submission-id>`.
+NOTARIZE_LOG="$(mktemp)"
+if ! xcrun notarytool submit "$NOTARIZE_ZIP" \
+        --apple-id "$SHIPYARD_NOTARIZE_APPLE_ID" \
+        --team-id "$SHIPYARD_NOTARIZE_TEAM_ID" \
+        --password "$SHIPYARD_NOTARIZE_APP_PASSWORD" \
+        --wait 2>&1 | tee "$NOTARIZE_LOG"; then
+    echo "ERROR: notarytool submit failed. Log: $NOTARIZE_LOG" >&2
+    exit 1
+fi
+
+if grep -q "status: Accepted" "$NOTARIZE_LOG"; then
+    echo "  ✓ Notarization Accepted"
+else
+    SUB_ID=$(grep -E "^\s+id:" "$NOTARIZE_LOG" | head -1 | awk '{print $NF}')
+    echo "ERROR: notarization not Accepted. Submission id: $SUB_ID" >&2
+    echo "       Fetch the log with:" >&2
+    echo "         xcrun notarytool log $SUB_ID \\" >&2
+    echo "           --apple-id \$SHIPYARD_NOTARIZE_APPLE_ID \\" >&2
+    echo "           --team-id \$SHIPYARD_NOTARIZE_TEAM_ID \\" >&2
+    echo "           --password \$SHIPYARD_NOTARIZE_APP_PASSWORD" >&2
+    exit 1
+fi
+
+# ── Local launch test (#219 — THE WHOLE POINT) ─────────────────────
+# CI's launch gate runs on a GH Actions macOS-15 runner, which is
+# NOT the Mac users will actually run the binary on. A notarized
+# binary that launches on the CI runner but SIGKILLs on the user's
+# Mac is exactly the #219 failure mode. Here we test on the ACTUAL
+# Mac that's about to ship the binary — if it dies here, we refuse
+# to upload.
+echo "Step 4/5: Local launch test (taskgated / Gatekeeper / codesign)..."
+if ! OUTPUT=$("$DIST_BINARY" --version 2>&1); then
+    echo "" >&2
+    echo "ERROR: LOCAL LAUNCH TEST FAILED on this Mac." >&2
+    echo "       Binary: $DIST_BINARY" >&2
+    echo "       This is the #219 failure shape. Do NOT ship this binary." >&2
+    echo "" >&2
+    echo "       Diagnostics:" >&2
+    codesign --verify --deep --strict --verbose=4 "$DIST_BINARY" 2>&1 | sed 's/^/         /' >&2
+    spctl --assess --type execute -vv "$DIST_BINARY" 2>&1 | sed 's/^/         /' >&2
+    xattr -l "$DIST_BINARY" 2>&1 | sed 's/^/         /' >&2
+    echo "" >&2
+    echo "       Crash report (if any) under:" >&2
+    echo "         ~/Library/Logs/DiagnosticReports/shipyard-*.ips" >&2
+    echo "" >&2
+    exit 3
+fi
+echo "  ✓ --version printed: ${OUTPUT}"
+
+# ── Upload (opt-in) ────────────────────────────────────────────────
+if [ "$DO_UPLOAD" -eq 1 ]; then
+    echo "Step 5/5: Uploading $DIST_BINARY to release $TAG..."
+    # Overwrite if an asset already exists — typically this script
+    # replaces CI's broken asset with a known-working local one.
+    gh release upload "$TAG" "$DIST_BINARY" --clobber
+    # Update the checksum line for this artifact. The release's
+    # checksums.sha256 contains one line per platform; we replace
+    # just our line. If the file doesn't exist yet, this creates it.
+    CHECKSUM=$(shasum -a 256 "$DIST_BINARY" | awk '{print $1}')
+    LINE="${CHECKSUM}  ${ARTIFACT}"
+    CHECKSUMS_TMP="$(mktemp)"
+    if gh release view "$TAG" --json assets --jq '.assets[] | select(.name=="checksums.sha256") | .name' | grep -q checksums.sha256; then
+        gh release download "$TAG" --pattern checksums.sha256 --output "$CHECKSUMS_TMP" --clobber
+        # Drop any existing line for this artifact; append the new one.
+        grep -v "  ${ARTIFACT}\$" "$CHECKSUMS_TMP" > "${CHECKSUMS_TMP}.new" || true
+        echo "$LINE" >> "${CHECKSUMS_TMP}.new"
+        mv "${CHECKSUMS_TMP}.new" "$CHECKSUMS_TMP"
+    else
+        echo "$LINE" > "$CHECKSUMS_TMP"
+    fi
+    gh release upload "$TAG" "$CHECKSUMS_TMP" --clobber
+    # Rename into the expected filename via clobber upload.
+    # gh upload uses the basename, so rename first:
+    mv "$CHECKSUMS_TMP" "$(dirname "$CHECKSUMS_TMP")/checksums.sha256"
+    gh release upload "$TAG" "$(dirname "$CHECKSUMS_TMP")/checksums.sha256" --clobber
+    echo "  ✓ Uploaded to release $TAG"
+else
+    echo "Step 5/5: SKIPPED (--upload not passed)."
+    echo ""
+    echo "Signed + notarized + tested binary is at: $DIST_BINARY"
+    echo "Re-run with --upload to ship it to release $TAG."
+fi
+
+echo ""
+echo "═══ Done. ═══"
+echo ""

--- a/tests/test_release_macos_local.py
+++ b/tests/test_release_macos_local.py
@@ -1,0 +1,150 @@
+"""Tests for scripts/release-macos-local.sh (#219 Option B).
+
+Can't actually exercise codesign / notarytool / PyInstaller from
+pytest — those require real Apple credentials + a signing identity
+in the keychain. What we CAN exercise is:
+
+- Help text renders
+- Missing --tag fails with exit 2 and a clear message
+- Missing env vars fail with exit 2 BEFORE any build work starts
+  (critical: the build burns ~60s; failing fast on missing creds
+  saves the operator that time)
+- The script is syntactically valid bash
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest  # noqa: TC002 — used at runtime via MonkeyPatch fixture
+
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="release-macos-local.sh is a POSIX shell script; macOS-only in practice",
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = REPO_ROOT / "scripts" / "release-macos-local.sh"
+
+
+def _run(
+    args: list[str] | None = None,
+    env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    merged = {**os.environ}
+    # Clear any signing creds the developer happens to have set so
+    # the test exercises the missing-env path deterministically.
+    for var in (
+        "SHIPYARD_NOTARIZE_APPLE_ID",
+        "SHIPYARD_NOTARIZE_TEAM_ID",
+        "SHIPYARD_NOTARIZE_APP_PASSWORD",
+        "SHIPYARD_SIGNING_IDENTITY",
+    ):
+        merged.pop(var, None)
+    if env:
+        merged.update(env)
+    return subprocess.run(
+        ["bash", str(SCRIPT), *(args or [])],
+        env=merged,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_script_exists_and_is_executable() -> None:
+    assert SCRIPT.exists(), f"script not found at {SCRIPT}"
+    assert os.access(SCRIPT, os.X_OK), "script must be executable"
+
+
+def test_bash_syntax_valid() -> None:
+    # `bash -n` parses without executing; catches typos that would
+    # otherwise fail at release time when the stakes are higher.
+    result = subprocess.run(
+        ["bash", "-n", str(SCRIPT)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, (
+        f"bash -n failed: stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+
+
+def test_help_flag_renders_usage() -> None:
+    result = _run(["--help"])
+    assert result.returncode == 0
+    # Help should name the required env vars so the user knows what
+    # to set up before their first run.
+    assert "SHIPYARD_NOTARIZE_APPLE_ID" in result.stdout
+    assert "SHIPYARD_SIGNING_IDENTITY" in result.stdout
+    assert "--upload" in result.stdout
+
+
+def test_missing_tag_when_not_on_tagged_commit_exits_2() -> None:
+    # On a branch that's not a tag, --tag must be explicit.
+    # The test workspace is typically on a branch; if it happens to
+    # be on a tagged commit this test is skipped — git describe
+    # --exact-match succeeding means the user really is releasing.
+    cwd_tag = subprocess.run(
+        ["git", "describe", "--tags", "--exact-match"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if cwd_tag.returncode == 0:
+        pytest.skip("test host HEAD is a tagged commit; --tag would default")
+
+    result = _run()
+    assert result.returncode == 2, (
+        f"expected exit 2 on missing --tag; got {result.returncode} "
+        f"stderr={result.stderr!r}"
+    )
+    assert "--tag required" in result.stderr or "not a tagged release" in result.stderr
+
+
+def test_missing_env_var_fails_fast_before_build() -> None:
+    # This is the load-bearing behavior: the PyInstaller build takes
+    # ~60s and we must NOT start it if we're going to fail anyway
+    # because creds aren't set. Failure must be exit 2 (input error)
+    # not exit 1 (build error) so wrappers can distinguish.
+    result = _run(["--tag", "v0.0.0-test"])
+    assert result.returncode == 2, (
+        f"expected exit 2 on missing env; got {result.returncode} "
+        f"stderr={result.stderr!r}"
+    )
+    # The error must name at least one specific missing var so the
+    # user knows what to set, not just "env var missing."
+    assert "SHIPYARD_NOTARIZE_APPLE_ID" in result.stderr or \
+           "SHIPYARD_NOTARIZE_TEAM_ID" in result.stderr or \
+           "SHIPYARD_NOTARIZE_APP_PASSWORD" in result.stderr or \
+           "SHIPYARD_SIGNING_IDENTITY" in result.stderr
+
+
+def test_missing_env_var_error_points_to_script_header() -> None:
+    # The header comment lists all four env vars + their purpose.
+    # The error message should point the operator there instead of
+    # dumping the full list inline (which rots when the list grows).
+    result = _run(["--tag", "v0.0.0-test"])
+    assert result.returncode == 2
+    assert "release-macos-local.sh" in result.stderr
+
+
+def test_all_env_vars_missing_names_first_missing_one_clearly() -> None:
+    # If every env var is missing, the error should name ONE of them
+    # first rather than dumping a concatenated blob. Predictable
+    # single-line error is easier to grep in CI logs than a paragraph.
+    result = _run(["--tag", "v0.0.0-test"])
+    # Count "ERROR: ... is not set" lines; first one is the signal.
+    error_lines = [
+        line for line in result.stderr.splitlines()
+        if "is not set in the environment" in line
+    ]
+    # At least one, but no more than one should be reported — the
+    # script bails on the first missing var.
+    assert len(error_lines) == 1, (
+        f"expected exactly one missing-env error line; got {error_lines}"
+    )


### PR DESCRIPTION
## Why

#219 keeps biting: v0.42.0 and v0.43.0 shipped notarized binaries that pass \`codesign --verify\`, pass CI's launch gate on a GH Actions macOS-15 runner, and still SIGKILL at launch on the primary maintainer's Mac. The CI runner is *not* the Mac users run the binary on — a binary that launches there but not here proves that CI validation is insufficient.

This PR implements Option B from the #219 discussion: **move macOS signing from CI to the Mac that's going to ship the binary**. If the binary launches where it was just signed, it'll launch for the user who signed it.

Also **diagnostic value**: running this script against the current commit will tell us definitively whether CI signing itself was the bug (local binary launches → yes, CI was broken) or whether it's a per-Mac issue (local binary also fails → we need the .dmg fix in task #52).

## Flow

1. **Fail fast** on missing env vars (exit 2) BEFORE any build work. Critical — PyInstaller takes ~60s and we must not start if we're going to fail anyway.
2. **Build** with \`pyinstaller --onefile --codesign-identity\` — mirrors CI exactly so any delta is signing-environment only.
3. **Re-sign** with \`--options runtime --timestamp\` (hardened runtime, required by notarytool).
4. **Notarize** via \`xcrun notarytool submit --wait\`. Parses output for \`status: Accepted\`.
5. **LOCAL LAUNCH TEST** — runs \`<binary> --version\` on the Mac the script is executing on. If it fails (the #219 shape), exit 3 with \`codesign --verify\`, \`spctl --assess\`, and \`xattr -l\` diagnostics. **Refuses to upload a binary that failed the local test.**
6. **Upload** (opt-in via \`--upload\`) — \`gh release upload --clobber\` + updated \`checksums.sha256\` line for the uploaded artifact.

## What's NOT in this PR

- No changes to release.yml yet. Once we've proven Option B works by running this script and comparing to v0.43.0's CI-signed asset, a follow-up PR removes the macOS matrix rows from CI. Until then both paths coexist.
- No .dmg packaging — that's task #52, which is still the right long-term answer if this diagnostic shows cloud signing is fine.

## Test plan

- [x] 7 tests in \`tests/test_release_macos_local.py\`: exists+executable, bash syntax, --help, missing --tag, missing env, error points at header, one missing var at a time.
- [x] Ruff + bash-n clean.
- [ ] **Actual diagnostic run**: maintainer runs \`./scripts/release-macos-local.sh --tag v0.43.0\` on their Mac, which should:
  - If it builds + signs + notarizes + passes local \`--version\` → **cloud signing was the bug**; we cut v0.44.0 locally and the maintainer's Mac should accept it
  - If local \`--version\` also fails → **per-Mac issue**; Option B doesn't help and we go straight to task #52 (.dmg)

## Usage

\`\`\`bash
export SHIPYARD_NOTARIZE_APPLE_ID=<your-apple-id-email>
export SHIPYARD_NOTARIZE_TEAM_ID=<your-team-id>
export SHIPYARD_NOTARIZE_APP_PASSWORD=<app-specific-password>
export SHIPYARD_SIGNING_IDENTITY=<Developer-ID-cert-SHA1-or-CN>

# Diagnostic (build + sign + test, no upload):
./scripts/release-macos-local.sh --tag v0.43.0

# Full local release:
./scripts/release-macos-local.sh --tag v0.44.0 --upload
\`\`\`

## Related

- #219 — the breakage this diagnoses / fixes
- Task #52 — .dmg distribution (still pending; relevant if local signing also fails)
- PR #220 — CI launch gate (kept in place as a first-line check; local is the second line)
- PR #223 (merged) — install.sh ad-hoc fallback (pragmatic mitigation that's now in main)