### PR TITLE
#231: shipyard daemon refresh + remove false-positive spctl probe

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -114,11 +114,43 @@ echo "Resolving ${VERSION_LABEL} from ${REPO}..."
 
 mkdir -p "${INSTALL_DIR}"
 
+# Short-circuit when the installed binary is already at the target
+# version (#231). Saves ~15MB per redundant invocation — common when
+# pulp + spectr pins both sit at the same Shipyard version and the
+# user runs both install-shipyard.sh wrappers back-to-back.
+#
+# Only applies when:
+#   - Target is a specific version (not "latest" — we'd have to
+#     resolve latest to know if there's drift, which defeats the
+#     purpose of skipping network work).
+#   - SHIPYARD_FORCE_REINSTALL is not set.
+#   - SHIPYARD_SKIP_DOWNLOAD is not set (tests need their own flow).
+#   - Existing binary actually reports a version. A SIGKILL'd binary
+#     falls through to the full install path where the smoke + ad-hoc
+#     fallback can recover it.
+SHIPYARD_ALREADY_AT_TARGET=0
+if [ "${SHIPYARD_SKIP_DOWNLOAD:-0}" != "1" ] \
+    && [ "${SHIPYARD_FORCE_REINSTALL:-0}" != "1" ] \
+    && [ -x "${INSTALL_DIR}/shipyard" ] \
+    && [ "${VERSION_LABEL}" != "latest" ]; then
+    # Expect `shipyard, version 0.46.0` — extract just the version.
+    existing=$("${INSTALL_DIR}/shipyard" --version 2>/dev/null \
+        | sed -n 's/^shipyard, version \([^ ]*\).*/\1/p' | head -1)
+    target="${VERSION_LABEL#v}"
+    if [ -n "${existing}" ] && [ "${existing}" = "${target}" ]; then
+        echo "Already at v${target} at ${INSTALL_DIR}/shipyard — skipping download."
+        echo "Set SHIPYARD_FORCE_REINSTALL=1 to re-download anyway."
+        SHIPYARD_ALREADY_AT_TARGET=1
+    fi
+fi
+
 # SHIPYARD_SKIP_DOWNLOAD=1 preserves an already-present binary at
 # ${INSTALL_DIR}/shipyard. Used by tests to exercise the smoke +
 # remediation paths without hitting the network. When it's set we
 # skip URL resolution entirely (tests don't want live API calls).
-if [ "${SHIPYARD_SKIP_DOWNLOAD:-0}" != "1" ]; then
+# Same when we short-circuited on version match above.
+if [ "${SHIPYARD_SKIP_DOWNLOAD:-0}" != "1" ] \
+    && [ "${SHIPYARD_ALREADY_AT_TARGET}" != "1" ]; then
     # `set -o pipefail` means a pipe containing `grep` that matches
     # nothing kills the script via set -e — so `|| true` the final
     # cut lets us handle the empty-URL case below instead of dying
@@ -156,7 +188,8 @@ else
     RELEASE_URL=""
 fi
 
-if [ "${SHIPYARD_SKIP_DOWNLOAD:-0}" = "1" ]; then
+if [ "${SHIPYARD_SKIP_DOWNLOAD:-0}" = "1" ] \
+    || [ "${SHIPYARD_ALREADY_AT_TARGET}" = "1" ]; then
     : # existing binary at INSTALL_DIR/shipyard is what we'll test
 elif [ -n "${DMG_URL}" ]; then
     echo "Downloading ${ARTIFACT}.dmg (${VERSION_LABEL})..."

--- a/src/shipyard/cli.py
+++ b/src/shipyard/cli.py
@@ -646,33 +646,41 @@ def _check_shipyard_path_shadows() -> dict[str, Any]:
 
 
 def _check_macos_gatekeeper_health() -> dict[str, Any] | None:
-    """Surface a broken notarization state on macOS before it bites.
+    """Surface a broken signing / Gatekeeper state on macOS.
 
-    Closes #216 — the user-facing failure is "exit 137 once, then
-    exit 0 with zero output forever after." That shape is exactly
-    what happens when Gatekeeper rejects a PyInstaller bundle whose
-    Developer-ID signature got destroyed: macOS SIGKILLs on first
-    run and then caches the rejection so subsequent runs exit
-    silently. Root cause was ``install.sh``'s pre-v0.36.0
-    ``codesign --force --sign -`` ad-hoc resign (#203 fixed the
-    install side). This check catches users already in the broken
-    state or whose future install path regresses.
+    Originally written for #216 (binary passed ``codesign --verify``
+    but SIGKILL'd at launch under pre-v0.36.0 install.sh notarization
+    strip). The check had three probes: xattr quarantine, spctl
+    --assess, and codesign --verify.
 
-    Three signals, any one of which flips ok=False:
+    Revised for #231 — the spctl probe false-positive'd on v0.44.0's
+    stapled-dmg installs. When install.sh copies a binary OUT of a
+    stapled .dmg, the binary inherits trusted provenance and
+    launches cleanly, but ``spctl --assess`` still rejects it
+    because spctl's default policy rejects bare CLI Mach-O
+    regardless of signature validity. That's NOT a real problem —
+    taskgated at launch uses a different trust path (the dmg
+    provenance) and accepts the binary just fine.
 
-    1. ``com.apple.quarantine`` xattr present on the running binary
-       — Gatekeeper's first-run evaluation is still pending or
-       failed.
-    2. ``spctl --assess`` rejects the binary — active Gatekeeper
-       rejection. The definitive "your binary is broken" signal.
-    3. ``codesign --verify --deep`` fails — signing integrity is
-       broken independent of policy.
+    New check shape: two signals, both DEFINITIVE, neither
+    false-positiving on valid CLI binaries:
+
+    1. ``com.apple.quarantine`` xattr present — first-run
+       evaluation genuinely pending/failed. Fix is mechanical
+       (strip the xattr).
+    2. ``codesign --verify --deep`` fails — signing integrity
+       actually broken. Fix is reinstall.
+
+    We DO NOT probe ``spctl --assess`` anymore — its policy
+    rejection on a signed+notarized CLI binary from a stapled dmg
+    is expected behavior, not a bug. The actual launch behavior
+    (which is what users care about) is covered by the install-time
+    post-install smoke in install.sh.
 
     Returns None on non-macOS and when the running CLI isn't a
-    frozen bundle (e.g. ``uv run shipyard doctor`` during
-    development) — a passing row there would be false confidence
-    since the Python interpreter is well-signed regardless of how
-    the release binary fared.
+    frozen bundle (``uv run`` during development) — a passing row
+    there would be false confidence since Python itself is
+    well-signed regardless of release-binary state.
     """
     if sys.platform != "darwin":
         return None
@@ -703,22 +711,6 @@ def _check_macos_gatekeeper_health() -> dict[str, Any] | None:
         pass
 
     try:
-        spctl = subprocess.run(
-            ["spctl", "--assess", "--verbose=2", str(binary)],
-            capture_output=True, text=True, timeout=10,
-        )
-        if spctl.returncode != 0:
-            detail = (spctl.stderr.strip() or spctl.stdout.strip())[:200]
-            problems.append(
-                f"spctl rejection: {detail}. Reinstall v0.36.0+ "
-                "(install.sh now preserves Developer-ID notarization): "
-                "curl -fsSL https://raw.githubusercontent.com/"
-                "danielraffel/Shipyard/main/install.sh | sh"
-            )
-    except (subprocess.SubprocessError, FileNotFoundError):
-        pass
-
-    try:
         verify = subprocess.run(
             ["codesign", "--verify", "--deep", str(binary)],
             capture_output=True, text=True, timeout=10,
@@ -728,7 +720,7 @@ def _check_macos_gatekeeper_health() -> dict[str, Any] | None:
             problems.append(
                 f"codesign --verify failed: {detail}. Binary "
                 "signature is broken; reinstall from the release "
-                "artifact."
+                "artifact via install.sh."
             )
     except (subprocess.SubprocessError, FileNotFoundError):
         pass
@@ -736,10 +728,10 @@ def _check_macos_gatekeeper_health() -> dict[str, Any] | None:
     if problems:
         return {
             "ok": False,
-            "version": "macOS Gatekeeper rejection risk",
+            "version": "macOS signing integrity issue",
             "detail": "\n  ".join(problems),
         }
-    return {"ok": True, "version": "Gatekeeper + codesign + xattr healthy"}
+    return {"ok": True, "version": "codesign + xattr healthy"}
 
 
 def _check_rich_bundle_health() -> dict[str, Any]:
@@ -823,9 +815,9 @@ def _check_daemon_version_drift(ctx: Context) -> dict[str, Any] | None:
             "version": f"daemon: <unknown>   cli: v{_self_version}",
             "detail": (
                 "The running daemon predates v0.26.0 and doesn't report "
-                "its own version. Run `shipyard daemon stop` to let the "
-                "next GUI launch (or `shipyard daemon start`) spawn a "
-                "fresh daemon from the current binary."
+                "its own version. Run `shipyard daemon refresh` to swap "
+                "the stale daemon for a fresh one built from the current "
+                "CLI binary (#231)."
             ),
         }
     if daemon_version == _self_version:
@@ -839,9 +831,8 @@ def _check_daemon_version_drift(ctx: Context) -> dict[str, Any] | None:
         "detail": (
             "The running daemon is an older build than the CLI on "
             "PATH. New IPC message types (e.g. ship-state-list, added "
-            "in v0.25.0) will be silently dropped. Run "
-            "`shipyard daemon stop` to let the next GUI launch spawn "
-            "a fresh daemon from the current binary."
+            "in v0.25.0) will be silently dropped. Fix with: "
+            "`shipyard daemon refresh` (#231)."
         ),
     }
 
@@ -7530,6 +7521,105 @@ def daemon_stop(ctx: Context) -> None:
             render_message("daemon stopped.", style="green")
         else:
             render_message("daemon wasn't running.", style="dim")
+
+
+@daemon.command("refresh")
+@click.option(
+    "--repo",
+    "repos",
+    multiple=True,
+    help="Repo slug to register on the fresh daemon (repeatable).",
+)
+@pass_context
+def daemon_refresh(ctx: Context, repos: tuple[str, ...]) -> None:
+    """Stop the running daemon and start a fresh one.
+
+    Closes the #231 gap: after ``install.sh`` upgrades the CLI
+    binary, the long-running daemon still holds the OLD code and
+    new IPC message types are silently dropped. ``doctor`` flags
+    the drift but there was no one-command fix — this is it.
+
+    If no daemon is running, skips the stop + just starts a new
+    one (idempotent). ``--repo`` is forwarded to the start step
+    so operators don't lose their registered repo list. If no
+    repos are passed, the previous daemon's registered set is
+    re-used from the last status snapshot.
+    """
+    from shipyard.daemon.controller import read_daemon_status
+    from shipyard.daemon.runner import stop_running
+
+    state_dir = ctx.config.state_dir
+
+    # Capture the registered repo list from the current daemon
+    # before we stop it — otherwise the operator has to remember
+    # + re-pass every repo on the refresh call. When the caller
+    # explicitly passes --repo, those win (lets the refresh also
+    # re-register).
+    prior_repos: list[str] = []
+    if not repos:
+        try:
+            status = read_daemon_status(state_dir)
+        except Exception:  # noqa: BLE001 — best-effort snapshot
+            status = None
+        if status is not None:
+            registered = status.get("registered_repos") or []
+            if isinstance(registered, list):
+                prior_repos = [r for r in registered if isinstance(r, str)]
+
+    stopped = stop_running(state_dir)
+
+    # Immediately after stop, spawn a fresh one. Using the same
+    # helper `daemon start` uses keeps behavior identical to
+    # running the two commands by hand.
+    from shipyard.daemon.runner import DaemonSpawnFailedError, spawn_detached
+
+    repo_list = list(repos) if repos else prior_repos
+    if not repo_list:
+        render_error(
+            "No repos to register on the refreshed daemon. Pass "
+            "`--repo owner/name` (repeatable) to register, or "
+            "run `shipyard daemon start --repo ...` yourself."
+        )
+        sys.exit(1)
+    try:
+        pid = spawn_detached(state_dir=state_dir, repos=repo_list)
+    except DaemonSpawnFailedError as exc:
+        if ctx.json_mode:
+            ctx.output(
+                "daemon:refresh",
+                {
+                    "ok": False,
+                    "stopped_prior": stopped,
+                    "error": str(exc),
+                    "repos": repo_list,
+                },
+            )
+        else:
+            render_message(str(exc), style="red")
+        sys.exit(3)
+
+    if ctx.json_mode:
+        ctx.output(
+            "daemon:refresh",
+            {
+                "stopped_prior": stopped,
+                "new_pid": pid,
+                "repos": repo_list,
+            },
+        )
+    else:
+        if stopped:
+            render_message(
+                f"↻ daemon refreshed (new pid {pid}); "
+                f"registered {len(repo_list)} repo(s).",
+                style="green",
+            )
+        else:
+            render_message(
+                f"→ no prior daemon; started fresh (pid {pid}); "
+                f"registered {len(repo_list)} repo(s).",
+                style="green",
+            )
 
 
 @daemon.command("status")

--- a/tests/test_cli_daemon_refresh.py
+++ b/tests/test_cli_daemon_refresh.py
@@ -1,0 +1,163 @@
+"""Tests for ``shipyard daemon refresh`` (#231).
+
+Drives the CLI with a mocked ``read_daemon_status`` + ``stop_running``
++ ``run_detached`` so the test doesn't need a real running daemon.
+"""
+
+from __future__ import annotations
+
+import json
+import os  # noqa: F401 — kept for symmetry with sibling test modules
+import sys
+from pathlib import Path  # noqa: TC003 — runtime use via tmp_path
+from typing import Any
+
+import pytest  # noqa: TC002 — used at runtime via MonkeyPatch fixture
+from click.testing import CliRunner
+
+from shipyard.cli import main
+
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason=(
+        "#198: Click CliRunner isolation flake on Windows across "
+        "this family of CLI tests. Coverage preserved on Linux + macOS."
+    ),
+)
+
+
+def _assert_cli_ok(result: Any) -> None:
+    assert result.exit_code == 0, (
+        f"exit={result.exit_code} output={result.output!r} "
+        f"exc={result.exception!r}"
+    )
+
+
+def _patch_daemon(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    prior_running: bool = True,
+    prior_repos: list[str] | None = None,
+) -> dict[str, Any]:
+    """Install fakes for the three daemon-module hooks refresh uses.
+
+    Returns a dict the test can inspect to confirm which calls
+    happened in which order.
+    """
+    calls: dict[str, Any] = {
+        "stop_called": False,
+        "run_detached_repos": None,
+        "run_detached_pid": 99999,
+    }
+
+    def fake_read_status(state_dir):
+        if not prior_running:
+            return None
+        return {
+            "shipyard_version": "0.38.0",
+            "registered_repos": prior_repos or [],
+        }
+
+    def fake_stop(state_dir):
+        calls["stop_called"] = True
+        return prior_running
+
+    def fake_spawn_detached(*, state_dir, repos):
+        calls["run_detached_repos"] = list(repos)
+        return calls["run_detached_pid"]
+
+    monkeypatch.setattr(
+        "shipyard.daemon.controller.read_daemon_status", fake_read_status,
+    )
+    monkeypatch.setattr(
+        "shipyard.daemon.runner.stop_running", fake_stop,
+    )
+    monkeypatch.setattr(
+        "shipyard.daemon.runner.spawn_detached", fake_spawn_detached,
+    )
+    return calls
+
+
+def test_refresh_restarts_with_explicit_repos(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    calls = _patch_daemon(
+        monkeypatch, prior_running=True, prior_repos=["owner/a"],
+    )
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        ["daemon", "refresh", "--repo", "owner/b", "--repo", "owner/c"],
+    )
+    _assert_cli_ok(result)
+    assert calls["stop_called"] is True
+    # Explicit --repo wins over whatever the prior daemon had.
+    assert calls["run_detached_repos"] == ["owner/b", "owner/c"]
+
+
+def test_refresh_reuses_prior_repos_when_none_passed(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    # Load-bearing UX: operators shouldn't have to remember which
+    # repos their daemon was serving. refresh reuses the prior set.
+    calls = _patch_daemon(
+        monkeypatch,
+        prior_running=True,
+        prior_repos=["owner/x", "owner/y"],
+    )
+    runner = CliRunner()
+    result = runner.invoke(main, ["daemon", "refresh"])
+    _assert_cli_ok(result)
+    assert calls["run_detached_repos"] == ["owner/x", "owner/y"]
+
+
+def test_refresh_without_running_daemon_starts_fresh(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    # If nothing's running, refresh still starts a fresh daemon —
+    # idempotent. The stop step runs but returns False (nothing to
+    # stop). Message text should reflect that.
+    _patch_daemon(
+        monkeypatch, prior_running=False,
+    )
+    runner = CliRunner()
+    result = runner.invoke(
+        main, ["daemon", "refresh", "--repo", "owner/a"],
+    )
+    _assert_cli_ok(result)
+    assert "no prior daemon" in result.output.lower() or \
+           "started fresh" in result.output.lower()
+
+
+def test_refresh_refuses_when_no_repos_available(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    # Prior daemon had no repos AND caller didn't pass --repo. We
+    # can't cleanly spawn a daemon with no repos registered, so
+    # refuse loudly and tell the operator how to recover.
+    _patch_daemon(
+        monkeypatch, prior_running=True, prior_repos=[],
+    )
+    runner = CliRunner()
+    result = runner.invoke(main, ["daemon", "refresh"])
+    assert result.exit_code != 0
+    assert "--repo" in result.output
+
+
+def test_refresh_emits_json_envelope(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    # Agent workflows (hooks, CI) need a parseable envelope.
+    _patch_daemon(
+        monkeypatch, prior_running=True, prior_repos=["owner/a"],
+    )
+    runner = CliRunner()
+    result = runner.invoke(
+        main, ["--json", "daemon", "refresh", "--repo", "owner/a"],
+    )
+    _assert_cli_ok(result)
+    parsed = json.loads(result.output)
+    assert parsed["command"] == "daemon:refresh"
+    assert parsed["stopped_prior"] is True
+    assert parsed["new_pid"] == 99999
+    assert parsed["repos"] == ["owner/a"]

--- a/tests/test_doctor_gatekeeper.py
+++ b/tests/test_doctor_gatekeeper.py
@@ -95,28 +95,37 @@ def test_quarantine_xattr_flagged(
     assert "xattr -d com.apple.quarantine" in result["detail"]
 
 
-def test_spctl_rejection_flagged(
+def test_spctl_rejection_is_NOT_flagged_anymore(  # noqa: N802 — load-bearing test name
     monkeypatch: pytest.MonkeyPatch, tmp_path
 ) -> None:
+    # #231: spctl --assess rejects v0.44.0 stapled-dmg-extracted CLI
+    # binaries by default policy even though the binary launches
+    # cleanly under taskgated. We intentionally DO NOT probe spctl
+    # anymore — a rejection there doesn't predict real-world
+    # launch failure. This test locks that decision in: if spctl
+    # is invoked despite the rejection policy, the test fails
+    # (spctl being called at all means someone reintroduced the
+    # probe).
     _force_frozen_macos(monkeypatch, tmp_path)
+    spctl_called = {"n": 0}
 
     def fake_run(cmd, **kw):
         if cmd[0] == "spctl":
-            return _ok_proc(
-                returncode=3,
-                stderr="rejected (the code is valid but does not seem to be an app)",
-            )
+            spctl_called["n"] += 1
         return _ok_proc(returncode=0)
 
     with patch("shipyard.cli.subprocess.run", side_effect=fake_run):
         result = _check_macos_gatekeeper_health()
 
     assert result is not None
-    assert result["ok"] is False
-    assert "spctl" in result["detail"].lower()
-    # Reinstall hint must point at install.sh so the operator gets
-    # the v0.36.0+ notarization-preserving path.
-    assert "install.sh" in result["detail"]
+    assert result["ok"] is True, (
+        "Binary with healthy xattr + codesign must be marked ok "
+        "regardless of spctl policy"
+    )
+    assert spctl_called["n"] == 0, (
+        "spctl probe was removed per #231 — reintroducing it would "
+        "false-positive on v0.44.0+ stapled-dmg installs"
+    )
 
 
 def test_codesign_verify_failure_flagged(
@@ -137,19 +146,22 @@ def test_codesign_verify_failure_flagged(
     assert "codesign" in result["detail"].lower()
 
 
-def test_multiple_problems_all_surface(
+def test_multiple_real_problems_all_surface(
     monkeypatch: pytest.MonkeyPatch, tmp_path
 ) -> None:
-    # The failure mode reported on #216 is the compounded case —
-    # quarantine xattr AND spctl rejection. Both must appear in the
-    # detail so the operator has the full picture.
+    # Compounded case: quarantine xattr AND broken codesign. Both
+    # must appear in the detail so the operator has the full
+    # picture. Previously this test also checked spctl rejection,
+    # but #231 removed that probe because it false-positives on
+    # stapled-dmg-extracted CLI binaries. Now we check the two
+    # REAL problems side-by-side.
     _force_frozen_macos(monkeypatch, tmp_path)
 
     def fake_run(cmd, **kw):
         if cmd[0] == "xattr":
             return _ok_proc(stdout="com.apple.quarantine\n")
-        if cmd[0] == "spctl":
-            return _ok_proc(returncode=3, stderr="rejected")
+        if cmd[0] == "codesign":
+            return _ok_proc(returncode=1, stderr="code object is not signed at all")
         return _ok_proc(returncode=0)
 
     with patch("shipyard.cli.subprocess.run", side_effect=fake_run):
@@ -158,7 +170,7 @@ def test_multiple_problems_all_surface(
     assert result is not None
     assert result["ok"] is False
     assert "quarantine" in result["detail"].lower()
-    assert "spctl" in result["detail"].lower()
+    assert "codesign" in result["detail"].lower()
 
 
 def test_missing_tool_falls_through_without_raising(

--- a/tests/test_install_sh.py
+++ b/tests/test_install_sh.py
@@ -38,6 +38,29 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 INSTALL_SH = REPO_ROOT / "install.sh"
 
 
+def _platform_artifact_name() -> str:
+    """Return the shipyard-<os>-<arch> artifact name for the current
+    host, matching install.sh's ARTIFACT computation.
+
+    Used by tests that shim curl: the fake release URL's filename
+    must match the ARTIFACT regex install.sh greps against, and
+    that's computed from ``uname`` at run time. Hardcoding
+    ``shipyard-macos-arm64`` in the test breaks on Linux CI.
+    """
+    osname = "linux"
+    if sys.platform == "darwin":
+        osname = "macos"
+    elif sys.platform == "win32":
+        osname = "windows"
+    import platform as _platform
+    machine = _platform.machine().lower()
+    if machine in {"arm64", "aarch64"}:
+        arch = "arm64"
+    else:
+        arch = "x64"
+    return f"shipyard-{osname}-{arch}"
+
+
 def _run_dry(env: dict[str, str] | None = None) -> dict[str, str]:
     """Run install.sh in dry-run mode; parse KEY=value output."""
     merged_env = {**os.environ, "SHIPYARD_DRY_RUN": "1"}
@@ -673,10 +696,10 @@ def test_install_sh_force_reinstall_overrides_idempotency(tmp_path: Path) -> Non
     existing.write_text("#!/bin/sh\necho 'shipyard, version 0.46.0'\n")
     existing.chmod(0o755)
 
-    # The "release asset" the shim points at must have a filename
-    # that matches install.sh's ARTIFACT regex (shipyard-<os>-<arch>).
-    # Use the local binary renamed to that shape.
-    asset_src = tmp_path / "shipyard-macos-arm64"
+    # The "release asset" must match install.sh's ARTIFACT regex
+    # (`shipyard-<os>-<arch>`). Derive the name from the test
+    # host's uname so this works on Linux CI + macOS dev alike.
+    asset_src = tmp_path / _platform_artifact_name()
     asset_src.write_text("#!/bin/sh\necho 'shipyard, version 0.46.0'\n")
     asset_src.chmod(0o755)
 
@@ -728,7 +751,7 @@ def test_install_sh_idempotency_skipped_for_latest(tmp_path: Path) -> None:
     existing.write_text("#!/bin/sh\necho 'shipyard, version 0.46.0'\n")
     existing.chmod(0o755)
 
-    asset_src = tmp_path / "shipyard-macos-arm64"
+    asset_src = tmp_path / _platform_artifact_name()
     asset_src.write_text("#!/bin/sh\necho 'shipyard, version 0.46.0'\n")
     asset_src.chmod(0o755)
 

--- a/tests/test_install_sh.py
+++ b/tests/test_install_sh.py
@@ -610,6 +610,164 @@ exec "$REAL_CURL" "$@"
     )
 
 
+def test_install_sh_skips_download_when_already_at_target(tmp_path: Path) -> None:
+    # #231: redundant pulp+spectr back-to-back installs were burning
+    # ~15MB each time even when the target version matched what's
+    # already on disk. install.sh now short-circuits the download
+    # when VERSION_LABEL is a specific tag AND the existing binary
+    # reports that exact version. This test proves no download
+    # happens by shimming curl to drop a sentinel if called.
+    install_dir = tmp_path / "bin"
+    install_dir.mkdir()
+    existing = install_dir / "shipyard"
+    existing.write_text("#!/bin/sh\necho 'shipyard, version 0.46.0'\n")
+    existing.chmod(0o755)
+
+    shim_dir = tmp_path / "shim"
+    shim_dir.mkdir()
+    fake_curl = shim_dir / "curl"
+    sentinel = tmp_path / "curl-was-called"
+    fake_curl.write_text(f"""#!/bin/sh
+touch {sentinel!s}
+echo '"browser_download_url": "file://{existing}"'
+""")
+    fake_curl.chmod(0o755)
+
+    env = {
+        **os.environ,
+        "SHIPYARD_INSTALL_DIR": str(install_dir),
+        "SHIPYARD_VERSION": "v0.46.0",
+        "PATH": f"{shim_dir}:{os.environ.get('PATH', '')}",
+        "SHIPYARD_SKIP_SMOKE": "1",
+    }
+    env.pop("SHIPYARD_SKIP_DOWNLOAD", None)
+    env.pop("SHIPYARD_FORCE_REINSTALL", None)
+
+    result = subprocess.run(
+        ["bash", str(INSTALL_SH)],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, (
+        f"idempotent install failed: stdout={result.stdout!r} "
+        f"stderr={result.stderr!r}"
+    )
+    # Announcement so the operator sees the elision.
+    assert "Already at v0.46.0" in result.stdout or \
+           "skipping download" in result.stdout.lower()
+    # Sentinel proves curl was never invoked.
+    assert not sentinel.exists(), (
+        "curl should not have been invoked when the binary is "
+        "already at the target version"
+    )
+
+
+def test_install_sh_force_reinstall_overrides_idempotency(tmp_path: Path) -> None:
+    # Escape hatch: SHIPYARD_FORCE_REINSTALL=1 re-downloads even when
+    # the binary is already at the target.
+    install_dir = tmp_path / "bin"
+    install_dir.mkdir()
+    existing = install_dir / "shipyard"
+    existing.write_text("#!/bin/sh\necho 'shipyard, version 0.46.0'\n")
+    existing.chmod(0o755)
+
+    # The "release asset" the shim points at must have a filename
+    # that matches install.sh's ARTIFACT regex (shipyard-<os>-<arch>).
+    # Use the local binary renamed to that shape.
+    asset_src = tmp_path / "shipyard-macos-arm64"
+    asset_src.write_text("#!/bin/sh\necho 'shipyard, version 0.46.0'\n")
+    asset_src.chmod(0o755)
+
+    shim_dir = tmp_path / "shim"
+    shim_dir.mkdir()
+    fake_curl = shim_dir / "curl"
+    sentinel = tmp_path / "curl-called"
+    fake_curl.write_text(f"""#!/bin/sh
+touch {sentinel!s}
+echo '"browser_download_url": "file://{asset_src}"'
+""")
+    fake_curl.chmod(0o755)
+
+    env = {
+        **os.environ,
+        "SHIPYARD_INSTALL_DIR": str(install_dir),
+        "SHIPYARD_VERSION": "v0.46.0",
+        "SHIPYARD_FORCE_REINSTALL": "1",
+        "PATH": f"{shim_dir}:{os.environ.get('PATH', '')}",
+        "SHIPYARD_SKIP_SMOKE": "1",
+    }
+    env.pop("SHIPYARD_SKIP_DOWNLOAD", None)
+
+    result = subprocess.run(
+        ["bash", str(INSTALL_SH)],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, (
+        f"--force-reinstall failed: stdout={result.stdout!r} "
+        f"stderr={result.stderr!r}"
+    )
+    assert sentinel.exists(), (
+        "SHIPYARD_FORCE_REINSTALL=1 must re-download even when "
+        "version matches"
+    )
+
+
+def test_install_sh_idempotency_skipped_for_latest(tmp_path: Path) -> None:
+    # VERSION_LABEL=latest requires a network round-trip to know
+    # what "latest" resolves to, so short-circuit doesn't apply.
+    # This test proves curl still gets called when targeting latest
+    # even when the existing binary "looks recent."
+    install_dir = tmp_path / "bin"
+    install_dir.mkdir()
+    existing = install_dir / "shipyard"
+    existing.write_text("#!/bin/sh\necho 'shipyard, version 0.46.0'\n")
+    existing.chmod(0o755)
+
+    asset_src = tmp_path / "shipyard-macos-arm64"
+    asset_src.write_text("#!/bin/sh\necho 'shipyard, version 0.46.0'\n")
+    asset_src.chmod(0o755)
+
+    shim_dir = tmp_path / "shim"
+    shim_dir.mkdir()
+    fake_curl = shim_dir / "curl"
+    sentinel = tmp_path / "curl-called"
+    fake_curl.write_text(f"""#!/bin/sh
+touch {sentinel!s}
+echo '"browser_download_url": "file://{asset_src}"'
+""")
+    fake_curl.chmod(0o755)
+
+    env = {
+        **os.environ,
+        "SHIPYARD_INSTALL_DIR": str(install_dir),
+        "PATH": f"{shim_dir}:{os.environ.get('PATH', '')}",
+        "SHIPYARD_SKIP_SMOKE": "1",
+    }
+    env.pop("SHIPYARD_SKIP_DOWNLOAD", None)
+    env.pop("SHIPYARD_VERSION", None)  # defaults to latest
+    env.pop("SHIPYARD_FORCE_REINSTALL", None)
+
+    result = subprocess.run(
+        ["bash", str(INSTALL_SH)],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, (
+        f"latest install failed: stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+    assert sentinel.exists(), (
+        "VERSION_LABEL=latest must consult the network — "
+        "can't short-circuit without resolving 'latest'"
+    )
+
+
 def test_install_sh_falls_back_to_bare_macho_when_no_dmg(tmp_path: Path) -> None:
     # Backward compat: if a tag has no .dmg asset (older releases,
     # forks without the local-sign script, etc.) install.sh must

--- a/tests/test_install_sh.py
+++ b/tests/test_install_sh.py
@@ -39,13 +39,21 @@ INSTALL_SH = REPO_ROOT / "install.sh"
 
 
 def _platform_artifact_name() -> str:
-    """Return the shipyard-<os>-<arch> artifact name for the current
-    host, matching install.sh's ARTIFACT computation.
+    """Return the full release-asset filename for the current host.
 
-    Used by tests that shim curl: the fake release URL's filename
-    must match the ARTIFACT regex install.sh greps against, and
-    that's computed from ``uname`` at run time. Hardcoding
-    ``shipyard-macos-arm64`` in the test breaks on Linux CI.
+    Matches install.sh's ARTIFACT + `.exe`-suffix convention so the
+    test fixture looks exactly like the real GitHub release asset:
+    ``shipyard-linux-x64`` / ``shipyard-macos-arm64`` / etc. —
+    with ``.exe`` appended on Windows.
+
+    Load-bearing for tests that shim curl: the fake URL's filename
+    must match install.sh's RELEASE_URL grep. Install.sh tolerates
+    both ``<ARTIFACT>"`` and ``<ARTIFACT>.exe"`` so technically
+    either works on any host, but we mirror reality so a reviewer
+    reading the fixture sees the real asset shape. Tests in this
+    module are currently skipped on Windows via the module-level
+    pytestmark; the Windows branch here is kept correct in case
+    that skip is lifted later.
     """
     osname = "linux"
     if sys.platform == "darwin":
@@ -58,7 +66,8 @@ def _platform_artifact_name() -> str:
         arch = "arm64"
     else:
         arch = "x64"
-    return f"shipyard-{osname}-{arch}"
+    base = f"shipyard-{osname}-{arch}"
+    return f"{base}.exe" if osname == "windows" else base
 
 
 def _run_dry(env: dict[str, str] | None = None) -> dict[str, str]:


### PR DESCRIPTION
Closes #231 (both asks).

## 1. \`shipyard daemon refresh\`

One-command replacement for \`daemon stop && daemon start\`. Doctor's daemon-version drift row now points at this command so the diagnostic is actionable instead of advisory.

\`\`\`
shipyard daemon refresh                 # reuse prior daemon's repo list
shipyard daemon refresh --repo o/r      # explicit repos
\`\`\`

## 2. Gatekeeper false-positive fix

\`spctl --assess\` default policy rejects bare CLI Mach-O by type (\"not an app\") regardless of signature validity. For v0.44.0's stapled-dmg-extracted binary that launches cleanly under taskgated, spctl still says \"rejected\" — which my doctor check then surfaced as \`✗ macos-gatekeeper\` even on a healthy install. Removed the spctl probe. Kept the two probes that ARE definitive:

- \`com.apple.quarantine\` xattr presence
- \`codesign --verify --deep\` integrity check

## Tests

- 5 new cases in \`tests/test_cli_daemon_refresh.py\` (explicit repos, prior-repo reuse, no-prior-daemon fresh start, refuse-without-any-repos, JSON envelope)
- Updated \`tests/test_doctor_gatekeeper.py\` — renamed the old spctl-rejection-flagged test to \`test_spctl_rejection_is_NOT_flagged_anymore\`, which fails if spctl is ever invoked again (lock-in)
- Replaced the compound-problem test with quarantine+codesign instead of quarantine+spctl

All 30 tests in the affected modules pass. Ruff clean.

## Ships as v0.46.0

Timeline:
- v0.45.0 (firing now from PR #232) — \`shipyard pin bump\` only
- v0.46.0 (this PR + version bump) — daemon refresh + doctor fix

Consumer pin bumps to v0.46.0 get everything — the pin-bump command AND the doctor fix AND the daemon refresh command, all in one installer run.