### PR TITLE
#238: warn that shipyard run requires a quiescent working tree (P3)

### DIFF
--- a/src/shipyard/cli.py
+++ b/src/shipyard/cli.py
@@ -201,7 +201,17 @@ def run(
     skip_target: tuple[str, ...],
     no_warm: bool,
 ) -> None:
-    """Validate current HEAD on configured targets."""
+    """Validate current HEAD on configured targets.
+
+    IMPORTANT: `shipyard run` reads the live working tree during
+    configure / build / test stages. Editing or deleting tracked
+    source files while a run is in flight causes non-deterministic
+    mid-stage failures — e.g. cmake's "Cannot find source file" if
+    a .cpp listed in CMakeLists.txt gets removed between
+    configure-list-read and configure-source-probe. Let the run
+    complete before refactoring, or queue the edits in a separate
+    worktree (#238).
+    """
     config = ctx.config
     mode = ValidationMode.SMOKE if smoke else ValidationMode.FULL
 
@@ -211,6 +221,21 @@ def run(
     if not sha or not branch:
         render_error("Not in a git repository")
         sys.exit(1)
+
+    # #238: warn operators that the working tree must stay quiescent
+    # during the run. A multi-agent flow (human + agent, or two
+    # agents in the same worktree) can race mid-run and produce
+    # failures that look like real build regressions but aren't.
+    # Quiet in --json mode — agents parse envelopes, they don't
+    # need human-readable banners.
+    if not ctx.json_mode:
+        render_message(
+            "→ Don't edit source files until this run completes — "
+            "concurrent edits cause non-deterministic mid-stage "
+            "failures (#238). Use a separate worktree for parallel "
+            "work.",
+            style="dim",
+        )
 
     # Resolve targets
     target_names = targets.split(",") if targets else list(config.targets.keys())

--- a/tests/test_run_tree_quiescence_warning.py
+++ b/tests/test_run_tree_quiescence_warning.py
@@ -1,0 +1,61 @@
+"""Tests for #238: `shipyard run` warns that the working tree must
+stay quiescent during the run.
+
+The warning is a cheap guard against a real failure mode — a
+multi-agent flow (human + agent editing in the same tree, or two
+agents in the same worktree) can race mid-run and produce
+non-deterministic mid-stage failures (e.g. cmake "Cannot find
+source file"). Full solution would be a sandboxed run tree or
+fail-fast tree-drift detection; for P3 we ship the discoverability
+fix and document the workaround.
+
+Regression guards:
+  - `shipyard run --help` surfaces the warning in the docstring
+  - issue # is referenced so someone reading the code can find the
+    discussion
+"""
+
+from __future__ import annotations
+
+import sys
+
+import pytest  # noqa: TC002 — MonkeyPatch fixture usage
+from click.testing import CliRunner
+
+from shipyard.cli import main
+
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason=(
+        "#198: Click CliRunner isolation flake on Windows across "
+        "this family of CLI tests. Coverage preserved on Linux + macOS."
+    ),
+)
+
+
+def test_run_help_includes_tree_quiescence_warning() -> None:
+    # The docstring is what `shipyard run --help` renders. Users
+    # who read --help before running should see the caveat.
+    runner = CliRunner()
+    result = runner.invoke(main, ["run", "--help"])
+    assert result.exit_code == 0
+    lowered = result.output.lower()
+    # Key phrase — don't over-constrain the wording. Must mention
+    # concurrent edits / working tree as the failure mode.
+    assert "edit" in lowered
+    assert "working tree" in lowered or "tracked source" in lowered \
+        or "source files" in lowered
+    # Issue number referenced so a reader can find the discussion.
+    assert "#238" in result.output
+
+
+def test_run_docstring_mentions_concrete_failure_shape() -> None:
+    # Keep the "Cannot find source file" breadcrumb in the docstring
+    # so anyone grepping the failure they hit lands on this context.
+    # If the test fails because someone cleaned up the docstring,
+    # they should leave at least a breadcrumb explaining what users
+    # would search for.
+    from shipyard.cli import run as run_cmd
+    doc = (run_cmd.__doc__ or "").lower()
+    assert "concurrent" in doc or "quiescent" in doc or "edit" in doc
+    assert "cmake" in doc or "configure" in doc or "source" in doc


### PR DESCRIPTION
Closes #238.

User filed P3 and said "happy with any of the four solutions (or none)." Shipping options #3 (warn) + #4 (docs) — the discoverability fix without building out sandbox/hash infrastructure for a P3.

## Surfaces

1. **docstring on \`shipyard run\`** (shown via \`--help\`) explains the constraint, cites the concrete failure shape ("cmake Cannot find source file" when a .cpp listed in CMakeLists.txt gets deleted mid-configure), and names the workaround.
2. **Run-start one-liner**: dim "→ Don't edit source files until this run completes — concurrent edits cause non-deterministic mid-stage failures (#238)" so operators who skip \`--help\` still see it. Suppressed under \`--json\` so agent pipelines don't get UI noise in their envelopes.

## Deliberately NOT doing

- Option #2 (tree hashing + fail-fast drift detection) — real engineering for a P3 the user said could wait.
- Option #1 (sandboxed run tree) — huge semantic change; will revisit if multi-agent workflows become common.

Tests: 2 regression guards assert \`--help\` surfaces the warning + the docstring mentions the concrete failure shape so someone grepping the error lands on this context.