### PR TITLE
#236: surface workflow scope as first-class install requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,12 +131,14 @@ You don't need everything — just what matches your setup:
 | Tool | Required? | What it's for | Install |
 |------|-----------|---------------|---------|
 | [git](https://github.com/git-guides/install-git) | Yes | Version control | Pre-installed on macOS |
-| [gh](https://github.com/cli/cli) | Yes (for PRs) | GitHub integration | `brew install gh` |
+| [gh](https://github.com/cli/cli) | Yes (for PRs) | GitHub integration[^gh-scope] | `brew install gh` |
 | `ssh` | For remote targets | Connect to VMs | Pre-installed on macOS / [Ubuntu](https://ubuntu.com/server/docs/how-to/security/openssh-server/) / [Windows](https://learn.microsoft.com/en-us/windows-server/administration/openssh/openssh_install_firstuse?tabs=gui&pivots=windows-11) |
 | [nsc](https://namespace.so/docs/reference/cli/installation) | For [Namespace](https://namespace.so) | Cloud runners | `brew install namespace-cli` |
 | [UTM](https://mac.getutm.app) / [Parallels](https://www.parallels.com/products/desktop/) | For VM fallback | Auto-boot VMs | `brew install --cask utm` |
 
 `shipyard doctor` checks all of this and tells you what's missing.
+
+[^gh-scope]: `gh` needs the **`workflow`** scope (classic PAT) or **Actions: Read and write** (fine-grained) for `shipyard cloud retarget`, `cloud handoff`, and any command that cancels + re-dispatches workflow runs. Quick fix: `gh auth refresh -h github.com -s workflow`. Full setup in [docs/install.md § First-run auth](docs/install.md#first-run-auth).
 
 ## This repo uses Shipyard
 

--- a/docs/cloud-retarget.md
+++ b/docs/cloud-retarget.md
@@ -103,11 +103,31 @@ Or run in parallel with `xargs -P` for faster propagation.
 
 ## Authentication
 
-Cancelling an individual job requires `gh api -X POST
-/repos/:owner/:repo/actions/jobs/:id/cancel`, which needs
-`actions:write` on the PAT `gh` is authenticated with. If your gh
-token lacks that scope, `cloud retarget` reports a clear message and
-exits 1 without attempting the dispatch half.
+Cancelling a workflow run uses `gh api -X POST
+/repos/:owner/:repo/actions/runs/:id/cancel` (the run-level endpoint
+GitHub exposes; `gh run cancel` wraps the same path). It needs the
+**`workflow` scope** on the PAT `gh` is authenticated with — GitHub's
+short name for `actions:write` on classic PATs, or **Actions: Read
+and write** on fine-grained tokens.
+
+If your gh token lacks that scope, `cloud retarget` reports a clear
+message and exits 1 without attempting the dispatch half:
+
+```
+error: Couldn't cancel the matching job(s). Your gh token may lack
+`actions:write` scope.
+```
+
+The fix is a one-liner for the common case: `gh auth refresh
+-h github.com -s workflow`. For fine-grained tokens and
+GitHub-App-backed identities (bots, `RELEASE_BOT_TOKEN`,
+`pulp-release-bot`, etc.), see [docs/install.md § First-run
+auth](install.md#first-run-auth) for where the scope actually lives
+per identity shape.
+
+`shipyard doctor` probes for the scope under the `Core` section
+(`gh-scope`); if it shows `✗`, you know to run the refresh before
+the next retarget.
 
 ## JSON mode
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -29,6 +29,47 @@ curl -fsSL https://generouscorp.com/Shipyard/install.sh | sh
 Downloads the right binary for your platform and installs it at
 `~/.local/bin/shipyard`.
 
+## First-run auth
+
+A few Shipyard commands (`cloud retarget`, `cloud handoff`, anything
+that cancels + re-dispatches a GitHub Actions workflow run) need a
+`gh` token with the **`workflow` scope** — GitHub's short name for
+`actions:write` on a classic PAT, or **Actions: Read and write** on a
+fine-grained token. Without it you'll hit:
+
+```
+error: Couldn't cancel the matching job(s). Your gh token may lack
+`actions:write` scope.
+```
+
+`shipyard doctor` probes for this; fix it at install time so the
+first retarget attempt doesn't surprise you.
+
+### Interactive gh login (most common)
+
+```bash
+gh auth refresh -h github.com -s workflow
+```
+
+Follow the browser prompt. You don't have to log out first —
+`refresh` adds the scope to your existing session.
+
+### Fine-grained personal access token
+
+github.com → Settings → Developer settings → Personal access tokens →
+**Fine-grained tokens** → edit the token that's stored in `gh auth` →
+**Actions: Read and write**. Save. `gh auth status` should now show
+the scope in its `Token scopes:` line.
+
+### GitHub App / bot identity
+
+If Shipyard is running under an App install (CI, `RELEASE_BOT_TOKEN`,
+a bot like `pulp-release-bot`), the scope lives on the **App's
+permissions**, not the invoking user's token. github.com →
+organizations/<org> → Settings → GitHub Apps → your app →
+**Permissions & events** → **Actions: Read and write**. Accept the
+install prompt on each repo after saving.
+
 ## Pin a specific version
 
 Pass `SHIPYARD_VERSION` to install an exact release instead of the

--- a/install.sh
+++ b/install.sh
@@ -382,6 +382,23 @@ if ! echo "${PATH}" | tr ':' '\n' | grep -q "^${INSTALL_DIR}$"; then
     echo ""
 fi
 
+# #236: classic PAT flow — flag missing `workflow` scope here so
+# the user fixes it at install time instead of discovering it
+# during `cloud retarget --apply`. Silent when gh isn't installed /
+# logged out (the doctor covers those) and silent for fine-grained
+# tokens + GitHub Apps which don't expose their scope list locally.
+if command -v gh >/dev/null 2>&1; then
+    gh_status_out=$(gh auth status 2>&1 || true)
+    if echo "${gh_status_out}" | grep -qi "Token scopes:" \
+        && ! echo "${gh_status_out}" | grep -q "'workflow'"; then
+        echo "heads up: \`shipyard cloud retarget\` + \`cloud handoff run --apply\`"
+        echo "  need the 'workflow' scope on your gh token, which isn't set."
+        echo "  Fix: gh auth refresh -h github.com -s workflow"
+        echo "  (Fine-grained tokens + GitHub Apps: docs/install.md § First-run auth)"
+        echo ""
+    fi
+fi
+
 echo "Next steps:"
 echo "  shipyard init        # set up a project"
 echo "  shipyard doctor      # check your environment"

--- a/src/shipyard/cli.py
+++ b/src/shipyard/cli.py
@@ -512,6 +512,12 @@ def doctor(ctx: Context, release_chain: bool, runners: bool) -> None:
     # Cloud providers
     cloud: dict[str, Any] = {}
     cloud["gh"] = _check_command("gh", "--version")
+    # #236: surface the workflow-scope requirement at install time
+    # instead of when the user hits `cloud retarget --apply` and
+    # gets "Couldn't cancel the matching job(s)" out of nowhere.
+    gh_scope = _check_gh_workflow_scope()
+    if gh_scope is not None:
+        cloud["gh-scope"] = gh_scope
     cloud["nsc"] = _check_command("nsc", "version")
     checks["Cloud providers"] = cloud
 
@@ -5459,6 +5465,59 @@ def _check_command(name: str, *args: str) -> dict[str, Any]:
         return {"ok": True, "version": version}
     except (FileNotFoundError, subprocess.TimeoutExpired):
         return {"ok": False, "error": "not installed"}
+
+
+def _check_gh_workflow_scope() -> dict[str, Any] | None:
+    """Probe the gh token for `workflow` scope. #236.
+
+    `shipyard cloud retarget --apply` and `cloud handoff run --apply`
+    both call `gh run cancel` / `gh api .../actions/runs/.../cancel`,
+    which need `workflow` (classic) / Actions: Read and write
+    (fine-grained). Without it, the first retarget attempt fails
+    partway through with "Couldn't cancel the matching job(s)".
+    Surface it here at install/doctor time instead.
+
+    Returns None when gh isn't installed or isn't authenticated
+    (not our problem to flag — the `gh` row already covers that).
+    Returns ok=True when the scope is present (classic PATs
+    include it in the `Token scopes:` line; fine-grained PATs have
+    no scope list at all, so we treat "gh auth status succeeded
+    but no scope line" as a neutral pass since we can't know
+    without hitting the API).
+    """
+    try:
+        result = subprocess.run(
+            ["gh", "auth", "status"],
+            capture_output=True, text=True, timeout=5,
+        )
+    except (subprocess.SubprocessError, FileNotFoundError):
+        return None
+    if result.returncode != 0:
+        # gh not logged in — unrelated to scope; stay quiet.
+        return None
+    combined = (result.stdout + result.stderr).lower()
+    # Classic PAT path prints `Token scopes: 'gist', 'repo', 'workflow'`.
+    if "token scopes" in combined:
+        if "'workflow'" in combined or '"workflow"' in combined:
+            return {"ok": True, "version": "workflow scope present"}
+        return {
+            "ok": False,
+            "version": "gh token missing `workflow` scope",
+            "detail": (
+                "`cloud retarget`/`cloud handoff run --apply` need "
+                "workflow scope to cancel runs. Fix:\n"
+                "  gh auth refresh -h github.com -s workflow\n"
+                "Fine-grained tokens + GitHub App identities: see "
+                "docs/install.md § First-run auth."
+            ),
+        }
+    # Fine-grained tokens + GitHub Apps don't list scopes in
+    # `gh auth status`. Can't verify without an API call; skip
+    # rather than false-positive.
+    return {
+        "ok": True,
+        "version": "gh auth (fine-grained / app) — scope not inspectable locally",
+    }
 
 
 def _resolve_validation(config: Config, mode: ValidationMode) -> dict[str, Any]:

--- a/tests/test_doctor_gh_workflow_scope.py
+++ b/tests/test_doctor_gh_workflow_scope.py
@@ -1,0 +1,133 @@
+"""Tests for doctor's `gh-scope` probe (#236).
+
+`shipyard cloud retarget --apply` + `cloud handoff run --apply` need
+`workflow` scope on the gh token to cancel runs. Pre-fix, the user
+only discovered the missing scope mid-retarget with a bare
+"Couldn't cancel the matching job(s)" error. The doctor probe
+surfaces it before that happens.
+
+Scope detection semantics covered here:
+  - gh not installed → probe returns None (silent; the `gh` row
+    already covers install state)
+  - gh logged out → probe returns None (unrelated to scope)
+  - classic PAT with workflow scope → ok=True
+  - classic PAT without workflow scope → ok=False + fix command
+  - fine-grained / GitHub App (no Token scopes line) → neutral pass
+    with a clarifying message (scopes not inspectable locally)
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import patch
+
+import pytest  # noqa: TC002 — MonkeyPatch fixture
+
+
+def _ok_proc(
+    returncode: int = 0,
+    stdout: str = "",
+    stderr: str = "",
+) -> Any:
+    return SimpleNamespace(returncode=returncode, stdout=stdout, stderr=stderr)
+
+
+def _call() -> Any:
+    from shipyard.cli import _check_gh_workflow_scope
+    return _check_gh_workflow_scope()
+
+
+def test_none_when_gh_not_installed(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_run(*args, **kw):
+        raise FileNotFoundError("gh")
+
+    with patch("shipyard.cli.subprocess.run", side_effect=fake_run):
+        assert _call() is None
+
+
+def test_none_when_gh_not_logged_in(monkeypatch: pytest.MonkeyPatch) -> None:
+    # gh exits non-zero with "You are not logged in" when unauthed.
+    def fake_run(*args, **kw):
+        return _ok_proc(
+            returncode=1, stderr="error: You are not logged in.",
+        )
+
+    with patch("shipyard.cli.subprocess.run", side_effect=fake_run):
+        assert _call() is None
+
+
+def test_ok_when_classic_pat_has_workflow_scope(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # gh's classic-PAT status output — real shape, stored on stderr
+    # for gh versions pre-2.46 and split across stdout/stderr for
+    # newer ones. We OR them when matching, so either works.
+    stderr_text = (
+        "github.com\n"
+        "  ✓ Logged in to github.com account danielraffel (keyring)\n"
+        "  - Active account: true\n"
+        "  - Git operations protocol: https\n"
+        "  - Token: gho_************************************\n"
+        "  - Token scopes: 'gist', 'read:org', 'repo', 'workflow'\n"
+    )
+    with patch(
+        "shipyard.cli.subprocess.run",
+        side_effect=lambda *a, **k: _ok_proc(stderr=stderr_text),
+    ):
+        result = _call()
+    assert result is not None
+    assert result["ok"] is True
+    assert "workflow" in result["version"].lower()
+
+
+def test_flags_missing_workflow_scope_on_classic_pat(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Same shape as above but `workflow` is absent — the exact
+    # state that bit the maintainer on pulp#711.
+    stderr_text = (
+        "github.com\n"
+        "  ✓ Logged in to github.com account danielraffel (keyring)\n"
+        "  - Token scopes: 'gist', 'read:org', 'repo'\n"
+    )
+    with patch(
+        "shipyard.cli.subprocess.run",
+        side_effect=lambda *a, **k: _ok_proc(stderr=stderr_text),
+    ):
+        result = _call()
+    assert result is not None
+    assert result["ok"] is False
+    # Version line names the missing scope so `render_doctor` surfaces it.
+    assert "workflow" in result["version"].lower()
+    # Detail must include the refresh command — one-liner fix.
+    assert "gh auth refresh -h github.com -s workflow" in result["detail"]
+    # And a pointer for fine-grained / GitHub App identities so
+    # users running under bots know where to look.
+    assert "fine-grained" in result["detail"].lower() or \
+           "install.md" in result["detail"].lower()
+
+
+def test_neutral_pass_when_no_token_scopes_line(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Fine-grained tokens + GitHub Apps don't list scopes in
+    # `gh auth status`. Classic-PAT grep misses → we neither
+    # false-positive nor silently skip; return ok=True with a
+    # clarifying version string so the operator knows we can't
+    # verify locally.
+    stderr_text = (
+        "github.com\n"
+        "  ✓ Logged in to github.com account danielraffel\n"
+        "  - Token: github_pat_11ABCDEF...\n"
+    )
+    with patch(
+        "shipyard.cli.subprocess.run",
+        side_effect=lambda *a, **k: _ok_proc(stderr=stderr_text),
+    ):
+        result = _call()
+    assert result is not None
+    assert result["ok"] is True
+    # Version string makes it clear we didn't verify.
+    assert "fine-grained" in result["version"].lower() \
+        or "not inspectable" in result["version"].lower()


### PR DESCRIPTION
Closes #236.

Five changes, all small:

1. **README.md Requirements footnote** on the gh row naming the `workflow` scope requirement + the one-liner fix.
2. **docs/install.md § First-run auth** — new section covering the three identity shapes (interactive gh login / fine-grained PAT / GitHub App).
3. **docs/cloud-retarget.md § Authentication** — fixed the API path (`/actions/runs/:id/cancel`, not `/actions/jobs/:id/cancel` — the job-level endpoint doesn't exist).
4. **shipyard doctor** — new `gh-scope` row parses `gh auth status` → flags missing `workflow` on classic PATs, neutral-passes fine-grained + App identities (scopes not inspectable locally).
5. **install.sh** — post-install reminder when classic-PAT gh is missing the scope.

## Tests

5 new cases in `tests/test_doctor_gh_workflow_scope.py`:
- gh not installed → None
- gh logged out → None  
- classic PAT with `workflow` → ok=True
- classic PAT without → ok=False with refresh command in detail
- no `Token scopes:` line (fine-grained/App) → neutral pass with clarifying msg

All 17 tests pass across affected suites. Ruff clean. `bash -n install.sh` clean.

## Acceptance

- [x] Scope requirement visible from README Requirements + install.md + doctor
- [x] cloud-retarget.md uses the correct API path
- [x] "Which identity" has an explicit answer for all three cases