### PR TITLE
codify: macOS signing is local-only (#219)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -258,90 +258,54 @@ jobs:
               src/shipyard/cli.py
           fi
 
-      - name: Re-sign with hardened runtime + notarize (macOS)
-        if: steps.import_signing_identity.outputs.identity != ''
-        env:
-          APPLE_ID: ${{ secrets.APPLE_ID }}
-          TEAM_ID: ${{ secrets.TEAM_ID }}
-          APP_SPECIFIC_PASSWORD: ${{ secrets.APP_SPECIFIC_PASSWORD }}
-          SIGNING_IDENTITY: ${{ steps.import_signing_identity.outputs.identity }}
-        run: |
-          set -euo pipefail
-          BINARY="dist/${{ matrix.artifact }}"
-
-          # PyInstaller already signed every embedded dylib with our
-          # identity (via --codesign-identity). Re-sign only the outer
-          # Mach-O to add --options runtime (hardened runtime) and
-          # --timestamp (secure timestamp) — both required for
-          # notarytool to accept the submission. Team IDs already match
-          # so dyld's runtime check passes. `--sign` takes the SHA-1
-          # fingerprint resolved at import time, so any Developer ID
-          # cert on Team ID ${TEAM_ID} works (forks, org certs,
-          # rotations) — no hardcoded subject CN. See #177.
-          codesign --force --options runtime --timestamp \
-            --sign "$SIGNING_IDENTITY" \
-            "$BINARY"
-          codesign -dv --verbose=4 "$BINARY"
-
-          # Notarize. --wait blocks up to 30min; in practice a bare
-          # Mach-O notarizes in <60s. submit needs a zip or dmg, so
-          # wrap first.
-          NOTARIZE_ZIP="$RUNNER_TEMP/${{ matrix.artifact }}.zip"
-          /usr/bin/ditto -c -k --keepParent "$BINARY" "$NOTARIZE_ZIP"
-          xcrun notarytool submit "$NOTARIZE_ZIP" \
-            --apple-id "$APPLE_ID" \
-            --team-id "$TEAM_ID" \
-            --password "$APP_SPECIFIC_PASSWORD" \
-            --wait
-
-          # Can't staple a bare Mach-O (no Info.plist). Gatekeeper
-          # verifies notarization online at first launch. The ticket
-          # is registered with Apple server-side and matches the
-          # binary's hash.
-
-      - name: End-to-end launch gate (macOS — #219)
-        # Runs the *signed + notarized* Mach-O as the CI runner would
-        # see it after an end-user install. Catches taskgated
-        # rejections (exit 137, "Code Signature Invalid") that
-        # `codesign --verify` and `spctl --assess` miss.
-        #
-        # install.sh's post-install smoke runs client-side on the
-        # end user's box; this runs server-side pre-upload, which is
-        # the only place we can block a broken binary from ever
-        # becoming a release asset.
-        #
-        # Tied to the notarize step's `needs`: if this job fails, the
-        # `release` job's `needs: build` dependency holds the tag from
-        # getting a release uploaded. Bad binaries never ship.
-        if: runner.os == 'macOS'
-        run: |
-          set -euo pipefail
-          BINARY="dist/${{ matrix.artifact }}"
-          echo "Running signed+notarized binary's --version to verify taskgated acceptance..."
-          # If taskgated will reject this binary, it'll do so here
-          # with exit 137 and zero output — the exact #219 shape.
-          if ! "$BINARY" --version >/dev/null 2>&1; then
-            echo "::error::Post-notarization launch gate FAILED for $BINARY"
-            echo "::error::This binary passes codesign --verify but taskgated rejects it at launch."
-            echo "::error::This is the #219 class of bug — fix before releasing."
-            echo "Attempting diagnostic capture:"
-            "$BINARY" --version || true
-            codesign -dvvv "$BINARY" 2>&1 | head -40 || true
-            spctl --assess --type execute -vv "$BINARY" 2>&1 || true
-            exit 1
-          fi
-          echo "✓ Binary launched cleanly under signed-and-notarized state."
-
+      # #219: macOS signing + notarization happens LOCALLY on the
+      # maintainer's Mac via scripts/release-macos-local.sh, NOT here.
+      # Two rounds of CI-signed+notarized macOS binaries (v0.42.0,
+      # v0.43.0) passed every CI check including the on-runner launch
+      # gate but SIGKILL'd at launch on the maintainer's actual Mac
+      # ("Taskgated Invalid Signature"). The CI runner and end-user
+      # Mac evidently differ enough on taskgated/Gatekeeper state
+      # that a CI-notarized binary is not reliably launchable. See
+      # RELEASING.md § "macOS signing is local-only" for the
+      # confirmed diagnosis + workflow.
+      #
+      # The macOS build step above still runs — it catches
+      # PyInstaller regressions. We just don't sign, notarize, or
+      # upload the CI-built binary: the maintainer's local script
+      # produces + uploads the asset that users actually download.
       - name: Delete signing keychain (macOS)
         if: always() && steps.import_signing_identity.outputs.keychain != ''
         run: |
           security delete-keychain "${{ steps.import_signing_identity.outputs.keychain }}" || true
 
-      - name: Upload artifact
+      # Skip uploading macOS artifacts to the workflow's artifact
+      # store — they're unsigned, unnotarized, and should not reach
+      # the release. The local script publishes the signed macOS
+      # assets directly via `gh release upload --clobber`.
+      - name: Upload artifact (non-macOS)
+        if: runner.os != 'macOS'
         uses: actions/upload-artifact@v5
         with:
           name: ${{ matrix.artifact }}
           path: dist/${{ matrix.artifact }}*
+
+      - name: macOS build health check (build-only, no asset upload)
+        if: runner.os == 'macOS'
+        # Explicitly surface in the CI log that the macOS build
+        # succeeded but is intentionally NOT being packaged into the
+        # release. Post-workflow, the maintainer runs
+        # scripts/release-macos-local.sh to sign+notarize on their
+        # Mac and upload the signed asset.
+        run: |
+          echo "✓ macOS build succeeded (${{ matrix.artifact }})."
+          echo ""
+          echo "This binary is NOT being uploaded to the release."
+          echo "macOS signing + notarization is local-only (see #219)."
+          echo "Run this on your Mac after the release tag appears:"
+          echo ""
+          echo "  ./scripts/release-macos-local.sh \\"
+          echo "    --tag ${{ github.ref_name }} --upload"
+          echo ""
 
   release:
     needs: build

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,6 +153,18 @@ rather than stacking them.
 
 `./scripts/release.sh` remains as a break-glass manual path. The default is the automatic path above (auto-release workflow on merge). Do not call `release.sh` directly unless the automatic path is genuinely blocked.
 
+## macOS binary is signed LOCALLY, not in CI
+
+As of #219 (2026-04-24), the macOS release binary is **built, signed, notarized, and launch-tested on the maintainer's own Mac** — CI only handles Linux + Windows. Two rounds of CI-signed binaries (v0.42.0, v0.43.0) passed every CI check (including an on-runner launch gate) but SIGKILL'd on the maintainer's actual Mac. The local-signing pipeline in `scripts/release-macos-local.sh` produces a binary that works where it matters, on the Mac that will need to launch it.
+
+After any new tag lands and the release workflow publishes non-macOS assets, run:
+
+```bash
+./scripts/release-macos-local.sh --tag vX.Y.Z --upload
+```
+
+The script fails loud if the local `--version` test fails, **refusing to upload a broken binary**. Do not edit `.github/workflows/release.yml` to re-enable CI macOS signing without first re-running the #219 diagnostic and proving the underlying issue is resolved. Full flow + env-var setup in `RELEASING.md` § "macOS signing is local-only".
+
 ## Development
 
 - `uv sync` to install.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -61,11 +61,45 @@ gh workflow run release.yml --ref v<x.y.z>
 
 Run that after the auto-tag appears. The release workflow will pick up the existing tag and publish the binaries. (Pulp's first auto-released tag, `v0.4.0`, used this fallback before its `RELEASE_BOT_TOKEN` was provisioned.)
 
-## Optional: sign + notarize the macOS CLI binary
+## macOS signing is local-only
 
-macOS 26.3+ refuses to execute ad-hoc-signed binaries that carry the `com.apple.provenance` xattr GitHub stamps on every release download — the OS SIGKILLs with "Taskgated Invalid Signature" and the user sees a bare `zsh: killed` with no context.
+**As of 2026-04-24, the macOS release binary is signed + notarized on the maintainer's own Mac, NOT on GitHub Actions.** Two rounds of CI-signed+notarized binaries (v0.42.0, v0.43.0) passed every CI check — `codesign --verify`, `spctl --assess`, and an on-runner launch gate that ran the notarized binary's `--version` — yet SIGKILL'd at launch on the primary maintainer's actual Mac with "Taskgated Invalid Signature" (issue [#219](https://github.com/danielraffel/Shipyard/issues/219)).
 
-`install.sh` works around this locally by stripping the xattr and re-applying an ad-hoc signature. Anyone installing via `gh release download` or a manual browser click still hits the crash. The proper fix is Developer-ID-signed + Apple-notarized binaries produced by the release workflow itself.
+The 2026-04-24 local-signing diagnostic (commit c112830 → `scripts/release-macos-local.sh`) confirmed the delta: a locally-built+signed+notarized binary from the **same commit as v0.43.0** with the **same Developer-ID cert** launches cleanly on the maintainer's Mac. The CI runner and the end-user Mac differ enough on taskgated/Gatekeeper state that CI-notarized binaries are not reliably launchable.
+
+### How to cut a macOS release
+
+CI still handles Linux + Windows. For the macOS binary:
+
+```bash
+# One-time setup — either .env file or shell rc.
+export SHIPYARD_NOTARIZE_APPLE_ID=<apple-id-email>
+export SHIPYARD_NOTARIZE_TEAM_ID=<team-id>              # 10-char from developer.apple.com/account
+export SHIPYARD_NOTARIZE_APP_PASSWORD=<app-specific>    # appleid.apple.com → Sign-In and Security
+export SHIPYARD_SIGNING_IDENTITY=<SHA1-or-CN>           # `security find-identity -v -p codesigning`
+
+# After the release.yml workflow publishes the non-macOS assets:
+./scripts/release-macos-local.sh --tag vX.Y.Z --upload
+```
+
+The script runs the full pipeline on the local Mac:
+
+1. Fails fast if any env var is missing (before the ~60s PyInstaller build).
+2. Builds via `pyinstaller --onefile --codesign-identity <...>` — identical flags to what CI used to do, only the environment differs.
+3. Re-signs outer Mach-O with `--options runtime --timestamp` (notarytool prerequisites).
+4. Submits to Apple via `xcrun notarytool submit --wait`, asserts `status: Accepted`.
+5. **Runs `<binary> --version` locally.** If this fails (the #219 shape), exits 3 with `codesign --verify`, `spctl --assess`, and `xattr -l` diagnostics, and does NOT upload. This is the whole point — the Mac running the script is the same Mac that will need to launch the binary tomorrow.
+6. On launch success: uploads via `gh release upload --clobber` and updates `checksums.sha256` for the artifact.
+
+Running without `--upload` is the diagnostic mode (used to confirm the local signing path actually works on a given Mac). Test coverage in `tests/test_release_macos_local.py` ensures missing creds / bad flags / bash syntax errors all surface before the expensive build step.
+
+### Why the repo secrets are still listed below
+
+The CI signing steps have been removed from `.github/workflows/release.yml` (build-only for macOS, no signing / notarizing / uploading). The five secrets below are kept in the repo for:
+
+- The x64 slice once we add Rosetta-hosted local cross-builds or move x64 to local too
+- Future `.dmg` stapling pipeline (task #52 — the long-term answer that eliminates Apple's online-check dependency entirely)
+- Forks that might want to re-enable CI signing for their own environments
 
 Five secrets on the repo (all `gh secret set NAME`):
 

--- a/scripts/release-macos-local.sh
+++ b/scripts/release-macos-local.sh
@@ -191,21 +191,28 @@ if [ "$DO_UPLOAD" -eq 1 ]; then
     # just our line. If the file doesn't exist yet, this creates it.
     CHECKSUM=$(shasum -a 256 "$DIST_BINARY" | awk '{print $1}')
     LINE="${CHECKSUM}  ${ARTIFACT}"
-    CHECKSUMS_TMP="$(mktemp)"
-    if gh release view "$TAG" --json assets --jq '.assets[] | select(.name=="checksums.sha256") | .name' | grep -q checksums.sha256; then
-        gh release download "$TAG" --pattern checksums.sha256 --output "$CHECKSUMS_TMP" --clobber
+    # Build the file at its final name from the start. The earlier
+    # approach uploaded a mktemp-named file first then re-uploaded
+    # a renamed copy, which left both on the release as sibling
+    # assets (observed on v0.43.0's first upload — stray `tmp.XYZ`
+    # asset had to be deleted by hand).
+    CHECKSUMS_DIR="$(mktemp -d)"
+    CHECKSUMS_FILE="${CHECKSUMS_DIR}/checksums.sha256"
+    if gh release view "$TAG" --json assets \
+            --jq '.assets[] | select(.name=="checksums.sha256") | .name' \
+            | grep -q checksums.sha256; then
+        gh release download "$TAG" --pattern checksums.sha256 \
+            --output "$CHECKSUMS_FILE" --clobber
         # Drop any existing line for this artifact; append the new one.
-        grep -v "  ${ARTIFACT}\$" "$CHECKSUMS_TMP" > "${CHECKSUMS_TMP}.new" || true
-        echo "$LINE" >> "${CHECKSUMS_TMP}.new"
-        mv "${CHECKSUMS_TMP}.new" "$CHECKSUMS_TMP"
+        grep -v "  ${ARTIFACT}\$" "$CHECKSUMS_FILE" \
+            > "${CHECKSUMS_FILE}.new" || true
+        echo "$LINE" >> "${CHECKSUMS_FILE}.new"
+        mv "${CHECKSUMS_FILE}.new" "$CHECKSUMS_FILE"
     else
-        echo "$LINE" > "$CHECKSUMS_TMP"
+        echo "$LINE" > "$CHECKSUMS_FILE"
     fi
-    gh release upload "$TAG" "$CHECKSUMS_TMP" --clobber
-    # Rename into the expected filename via clobber upload.
-    # gh upload uses the basename, so rename first:
-    mv "$CHECKSUMS_TMP" "$(dirname "$CHECKSUMS_TMP")/checksums.sha256"
-    gh release upload "$TAG" "$(dirname "$CHECKSUMS_TMP")/checksums.sha256" --clobber
+    gh release upload "$TAG" "$CHECKSUMS_FILE" --clobber
+    rm -rf "$CHECKSUMS_DIR"
     echo "  ✓ Uploaded to release $TAG"
 else
     echo "Step 5/5: SKIPPED (--upload not passed)."


### PR DESCRIPTION
## TL;DR

The 2026-04-24 diagnostic (run via \`scripts/release-macos-local.sh\` against v0.43.0's commit) **confirmed CI signing was the bug**. A locally-built+signed+notarized binary on the same commit, with the same Developer-ID cert, launches cleanly on the maintainer's Mac. The CI-signed v0.43.0 asset SIGKILLs at launch. The delta is signing environment only.

This PR:
1. **Removes macOS signing from CI**: the release workflow no longer runs \`--options runtime --timestamp\` re-sign, notarytool submit, or the post-notarize launch gate on macOS. Only Linux + Windows are CI-signed now.
2. **Makes the local script canonical**: \`scripts/release-macos-local.sh\` is how macOS binaries get signed, notarized, and uploaded going forward. It refuses to upload if the local \`--version\` test fails.
3. **Documents the flow** in RELEASING.md and CLAUDE.md so future sessions (mine or anyone else's) don't re-introduce CI signing without re-running the diagnostic first.
4. **Fixes a script bug** — the first \`--upload\` on v0.43.0 left a stray \`tmp.XYZ\` asset on the release alongside \`checksums.sha256\` because the script uploaded the mktemp name first then renamed. Now writes directly to the final name.

## What CI still does

- Builds macOS (health check for PyInstaller regressions)
- Does NOT sign, notarize, or upload the macOS artifact
- Prints a visible \"run scripts/release-macos-local.sh --tag vX.Y.Z --upload\" reminder so the maintainer sees it in the workflow log

## What the maintainer does per release

\`\`\`bash
# One-time setup — sources from .env or shell rc:
export SHIPYARD_NOTARIZE_APPLE_ID=<...>
export SHIPYARD_NOTARIZE_TEAM_ID=<...>
export SHIPYARD_NOTARIZE_APP_PASSWORD=<...>
export SHIPYARD_SIGNING_IDENTITY=<...>

# After release.yml publishes non-macOS assets:
./scripts/release-macos-local.sh --tag vX.Y.Z --upload
\`\`\`

## Test plan

- [x] \`uv run pytest tests/test_release_macos_local.py tests/test_install_sh.py -q\` → 23 passed + 1 Linux-skipped
- [x] **Diagnostic confirmed on 2026-04-24**: \`./scripts/release-macos-local.sh --tag v0.43.0\` built + signed + notarized + launched \`--version\` successfully on the maintainer's Mac. \`--upload\` then replaced v0.43.0's broken CI asset with the working local one (verified by SHA256 match).
- [ ] CI green on Linux / macOS / Windows (macOS matrix should succeed on build but emit the reminder)

## Related

- #219 — the breakage this resolves
- Task #52 (pending) — the proper \`.dmg\`-with-stapled-ticket fix that eliminates Apple's online-check dependency entirely. Local signing is the pragmatic middle ground until that lands.