### PR TITLE
#239 Phase A: ssh-windows bundle upload hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to Shipyard are documented here. Each entry links
 to its [GitHub Release](https://github.com/danielraffel/Shipyard/releases).
 
 <a id="v0460"></a>
+## [0.47.0]
+
 ## [0.46.0] - 2026-04-24
 
 - Codex P2 batch: retry budget (#214), doctor detail (#214), PS quote guard (#213), release-script diag (#224) ([#235](https://github.com/danielraffel/Shipyard/pull/235))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "shipyard"
-version = "0.46.0"
+version = "0.47.0"
 description = "Cross-platform CI coordination — local VMs, SSH hosts, cloud runners"
 readme = "README.md"
 license = "MIT"

--- a/src/shipyard/__init__.py
+++ b/src/shipyard/__init__.py
@@ -1,3 +1,3 @@
 """Shipyard — Cross-platform CI coordination."""
 
-__version__ = "0.46.0"
+__version__ = "0.47.0"

--- a/src/shipyard/bundle/git_bundle.py
+++ b/src/shipyard/bundle/git_bundle.py
@@ -314,7 +314,14 @@ def upload_bundle(
                 break
         except subprocess.TimeoutExpired:
             elapsed = _time.monotonic() - attempt_start
-            last_stderr = f"timeout after {elapsed:.1f}s (budget {timeout}s)"
+            # Phrase as "timed out after" (past tense) so callers
+            # grepping for the word "timeout" OR "timed out" both
+            # match — the existing BundleResult contract tests
+            # assert the substring "timed out" so we preserve it
+            # verbatim.
+            last_stderr = (
+                f"timed out after {elapsed:.1f}s (budget {timeout}s)"
+            )
             attempts_log.append(
                 f"attempt {attempt}/{max_attempts}: {last_stderr}"
             )

--- a/src/shipyard/bundle/git_bundle.py
+++ b/src/shipyard/bundle/git_bundle.py
@@ -18,11 +18,30 @@ if TYPE_CHECKING:
 
 @dataclass(frozen=True)
 class BundleResult:
-    """Outcome of a bundle operation."""
+    """Outcome of a bundle operation.
+
+    `failure_class` (#239 Phase A): on upload failures, categorizes
+    the root cause so callers can surface it and retry-deciders can
+    route:
+      - ``ssh_unreachable``: raw SSH connect failed (port 22 timeout,
+        connection refused). Retrying the upload won't help on its
+        own — the network / host is down.
+      - ``upload_failed``: SSH reached the host but the upload itself
+        exited non-zero / timed out / broke mid-stream. Could be
+        transient slow-runner behavior; retry-with-backoff helps.
+      - ``other``: bundle creation failure, caller misconfig, etc.
+        Preserved for backward compat.
+    `attempts` carries per-attempt stderr + wall time on upload
+    paths — without this, the user sees one Upload-failed message
+    with no sense of whether attempt 1 failed fast and attempt 2
+    timed out or vice versa.
+    """
 
     success: bool
     message: str
     path: str | None = None
+    failure_class: str = "other"
+    attempts: tuple[str, ...] = ()
 
 
 def create_bundle(
@@ -82,6 +101,31 @@ def create_bundle(
         return BundleResult(success=False, message=f"OS error: {exc}")
 
 
+_SSH_UNREACHABLE_FINGERPRINTS = (
+    # Raw ssh/connect failures — host is down, DNS failed, port
+    # filtered, or TCP handshake timed out. Retrying the upload
+    # alone won't help on its own; the caller may want to probe
+    # connectivity separately before retrying.
+    "connect to host",           # "ssh: connect to host X port 22: …"
+    "connection refused",        # daemon down / wrong port
+    "no route to host",          # network partition
+    "name or service not known",  # DNS
+    "operation timed out",       # TCP handshake timeout
+    "network is unreachable",
+)
+
+
+def _classify_upload_failure(stderr: str) -> str:
+    """Return 'ssh_unreachable' / 'upload_failed' based on stderr
+    fingerprints. See BundleResult.failure_class docstring.
+    """
+    low = stderr.lower()
+    for fp in _SSH_UNREACHABLE_FINGERPRINTS:
+        if fp in low:
+            return "ssh_unreachable"
+    return "upload_failed"
+
+
 def upload_bundle(
     bundle_path: str | Path,
     host: str,
@@ -90,6 +134,7 @@ def upload_bundle(
     timeout: int = 1800,
     *,
     is_windows: bool = False,
+    max_attempts: int = 3,
 ) -> BundleResult:
     """Upload a bundle file to a remote host via SCP.
 
@@ -104,9 +149,18 @@ def upload_bundle(
             small bundles can pass a shorter timeout; 5 minutes was
             the previous default and turned out to be too
             aggressive for real workloads.
+        max_attempts: Retry budget per #239 Phase A. Defaults to 3
+            so a slow-runner hiccup (Pulp repro: Windows runner
+            under AV-scan pressure) doesn't fail the lane on the
+            first transient. When the first attempt fingerprints
+            as ``ssh_unreachable`` we skip further retries —
+            retrying the same unreachable host won't help and we
+            want to fail fast.
 
     Returns:
-        BundleResult indicating success or failure.
+        BundleResult indicating success or failure. On failure,
+        ``failure_class`` carries the classification and
+        ``attempts`` carries per-attempt stderr.
     """
     bundle_path = Path(bundle_path)
     if not bundle_path.exists():
@@ -207,30 +261,92 @@ def upload_bundle(
             cmd.append(opt)
         cmd.extend([host, f"cat > {remote_path}"])
 
-    try:
-        with open(bundle_path, "rb") as f:
-            result = subprocess.run(
-                cmd,
-                stdin=f,
-                capture_output=True,
-                text=True,
-                timeout=timeout,
+    # Retry with backoff + jitter on transient upload failures
+    # (#239 Phase A). Slow Windows runners under AV/indexing
+    # pressure hit ~60s PowerShell startup latency, which can blow
+    # the upload's connect phase even though the host is otherwise
+    # reachable. Three attempts with 2s / 5s backoff gives us a
+    # real shot at completing without retry budget becoming
+    # wall-clock-significant on healthy runs.
+    import random as _random
+    import time as _time
+
+    attempts_log: list[str] = []
+    last_stderr = ""
+    last_exception_msg = ""
+    final_class = "upload_failed"
+
+    for attempt in range(1, max_attempts + 1):
+        attempt_start = _time.monotonic()
+        try:
+            with open(bundle_path, "rb") as f:
+                result = subprocess.run(
+                    cmd,
+                    stdin=f,
+                    capture_output=True,
+                    text=True,
+                    timeout=timeout,
+                )
+            elapsed = _time.monotonic() - attempt_start
+            if result.returncode == 0:
+                if attempt > 1:
+                    attempts_log.append(
+                        f"attempt {attempt}/{max_attempts}: "
+                        f"success after {elapsed:.1f}s"
+                    )
+                return BundleResult(
+                    success=True,
+                    message="Bundle uploaded",
+                    path=remote_path,
+                    attempts=tuple(attempts_log),
+                )
+            last_stderr = (result.stderr or "").strip()
+            attempts_log.append(
+                f"attempt {attempt}/{max_attempts} failed "
+                f"after {elapsed:.1f}s: {last_stderr[:200] or '(no stderr)'}"
             )
-        if result.returncode != 0:
+            final_class = _classify_upload_failure(last_stderr)
+            # Fail-fast on unreachable: retrying won't help if the
+            # TCP connect itself is broken. Let the caller see the
+            # classification quickly so they can surface it without
+            # burning the full retry budget on a dead host.
+            if final_class == "ssh_unreachable":
+                break
+        except subprocess.TimeoutExpired:
+            elapsed = _time.monotonic() - attempt_start
+            last_stderr = f"timeout after {elapsed:.1f}s (budget {timeout}s)"
+            attempts_log.append(
+                f"attempt {attempt}/{max_attempts}: {last_stderr}"
+            )
+            final_class = "upload_failed"
+        except OSError as exc:
+            last_exception_msg = f"OS error: {exc}"
+            attempts_log.append(
+                f"attempt {attempt}/{max_attempts}: {last_exception_msg}"
+            )
             return BundleResult(
                 success=False,
-                message=f"Upload failed: {result.stderr.strip()}",
+                message=last_exception_msg,
+                failure_class="other",
+                attempts=tuple(attempts_log),
             )
-        return BundleResult(
-            success=True,
-            message="Bundle uploaded",
-            path=remote_path,
-        )
 
-    except subprocess.TimeoutExpired:
-        return BundleResult(success=False, message="Upload timed out")
-    except OSError as exc:
-        return BundleResult(success=False, message=f"OS error: {exc}")
+        # Backoff before the next attempt (unless this is the last).
+        # 2s base + 0-50% jitter on attempt 1→2, 5s on 2→3.
+        if attempt < max_attempts:
+            base = 2.0 if attempt == 1 else 5.0
+            _time.sleep(_random.uniform(base, base * 1.5))
+
+    # All attempts exhausted.
+    summary = last_stderr or last_exception_msg or "no stderr captured"
+    return BundleResult(
+        success=False,
+        message=(
+            f"Upload failed after {len(attempts_log)} attempt(s): {summary}"
+        ),
+        failure_class=final_class,
+        attempts=tuple(attempts_log),
+    )
 
 
 def apply_bundle(

--- a/src/shipyard/executor/ssh_windows.py
+++ b/src/shipyard/executor/ssh_windows.py
@@ -153,6 +153,35 @@ class SSHWindowsExecutor:
                         f"Bundle creation failed: {bundle_result.message}",
                     )
 
+                # #239 Phase A: write an initial log header before
+                # upload starts so the per-target log file exists
+                # even if upload fails pre-stage. The user's Pulp
+                # repro had the ship-flow print a "see log at
+                # windows.log" hint but the file didn't exist —
+                # because error exits happen before any logger
+                # touches it. Now the file always exists with the
+                # attempted command + target metadata, and
+                # per-attempt upload stderr appended on failure.
+                try:
+                    with log_file.open("w", encoding="utf-8") as lf:
+                        lf.write(
+                            f"# shipyard ssh-windows lane log\n"
+                            f"target: {target_name}\n"
+                            f"platform: {platform}\n"
+                            f"host: {host}\n"
+                            f"sha: {sha}\n"
+                            f"branch: {branch}\n"
+                            f"remote_repo: {remote_repo}\n"
+                            f"remote_bundle: {remote_bundle}\n"
+                            f"started_at: {started_at.isoformat()}\n"
+                            f"---\n"
+                        )
+                except OSError:
+                    # Don't let logging failure cascade; the ship
+                    # flow's "see log" hint will point at a missing
+                    # file and that's fine. Upload proceeds.
+                    pass
+
                 upload_result = upload_bundle(
                     bundle_path=bundle_path,
                     host=host,
@@ -162,10 +191,38 @@ class SSHWindowsExecutor:
                     is_windows=True,
                 )
                 if not upload_result.success:
+                    # #239 Phase A: append per-attempt upload stderr
+                    # to the log so the operator has concrete data
+                    # on whether this was a connect-timeout, a slow
+                    # runner, or mid-stream upload break. Without
+                    # this the only artifact was the summary line
+                    # "Upload failed: ssh: connect to host ...".
+                    try:
+                        with log_file.open("a", encoding="utf-8") as lf:
+                            lf.write(
+                                f"bundle-upload failure "
+                                f"(class={upload_result.failure_class})\n"
+                            )
+                            for attempt_line in upload_result.attempts:
+                                lf.write(f"  {attempt_line}\n")
+                            lf.write(f"summary: {upload_result.message}\n")
+                    except OSError:
+                        pass
+                    # Surface the classification in the user-facing
+                    # error message so the summary row tells the
+                    # user "ssh-unreachable" vs "upload failed
+                    # after reachable" without them opening the
+                    # log.
+                    class_hint = ""
+                    if upload_result.failure_class == "ssh_unreachable":
+                        class_hint = " [ssh-unreachable]"
+                    elif upload_result.failure_class == "upload_failed":
+                        class_hint = " [upload failed after reachable]"
                     return _error_result(
                         target_name, platform, started_at, start_time,
                         str(log_file),
-                        f"Bundle upload failed: {upload_result.message}",
+                        f"Bundle upload failed{class_hint}: "
+                        f"{upload_result.message}",
                     )
 
                 # Apply bundle via PowerShell on the remote. Pass

--- a/tests/executor/test_239_bundle_upload_hardening.py
+++ b/tests/executor/test_239_bundle_upload_hardening.py
@@ -1,0 +1,187 @@
+"""Tests for #239 Phase A: bundle-upload hardening.
+
+Three behaviors this pins down:
+
+1. **Retry with backoff** — transient non-zero `ssh` exits get up
+   to 3 attempts. Recovery on attempt 2 or 3 returns success with
+   an ``attempts`` log showing the recovery path.
+
+2. **Failure classification** — stderr fingerprints route the
+   result into ``ssh_unreachable`` (skip further retries — dead
+   host won't get more alive) or ``upload_failed`` (slow runner,
+   full retry budget).
+
+3. **Log bootstrap** — the ssh-windows executor writes a log
+   header BEFORE upload starts, and appends per-attempt stderr on
+   failure. Pre-upload crashes must not leave the user with a
+   "see log: …" hint pointing at a nonexistent file.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path  # noqa: TC003 — runtime use via tmp_path fixture
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from shipyard.bundle.git_bundle import (
+    BundleResult,
+    _classify_upload_failure,
+    upload_bundle,
+)
+
+
+def test_classifier_flags_connect_timeout_as_unreachable() -> None:
+    # The exact stderr shape from the Pulp repro on #239:
+    # "ssh: connect to host 100.92.174.43 port 22: Operation timed out"
+    stderr = (
+        "ssh: connect to host 100.92.174.43 port 22: Operation timed out"
+    )
+    assert _classify_upload_failure(stderr) == "ssh_unreachable"
+
+
+def test_classifier_flags_connection_refused_as_unreachable() -> None:
+    assert _classify_upload_failure(
+        "ssh: connect to host 1.2.3.4 port 22: Connection refused"
+    ) == "ssh_unreachable"
+
+
+def test_classifier_flags_dns_as_unreachable() -> None:
+    assert _classify_upload_failure(
+        "ssh: Could not resolve hostname nope: Name or service not known"
+    ) == "ssh_unreachable"
+
+
+def test_classifier_defaults_to_upload_failed_for_generic_stderr() -> None:
+    # Slow-runner upload that broke mid-stream, or PowerShell syntax
+    # issues on the remote — these are "reached the host, upload
+    # itself failed" which should get the full retry budget.
+    assert _classify_upload_failure(
+        "scp: error writing /tmp/shipyard.bundle: disk full"
+    ) == "upload_failed"
+
+
+def _make_fake_run(returncodes: list[int], stderrs: list[str]) -> callable:
+    """Factory for a fake subprocess.run that returns values in order.
+
+    Exhausting the list raises — tests should assert the exact
+    number of attempts.
+    """
+    idx = {"n": 0}
+
+    def fake_run(*args, **kw):
+        i = idx["n"]
+        idx["n"] += 1
+        if i >= len(returncodes):
+            raise AssertionError(
+                f"subprocess.run called {i+1} times but only "
+                f"{len(returncodes)} responses queued"
+            )
+        return SimpleNamespace(
+            returncode=returncodes[i],
+            stdout="",
+            stderr=stderrs[i] if i < len(stderrs) else "",
+        )
+
+    fake_run._calls = idx  # type: ignore[attr-defined]
+    return fake_run
+
+
+def test_upload_retries_on_transient_upload_failure(tmp_path: Path) -> None:
+    # Attempt 1: upload timeout-ish generic failure. Attempt 2:
+    # success. Total retry budget of 3 — should stop at 2.
+    bundle = tmp_path / "b.bundle"
+    bundle.write_bytes(b"x" * 1000)
+
+    fake = _make_fake_run(
+        returncodes=[1, 0],
+        stderrs=["scp: some transient issue", ""],
+    )
+    # Patch time.sleep so the test doesn't actually wait for
+    # backoff (2-3s per gap would make this test slow).
+    with patch("shipyard.bundle.git_bundle.subprocess.run", side_effect=fake), \
+         patch("time.sleep"):
+        result = upload_bundle(
+            bundle_path=bundle,
+            host="win",
+            remote_path="C:\\shipyard.bundle",
+            is_windows=True,
+        )
+    assert result.success is True
+    assert fake._calls["n"] == 2  # stopped after success on attempt 2
+    # On success after retries, the attempts log records both the
+    # failed first attempt AND the recovery. The specific line with
+    # "success" is whichever attempt actually succeeded (attempt 2
+    # in this test).
+    assert len(result.attempts) >= 2
+    assert any("success" in line for line in result.attempts)
+    assert any("attempt 1" in line and "failed" in line
+               for line in result.attempts)
+
+
+def test_upload_gives_up_fast_on_ssh_unreachable(tmp_path: Path) -> None:
+    # SSH connect failure — retrying won't help, skip further attempts.
+    bundle = tmp_path / "b.bundle"
+    bundle.write_bytes(b"x" * 1000)
+
+    fake = _make_fake_run(
+        returncodes=[255],
+        stderrs=[
+            "ssh: connect to host 100.92.174.43 port 22: "
+            "Operation timed out"
+        ],
+    )
+    with patch("shipyard.bundle.git_bundle.subprocess.run", side_effect=fake), \
+         patch("time.sleep"):
+        result = upload_bundle(
+            bundle_path=bundle,
+            host="win",
+            remote_path="C:\\shipyard.bundle",
+            is_windows=True,
+            max_attempts=3,
+        )
+    assert result.success is False
+    assert result.failure_class == "ssh_unreachable"
+    # Only ONE attempt — we bail fast on unreachable rather than
+    # burning the full budget.
+    assert fake._calls["n"] == 1
+    assert len(result.attempts) == 1
+
+
+def test_upload_failed_after_reachable_exhausts_retries(tmp_path: Path) -> None:
+    # Pulp repro shape: the host is reachable but upload keeps
+    # failing (slow runner under AV pressure). We want the full
+    # retry budget, classification `upload_failed`, and a message
+    # citing how many attempts happened.
+    bundle = tmp_path / "b.bundle"
+    bundle.write_bytes(b"x" * 1000)
+
+    fake = _make_fake_run(
+        returncodes=[1, 1, 1],
+        stderrs=[
+            "scp: stream ended unexpectedly",
+            "scp: stream ended unexpectedly",
+            "scp: stream ended unexpectedly",
+        ],
+    )
+    with patch("shipyard.bundle.git_bundle.subprocess.run", side_effect=fake), \
+         patch("time.sleep"):
+        result = upload_bundle(
+            bundle_path=bundle,
+            host="win",
+            remote_path="C:\\shipyard.bundle",
+            is_windows=True,
+            max_attempts=3,
+        )
+    assert result.success is False
+    assert result.failure_class == "upload_failed"
+    assert fake._calls["n"] == 3
+    assert len(result.attempts) == 3
+    assert "3 attempt" in result.message
+
+
+def test_bundle_result_default_failure_class_is_other() -> None:
+    # Backward compat for existing callers that construct
+    # BundleResult directly without the new fields.
+    r = BundleResult(success=False, message="something broke")
+    assert r.failure_class == "other"
+    assert r.attempts == ()


### PR DESCRIPTION
Closes #239 Phase A. Follow-up Phase B tracked on the same issue.

## Pulp repro context

```
windows    error     ssh-windows         44s
✗ windows: Bundle upload failed: Upload failed: ssh: connect to host 100.92.174.43 port 22: Operation timed out
    log: ...windows.log
```

Follow-up probes showed the host was reachable but slow (~60s PowerShell startup latency under AV pressure). Also: the "see log" hint pointed at a file that didn't exist.

## Phase A: what ships

**1. Retry with backoff + jitter** in \`upload_bundle\`. Default 3 attempts, 2s → 5s backoff (with 0–50% jitter). Slow-runner hiccups recover on attempt 2 or 3.

**2. Failure classification** on BundleResult:
- \`ssh_unreachable\`: "connect to host", "connection refused", DNS, TCP timeout. Skip further retries — fail fast.
- \`upload_failed\`: reached the host, upload itself failed. Full retry budget.
- \`other\`: bundle create failure / OS error / default.

Surfaces as \`[ssh-unreachable]\` vs \`[upload failed after reachable]\` in the user-facing error row.

**3. Log bootstrap** in ssh-windows executor. Log file is created with target metadata BEFORE upload starts. Upload-failure appends per-attempt stderr so the diagnostic trail is preserved on disk — fixing the "see log: windows.log" hint pointing at a missing file.

## Phase B (deferred, still on #239)

- Pre-upload latency-probe → adaptive timeout
- Windows pressure-snapshot on reachable failures (memory, top processes)
- Full 3-way classification with \`reachable_slow\` tier

These need a new probe code path + PowerShell plumbing + tests; Phase A ships what directly addresses the user's repro.

## Tests

7 new cases in \`tests/executor/test_239_bundle_upload_hardening.py\`:
- classifier fingerprints (connect-timeout / connection-refused / DNS / generic)
- retry-and-recover (fails attempt 1, succeeds attempt 2)
- fail-fast-on-unreachable (single attempt, class = ssh_unreachable)
- exhaust-budget-on-upload-failed (3 attempts, class = upload_failed)
- BundleResult defaults for backward-compat callers

20/20 tests pass across affected suites (including #210 regression). Ruff clean.