### PR TITLE
chore: bump CLI 0.43.0 → 0.44.0 — first stapled-.dmg release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "shipyard"
-version = "0.43.0"
+version = "0.44.0"
 description = "Cross-platform CI coordination — local VMs, SSH hosts, cloud runners"
 readme = "README.md"
 license = "MIT"

--- a/src/shipyard/__init__.py
+++ b/src/shipyard/__init__.py
@@ -1,3 +1,3 @@
 """Shipyard — Cross-platform CI coordination."""
 
-__version__ = "0.43.0"
+__version__ = "0.44.0"


### PR DESCRIPTION
## Why

v0.44.0 is the first release where macOS ships as a **stapled .dmg** — Gatekeeper verifies the notarization ticket **offline** when the DMG is mounted, so no per-Mac online-notarization-check flakiness (the root cause of v0.42.0 + v0.43.0 SIGKILLs).

## Released in this bump

- \`.dmg\` distribution with stapled notarization ticket (#52 / #219)
- install.sh: mount + extract logic on macOS, bare Mach-O fallback for older tags + forks
- \`scripts/release-macos-local.sh\` codified 8-step pipeline, refuses to upload unless local launch test passes, refuses to declare shipped unless end-to-end install.sh → mount → extract → launch passes
- CI routing fix: macOS PR checks + Binary-smoke route to \`namespace-profile-generouscorp-macos\` (#228)
- Codex P1 fix: install.sh URL grep preserves Windows \`.exe\` match

## After merge

Auto-release publishes Linux + Windows. Then locally:

\`\`\`bash
./scripts/release-macos-local.sh --tag v0.44.0 --upload
\`\`\`

Step 8 of the script runs the end-to-end verification — fresh install.sh → mount → extract → launch — on the maintainer's Mac. Only exits 0 if the binary actually launches after a full install flow. This is the codified lesson from v0.42.0 + v0.43.0 sloppiness.

## Test plan

- [x] Pipeline verified end-to-end on maintainer's Mac against v0.43.0 (stapled DMG uploaded, fresh install.sh against v0.43.0 downloaded+mounted+extracted+launched cleanly)
- [ ] Auto-release fires on merge, non-macOS assets upload
- [ ] Local script runs against v0.44.0 with --upload, step 8 passes
- [ ] Pulp + spectr pin bumps target v0.44.0 cleanly (no ad-hoc fallback needed)

No code changes beyond the two version fields.