### PR TITLE
chore: bump CLI 0.44.0 → 0.45.0 for shipyard pin bump

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "shipyard"
-version = "0.44.0"
+version = "0.45.0"
 description = "Cross-platform CI coordination — local VMs, SSH hosts, cloud runners"
 readme = "README.md"
 license = "MIT"

--- a/src/shipyard/__init__.py
+++ b/src/shipyard/__init__.py
@@ -1,3 +1,3 @@
 """Shipyard — Cross-platform CI coordination."""
 
-__version__ = "0.44.0"
+__version__ = "0.45.0"


### PR DESCRIPTION
## What ships in v0.45.0

- \`shipyard pin show\` / \`shipyard pin bump\` (#222, PR #230)

Consumer pin bumps collapse to one command:

\`\`\`
cd ~/Code/pulp
shipyard pin bump          # edits pin, runs install.sh, verifies, opens PR
\`\`\`

## After merge

- Auto-release publishes Linux + Windows assets
- Local script produces + uploads + e2e-verifies the stapled macOS dmg (same codified 8-step pipeline introduced in v0.44.0)
- Pulp + spectr can use \`shipyard pin bump\` from v0.45.0 onwards instead of the manual prompts

## Test plan

- [x] v0.44.0's pipeline was end-to-end verified on this Mac; same pipeline applies to v0.45.0
- [ ] Auto-release → non-macOS assets land
- [ ] Local script runs v0.45.0 with --upload, step 8 passes
- [ ] Dogfood: try running \`shipyard pin bump\` in spectr against v0.45.0 once the release is out