### PR TITLE
Codex P2 batch: retry budget (#214), doctor detail (#214), PS quote guard (#213), release-script diag (#224)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to Shipyard are documented here. Each entry links
 to its [GitHub Release](https://github.com/danielraffel/Shipyard/releases).
 
 <a id="v0450"></a>
+## [0.46.0]
+
 ## [0.45.0] - 2026-04-24
 
 - feat(cli): shipyard pin show + shipyard pin bump (#222) ([#230](https://github.com/danielraffel/Shipyard/pull/230))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "shipyard"
-version = "0.45.0"
+version = "0.46.0"
 description = "Cross-platform CI coordination — local VMs, SSH hosts, cloud runners"
 readme = "README.md"
 license = "MIT"

--- a/scripts/release-macos-local.sh
+++ b/scripts/release-macos-local.sh
@@ -225,9 +225,17 @@ if ! OUTPUT=$("$MOUNT_POINT/shipyard" --version 2>&1); then
     echo "       Do NOT ship this binary." >&2
     echo "" >&2
     echo "       Diagnostics:" >&2
-    codesign --verify --deep --strict --verbose=4 "$DIST_DMG" 2>&1 | sed 's/^/         /' >&2
-    xcrun stapler validate -v "$DIST_DMG" 2>&1 | sed 's/^/         /' >&2
-    spctl --assess --type install -vv "$DIST_DMG" 2>&1 | sed 's/^/         /' >&2
+    # `|| true` on every probe (Codex P2 on #224). These run under
+    # `set -euo pipefail`, and on a genuinely-broken DMG
+    # `codesign --verify` / `stapler validate` / `spctl --assess`
+    # will all exit non-zero — which is the *point* of running them.
+    # Without the fallthrough, pipefail terminates the script on the
+    # first probe failure and the operator loses the rest of the
+    # diagnostics AND the documented exit 3 (launch-test failure
+    # signal) becomes a generic exit 1 instead.
+    codesign --verify --deep --strict --verbose=4 "$DIST_DMG" 2>&1 | sed 's/^/         /' >&2 || true
+    xcrun stapler validate -v "$DIST_DMG" 2>&1 | sed 's/^/         /' >&2 || true
+    spctl --assess --type install -vv "$DIST_DMG" 2>&1 | sed 's/^/         /' >&2 || true
     echo "" >&2
     echo "       Crash report (if any) under:" >&2
     echo "         ~/Library/Logs/DiagnosticReports/shipyard-*.ips" >&2

--- a/src/shipyard/__init__.py
+++ b/src/shipyard/__init__.py
@@ -1,3 +1,3 @@
 """Shipyard — Cross-platform CI coordination."""
 
-__version__ = "0.45.0"
+__version__ = "0.46.0"

--- a/src/shipyard/bundle/git_bundle.py
+++ b/src/shipyard/bundle/git_bundle.py
@@ -161,6 +161,18 @@ def upload_bundle(
         # written to `$HOME/tmp/x.bundle` on upload but read from
         # `/tmp/x.bundle` on apply, reproducing the exact #210 bug
         # for a different path shape (Codex P1 on #211).
+        # The PS single-quote literal we build below doesn't escape
+        # embedded `'`. Reject paths that contain one — that's
+        # script-injection surface on the rooted branch and a silent
+        # syntax break on both. Codex P2 on #213 caught that my #211
+        # fix only checked the relative branch; before then, rooted
+        # paths couldn't reach this code at all, so my change made it
+        # a regression. Apply the guard uniformly by hoisting it.
+        if "'" in remote_path:
+            return BundleResult(
+                success=False,
+                message=f"Refusing single-quoted remote_path: {remote_path!r}",
+            )
         is_rooted = (
             remote_path.startswith("\\\\")
             or remote_path.startswith("\\")
@@ -171,18 +183,10 @@ def upload_bundle(
                 and remote_path[0].isalpha()
             )
         )
-        if is_rooted:
-            resolved_dest = f"'{remote_path}'"
-        else:
-            # PS single-quote string → no escape needed for ordinary
-            # filenames; reject anything with a quote just in case a
-            # caller's path is adversarial.
-            if "'" in remote_path:
-                return BundleResult(
-                    success=False,
-                    message=f"Refusing single-quoted remote_path: {remote_path!r}",
-                )
-            resolved_dest = f"(Join-Path $HOME '{remote_path}')"
+        resolved_dest = (
+            f"'{remote_path}'" if is_rooted
+            else f"(Join-Path $HOME '{remote_path}')"
+        )
         ps_script = (
             f"$Dest = {resolved_dest};"
             f"$stdin = [Console]::OpenStandardInput();"

--- a/src/shipyard/core/queue.py
+++ b/src/shipyard/core/queue.py
@@ -399,8 +399,14 @@ def _retry_replace_on_windows(src: Path, dst: Path) -> None:
         except PermissionError as exc:
             last_exc = exc
             base = 0.05 * (attempt + 1)
-            jitter = _random.uniform(0.0, base)
-            _time.sleep(base + jitter)
+            # Jittered backoff AROUND base, not base + unsigned jitter.
+            # Original code did `base + random.uniform(0, base)` which
+            # spans [base, 2*base] per attempt (mean 1.5*base), stretching
+            # the 18-attempt budget from ~8s to up to ~17s worst case
+            # and making a genuinely-denied target appear to hang.
+            # Codex P2 on #214. Use [0.5*base, 1.5*base] — same range
+            # centered on base, total budget stays at ~8s mean.
+            _time.sleep(_random.uniform(0.5 * base, 1.5 * base))
     assert last_exc is not None
     raise last_exc
 

--- a/src/shipyard/output/human.py
+++ b/src/shipyard/output/human.py
@@ -258,7 +258,7 @@ def render_doctor(checks: dict[str, Any], ready: bool) -> None:
         for name, info in items.items():
             ok = info.get("ok", False)
             icon = "[green]✓[/]" if ok else "[red]✗[/]"
-            detail = info.get("version", info.get("error", info.get("detail", "")))
+            summary = info.get("version", info.get("error", info.get("detail", "")))
             extra = ""
             if info.get("user"):
                 extra = f" (as {info['user']})"
@@ -266,7 +266,19 @@ def render_doctor(checks: dict[str, Any], ready: bool) -> None:
                 extra = f" ({info['workspace']})"
             elif info.get("latency_ms"):
                 extra = f" ({info['latency_ms']}ms)"
-            console.print(f"    {icon} {name} {detail}{extra}")
+            console.print(f"    {icon} {name} {summary}{extra}")
+            # Codex P2 on #214: pre-fix, `detail` was only rendered
+            # when `version` was absent — which it never is for
+            # failure rows that want to show actionable recovery info
+            # (e.g. the rich-bundle reinstall hint on corrupt
+            # PyInstaller installs). Show `detail` on every failing
+            # row as indented follow-up lines so the user sees the
+            # fix command without needing --json mode.
+            failure_detail = info.get("detail") if not ok else None
+            if failure_detail and failure_detail != summary:
+                for line in failure_detail.splitlines():
+                    if line.strip():
+                        console.print(f"        [dim]{line.rstrip()}[/]")
         console.print()
 
     if ready:

--- a/tests/core/test_queue_atomic_writes.py
+++ b/tests/core/test_queue_atomic_writes.py
@@ -329,12 +329,17 @@ def test_retry_replace_uses_jittered_backoff(monkeypatch, tmp_path: Path) -> Non
     assert len(sleeps) == 3
     assert len(jitter_calls) == 3
 
-    # Jitter bounds grow with the attempt — base = 0.05 * (n+1).
+    # Jitter range is [0.5*base, 1.5*base] with base = 0.05 * (n+1).
+    # Codex P2 on #214: the earlier [base, 2*base] shape stretched the
+    # budget mean to 1.5*base (17s worst case for 18 attempts instead
+    # of the documented ~8s). The [0.5*base, 1.5*base] shape keeps
+    # mean = base.
     # Verifies the jitter range isn't constant (which would preserve
-    # lockstep across concurrent callers).
-    assert jitter_calls[0][1] == pytest.approx(0.05)
-    assert jitter_calls[1][1] == pytest.approx(0.10)
-    assert jitter_calls[2][1] == pytest.approx(0.15)
+    # lockstep across concurrent callers) AND that it's centered on
+    # base (Codex P2 budget-preservation fix).
+    assert jitter_calls[0] == (pytest.approx(0.025), pytest.approx(0.075))
+    assert jitter_calls[1] == (pytest.approx(0.050), pytest.approx(0.150))
+    assert jitter_calls[2] == (pytest.approx(0.075), pytest.approx(0.225))
 
 
 def test_retry_replace_surfaces_error_when_budget_exhausted(

--- a/tests/executor/test_210_bundle_path_fixes.py
+++ b/tests/executor/test_210_bundle_path_fixes.py
@@ -172,6 +172,55 @@ def test_decoder_no_sentinel_unchanged() -> None:
     assert maybe_decode_clixml("just a regular error") == "just a regular error"
 
 
+# -- Codex P2 on #213: single-quote guard applies to rooted paths too
+# Pre-fix (#213), only the non-rooted (Join-Path) branch rejected
+# single-quoted paths. The rooted branch interpolated the raw value
+# into `$Dest = '...'` with no escaping, which breaks PS parsing
+# (`$Dest = '/tmp/o'hare.bundle'`) and — with untrusted config —
+# becomes script-injection surface. This test locks in that the
+# guard now applies uniformly.
+
+def test_upload_rejects_single_quoted_rooted_path(tmp_path) -> None:
+    bundle = tmp_path / "shipyard.bundle"
+    bundle.write_bytes(b"fake")
+
+    def fake_run(cmd, **kw):
+        raise AssertionError(
+            "subprocess.run must NOT be called when the rooted path "
+            "contains a single quote — the script should refuse before "
+            "handing a broken PS command to ssh"
+        )
+
+    with patch("shipyard.bundle.git_bundle.subprocess.run", side_effect=fake_run):
+        result = upload_bundle(
+            bundle_path=bundle,
+            host="win",
+            remote_path=r"/tmp/o'hare.bundle",
+            is_windows=True,
+        )
+    assert result.success is False
+    assert "single-quoted" in result.message.lower()
+
+
+def test_upload_rejects_single_quoted_unc_path(tmp_path) -> None:
+    # Same guard for UNC paths (\\server\share\…).
+    bundle = tmp_path / "shipyard.bundle"
+    bundle.write_bytes(b"fake")
+
+    def fake_run(cmd, **kw):
+        raise AssertionError("should refuse before subprocess")
+
+    with patch("shipyard.bundle.git_bundle.subprocess.run", side_effect=fake_run):
+        result = upload_bundle(
+            bundle_path=bundle,
+            host="win",
+            remote_path=r"\\server\share\o'hare.bundle",
+            is_windows=True,
+        )
+    assert result.success is False
+    assert "single-quoted" in result.message.lower()
+
+
 # -- Codex P1 on #211 (slash-prefixed absolute paths) --------------
 # `_is_windows_absolute_path` in executor/ssh_windows.py treats
 # `/foo` as absolute (line 379). The earlier #210 upload-side

--- a/tests/output/test_render_doctor_detail.py
+++ b/tests/output/test_render_doctor_detail.py
@@ -1,0 +1,98 @@
+"""render_doctor must show `detail` on failing rows (Codex P2 on #214).
+
+Before the fix, render_doctor only rendered `version` (via
+``info.get("version", info.get("error", info.get("detail", "")))``),
+so a failing check's actionable recovery text — stored in
+``detail`` — never reached the non-JSON user. Doctor would say
+``✗ rich-bundle rich bundle read failed (zlib.error)`` with no
+reinstall command, leaving users stranded.
+"""
+
+from __future__ import annotations
+
+import io
+from contextlib import redirect_stdout
+
+
+def _render(checks: dict) -> str:
+    # render_doctor prints via rich.console.Console; redirect stdout
+    # and strip rich's style markup by telling Console to render
+    # plain. Simpler: capture stdout raw — rich uses ANSI codes but
+    # the text content is still assertable.
+    from shipyard.output.human import render_doctor
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        render_doctor(checks, ready=False)
+    # Strip ANSI escape sequences for stable assertions.
+    import re
+    return re.sub(r"\x1b\[[0-9;]*m", "", buf.getvalue())
+
+
+def test_failure_row_surfaces_detail_below_summary() -> None:
+    # A check with ok=False AND a detail must render the detail as
+    # an indented follow-up line. Rich-bundle is the motivating case
+    # (#214 P2): the reinstall command lives in detail.
+    out = _render({
+        "Core": {
+            "rich-bundle": {
+                "ok": False,
+                "version": "rich bundle read failed (zlib.error)",
+                "detail": (
+                    "Error -3 while decompressing data: incorrect header check\n"
+                    "  Fix: Reinstall with: curl -fsSL https://example/install.sh | sh"
+                ),
+            },
+        },
+    })
+    # Summary line present.
+    assert "rich bundle read failed (zlib.error)" in out
+    # Detail surfaced too — the fix command must be visible.
+    assert "incorrect header check" in out
+    assert "curl -fsSL https://example/install.sh | sh" in out
+
+
+def test_passing_row_suppresses_detail() -> None:
+    # On ok=True rows, detail stays hidden. Healthy checks don't
+    # need multi-line recovery text cluttering the output.
+    out = _render({
+        "Core": {
+            "git": {
+                "ok": True,
+                "version": "git version 2.45.0",
+                "detail": "this should NOT appear",
+            },
+        },
+    })
+    assert "git version 2.45.0" in out
+    assert "this should NOT appear" not in out
+
+
+def test_failure_row_without_detail_still_renders() -> None:
+    # Backward compat: a failing check that has only `version`
+    # (no detail) renders the same one-line shape as before — no
+    # crash, no stray "None" text.
+    out = _render({
+        "Core": {
+            "something": {
+                "ok": False,
+                "version": "broke",
+            },
+        },
+    })
+    assert "broke" in out
+    assert "None" not in out
+
+
+def test_detail_same_as_version_is_not_duplicated() -> None:
+    # If detail == version (some checks do this), don't double-
+    # render. Keeps the output tight.
+    out = _render({
+        "Core": {
+            "x": {
+                "ok": False,
+                "version": "same text",
+                "detail": "same text",
+            },
+        },
+    })
+    assert out.count("same text") == 1


### PR DESCRIPTION
Four P2 review comments from recent PRs, folded into one follow-up since they're small.

## What's fixed

- **#214 P2a — Windows retry backoff stays within 8s budget.** My earlier jitter (\`base + random.uniform(0, base)\`) stretched the budget from ~8s to ~17s worst case. Now \`random.uniform(0.5*base, 1.5*base)\` centers on base with same spread.
- **#214 P2b — doctor renders \`detail\` on failing rows.** render_doctor prefers \`version\`; detail never reached non-JSON output. Now detail surfaces as indented follow-up lines on ok=False rows, so the rich-bundle reinstall hint (etc.) is visible.
- **#213 P2 — single-quote guard applies uniformly.** My #211 fix only checked the non-rooted Join-Path branch. A rooted path like \`/tmp/o'hare.bundle\` would break PS parsing AND opened script-injection surface. Guard is now at the top of the function.
- **#224 P2 — release script preserves exit 3 on launch-failure.** Under \`set -euo pipefail\`, diagnostic probes (\`codesign --verify\`, \`spctl --assess\`) returning non-zero kill the script before \`exit 3\` runs. Added \`|| true\` to each.

## Tests

- \`test_retry_replace_uses_jittered_backoff\` — asserts the new \`[0.5*base, 1.5*base]\` range
- \`tests/output/test_render_doctor_detail.py\` — 4 new cases (failure surfaces, passing hides, no-detail compat, no-duplication)
- \`test_upload_rejects_single_quoted_{rooted,unc}_path\` — refuse-before-subprocess

31 tests pass across the affected suites. Ruff clean.

## Related

- #214, #213, #224 — the PRs whose P2 comments this closes
- PR #234 (just merged) — the P1 sibling of this batch