### PR TITLE
#237 follow-up: scope gh auth status probe to github.com (Codex P2)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -388,7 +388,12 @@ fi
 # logged out (the doctor covers those) and silent for fine-grained
 # tokens + GitHub Apps which don't expose their scope list locally.
 if command -v gh >/dev/null 2>&1; then
-    gh_status_out=$(gh auth status 2>&1 || true)
+    # Scope probe to github.com specifically (Codex P2 on #237).
+    # Bare `gh auth status` inspects every configured host (GHE,
+    # etc.) and would false-positive or false-negative from
+    # unrelated hosts. Shipyard's retarget/handoff calls go to
+    # github.com, so that's the only host whose scope matters.
+    gh_status_out=$(gh auth status --hostname github.com 2>&1 || true)
     if echo "${gh_status_out}" | grep -qi "Token scopes:" \
         && ! echo "${gh_status_out}" | grep -q "'workflow'"; then
         echo "heads up: \`shipyard cloud retarget\` + \`cloud handoff run --apply\`"

--- a/src/shipyard/cli.py
+++ b/src/shipyard/cli.py
@@ -5485,15 +5485,23 @@ def _check_gh_workflow_scope() -> dict[str, Any] | None:
     but no scope line" as a neutral pass since we can't know
     without hitting the API).
     """
+    # Scope to github.com specifically (Codex P2 on #237). Without
+    # `--hostname`, `gh auth status` inspects every configured host
+    # (GHE, GitHub App tokens on enterprise, etc.) and can exit
+    # non-zero from an unrelated host's auth problem — or show a
+    # `Token scopes:` line from the wrong host and grep past the
+    # github.com answer. Shipyard's cancel/dispatch calls go to
+    # github.com, so that's the only host whose scope matters.
     try:
         result = subprocess.run(
-            ["gh", "auth", "status"],
+            ["gh", "auth", "status", "--hostname", "github.com"],
             capture_output=True, text=True, timeout=5,
         )
     except (subprocess.SubprocessError, FileNotFoundError):
         return None
     if result.returncode != 0:
-        # gh not logged in — unrelated to scope; stay quiet.
+        # gh not logged in to github.com specifically — unrelated
+        # to scope; stay quiet.
         return None
     combined = (result.stdout + result.stderr).lower()
     # Classic PAT path prints `Token scopes: 'gist', 'repo', 'workflow'`.

--- a/tests/test_doctor_gh_workflow_scope.py
+++ b/tests/test_doctor_gh_workflow_scope.py
@@ -131,3 +131,30 @@ def test_neutral_pass_when_no_token_scopes_line(
     # Version string makes it clear we didn't verify.
     assert "fine-grained" in result["version"].lower() \
         or "not inspectable" in result["version"].lower()
+
+
+def test_probe_scopes_gh_auth_status_to_github_com(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Codex P2 on #237: `gh auth status` without --hostname inspects
+    # every configured host (GHE enterprise tokens, etc.) and can
+    # exit non-zero from an unrelated host's auth problem — or show
+    # a `Token scopes:` line from the wrong host. Lock in that the
+    # probe always passes `--hostname github.com`.
+    captured: dict[str, Any] = {"cmd": None}
+
+    def fake_run(cmd, **kw):
+        captured["cmd"] = list(cmd)
+        return _ok_proc(stderr="Token scopes: 'workflow'")
+
+    with patch("shipyard.cli.subprocess.run", side_effect=fake_run):
+        _call()
+    assert captured["cmd"] is not None
+    assert "--hostname" in captured["cmd"], (
+        "probe must be scoped to a specific host; reintroducing the "
+        "unscoped `gh auth status` call regresses #237"
+    )
+    # And the host must be github.com — Shipyard's retarget/handoff
+    # calls hit github.com, not GHE.
+    host_idx = captured["cmd"].index("--hostname")
+    assert captured["cmd"][host_idx + 1] == "github.com"


### PR DESCRIPTION
Two P2 Codex comments on merged PR #237 flagged the same concern: bare \`gh auth status\` inspects every configured gh host, and the probe / install-time warning would show the wrong answer (or suppress entirely) when an unrelated GHE/App token has issues.

Fix: pass \`--hostname github.com\` in both sites. Shipyard's retarget/handoff commands hit github.com specifically, so that's the only host whose scope matters.

## Test

New regression test asserts the probe command contains \`--hostname github.com\` so reintroducing the unscoped call regresses #237.

6/6 tests pass, ruff clean.

Also — the v0.46.0 bump is NOT included here; this is a tiny cleanup that'll roll into the next user-visible release's content.

## Related

- #237 (merged) — where the two P2 comments live