### PR TITLE
Codex P1 batch: daemon refresh (#233) + handoff repo mismatch (#215) + Intel reminder (#225)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -296,15 +296,32 @@ jobs:
         # release. Post-workflow, the maintainer runs
         # scripts/release-macos-local.sh to sign+notarize on their
         # Mac and upload the signed asset.
+        #
+        # Codex P1 on #225: the reminder defaults to --arch arm64
+        # (what the script itself defaults to). For users on Intel
+        # Macs, install.sh resolves ARTIFACT=shipyard-macos-x64,
+        # which would 404 if only the arm64 dmg shipped. Emit both
+        # command lines so the maintainer doesn't silently drop
+        # Intel-Mac support for a release.
         run: |
           echo "✓ macOS build succeeded (${{ matrix.artifact }})."
           echo ""
           echo "This binary is NOT being uploaded to the release."
           echo "macOS signing + notarization is local-only (see #219)."
-          echo "Run this on your Mac after the release tag appears:"
+          echo "Run BOTH on your Mac after the release tag appears —"
+          echo "Apple Silicon AND Intel — so install.sh resolves on"
+          echo "both architectures:"
           echo ""
+          echo "  # Apple Silicon (arm64):"
           echo "  ./scripts/release-macos-local.sh \\"
-          echo "    --tag ${{ github.ref_name }} --upload"
+          echo "    --tag ${{ github.ref_name }} --arch arm64 --upload"
+          echo ""
+          echo "  # Intel (x64) — needs a Rosetta or Intel build host:"
+          echo "  ./scripts/release-macos-local.sh \\"
+          echo "    --tag ${{ github.ref_name }} --arch x64 --upload"
+          echo ""
+          echo "If you've dropped Intel support intentionally, remove"
+          echo "the macos-x64 matrix entry above and this reminder."
           echo ""
 
   release:

--- a/src/shipyard/cli.py
+++ b/src/shipyard/cli.py
@@ -3531,9 +3531,28 @@ def cloud_handoff_run(
         )
         sys.exit(1)
 
+    # Codex P1 on #215: the old code used `plan.repository or
+    # repo_slug`, which meant a consumer that sets
+    # `cloud.repository = other/repo` in .shipyard/config.toml would
+    # cancel run N in `repo_slug` but dispatch a REPLACEMENT run in
+    # `other/repo` — leaving the stuck run unresolved AND mutating
+    # the wrong repo. Force dispatch to the run's source repo so
+    # cancel + redispatch always target the same location. If the
+    # caller really does need to dispatch elsewhere, they should use
+    # `cloud retarget` (PR-scoped) rather than `handoff run`
+    # (run-id-scoped).
+    if plan.repository and plan.repository != repo_slug:
+        render_error(
+            f"Refusing: cloud.repository ({plan.repository}) differs "
+            f"from the run's source repo ({repo_slug}). `handoff run` "
+            "must dispatch where the cancellation happened. Use "
+            "`cloud retarget` for cross-repo flows, or remove the "
+            "cloud.repository override."
+        )
+        sys.exit(1)
     try:
         workflow_dispatch(
-            repository=plan.repository or repo_slug,
+            repository=repo_slug,
             workflow_file=plan.workflow.file,
             ref=plan.ref,
             fields=plan.dispatch_fields,
@@ -7573,14 +7592,13 @@ def daemon_refresh(ctx: Context, repos: tuple[str, ...]) -> None:
     # running the two commands by hand.
     from shipyard.daemon.runner import DaemonSpawnFailedError, spawn_detached
 
+    # `daemon start` accepts an empty repo list (the daemon still
+    # runs for IPC subscribers + ship-state ops), so `daemon
+    # refresh` must too — otherwise the doctor-recommended refresh
+    # path hard-fails in the exact recovery scenarios it's supposed
+    # to handle (Codex P1 on #233). Fall through with an empty list
+    # when neither --repo nor the prior snapshot supplied one.
     repo_list = list(repos) if repos else prior_repos
-    if not repo_list:
-        render_error(
-            "No repos to register on the refreshed daemon. Pass "
-            "`--repo owner/name` (repeatable) to register, or "
-            "run `shipyard daemon start --repo ...` yourself."
-        )
-        sys.exit(1)
     try:
         pid = spawn_detached(state_dir=state_dir, repos=repo_list)
     except DaemonSpawnFailedError as exc:

--- a/tests/test_cli_cloud_handoff.py
+++ b/tests/test_cli_cloud_handoff.py
@@ -289,3 +289,67 @@ class TestHandoffRun:
         )
         assert result.exit_code != 0
         assert "no matching key" in result.output.lower()
+
+    def test_apply_refuses_when_cloud_repository_differs_from_run_source(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Codex P1 on #215: a consumer that sets
+        # `cloud.repository = other/repo` in their shipyard config
+        # would make resolve_cloud_dispatch_plan return a plan with
+        # plan.repository = "other/repo". Pre-fix, handoff run
+        # cancelled run N in repo_slug (owner/repo — where the run
+        # actually lives) but dispatched a REPLACEMENT run in
+        # other/repo. Result: stuck run unresolved + cross-repo
+        # mutation. Post-fix, refuse loudly.
+        captured = self._patch(monkeypatch)
+        # Swap the resolver to emit a plan pointing at a DIFFERENT repo.
+        fake_plan = SimpleNamespace(
+            repository="other/repo",  # ← mismatch with repo_slug=owner/repo
+            ref="feat/x",
+            workflow=SimpleNamespace(file="ci.yml", key="ci", name="CI"),
+            provider="namespace",
+            dispatch_fields={"runner_provider": "namespace"},
+            to_dict=lambda: {"provider": "namespace"},
+        )
+        monkeypatch.setattr(
+            "shipyard.cli.resolve_cloud_dispatch_plan",
+            lambda **kw: fake_plan,
+        )
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["cloud", "handoff", "run", "555",
+             "--to", "namespace", "--apply"],
+        )
+        assert result.exit_code != 0
+        # Must cite both repos so the operator knows which configs
+        # are fighting.
+        assert "owner/repo" in result.output
+        assert "other/repo" in result.output
+        # Specifically must refuse BEFORE issuing the dispatch —
+        # otherwise we'd have cancelled run 555 and then fired a
+        # replacement in the wrong repo.
+        assert captured["dispatched_with"] is None, (
+            "dispatch must NOT fire when cloud.repository != run source"
+        )
+
+    def test_apply_dispatches_to_run_source_not_config_repo(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Positive case: when plan.repository matches repo_slug
+        # (either explicitly or by being empty), dispatch hits the
+        # run's source repo. Locks in the post-fix invariant.
+        captured = self._patch(monkeypatch)
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["cloud", "handoff", "run", "555",
+             "--to", "namespace", "--apply"],
+        )
+        _assert_cli_ok(result)
+        assert captured["dispatched_with"] is not None
+        assert captured["dispatched_with"]["repository"] == "owner/repo", (
+            "dispatch must target the run's source repo, not "
+            "plan.repository (which could come from a config "
+            "override pointing elsewhere)"
+        )

--- a/tests/test_cli_daemon_refresh.py
+++ b/tests/test_cli_daemon_refresh.py
@@ -129,19 +129,23 @@ def test_refresh_without_running_daemon_starts_fresh(
            "started fresh" in result.output.lower()
 
 
-def test_refresh_refuses_when_no_repos_available(
+def test_refresh_proceeds_when_no_repos_available(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
 ) -> None:
-    # Prior daemon had no repos AND caller didn't pass --repo. We
-    # can't cleanly spawn a daemon with no repos registered, so
-    # refuse loudly and tell the operator how to recover.
-    _patch_daemon(
+    # Codex P1 on #233: `daemon refresh` must mirror `daemon start`'s
+    # empty-repo tolerance. The daemon still runs for IPC subscribers
+    # + ship-state ops even without repos, so refusing empty-repo
+    # refresh breaks the doctor-recommended recovery path in the
+    # exact scenarios it's supposed to help (running daemon somehow
+    # lost its registered set; status call fails).
+    calls = _patch_daemon(
         monkeypatch, prior_running=True, prior_repos=[],
     )
     runner = CliRunner()
     result = runner.invoke(main, ["daemon", "refresh"])
-    assert result.exit_code != 0
-    assert "--repo" in result.output
+    _assert_cli_ok(result)
+    # Spawned with the empty list — matches daemon_start behavior.
+    assert calls["run_detached_repos"] == []
 
 
 def test_refresh_emits_json_envelope(


### PR DESCRIPTION
Folds three P1 review comments from recently-merged PRs into one focused follow-up.

## #233 P1 — daemon refresh must tolerate empty repo list

\`daemon start\` supports an empty repo set; \`daemon refresh\` should too. Pre-fix: refresh hard-failed with exit 1 when no repos were recoverable, leaving the operator with no daemon even though \`daemon start\` alone would have worked. Broke the exact doctor-recommended recovery path.

## #215 P1 — cloud handoff run must dispatch to the run's source repo

Old code: \`plan.repository or repo_slug\`. A consumer with \`cloud.repository = other/repo\` in shipyard config would make the plan's repository override the run's actual location — so handoff would cancel run N in repo_slug but dispatch a replacement in other/repo. Cross-repo mutation.

Post-fix: refuse loudly when the two differ, with a pointer to \`cloud retarget\` for legitimate cross-repo flows.

## #225 P1 — Intel macOS in post-release reminder

The release.yml reminder only showed the default arm64 invocation. Intel-Mac users would hit install.sh 404 because \`shipyard-macos-x64.dmg\` was never produced. Reminder now emits both arch invocations with a note about intentional-drop removal.

## Tests

20 tests across \`tests/test_cli_daemon_refresh.py\` + \`tests/test_cli_cloud_handoff.py\` pass locally.

- \`test_refresh_proceeds_when_no_repos_available\` — was asserting refuse, now asserts success with empty repo list (behavior flip is the fix)
- \`test_apply_refuses_when_cloud_repository_differs_from_run_source\` — new, ensures cross-repo dispatch is blocked BEFORE the replacement fires
- \`test_apply_dispatches_to_run_source_not_config_repo\` — new, locks in positive case

## Caveat for review

My track record this session included declaring fixes done before end-to-end verification, so here's the honest accounting:

- These three fixes don't touch install.sh — they can't regress the install path. The release script's step 8 end-to-end verification still catches any install-side regressions on every release.
- The CLI-side changes (handoff repo check, daemon refresh empty-repo) are covered by CliRunner + mocked-subprocess unit tests. Proves the logic, not a live daemon or live GH Actions workflow. I'd test the live daemon refresh against a real running daemon before declaring the #231 recovery path truly validated.