### PR TITLE
feat(release): ship macOS as stapled .dmg + codify e2e verification (#52, #55, #219)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,9 +153,9 @@ rather than stacking them.
 
 `./scripts/release.sh` remains as a break-glass manual path. The default is the automatic path above (auto-release workflow on merge). Do not call `release.sh` directly unless the automatic path is genuinely blocked.
 
-## macOS binary is signed LOCALLY, not in CI
+## macOS release is a stapled .dmg, built LOCALLY
 
-As of #219 (2026-04-24), the macOS release binary is **built, signed, notarized, and launch-tested on the maintainer's own Mac** — CI only handles Linux + Windows. Two rounds of CI-signed binaries (v0.42.0, v0.43.0) passed every CI check (including an on-runner launch gate) but SIGKILL'd on the maintainer's actual Mac. The local-signing pipeline in `scripts/release-macos-local.sh` produces a binary that works where it matters, on the Mac that will need to launch it.
+As of #219 (2026-04-24 evening), macOS binaries ship as stapled **.dmg** artifacts built on the maintainer's Mac. CI handles Linux + Windows. The `.dmg` wrapper puts the notarization ticket **inside** the artifact so Gatekeeper verifies offline — no online notarization check, no per-Mac taskgated flakiness. Bare Mach-O binaries depend on an online check that proved unreliable (v0.42.0 and v0.43.0 both shipped bare Mach-O and both SIGKILL'd on the maintainer's Mac).
 
 After any new tag lands and the release workflow publishes non-macOS assets, run:
 
@@ -163,7 +163,11 @@ After any new tag lands and the release workflow publishes non-macOS assets, run
 ./scripts/release-macos-local.sh --tag vX.Y.Z --upload
 ```
 
-The script fails loud if the local `--version` test fails, **refusing to upload a broken binary**. Do not edit `.github/workflows/release.yml` to re-enable CI macOS signing without first re-running the #219 diagnostic and proving the underlying issue is resolved. Full flow + env-var setup in `RELEASING.md` § "macOS signing is local-only".
+The script is 8 steps: build, re-sign, package-to-dmg, sign-dmg, notarize+staple, **mount + launch test** (exit 3 if it fails), upload, **end-to-end install.sh → launch test** (exit 4 if it fails). Refuses to upload a dmg that doesn't mount-and-launch cleanly; refuses to declare success after upload if the download+install chain doesn't end in a working `--version`.
+
+**Load-bearing rule:** the success criterion is a working `--version` after fresh install.sh → mount → extract → launch. Not `codesign --verify`, not `spctl --assess`, not the on-runner launch gate in isolation. We shipped v0.42.0 and v0.43.0 with the same breakage because we declared victory on partial verification. Don't do that again.
+
+Full flow + env-var setup in `RELEASING.md` § "macOS release is a locally-signed + stapled .dmg". Do not revert to CI signing or bare Mach-O without re-running the #219 diagnostic and proving the online-notarization-check issue is resolved (tracked in #226).
 
 ## Development
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -61,11 +61,55 @@ gh workflow run release.yml --ref v<x.y.z>
 
 Run that after the auto-tag appears. The release workflow will pick up the existing tag and publish the binaries. (Pulp's first auto-released tag, `v0.4.0`, used this fallback before its `RELEASE_BOT_TOKEN` was provisioned.)
 
-## macOS signing is local-only
+## macOS release is a locally-signed + stapled .dmg
 
-**As of 2026-04-24, the macOS release binary is signed + notarized on the maintainer's own Mac, NOT on GitHub Actions.** Two rounds of CI-signed+notarized binaries (v0.42.0, v0.43.0) passed every CI check — `codesign --verify`, `spctl --assess`, and an on-runner launch gate that ran the notarized binary's `--version` — yet SIGKILL'd at launch on the primary maintainer's actual Mac with "Taskgated Invalid Signature" (issue [#219](https://github.com/danielraffel/Shipyard/issues/219)).
+**As of 2026-04-24 evening, macOS binaries ship as stapled `.dmg` artifacts built on the maintainer's Mac.** This supersedes the "bare Mach-O, notarized at release" path used through v0.43.0.
 
-The 2026-04-24 local-signing diagnostic (commit c112830 → `scripts/release-macos-local.sh`) confirmed the delta: a locally-built+signed+notarized binary from the **same commit as v0.43.0** with the **same Developer-ID cert** launches cleanly on the maintainer's Mac. The CI runner and the end-user Mac differ enough on taskgated/Gatekeeper state that CI-notarized binaries are not reliably launchable.
+**What we learned** (issue [#219](https://github.com/danielraffel/Shipyard/issues/219)):
+
+1. **CI-signed bare Mach-O binaries (v0.42.0, v0.43.0):** passed every CI check — `codesign --verify`, `spctl --assess`, an on-runner launch gate running `--version` under the signed+notarized state — and still SIGKILL'd with "Taskgated Invalid Signature" on the maintainer's Mac. We originally blamed CI signing.
+2. **Locally-signed bare Mach-O (v0.43.0 re-upload):** worked the first time, then SIGKILL'd a few hours later on the same Mac with the same bytes. The delta wasn't CI vs local — it was that **bare Mach-O binaries depend on an online notarization check at launch**, and that check is unreliable on some Macs (contention, Apple CDN state, macOS 26.3+ `com.apple.provenance` enforcement, or all three).
+3. **Stapled `.dmg`:** the only durable fix. A `.dmg` wrapper carries the notarization ticket **inside** the artifact. When macOS mounts the dmg, Gatekeeper verifies the ticket **offline**. The binary extracted from the mount inherits "trusted origin" provenance. No online check, no per-Mac flakiness, no dice rolls. End-to-end verified working on the same Mac that rejected every earlier artifact.
+
+### How to cut a macOS release
+
+CI handles Linux + Windows. For the macOS `.dmg`:
+
+```bash
+# One-time setup — either .env or shell rc.
+export SHIPYARD_NOTARIZE_APPLE_ID=<apple-id-email>
+export SHIPYARD_NOTARIZE_TEAM_ID=<team-id>              # 10-char from developer.apple.com/account
+export SHIPYARD_NOTARIZE_APP_PASSWORD=<app-specific>    # appleid.apple.com → Sign-In and Security
+export SHIPYARD_SIGNING_IDENTITY=<SHA1-or-CN>           # `security find-identity -v -p codesigning`
+
+# After release.yml workflow publishes non-macOS assets:
+./scripts/release-macos-local.sh --tag vX.Y.Z --upload
+```
+
+The script is 8 steps:
+
+1. Fail fast on missing env vars (before the ~60s PyInstaller build).
+2. Build via `pyinstaller --onefile --codesign-identity <...>`.
+3. Re-sign outer Mach-O with `--options runtime --timestamp`.
+4. Package the signed Mach-O into a `.dmg` (`hdiutil create`, volname "Shipyard").
+5. Sign the DMG itself.
+6. Submit to Apple, wait for `status: Accepted`, then `xcrun stapler staple` and `xcrun stapler validate`.
+7. **Local launch test** — mount the stapled DMG read-only, run `<binary> --version`. Refuses to upload if this fails. Distinguishes exit 3 (local launch broke) from exit 4 (download path broke).
+8. **End-to-end verification after upload** — runs the local `install.sh` against the just-uploaded tag. Downloads the dmg, mounts, extracts, launches. Exit 4 if this fails, with a warning that the upload already happened and needs manual deletion.
+
+### Lesson codified
+
+We shipped v0.42.0 and v0.43.0 with the same class of breakage because we declared "works" based on partial verification. The release script now enforces what we should have been doing all along: **the only success criterion is `--version` printing after a fresh install.sh → mount → extract → launch flow**. If any step in that chain fails, the release fails, regardless of what `codesign --verify` or `spctl --assess` say.
+
+### Why the repo secrets stay
+
+The five secrets below are kept in the repo even though CI doesn't use them today — they're needed for:
+
+- Future Rosetta-hosted local cross-builds for x64
+- Forks that may re-enable CI signing for their own environments
+- The `.dmg` pipeline above reuses `SHIPYARD_SIGNING_IDENTITY` conceptually (the cert is in the local keychain rather than a GH secret, but the same cert)
+
+Five secrets on the repo (all `gh secret set NAME`):
 
 ### How to cut a macOS release
 

--- a/install.sh
+++ b/install.sh
@@ -99,25 +99,89 @@ fi
 echo "Resolving ${VERSION_LABEL} from ${REPO}..."
 
 # ── fetch release asset URL ─────────────────────────────────────────
+#
+# macOS release assets are distributed as a stapled .dmg starting
+# in v0.44.0 (task #52 / #219). The DMG wraps a single Mach-O with
+# the notarization ticket stapled to the DMG container — Gatekeeper
+# verifies the ticket OFFLINE when the DMG is mounted, eliminating
+# the per-Mac online-check flakiness that sank v0.42.0 + v0.43.0
+# launches.
+#
+# Fallback to bare Mach-O for:
+#   - non-macOS platforms (Linux, Windows)
+#   - older tags that predate the .dmg pipeline
+#   - self-built forks that haven't run scripts/release-macos-local.sh
 
-RELEASE_URL=$(curl -sL "https://api.github.com/repos/${REPO}/${API_PATH}" \
-    | grep "browser_download_url.*${ARTIFACT}" \
-    | head -1 \
-    | cut -d '"' -f 4)
+mkdir -p "${INSTALL_DIR}"
 
-if [ -z "${RELEASE_URL}" ]; then
-    echo "No binary found for ${ARTIFACT} in ${VERSION_LABEL}." >&2
-    echo "Check https://github.com/${REPO}/releases for available builds." >&2
-    exit 1
+# SHIPYARD_SKIP_DOWNLOAD=1 preserves an already-present binary at
+# ${INSTALL_DIR}/shipyard. Used by tests to exercise the smoke +
+# remediation paths without hitting the network. When it's set we
+# skip URL resolution entirely (tests don't want live API calls).
+if [ "${SHIPYARD_SKIP_DOWNLOAD:-0}" != "1" ]; then
+    # `set -o pipefail` means a pipe containing `grep` that matches
+    # nothing kills the script via set -e — so `|| true` the final
+    # cut lets us handle the empty-URL case below instead of dying
+    # silently mid-script.
+    DMG_URL=""
+    if [ "${OS}" = "macos" ]; then
+        DMG_URL=$(curl -sL "https://api.github.com/repos/${REPO}/${API_PATH}" \
+            | grep "browser_download_url.*${ARTIFACT}\.dmg" \
+            | head -1 \
+            | cut -d '"' -f 4 || true)
+    fi
+
+    RELEASE_URL=""
+    if [ -z "${DMG_URL}" ]; then
+        RELEASE_URL=$(curl -sL "https://api.github.com/repos/${REPO}/${API_PATH}" \
+            | grep "browser_download_url.*${ARTIFACT}\"" \
+            | head -1 \
+            | cut -d '"' -f 4 || true)
+    fi
+
+    if [ -z "${DMG_URL}" ] && [ -z "${RELEASE_URL}" ]; then
+        echo "No binary found for ${ARTIFACT} in ${VERSION_LABEL}." >&2
+        echo "Check https://github.com/${REPO}/releases for available builds." >&2
+        exit 1
+    fi
+else
+    DMG_URL=""
+    RELEASE_URL=""
 fi
 
-echo "Downloading ${ARTIFACT} (${VERSION_LABEL})..."
-mkdir -p "${INSTALL_DIR}"
-# SHIPYARD_SKIP_DOWNLOAD=1 preserves an already-present binary at
-# ${INSTALL_DIR}/shipyard. Used by the tests to exercise the
-# post-install smoke + remediation paths without hitting the
-# network or needing a real release asset.
-if [ "${SHIPYARD_SKIP_DOWNLOAD:-0}" != "1" ]; then
+if [ "${SHIPYARD_SKIP_DOWNLOAD:-0}" = "1" ]; then
+    : # existing binary at INSTALL_DIR/shipyard is what we'll test
+elif [ -n "${DMG_URL}" ]; then
+    echo "Downloading ${ARTIFACT}.dmg (${VERSION_LABEL})..."
+    # Stapled DMG path (#52): download the dmg, mount read-only,
+    # copy the binary OUT of the mount, detach. The ticket binding
+    # is on the DMG and Gatekeeper evaluated it at mount time, so
+    # the extracted binary inherits "trusted origin" state in
+    # macOS's provenance tracking — taskgated won't trigger an
+    # online check on first launch.
+    DMG_TMP="$(mktemp -d)/shipyard.dmg"
+    curl -sL "${DMG_URL}" -o "${DMG_TMP}"
+    MOUNT_POINT="$(mktemp -d)/mnt"
+    if ! hdiutil attach -nobrowse -readonly \
+            -mountpoint "${MOUNT_POINT}" "${DMG_TMP}" >/dev/null 2>&1; then
+        echo "Failed to mount ${DMG_TMP} — the DMG may be corrupt or" >&2
+        echo "unsigned. Try re-downloading or check the release page." >&2
+        rm -f "${DMG_TMP}"
+        exit 1
+    fi
+    if [ ! -f "${MOUNT_POINT}/shipyard" ]; then
+        echo "DMG mounted but no 'shipyard' binary inside at ${MOUNT_POINT}." >&2
+        echo "Contents:" >&2
+        ls -la "${MOUNT_POINT}" >&2 || true
+        hdiutil detach "${MOUNT_POINT}" >/dev/null 2>&1 || true
+        rm -f "${DMG_TMP}"
+        exit 1
+    fi
+    cp "${MOUNT_POINT}/shipyard" "${INSTALL_DIR}/shipyard"
+    hdiutil detach "${MOUNT_POINT}" >/dev/null 2>&1 || true
+    rm -f "${DMG_TMP}"
+else
+    echo "Downloading ${ARTIFACT} (${VERSION_LABEL})..."
     curl -sL "${RELEASE_URL}" -o "${INSTALL_DIR}/shipyard"
 fi
 chmod +x "${INSTALL_DIR}/shipyard"

--- a/install.sh
+++ b/install.sh
@@ -133,8 +133,15 @@ if [ "${SHIPYARD_SKIP_DOWNLOAD:-0}" != "1" ]; then
 
     RELEASE_URL=""
     if [ -z "${DMG_URL}" ]; then
+        # Match either `<ARTIFACT>"` (bare Mach-O / Linux binaries)
+        # or `<ARTIFACT>.exe"` (Windows) at the end of the asset name.
+        # The trailing double-quote anchor is load-bearing: without it,
+        # `shipyard-macos-arm64` would also match `shipyard-macos-arm64.dmg`
+        # in the JSON, which is the bug the DMG_URL branch is there to
+        # handle separately. Codex caught an earlier iteration that
+        # anchored with just `"` and broke Windows (#227 P1).
         RELEASE_URL=$(curl -sL "https://api.github.com/repos/${REPO}/${API_PATH}" \
-            | grep "browser_download_url.*${ARTIFACT}\"" \
+            | grep -E "browser_download_url.*${ARTIFACT}(\.exe)?\"" \
             | head -1 \
             | cut -d '"' -f 4 || true)
     fi

--- a/scripts/release-macos-local.sh
+++ b/scripts/release-macos-local.sh
@@ -123,16 +123,51 @@ codesign --force --options runtime --timestamp \
     "$DIST_BINARY"
 codesign -dv --verbose=4 "$DIST_BINARY" 2>&1 | grep -E "Authority|TeamIdentifier|Timestamp" | head -5
 
-# ── Notarize ───────────────────────────────────────────────────────
-echo "Step 3/5: Submit to Apple notarization service (this takes ~30-90s)..."
-NOTARIZE_ZIP="$(mktemp -d)/${ARTIFACT}.zip"
-/usr/bin/ditto -c -k --keepParent "$DIST_BINARY" "$NOTARIZE_ZIP"
+# ── Package into .dmg ──────────────────────────────────────────────
+# #219 / task #52: bare Mach-O binaries cannot be stapled (no
+# Info.plist for stapler to anchor the ticket to). The online
+# notarization check Apple falls back to is demonstrably flaky on
+# some Macs — v0.42.0 + v0.43.0 both shipped binaries that launched
+# on CI + on the build machine but SIGKILL'd on the end-user Mac.
+# Wrapping the binary in a .dmg and stapling the DMG puts the
+# notarization ticket in a local file the mount path reads
+# offline. Gatekeeper + taskgated verify against that ticket
+# instead of calling Apple, so per-Mac network/CDN/provenance
+# state stops mattering.
+echo "Step 3/6: Package signed Mach-O into .dmg..."
+DMG_NAME="${ARTIFACT}.dmg"
+DIST_DMG="dist/${DMG_NAME}"
+DMG_STAGING="$(mktemp -d)/stage"
+mkdir -p "$DMG_STAGING"
+# Staging dir contains just the bare binary — hdiutil turns the
+# directory into a mountable volume whose root has that binary.
+# install.sh's mount-extract step looks for /Volumes/Shipyard/shipyard
+# (volname matches the HFS+ volume label).
+cp "$DIST_BINARY" "$DMG_STAGING/shipyard"
+rm -f "$DIST_DMG"
+hdiutil create -volname "Shipyard" \
+    -srcfolder "$DMG_STAGING" \
+    -ov -format UDZO \
+    "$DIST_DMG" >/dev/null
 
-# Capture notarytool output so we can grep for the submission id on
-# failure — Apple's rejection reasons are only findable via
-# `notarytool log <submission-id>`.
+# ── Sign the DMG ───────────────────────────────────────────────────
+# The DMG itself needs to carry a valid Developer-ID signature so
+# notarytool can match + return a staple-able ticket. Without this
+# the DMG ships unsigned and notarize fails with "package is not
+# signed".
+echo "Step 4/6: Sign the DMG..."
+codesign --force --sign "$SHIPYARD_SIGNING_IDENTITY" "$DIST_DMG"
+codesign -dv --verbose=2 "$DIST_DMG" 2>&1 | grep -E "Authority|TeamIdentifier" | head -3
+
+# ── Notarize the DMG, then staple ──────────────────────────────────
+# Submit the DMG itself (not a zip-wrapped Mach-O like the
+# pre-#52 path). notarytool accepts .dmg as a first-class input.
+# After acceptance, `stapler staple` embeds the ticket in the DMG
+# so first-launch verification is OFFLINE — the entire point of
+# task #52.
+echo "Step 5/6: Submit DMG to Apple notarization service (~30-90s)..."
 NOTARIZE_LOG="$(mktemp)"
-if ! xcrun notarytool submit "$NOTARIZE_ZIP" \
+if ! xcrun notarytool submit "$DIST_DMG" \
         --apple-id "$SHIPYARD_NOTARIZE_APPLE_ID" \
         --team-id "$SHIPYARD_NOTARIZE_TEAM_ID" \
         --password "$SHIPYARD_NOTARIZE_APP_PASSWORD" \
@@ -140,10 +175,7 @@ if ! xcrun notarytool submit "$NOTARIZE_ZIP" \
     echo "ERROR: notarytool submit failed. Log: $NOTARIZE_LOG" >&2
     exit 1
 fi
-
-if grep -q "status: Accepted" "$NOTARIZE_LOG"; then
-    echo "  ✓ Notarization Accepted"
-else
+if ! grep -q "status: Accepted" "$NOTARIZE_LOG"; then
     SUB_ID=$(grep -E "^\s+id:" "$NOTARIZE_LOG" | head -1 | awk '{print $NF}')
     echo "ERROR: notarization not Accepted. Submission id: $SUB_ID" >&2
     echo "       Fetch the log with:" >&2
@@ -153,49 +185,74 @@ else
     echo "           --password \$SHIPYARD_NOTARIZE_APP_PASSWORD" >&2
     exit 1
 fi
+echo "  ✓ Notarization Accepted"
+
+echo "  Stapling ticket to DMG..."
+if ! xcrun stapler staple "$DIST_DMG"; then
+    echo "ERROR: xcrun stapler staple failed. DMG ships unstapled —" >&2
+    echo "       refusing to upload because that re-introduces the" >&2
+    echo "       online-check dependency #52 is supposed to remove." >&2
+    exit 1
+fi
+# Validate the staple — if this passes, the ticket is bound to
+# the DMG and Gatekeeper can verify offline.
+if ! xcrun stapler validate "$DIST_DMG" >/dev/null 2>&1; then
+    echo "ERROR: stapler validate failed — ticket is not bound to DMG." >&2
+    exit 1
+fi
+echo "  ✓ Ticket stapled and validated"
 
 # ── Local launch test (#219 — THE WHOLE POINT) ─────────────────────
-# CI's launch gate runs on a GH Actions macOS-15 runner, which is
-# NOT the Mac users will actually run the binary on. A notarized
-# binary that launches on the CI runner but SIGKILLs on the user's
-# Mac is exactly the #219 failure mode. Here we test on the ACTUAL
-# Mac that's about to ship the binary — if it dies here, we refuse
-# to upload.
-echo "Step 4/5: Local launch test (taskgated / Gatekeeper / codesign)..."
-if ! OUTPUT=$("$DIST_BINARY" --version 2>&1); then
+# Mount the stapled DMG, run the binary inside. This simulates the
+# Gatekeeper-verifies-offline flow end users will hit after
+# install.sh extracts. If it fails here, the dmg is broken —
+# refuse to upload.
+echo "Step 6/6: Local launch test via mounted DMG..."
+MOUNT_POINT="$(mktemp -d)/mnt"
+# -nobrowse: don't show the volume in Finder. -readonly: prevent
+# accidental writes. Explicit mountpoint so we don't scrape
+# /Volumes/ looking for the right volume.
+if ! hdiutil attach -nobrowse -readonly \
+        -mountpoint "$MOUNT_POINT" "$DIST_DMG" >/dev/null; then
+    echo "ERROR: could not mount DMG." >&2
+    exit 1
+fi
+trap 'hdiutil detach "$MOUNT_POINT" >/dev/null 2>&1 || true' EXIT
+if ! OUTPUT=$("$MOUNT_POINT/shipyard" --version 2>&1); then
     echo "" >&2
-    echo "ERROR: LOCAL LAUNCH TEST FAILED on this Mac." >&2
-    echo "       Binary: $DIST_BINARY" >&2
-    echo "       This is the #219 failure shape. Do NOT ship this binary." >&2
+    echo "ERROR: LOCAL LAUNCH TEST FAILED from mounted DMG." >&2
+    echo "       DMG: $DIST_DMG" >&2
+    echo "       Do NOT ship this binary." >&2
     echo "" >&2
     echo "       Diagnostics:" >&2
-    codesign --verify --deep --strict --verbose=4 "$DIST_BINARY" 2>&1 | sed 's/^/         /' >&2
-    spctl --assess --type execute -vv "$DIST_BINARY" 2>&1 | sed 's/^/         /' >&2
-    xattr -l "$DIST_BINARY" 2>&1 | sed 's/^/         /' >&2
+    codesign --verify --deep --strict --verbose=4 "$DIST_DMG" 2>&1 | sed 's/^/         /' >&2
+    xcrun stapler validate -v "$DIST_DMG" 2>&1 | sed 's/^/         /' >&2
+    spctl --assess --type install -vv "$DIST_DMG" 2>&1 | sed 's/^/         /' >&2
     echo "" >&2
     echo "       Crash report (if any) under:" >&2
     echo "         ~/Library/Logs/DiagnosticReports/shipyard-*.ips" >&2
     echo "" >&2
+    hdiutil detach "$MOUNT_POINT" >/dev/null 2>&1 || true
     exit 3
 fi
 echo "  ✓ --version printed: ${OUTPUT}"
 
+# Detach the DMG before further work — the mount is no longer
+# needed and leaving it attached confuses the later e2e step
+# which mounts a freshly-downloaded copy.
+hdiutil detach "$MOUNT_POINT" >/dev/null 2>&1 || true
+trap - EXIT
+
 # ── Upload (opt-in) ────────────────────────────────────────────────
 if [ "$DO_UPLOAD" -eq 1 ]; then
-    echo "Step 5/5: Uploading $DIST_BINARY to release $TAG..."
-    # Overwrite if an asset already exists — typically this script
-    # replaces CI's broken asset with a known-working local one.
-    gh release upload "$TAG" "$DIST_BINARY" --clobber
-    # Update the checksum line for this artifact. The release's
-    # checksums.sha256 contains one line per platform; we replace
-    # just our line. If the file doesn't exist yet, this creates it.
-    CHECKSUM=$(shasum -a 256 "$DIST_BINARY" | awk '{print $1}')
-    LINE="${CHECKSUM}  ${ARTIFACT}"
-    # Build the file at its final name from the start. The earlier
-    # approach uploaded a mktemp-named file first then re-uploaded
-    # a renamed copy, which left both on the release as sibling
-    # assets (observed on v0.43.0's first upload — stray `tmp.XYZ`
-    # asset had to be deleted by hand).
+    echo "Step 7/8: Uploading $DIST_DMG to release $TAG..."
+    gh release upload "$TAG" "$DIST_DMG" --clobber
+    # Update the checksum line for this artifact. Keyed on the
+    # full asset filename (e.g. shipyard-macos-arm64.dmg) so an
+    # older shipyard-macos-arm64 (bare Mach-O) line from a
+    # previous release of the same tag doesn't collide.
+    CHECKSUM=$(shasum -a 256 "$DIST_DMG" | awk '{print $1}')
+    LINE="${CHECKSUM}  ${DMG_NAME}"
     CHECKSUMS_DIR="$(mktemp -d)"
     CHECKSUMS_FILE="${CHECKSUMS_DIR}/checksums.sha256"
     if gh release view "$TAG" --json assets \
@@ -203,8 +260,7 @@ if [ "$DO_UPLOAD" -eq 1 ]; then
             | grep -q checksums.sha256; then
         gh release download "$TAG" --pattern checksums.sha256 \
             --output "$CHECKSUMS_FILE" --clobber
-        # Drop any existing line for this artifact; append the new one.
-        grep -v "  ${ARTIFACT}\$" "$CHECKSUMS_FILE" \
+        grep -v "  ${DMG_NAME}\$" "$CHECKSUMS_FILE" \
             > "${CHECKSUMS_FILE}.new" || true
         echo "$LINE" >> "${CHECKSUMS_FILE}.new"
         mv "${CHECKSUMS_FILE}.new" "$CHECKSUMS_FILE"
@@ -214,10 +270,58 @@ if [ "$DO_UPLOAD" -eq 1 ]; then
     gh release upload "$TAG" "$CHECKSUMS_FILE" --clobber
     rm -rf "$CHECKSUMS_DIR"
     echo "  ✓ Uploaded to release $TAG"
+
+    # ── End-to-end verification (#55 codification) ─────────────────
+    # Test the same install.sh → launch path end users hit. The
+    # local launch test above proved the DMG works when mounted
+    # directly; this proves the DOWNLOAD + install path works,
+    # which is the gap we kept shipping past.
+    #
+    # Uses the install.sh in THIS checkout — not the remote copy on
+    # main — so a change-in-progress to install.sh gets validated
+    # against the real DMG *before* the change is merged. After
+    # merge + release, the tag's install.sh and this checkout's
+    # install.sh are the same file, so the test remains honest.
+    #
+    # If this fails, the upload already happened: operator must
+    # manually delete the uploaded asset or re-run after fixing.
+    # Exit 4 distinguishes this from the local mounted-launch test
+    # failure (exit 3).
+    echo "Step 8/8: End-to-end verification (local install.sh → launch)..."
+    E2E_TMPDIR="$(mktemp -d)"
+    E2E_INSTALL_DIR="$E2E_TMPDIR/bin"
+    LOCAL_INSTALL_SH="$(cd "$(dirname "$0")/.." && pwd)/install.sh"
+    if ! SHIPYARD_INSTALL_DIR="$E2E_INSTALL_DIR" \
+            SHIPYARD_VERSION="$TAG" \
+            bash "$LOCAL_INSTALL_SH" \
+            >"$E2E_TMPDIR/install.log" 2>&1; then
+        echo "" >&2
+        echo "ERROR: E2E install.sh FAILED for $TAG." >&2
+        echo "       Upload already happened — this DMG is live but" >&2
+        echo "       end-users won't be able to install it cleanly." >&2
+        echo "       Install log:" >&2
+        sed 's/^/         /' "$E2E_TMPDIR/install.log" >&2
+        rm -rf "$E2E_TMPDIR"
+        exit 4
+    fi
+    if ! E2E_OUTPUT=$("$E2E_INSTALL_DIR/shipyard" --version 2>&1); then
+        echo "" >&2
+        echo "ERROR: E2E installed binary FAILED to launch." >&2
+        echo "       Upload already happened. The DMG mounts + verifies" >&2
+        echo "       but the extracted binary does not survive the" >&2
+        echo "       install.sh download + post-processing path." >&2
+        echo "       Install log:" >&2
+        sed 's/^/         /' "$E2E_TMPDIR/install.log" >&2
+        rm -rf "$E2E_TMPDIR"
+        exit 4
+    fi
+    echo "  ✓ End-to-end install.sh + launch passed: ${E2E_OUTPUT}"
+    rm -rf "$E2E_TMPDIR"
 else
-    echo "Step 5/5: SKIPPED (--upload not passed)."
+    echo "Step 7/8: SKIPPED (--upload not passed)."
+    echo "Step 8/8: E2E verification SKIPPED (requires upload)."
     echo ""
-    echo "Signed + notarized + tested binary is at: $DIST_BINARY"
+    echo "Signed + notarized + stapled DMG at: $DIST_DMG"
     echo "Re-run with --upload to ship it to release $TAG."
 fi
 

--- a/tests/test_install_sh.py
+++ b/tests/test_install_sh.py
@@ -385,3 +385,200 @@ def test_adhoc_fallback_does_not_trigger_on_linux(tmp_path: Path) -> None:
     assert result.returncode != 0
     # Ad-hoc messaging must be absent on Linux.
     assert "ad-hoc" not in result.stderr.lower()
+
+
+# -- #52: .dmg mount-and-extract path ------------------------------
+# install.sh on macOS downloads a stapled .dmg (new default in
+# v0.44.0+), mounts it, copies the binary out. This test drives
+# that path with a real dmg built by hdiutil + a stub binary that
+# prints a known version string. Verifies:
+#   - install.sh correctly detects the .dmg asset and takes the
+#     mount path instead of the bare-Mach-O path
+#   - After mount + copy + detach, the installed binary at
+#     $INSTALL_DIR/shipyard is executable and prints the expected
+#     content
+#   - post-install smoke passes on the extracted binary
+
+def _make_fake_dmg(tmp_path: Path, version_string: str = "shipyard, version test") -> Path:
+    """Build a real stapled-shape .dmg with a stub shipyard inside.
+
+    The dmg won't be *actually* stapled (no notarization ticket for
+    a fake binary), but the mount + extract logic in install.sh is
+    independent of the ticket — we're testing the mechanics, not
+    the cryptography. Returns the dmg path.
+    """
+    if sys.platform != "darwin":
+        raise RuntimeError("hdiutil is macOS-only")
+    stage = tmp_path / "dmg-stage"
+    stage.mkdir()
+    stub = stage / "shipyard"
+    stub.write_text(f"#!/bin/sh\necho '{version_string}'\n")
+    stub.chmod(0o755)
+    dmg = tmp_path / "shipyard-macos-arm64.dmg"
+    subprocess.run(
+        [
+            "hdiutil", "create", "-volname", "Shipyard",
+            "-srcfolder", str(stage), "-ov", "-format", "UDZO",
+            str(dmg),
+        ],
+        check=True,
+        capture_output=True,
+    )
+    return dmg
+
+
+def test_install_sh_mounts_dmg_and_extracts_binary(tmp_path: Path) -> None:
+    # macOS only — hdiutil + mount semantics don't exist on Linux
+    # and the dmg path in install.sh only runs on OS=macos.
+    if sys.platform != "darwin":
+        pytest.skip("dmg path is macOS-only")
+
+    dmg = _make_fake_dmg(tmp_path, version_string="shipyard, version dmg-test")
+    install_dir = tmp_path / "bin"
+    install_dir.mkdir()
+
+    # Fake the GitHub API response by shimming curl. install.sh's
+    # URL-resolution step calls curl twice: once for the API JSON,
+    # once for the actual asset download. We return a json blob
+    # that points at our local dmg (via file://) for both.
+    shim_dir = tmp_path / "shim"
+    shim_dir.mkdir()
+    fake_curl = shim_dir / "curl"
+    # First invocation (API JSON lookup) gets faked JSON that
+    # contains a browser_download_url pointing at our local dmg.
+    # Second invocation (the asset download) gets the real curl
+    # which can handle file:// URLs. Use a marker file to track
+    # which call we're on.
+    fake_curl.write_text(f"""#!/bin/sh
+REAL_CURL=/usr/bin/curl
+MARKER={tmp_path}/curl-call-count
+if [ ! -f "$MARKER" ]; then echo 0 > "$MARKER"; fi
+COUNT=$(cat "$MARKER")
+NEW=$((COUNT + 1))
+echo "$NEW" > "$MARKER"
+# Any call that mentions api.github.com: return a fake JSON with
+# browser_download_url pointing at the local dmg. Any other call:
+# pass through to real curl.
+for arg in "$@"; do
+    case "$arg" in
+        *api.github.com*)
+            echo '"browser_download_url": "file://{dmg}"'
+            exit 0
+            ;;
+    esac
+done
+exec "$REAL_CURL" "$@"
+""")
+    fake_curl.chmod(0o755)
+
+    env = {
+        **os.environ,
+        "SHIPYARD_INSTALL_DIR": str(install_dir),
+        "PATH": f"{shim_dir}:{os.environ.get('PATH', '')}",
+    }
+    # Don't skip download — we're exercising the dmg mount path.
+    env.pop("SHIPYARD_SKIP_DOWNLOAD", None)
+    # Skip the smoke since it would codesign-probe the stub as if
+    # it's a shipyard binary; the mount + extract mechanics are
+    # what this test covers.
+    env["SHIPYARD_SKIP_SMOKE"] = "1"
+
+    result = subprocess.run(
+        ["bash", str(INSTALL_SH)],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, (
+        f"dmg install failed: stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+    # The dmg path's download message must have fired, proving
+    # install.sh took the dmg branch rather than bare Mach-O.
+    assert ".dmg" in result.stdout, (
+        f"expected .dmg download message; got stdout={result.stdout!r}"
+    )
+    # The extracted binary must exist and be executable.
+    installed = install_dir / "shipyard"
+    assert installed.exists(), f"binary missing: {list(install_dir.iterdir())}"
+    assert os.access(installed, os.X_OK)
+    # And it must contain what we put in the dmg — confirms the
+    # copy actually happened, not just a pre-existing file.
+    run = subprocess.run(
+        [str(installed)], capture_output=True, text=True, check=False,
+    )
+    assert "dmg-test" in run.stdout, (
+        f"extracted binary produced {run.stdout!r}; expected the "
+        "dmg-test marker, which proves the binary came OUT of the dmg"
+    )
+
+
+def test_install_sh_falls_back_to_bare_macho_when_no_dmg(tmp_path: Path) -> None:
+    # Backward compat: if a tag has no .dmg asset (older releases,
+    # forks without the local-sign script, etc.) install.sh must
+    # still find the bare Mach-O and install it.
+    if sys.platform != "darwin":
+        pytest.skip("test exercises macOS-specific branch selection")
+
+    install_dir = tmp_path / "bin"
+    install_dir.mkdir()
+
+    # Fake a Mach-O. The filename has to match the ARTIFACT grep
+    # pattern install.sh runs (`browser_download_url.*${ARTIFACT}"`)
+    # so that URL resolution finds it — use the real artifact name.
+    bare_binary = tmp_path / "shipyard-macos-arm64"
+    bare_binary.write_text("#!/bin/sh\necho 'shipyard, version bare-test'\n")
+    bare_binary.chmod(0o755)
+
+    shim_dir = tmp_path / "shim"
+    shim_dir.mkdir()
+    fake_curl = shim_dir / "curl"
+    # API shim returns ONLY a bare-Mach-O URL (no dmg entry), so
+    # install.sh's DMG_URL check comes up empty and it falls back
+    # to RELEASE_URL.
+    fake_curl.write_text(f"""#!/bin/sh
+REAL_CURL=/usr/bin/curl
+for arg in "$@"; do
+    case "$arg" in
+        *api.github.com*)
+            # Only the bare artifact — no .dmg sibling. The trailing
+            # double quote matches install.sh's RELEASE_URL grep
+            # pattern (`browser_download_url.*${{ARTIFACT}}"`).
+            echo '"browser_download_url": "file://{bare_binary}"'
+            exit 0
+            ;;
+    esac
+done
+exec "$REAL_CURL" "$@"
+""")
+    fake_curl.chmod(0o755)
+
+    env = {
+        **os.environ,
+        "SHIPYARD_INSTALL_DIR": str(install_dir),
+        "PATH": f"{shim_dir}:{os.environ.get('PATH', '')}",
+        "SHIPYARD_SKIP_SMOKE": "1",
+    }
+    env.pop("SHIPYARD_SKIP_DOWNLOAD", None)
+
+    result = subprocess.run(
+        ["bash", str(INSTALL_SH)],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, (
+        f"bare-fallback install failed: stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+    # Must NOT have taken the dmg mount path (no mention of .dmg
+    # in the download message — bare path uses the artifact name).
+    assert ".dmg" not in result.stdout, (
+        f"expected bare-Mach-O path; got dmg-like stdout={result.stdout!r}"
+    )
+    installed = install_dir / "shipyard"
+    assert installed.exists()
+    run = subprocess.run(
+        [str(installed)], capture_output=True, text=True, check=False,
+    )
+    assert "bare-test" in run.stdout

--- a/tests/test_install_sh.py
+++ b/tests/test_install_sh.py
@@ -513,6 +513,103 @@ exec "$REAL_CURL" "$@"
     )
 
 
+def test_install_sh_matches_windows_exe_asset(tmp_path: Path) -> None:
+    # Codex P1 on #227: my earlier RELEASE_URL grep anchored with
+    # just `"` after `${ARTIFACT}`, which worked for Linux + macOS
+    # bare Mach-O (where the asset name ends right before the
+    # closing quote) but broke Windows — `shipyard-windows-x64.exe`
+    # has `.exe` between ARTIFACT and the quote. The fix allows an
+    # optional `.exe` suffix.
+    #
+    # Drive install.sh through the RELEASE_URL branch with a fake
+    # windows-x64.exe asset. We can't actually RUN a .exe on
+    # macOS/Linux, but we CAN verify the URL-resolution step picks
+    # the right asset and gets through the download step. Skip the
+    # final smoke since the stub isn't a real Windows binary.
+    if sys.platform == "win32":
+        pytest.skip("drives install.sh URL resolution; macOS+Linux enough")
+
+    install_dir = tmp_path / "bin"
+    install_dir.mkdir()
+
+    # A fake Windows-named artifact. install.sh sees OS/ARCH from
+    # `uname`, so ARTIFACT on a non-Windows test host is always
+    # `shipyard-<os>-<arch>` (no .exe). To exercise the .exe match
+    # path specifically we shim curl + force the grep target via
+    # the fake JSON name — but install.sh computes ARTIFACT locally
+    # from uname, so we also need the on-disk file to match the
+    # local artifact name PLUS the .exe suffix case.
+    #
+    # Easier: build a test binary file that simulates a
+    # platform-appropriate "windows-ish" asset name the grep would
+    # see, and check install.sh follows it through to download.
+    # We confirm the match by asserting install.sh writes the
+    # downloaded bytes to ${INSTALL_DIR}/shipyard.
+    platform_artifact = subprocess.run(
+        ["bash", "-c",
+         'case "$(uname -s)" in Darwin) echo "shipyard-macos-$(uname -m | sed s/x86_64/x64/;s/arm64/arm64/)";; '
+         'Linux) echo "shipyard-linux-$(uname -m | sed s/x86_64/x64/;s/aarch64/arm64/)";; '
+         'esac'],
+        capture_output=True, text=True, check=True,
+    ).stdout.strip()
+    # We're going to pretend the release serves the platform artifact
+    # with a `.exe` suffix — the grep must still match. We write a
+    # file with .exe in the name and make the fake curl return a URL
+    # pointing at it.
+    exe_asset = tmp_path / f"{platform_artifact}.exe"
+    exe_asset.write_text("fake-windows-payload\n")
+
+    shim_dir = tmp_path / "shim"
+    shim_dir.mkdir()
+    fake_curl = shim_dir / "curl"
+    fake_curl.write_text(f"""#!/bin/sh
+REAL_CURL=/usr/bin/curl
+for arg in "$@"; do
+    case "$arg" in
+        *api.github.com*)
+            # Asset name carries .exe suffix. Before the fix this
+            # line would NOT match the RELEASE_URL grep because the
+            # grep anchored with just `"` right after ARTIFACT.
+            echo '"browser_download_url": "file://{exe_asset}"'
+            exit 0
+            ;;
+    esac
+done
+exec "$REAL_CURL" "$@"
+""")
+    fake_curl.chmod(0o755)
+
+    env = {
+        **os.environ,
+        "SHIPYARD_INSTALL_DIR": str(install_dir),
+        "PATH": f"{shim_dir}:{os.environ.get('PATH', '')}",
+        "SHIPYARD_SKIP_SMOKE": "1",  # the fake payload isn't a real binary
+    }
+    env.pop("SHIPYARD_SKIP_DOWNLOAD", None)
+
+    result = subprocess.run(
+        ["bash", str(INSTALL_SH)],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, (
+        f".exe asset detection failed: stdout={result.stdout!r} "
+        f"stderr={result.stderr!r}"
+    )
+    # The downloaded file must end up at ${INSTALL_DIR}/shipyard
+    # with the payload we placed in exe_asset. If the grep failed
+    # to match, install.sh would have exited with "No binary found"
+    # before downloading anything.
+    installed = install_dir / "shipyard"
+    assert installed.exists(), "install.sh should have downloaded the .exe asset"
+    assert installed.read_text() == "fake-windows-payload\n", (
+        "downloaded content must match the .exe asset — proves the "
+        "grep picked the .exe URL, not some other line"
+    )
+
+
 def test_install_sh_falls_back_to_bare_macho_when_no_dmg(tmp_path: Path) -> None:
     # Backward compat: if a tag has no .dmg asset (older releases,
     # forks without the local-sign script, etc.) install.sh must


### PR DESCRIPTION
## TL;DR

**Verified end-to-end on the Mac that SIGKILL'd every earlier v0.42/43 attempt.** Uploaded a stapled .dmg to v0.43.0 (alongside the bare Mach-O), ran install.sh from this branch, binary launched cleanly with \`--version\`. No SIGKILL, no ad-hoc fallback, no online notarization check.

## The actual fix

Bare Mach-O binaries cannot be stapled — Gatekeeper falls back to an **online** notarization check at first launch, which proved unreliable per-Mac (v0.42.0 + v0.43.0 both SIGKILL'd with \"Taskgated Invalid Signature\" on the maintainer's Mac even though both were valid Developer-ID + Apple-notarized).

Wrapping the binary in a \`.dmg\` and stapling the DMG puts the notarization ticket **inside the artifact**. Gatekeeper verifies the ticket OFFLINE when the DMG is mounted. The binary extracted from the mount inherits trusted provenance. No online check, no per-Mac flakiness, no dice rolls.

## What ships

### \`scripts/release-macos-local.sh\`: now 8 steps (was 5)

1. Fail fast on missing env vars
2. PyInstaller build with \`--codesign-identity\`
3. Re-sign with \`--options runtime --timestamp\`
4. Package Mach-O into .dmg (\`hdiutil create\`, volname \"Shipyard\")
5. Sign the DMG
6. Notarize DMG → \`xcrun stapler staple\` → \`stapler validate\`
7. **Mount + launch test** — mount the stapled DMG, run \`--version\`. Exit 3 if broken.
8. **Upload + end-to-end install.sh verification** — after \`gh release upload\`, run this checkout's install.sh against the uploaded tag. Fresh download, fresh mount, fresh extract, fresh launch. Exit 4 if broken, with a warning that the upload happened and needs manual cleanup.

### \`install.sh\`: .dmg preference path on macOS

- Prefers \`.dmg\` asset (v0.44.0+), falls back to bare Mach-O for older tags + forks
- Downloads dmg → \`hdiutil attach -nobrowse -readonly -mountpoint\` → copies binary out → detaches
- Rest of flow (xattr strip, smoke, ad-hoc fallback from PR #223) unchanged
- Also fixed: \`set -o pipefail\` interaction where grep with no match used to kill the script silently; now tolerates empty URL resolution and surfaces a proper \"No binary found\" error

### Tests (2 new)

- \`test_install_sh_mounts_dmg_and_extracts_binary\` — builds a real .dmg via \`hdiutil\`, shims curl to serve it, verifies install.sh takes the .dmg branch and the extracted binary carries the content put in the dmg (not a pre-existing file).
- \`test_install_sh_falls_back_to_bare_macho_when_no_dmg\` — shims curl to serve ONLY a bare binary, verifies the bare-Mach-O fallback path still works.

### Codification (the load-bearing lesson)

Shipped v0.42.0 and v0.43.0 with the same class of breakage because \"works\" was declared based on partial verification. Now enforced in the script and in CLAUDE.md + RELEASING.md:

> The success criterion is \`--version\` printing after a fresh install.sh → mount → extract → launch flow. Not \`codesign --verify\`, not \`spctl --assess\`, not the on-runner launch gate alone. If any step in that chain fails, the release fails.

## Test plan

- [x] \`uv run pytest tests/test_install_sh.py tests/test_release_macos_local.py -q\` → 25 passed + 1 Linux-skipped
- [x] **Manual end-to-end on the maintainer's Mac**:
  - Built signed+notarized+stapled DMG via \`./scripts/release-macos-local.sh --tag v0.43.0\` → all steps green
  - Uploaded to v0.43.0 alongside bare Mach-O (clobber preserves both, new checksums line added)
  - \`SHIPYARD_VERSION=v0.43.0 bash install.sh\` with fresh \`\$SHIPYARD_INSTALL_DIR\` → detected .dmg, downloaded, mounted, extracted, post-install smoke passed
  - \`shipyard --version\` → \`shipyard, version 0.43.0\` — **first time this Mac accepts a notarized Shipyard binary without falling back to ad-hoc**
- [ ] CI green on Linux / macOS / Windows (macOS build still runs for PyInstaller health; no sign/notarize in CI)
- [ ] **After merge**: bump to v0.44.0, run \`./scripts/release-macos-local.sh --tag v0.44.0 --upload\` from a fresh clone, verify the step-8 e2e auto-verification passes.

## Related

- #219 — the breakage this resolves
- #226 — future-work tracker for re-enabling CI signing safely (kept open)
- Task #52 (this PR, closing) — .dmg distribution with stapled ticket
- Task #55 (this PR, closing) — codify end-to-end verification