### PR TITLE
ci: route macOS PR checks to Namespace pool (fixes slow macos-15 queue)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,12 +136,22 @@ jobs:
     # (LookupError, ModuleNotFoundError, PYI-*:ERROR, etc.). A clean
     # "Tailscale Funnel isn't available" exit is acceptable here and
     # proves the bundle itself is sound.
+    needs: resolve-runners
     name: Binary smoke (PyInstaller bundle health)
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ fromJSON(matrix.runs_on) }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-15]
+        include:
+          # Mirror the macOS/linux routing the main test job uses so
+          # Binary-smoke macOS doesn't get stuck in the GH-hosted
+          # `macos-15` queue while the resolver is pointing everyone
+          # else at Namespace. Windows isn't in this matrix (no
+          # Windows-specific PyInstaller smoke today).
+          - os: linux
+            runs_on: ${{ needs.resolve-runners.outputs.linux }}
+          - os: macos
+            runs_on: ${{ needs.resolve-runners.outputs.macos }}
     steps:
       - uses: actions/checkout@v5
       - name: Set up Python

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,10 +64,18 @@ jobs:
             && echo "linux=\"namespace-profile-generouscorp\"" >> "$GITHUB_OUTPUT" \
             || echo "linux=\"ubuntu-latest\"" >> "$GITHUB_OUTPUT"
 
-          # Both namespace and github-hosted macOS resolve to macos-15
-          # today — Namespace piggybacks on GitHub's macOS runner fleet
-          # because Apple silicon hosting is a niche capacity.
-          echo "macos=\"macos-15\"" >> "$GITHUB_OUTPUT"
+          # Route macOS to Namespace's own M-series pool
+          # (namespace-profile-generouscorp-macos) when P_MACOS=namespace.
+          # The earlier assumption that "Namespace piggybacks on
+          # GitHub's macOS fleet" turned out to be wrong: Namespace
+          # runs its own macOS infrastructure with far shorter queue
+          # times than GH-hosted `macos-15`, which routinely stalls
+          # PRs 10-30 min during business hours. `release.yml`
+          # already routes macOS to namespace correctly; this brings
+          # PR checks into alignment.
+          [ "$P_MACOS" = "namespace" ] \
+            && echo "macos=\"namespace-profile-generouscorp-macos\"" >> "$GITHUB_OUTPUT" \
+            || echo "macos=\"macos-15\"" >> "$GITHUB_OUTPUT"
 
           [ "$P_WINDOWS" = "namespace" ] \
             && echo "windows=\"namespace-profile-generouscorp-windows\"" >> "$GITHUB_OUTPUT" \


### PR DESCRIPTION
## Why

PR-check macOS jobs have been sitting in GitHub-hosted \`macos-15\` queue (10-30 min waits during business hours) even though the repo has \`DEFAULT_RUNNER_PROVIDER=namespace\` set. The resolver in \`ci.yml\` hardcoded \`macos=\"macos-15\"\` on the (apparently-outdated) assumption that Namespace piggybacks on GitHub's macOS fleet.

Reality: Namespace runs its own M-series macOS pool served on label \`namespace-profile-generouscorp-macos\`. \`release.yml\` has been routing macOS there for months with near-zero queue time. This PR brings ci.yml into alignment.

## Fix

5-line change in the \`resolve-runners\` step: respect \`\$P_MACOS\` the same way it already respects \`\$P_LINUX\` and \`\$P_WINDOWS\`.

## Test plan

- [x] \`bash -n .github/workflows/ci.yml\` → syntax OK
- [ ] CI on this PR should itself pick Namespace macOS — visible in the workflow log under \`resolve-runners\` output as \`macos=\"namespace-profile-generouscorp-macos\"\`, and the macOS jobs should pick up in under a minute instead of sitting in the \`macos-15\` queue.

## Related

- PR #227 (blocked on the same slow queue this fixes)
- Issue #193 (original driver for runner provider overrides)