### PR TITLE
pin bump: worktree-safety guards (#243)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to Shipyard are documented here. Each entry links
 to its [GitHub Release](https://github.com/danielraffel/Shipyard/releases).
 
 <a id="v0460"></a>
+## [0.47.0]
+
 ## [0.46.0] - 2026-04-24
 
 - Codex P2 batch: retry budget (#214), doctor detail (#214), PS quote guard (#213), release-script diag (#224) ([#235](https://github.com/danielraffel/Shipyard/pull/235))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "shipyard"
-version = "0.46.0"
+version = "0.47.0"
 description = "Cross-platform CI coordination — local VMs, SSH hosts, cloud runners"
 readme = "README.md"
 license = "MIT"

--- a/skills/ci/SKILL.md
+++ b/skills/ci/SKILL.md
@@ -655,6 +655,19 @@ Never run `gh pr create` + release separately. Never run the Python gate scripts
 
 Missing-script errors list every probed location and every override knob. Consumer repos that keep their tooling under `tools/scripts/` need no configuration; other layouts should set the env var or the `[validation]` key rather than moving the script.
 
+## Consumer-repo pin bumps (`shipyard pin bump`)
+
+Consumer repos (pulp, spectr, …) pin a specific Shipyard release via `tools/shipyard.toml` and install it through `./tools/install-shipyard.sh`. `shipyard pin bump` is the one-shot: it rewrites the pin, runs the installer, verifies `shipyard --version` matches, and opens the PR.
+
+**Mental model for multi-worktree / multi-project setups:** just run `shipyard pin bump` in whichever consumer worktree is most up-to-date. Don't hand-edit `tools/shipyard.toml` — the command's guards are what keep you out of trouble. Two refuse-by-default guards fire before any side effect:
+
+1. **Downgrade refusal** — if the target is older than the currently-installed `shipyard` binary (the `~/.local/bin/shipyard` that `install-shipyard.sh` will overwrite), the command refuses. The common trigger is running this in a stale worktree that still pins an old version. Remediation: rebase onto main, or pass `--allow-downgrade` if you really do mean to regress the global.
+2. **Redundant-branch refusal** — if `origin/main:tools/shipyard.toml` already pins a version >= the target, the command refuses. Trigger: branch is behind main; opening a PR here produces a no-op at merge time or a conflict. Remediation: rebase/merge `origin/main`, or pass `--allow-redundant`.
+
+Both guards are skipped silently when their inputs are unavailable (no `shipyard` on PATH, offline, no `origin/main`) — advisory, not load-bearing.
+
+`shipyard pin show` reports the current pin and the latest upstream release without touching anything — safe to run anywhere.
+
 ## State-machine lane + doc-sync gate
 
 A dedicated `state-machine` CI job runs `pytest -m state_machine -v` on ubuntu-latest. Failures show up as a distinct check row (not mixed into the cross-platform `test` matrix), so a ship-state regression is visually separable from an infra blip. When writing a test that exercises ship-state transitions, add `pytestmark = pytest.mark.state_machine` at module scope.

--- a/src/shipyard/__init__.py
+++ b/src/shipyard/__init__.py
@@ -1,3 +1,3 @@
 """Shipyard — Cross-platform CI coordination."""
 
-__version__ = "0.46.0"
+__version__ = "0.47.0"

--- a/src/shipyard/bundle/git_bundle.py
+++ b/src/shipyard/bundle/git_bundle.py
@@ -314,7 +314,14 @@ def upload_bundle(
                 break
         except subprocess.TimeoutExpired:
             elapsed = _time.monotonic() - attempt_start
-            last_stderr = f"timeout after {elapsed:.1f}s (budget {timeout}s)"
+            # Phrase as "timed out after" (past tense) so callers
+            # grepping for the word "timeout" OR "timed out" both
+            # match — the existing BundleResult contract tests
+            # assert the substring "timed out" so we preserve it
+            # verbatim.
+            last_stderr = (
+                f"timed out after {elapsed:.1f}s (budget {timeout}s)"
+            )
             attempts_log.append(
                 f"attempt {attempt}/{max_attempts}: {last_stderr}"
             )

--- a/src/shipyard/bundle/git_bundle.py
+++ b/src/shipyard/bundle/git_bundle.py
@@ -18,11 +18,30 @@ if TYPE_CHECKING:
 
 @dataclass(frozen=True)
 class BundleResult:
-    """Outcome of a bundle operation."""
+    """Outcome of a bundle operation.
+
+    `failure_class` (#239 Phase A): on upload failures, categorizes
+    the root cause so callers can surface it and retry-deciders can
+    route:
+      - ``ssh_unreachable``: raw SSH connect failed (port 22 timeout,
+        connection refused). Retrying the upload won't help on its
+        own — the network / host is down.
+      - ``upload_failed``: SSH reached the host but the upload itself
+        exited non-zero / timed out / broke mid-stream. Could be
+        transient slow-runner behavior; retry-with-backoff helps.
+      - ``other``: bundle creation failure, caller misconfig, etc.
+        Preserved for backward compat.
+    `attempts` carries per-attempt stderr + wall time on upload
+    paths — without this, the user sees one Upload-failed message
+    with no sense of whether attempt 1 failed fast and attempt 2
+    timed out or vice versa.
+    """
 
     success: bool
     message: str
     path: str | None = None
+    failure_class: str = "other"
+    attempts: tuple[str, ...] = ()
 
 
 def create_bundle(
@@ -82,6 +101,31 @@ def create_bundle(
         return BundleResult(success=False, message=f"OS error: {exc}")
 
 
+_SSH_UNREACHABLE_FINGERPRINTS = (
+    # Raw ssh/connect failures — host is down, DNS failed, port
+    # filtered, or TCP handshake timed out. Retrying the upload
+    # alone won't help on its own; the caller may want to probe
+    # connectivity separately before retrying.
+    "connect to host",           # "ssh: connect to host X port 22: …"
+    "connection refused",        # daemon down / wrong port
+    "no route to host",          # network partition
+    "name or service not known",  # DNS
+    "operation timed out",       # TCP handshake timeout
+    "network is unreachable",
+)
+
+
+def _classify_upload_failure(stderr: str) -> str:
+    """Return 'ssh_unreachable' / 'upload_failed' based on stderr
+    fingerprints. See BundleResult.failure_class docstring.
+    """
+    low = stderr.lower()
+    for fp in _SSH_UNREACHABLE_FINGERPRINTS:
+        if fp in low:
+            return "ssh_unreachable"
+    return "upload_failed"
+
+
 def upload_bundle(
     bundle_path: str | Path,
     host: str,
@@ -90,6 +134,7 @@ def upload_bundle(
     timeout: int = 1800,
     *,
     is_windows: bool = False,
+    max_attempts: int = 3,
 ) -> BundleResult:
     """Upload a bundle file to a remote host via SCP.
 
@@ -104,9 +149,18 @@ def upload_bundle(
             small bundles can pass a shorter timeout; 5 minutes was
             the previous default and turned out to be too
             aggressive for real workloads.
+        max_attempts: Retry budget per #239 Phase A. Defaults to 3
+            so a slow-runner hiccup (Pulp repro: Windows runner
+            under AV-scan pressure) doesn't fail the lane on the
+            first transient. When the first attempt fingerprints
+            as ``ssh_unreachable`` we skip further retries —
+            retrying the same unreachable host won't help and we
+            want to fail fast.
 
     Returns:
-        BundleResult indicating success or failure.
+        BundleResult indicating success or failure. On failure,
+        ``failure_class`` carries the classification and
+        ``attempts`` carries per-attempt stderr.
     """
     bundle_path = Path(bundle_path)
     if not bundle_path.exists():
@@ -207,30 +261,92 @@ def upload_bundle(
             cmd.append(opt)
         cmd.extend([host, f"cat > {remote_path}"])
 
-    try:
-        with open(bundle_path, "rb") as f:
-            result = subprocess.run(
-                cmd,
-                stdin=f,
-                capture_output=True,
-                text=True,
-                timeout=timeout,
+    # Retry with backoff + jitter on transient upload failures
+    # (#239 Phase A). Slow Windows runners under AV/indexing
+    # pressure hit ~60s PowerShell startup latency, which can blow
+    # the upload's connect phase even though the host is otherwise
+    # reachable. Three attempts with 2s / 5s backoff gives us a
+    # real shot at completing without retry budget becoming
+    # wall-clock-significant on healthy runs.
+    import random as _random
+    import time as _time
+
+    attempts_log: list[str] = []
+    last_stderr = ""
+    last_exception_msg = ""
+    final_class = "upload_failed"
+
+    for attempt in range(1, max_attempts + 1):
+        attempt_start = _time.monotonic()
+        try:
+            with open(bundle_path, "rb") as f:
+                result = subprocess.run(
+                    cmd,
+                    stdin=f,
+                    capture_output=True,
+                    text=True,
+                    timeout=timeout,
+                )
+            elapsed = _time.monotonic() - attempt_start
+            if result.returncode == 0:
+                if attempt > 1:
+                    attempts_log.append(
+                        f"attempt {attempt}/{max_attempts}: "
+                        f"success after {elapsed:.1f}s"
+                    )
+                return BundleResult(
+                    success=True,
+                    message="Bundle uploaded",
+                    path=remote_path,
+                    attempts=tuple(attempts_log),
+                )
+            last_stderr = (result.stderr or "").strip()
+            attempts_log.append(
+                f"attempt {attempt}/{max_attempts} failed "
+                f"after {elapsed:.1f}s: {last_stderr[:200] or '(no stderr)'}"
             )
-        if result.returncode != 0:
+            final_class = _classify_upload_failure(last_stderr)
+            # Fail-fast on unreachable: retrying won't help if the
+            # TCP connect itself is broken. Let the caller see the
+            # classification quickly so they can surface it without
+            # burning the full retry budget on a dead host.
+            if final_class == "ssh_unreachable":
+                break
+        except subprocess.TimeoutExpired:
+            elapsed = _time.monotonic() - attempt_start
+            last_stderr = f"timeout after {elapsed:.1f}s (budget {timeout}s)"
+            attempts_log.append(
+                f"attempt {attempt}/{max_attempts}: {last_stderr}"
+            )
+            final_class = "upload_failed"
+        except OSError as exc:
+            last_exception_msg = f"OS error: {exc}"
+            attempts_log.append(
+                f"attempt {attempt}/{max_attempts}: {last_exception_msg}"
+            )
             return BundleResult(
                 success=False,
-                message=f"Upload failed: {result.stderr.strip()}",
+                message=last_exception_msg,
+                failure_class="other",
+                attempts=tuple(attempts_log),
             )
-        return BundleResult(
-            success=True,
-            message="Bundle uploaded",
-            path=remote_path,
-        )
 
-    except subprocess.TimeoutExpired:
-        return BundleResult(success=False, message="Upload timed out")
-    except OSError as exc:
-        return BundleResult(success=False, message=f"OS error: {exc}")
+        # Backoff before the next attempt (unless this is the last).
+        # 2s base + 0-50% jitter on attempt 1→2, 5s on 2→3.
+        if attempt < max_attempts:
+            base = 2.0 if attempt == 1 else 5.0
+            _time.sleep(_random.uniform(base, base * 1.5))
+
+    # All attempts exhausted.
+    summary = last_stderr or last_exception_msg or "no stderr captured"
+    return BundleResult(
+        success=False,
+        message=(
+            f"Upload failed after {len(attempts_log)} attempt(s): {summary}"
+        ),
+        failure_class=final_class,
+        attempts=tuple(attempts_log),
+    )
 
 
 def apply_bundle(

--- a/src/shipyard/cli.py
+++ b/src/shipyard/cli.py
@@ -2088,6 +2088,82 @@ def _latest_shipyard_release() -> str | None:
     return tag or None
 
 
+def _parse_version_tuple(version: str) -> tuple[int, int, int] | None:
+    """Parse ``v0.47.0`` / ``0.47.0`` to ``(0, 47, 0)``.
+
+    Returns None for unparseable input (pre-release suffixes, dev
+    builds, etc.) — callers treat that as "can't compare, skip the
+    guard" so non-semver tags never false-trigger a refusal.
+    """
+    import re
+    match = re.match(r"^v?(\d+)\.(\d+)\.(\d+)\s*$", version.strip())
+    if not match:
+        return None
+    a, b, c = match.groups()
+    return (int(a), int(b), int(c))
+
+
+def _current_global_shipyard_version() -> str | None:
+    """Return the version string (without leading ``v``) of the
+    ``shipyard`` binary currently on PATH, or None if we can't
+    determine it.
+
+    We shell out rather than read ``__version__`` because in
+    ``shipyard pin bump`` the whole point is to compare against the
+    *globally-installed* binary the consumer's install script would
+    overwrite — not against the in-process copy (which may be a dev
+    `uv run`).
+    """
+    try:
+        result = subprocess.run(
+            ["shipyard", "--version"],
+            capture_output=True, text=True, timeout=15,
+        )
+    except (subprocess.SubprocessError, FileNotFoundError):
+        return None
+    if result.returncode != 0:
+        return None
+    import re
+    # `shipyard --version` prints "shipyard, version 0.47.0".
+    match = re.search(r"version\s+(\S+)", result.stdout)
+    return match.group(1).strip() if match else None
+
+
+def _main_pinned_version_at_origin(repo_root: Path) -> str | None:
+    """Best-effort read of ``origin/main:tools/shipyard.toml`` and
+    extract its pinned version.
+
+    Returns None when:
+      * ``git fetch`` fails (offline / no origin / no main branch)
+      * ``tools/shipyard.toml`` doesn't exist on origin/main
+      * the file exists but has no ``version = "..."`` line
+
+    Any None result means the redundant-branch guard is skipped —
+    better to let a bump proceed than to refuse on a flaky network.
+    """
+    try:
+        subprocess.run(
+            ["git", "fetch", "--quiet", "origin", "main"],
+            cwd=repo_root, capture_output=True, text=True, timeout=30,
+        )
+    except (subprocess.SubprocessError, FileNotFoundError):
+        return None
+    try:
+        result = subprocess.run(
+            ["git", "show", "origin/main:tools/shipyard.toml"],
+            cwd=repo_root, capture_output=True, text=True, timeout=10,
+        )
+    except (subprocess.SubprocessError, FileNotFoundError):
+        return None
+    if result.returncode != 0:
+        return None
+    import re
+    match = re.search(
+        r'^\s*version\s*=\s*"([^"]+)"', result.stdout, re.MULTILINE,
+    )
+    return match.group(1) if match else None
+
+
 @pin.command("show")
 @click.pass_obj
 def pin_show(ctx: Context) -> None:
@@ -2165,9 +2241,35 @@ def pin_show(ctx: Context) -> None:
         "is to catch install failures before the PR."
     ),
 )
+@click.option(
+    "--allow-downgrade",
+    is_flag=True,
+    default=False,
+    help=(
+        "Proceed even if the target version is older than the "
+        "currently-installed shipyard binary (usually a sign of a "
+        "stale worktree). Defaults refuse so install-shipyard.sh "
+        "can't silently downgrade your global binary."
+    ),
+)
+@click.option(
+    "--allow-redundant",
+    is_flag=True,
+    default=False,
+    help=(
+        "Proceed even if origin/main already pins >= the target "
+        "version. Defaults refuse so branches behind main don't "
+        "open redundant pin-bump PRs."
+    ),
+)
 @click.pass_obj
 def pin_bump(
-    ctx: Context, target: str | None, no_pr: bool, skip_verify: bool,
+    ctx: Context,
+    target: str | None,
+    no_pr: bool,
+    skip_verify: bool,
+    allow_downgrade: bool,
+    allow_redundant: bool,
 ) -> None:
     """Bump the pinned Shipyard version to ``--to`` (or latest).
 
@@ -2175,9 +2277,17 @@ def pin_bump(
     ``./tools/install-shipyard.sh``, verify ``shipyard --version``
     matches the target, commit, push, open a PR.
 
-    Refuses with a dirty working tree — folding unrelated changes
-    into a pin-bump PR is exactly the class of release slippage we
-    want to prevent.
+    Refuses:
+
+    * with a dirty working tree — folding unrelated changes into a
+      pin-bump PR is exactly the class of release slippage we want
+      to prevent.
+    * when target < currently-installed binary (stale worktree
+      would silently downgrade the global install). Override with
+      ``--allow-downgrade``.
+    * when origin/main already pins >= target (branch is behind
+      main, PR would be redundant). Override with
+      ``--allow-redundant``.
     """
     toml_path = _detect_consumer_pin()
     if toml_path is None:
@@ -2242,6 +2352,48 @@ def pin_bump(
                 style="dim",
             )
         return
+
+    # Guard A (#243) — refuse a downgrade of the global binary.
+    # `./tools/install-shipyard.sh` fetches the pinned version and
+    # overwrites ~/.local/bin/shipyard, so bumping a stale worktree's
+    # pin backwards silently regresses the operator's global install.
+    target_tuple = _parse_version_tuple(target)
+    if not allow_downgrade and target_tuple is not None:
+        installed = _current_global_shipyard_version()
+        installed_tuple = (
+            _parse_version_tuple(installed) if installed else None
+        )
+        if installed_tuple is not None and target_tuple < installed_tuple:
+            render_error(
+                f"Refusing: target {target} is older than the currently-"
+                f"installed shipyard binary (v{installed}). Running "
+                f"./tools/install-shipyard.sh would DOWNGRADE your "
+                f"global binary.\n"
+                "Likely cause: this worktree is stale — rebase onto "
+                "main before bumping, or pass --allow-downgrade to "
+                "proceed anyway."
+            )
+            sys.exit(1)
+
+    # Guard B (#243) — refuse when origin/main already pins >= target.
+    # A branch behind main that runs pin bump just creates a redundant
+    # or conflict-prone PR. Skipped silently if we can't resolve
+    # origin/main (offline, no remote, etc.) — guards are advisory.
+    if not allow_redundant and target_tuple is not None:
+        main_pin = _main_pinned_version_at_origin(repo_root)
+        main_tuple = (
+            _parse_version_tuple(main_pin) if main_pin else None
+        )
+        if main_tuple is not None and main_tuple >= target_tuple:
+            render_error(
+                f"Refusing: origin/main already pins {main_pin}, which "
+                f"is >= target {target}. Opening a PR here would be "
+                f"redundant or regressive.\n"
+                "Likely cause: this worktree is behind main — rebase "
+                "or merge origin/main first, or pass --allow-redundant "
+                "to proceed anyway."
+            )
+            sys.exit(1)
 
     render_message(f"Bumping pin: {current} → {target}")
     _rewrite_pinned_version(toml_path, target)

--- a/src/shipyard/executor/ssh_windows.py
+++ b/src/shipyard/executor/ssh_windows.py
@@ -153,6 +153,35 @@ class SSHWindowsExecutor:
                         f"Bundle creation failed: {bundle_result.message}",
                     )
 
+                # #239 Phase A: write an initial log header before
+                # upload starts so the per-target log file exists
+                # even if upload fails pre-stage. The user's Pulp
+                # repro had the ship-flow print a "see log at
+                # windows.log" hint but the file didn't exist —
+                # because error exits happen before any logger
+                # touches it. Now the file always exists with the
+                # attempted command + target metadata, and
+                # per-attempt upload stderr appended on failure.
+                try:
+                    with log_file.open("w", encoding="utf-8") as lf:
+                        lf.write(
+                            f"# shipyard ssh-windows lane log\n"
+                            f"target: {target_name}\n"
+                            f"platform: {platform}\n"
+                            f"host: {host}\n"
+                            f"sha: {sha}\n"
+                            f"branch: {branch}\n"
+                            f"remote_repo: {remote_repo}\n"
+                            f"remote_bundle: {remote_bundle}\n"
+                            f"started_at: {started_at.isoformat()}\n"
+                            f"---\n"
+                        )
+                except OSError:
+                    # Don't let logging failure cascade; the ship
+                    # flow's "see log" hint will point at a missing
+                    # file and that's fine. Upload proceeds.
+                    pass
+
                 upload_result = upload_bundle(
                     bundle_path=bundle_path,
                     host=host,
@@ -162,10 +191,38 @@ class SSHWindowsExecutor:
                     is_windows=True,
                 )
                 if not upload_result.success:
+                    # #239 Phase A: append per-attempt upload stderr
+                    # to the log so the operator has concrete data
+                    # on whether this was a connect-timeout, a slow
+                    # runner, or mid-stream upload break. Without
+                    # this the only artifact was the summary line
+                    # "Upload failed: ssh: connect to host ...".
+                    try:
+                        with log_file.open("a", encoding="utf-8") as lf:
+                            lf.write(
+                                f"bundle-upload failure "
+                                f"(class={upload_result.failure_class})\n"
+                            )
+                            for attempt_line in upload_result.attempts:
+                                lf.write(f"  {attempt_line}\n")
+                            lf.write(f"summary: {upload_result.message}\n")
+                    except OSError:
+                        pass
+                    # Surface the classification in the user-facing
+                    # error message so the summary row tells the
+                    # user "ssh-unreachable" vs "upload failed
+                    # after reachable" without them opening the
+                    # log.
+                    class_hint = ""
+                    if upload_result.failure_class == "ssh_unreachable":
+                        class_hint = " [ssh-unreachable]"
+                    elif upload_result.failure_class == "upload_failed":
+                        class_hint = " [upload failed after reachable]"
                     return _error_result(
                         target_name, platform, started_at, start_time,
                         str(log_file),
-                        f"Bundle upload failed: {upload_result.message}",
+                        f"Bundle upload failed{class_hint}: "
+                        f"{upload_result.message}",
                     )
 
                 # Apply bundle via PowerShell on the remote. Pass

--- a/tests/executor/test_239_bundle_upload_hardening.py
+++ b/tests/executor/test_239_bundle_upload_hardening.py
@@ -1,0 +1,187 @@
+"""Tests for #239 Phase A: bundle-upload hardening.
+
+Three behaviors this pins down:
+
+1. **Retry with backoff** — transient non-zero `ssh` exits get up
+   to 3 attempts. Recovery on attempt 2 or 3 returns success with
+   an ``attempts`` log showing the recovery path.
+
+2. **Failure classification** — stderr fingerprints route the
+   result into ``ssh_unreachable`` (skip further retries — dead
+   host won't get more alive) or ``upload_failed`` (slow runner,
+   full retry budget).
+
+3. **Log bootstrap** — the ssh-windows executor writes a log
+   header BEFORE upload starts, and appends per-attempt stderr on
+   failure. Pre-upload crashes must not leave the user with a
+   "see log: …" hint pointing at a nonexistent file.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path  # noqa: TC003 — runtime use via tmp_path fixture
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from shipyard.bundle.git_bundle import (
+    BundleResult,
+    _classify_upload_failure,
+    upload_bundle,
+)
+
+
+def test_classifier_flags_connect_timeout_as_unreachable() -> None:
+    # The exact stderr shape from the Pulp repro on #239:
+    # "ssh: connect to host 100.92.174.43 port 22: Operation timed out"
+    stderr = (
+        "ssh: connect to host 100.92.174.43 port 22: Operation timed out"
+    )
+    assert _classify_upload_failure(stderr) == "ssh_unreachable"
+
+
+def test_classifier_flags_connection_refused_as_unreachable() -> None:
+    assert _classify_upload_failure(
+        "ssh: connect to host 1.2.3.4 port 22: Connection refused"
+    ) == "ssh_unreachable"
+
+
+def test_classifier_flags_dns_as_unreachable() -> None:
+    assert _classify_upload_failure(
+        "ssh: Could not resolve hostname nope: Name or service not known"
+    ) == "ssh_unreachable"
+
+
+def test_classifier_defaults_to_upload_failed_for_generic_stderr() -> None:
+    # Slow-runner upload that broke mid-stream, or PowerShell syntax
+    # issues on the remote — these are "reached the host, upload
+    # itself failed" which should get the full retry budget.
+    assert _classify_upload_failure(
+        "scp: error writing /tmp/shipyard.bundle: disk full"
+    ) == "upload_failed"
+
+
+def _make_fake_run(returncodes: list[int], stderrs: list[str]) -> callable:
+    """Factory for a fake subprocess.run that returns values in order.
+
+    Exhausting the list raises — tests should assert the exact
+    number of attempts.
+    """
+    idx = {"n": 0}
+
+    def fake_run(*args, **kw):
+        i = idx["n"]
+        idx["n"] += 1
+        if i >= len(returncodes):
+            raise AssertionError(
+                f"subprocess.run called {i+1} times but only "
+                f"{len(returncodes)} responses queued"
+            )
+        return SimpleNamespace(
+            returncode=returncodes[i],
+            stdout="",
+            stderr=stderrs[i] if i < len(stderrs) else "",
+        )
+
+    fake_run._calls = idx  # type: ignore[attr-defined]
+    return fake_run
+
+
+def test_upload_retries_on_transient_upload_failure(tmp_path: Path) -> None:
+    # Attempt 1: upload timeout-ish generic failure. Attempt 2:
+    # success. Total retry budget of 3 — should stop at 2.
+    bundle = tmp_path / "b.bundle"
+    bundle.write_bytes(b"x" * 1000)
+
+    fake = _make_fake_run(
+        returncodes=[1, 0],
+        stderrs=["scp: some transient issue", ""],
+    )
+    # Patch time.sleep so the test doesn't actually wait for
+    # backoff (2-3s per gap would make this test slow).
+    with patch("shipyard.bundle.git_bundle.subprocess.run", side_effect=fake), \
+         patch("time.sleep"):
+        result = upload_bundle(
+            bundle_path=bundle,
+            host="win",
+            remote_path="C:\\shipyard.bundle",
+            is_windows=True,
+        )
+    assert result.success is True
+    assert fake._calls["n"] == 2  # stopped after success on attempt 2
+    # On success after retries, the attempts log records both the
+    # failed first attempt AND the recovery. The specific line with
+    # "success" is whichever attempt actually succeeded (attempt 2
+    # in this test).
+    assert len(result.attempts) >= 2
+    assert any("success" in line for line in result.attempts)
+    assert any("attempt 1" in line and "failed" in line
+               for line in result.attempts)
+
+
+def test_upload_gives_up_fast_on_ssh_unreachable(tmp_path: Path) -> None:
+    # SSH connect failure — retrying won't help, skip further attempts.
+    bundle = tmp_path / "b.bundle"
+    bundle.write_bytes(b"x" * 1000)
+
+    fake = _make_fake_run(
+        returncodes=[255],
+        stderrs=[
+            "ssh: connect to host 100.92.174.43 port 22: "
+            "Operation timed out"
+        ],
+    )
+    with patch("shipyard.bundle.git_bundle.subprocess.run", side_effect=fake), \
+         patch("time.sleep"):
+        result = upload_bundle(
+            bundle_path=bundle,
+            host="win",
+            remote_path="C:\\shipyard.bundle",
+            is_windows=True,
+            max_attempts=3,
+        )
+    assert result.success is False
+    assert result.failure_class == "ssh_unreachable"
+    # Only ONE attempt — we bail fast on unreachable rather than
+    # burning the full budget.
+    assert fake._calls["n"] == 1
+    assert len(result.attempts) == 1
+
+
+def test_upload_failed_after_reachable_exhausts_retries(tmp_path: Path) -> None:
+    # Pulp repro shape: the host is reachable but upload keeps
+    # failing (slow runner under AV pressure). We want the full
+    # retry budget, classification `upload_failed`, and a message
+    # citing how many attempts happened.
+    bundle = tmp_path / "b.bundle"
+    bundle.write_bytes(b"x" * 1000)
+
+    fake = _make_fake_run(
+        returncodes=[1, 1, 1],
+        stderrs=[
+            "scp: stream ended unexpectedly",
+            "scp: stream ended unexpectedly",
+            "scp: stream ended unexpectedly",
+        ],
+    )
+    with patch("shipyard.bundle.git_bundle.subprocess.run", side_effect=fake), \
+         patch("time.sleep"):
+        result = upload_bundle(
+            bundle_path=bundle,
+            host="win",
+            remote_path="C:\\shipyard.bundle",
+            is_windows=True,
+            max_attempts=3,
+        )
+    assert result.success is False
+    assert result.failure_class == "upload_failed"
+    assert fake._calls["n"] == 3
+    assert len(result.attempts) == 3
+    assert "3 attempt" in result.message
+
+
+def test_bundle_result_default_failure_class_is_other() -> None:
+    # Backward compat for existing callers that construct
+    # BundleResult directly without the new fields.
+    r = BundleResult(success=False, message="something broke")
+    assert r.failure_class == "other"
+    assert r.attempts == ()

--- a/tests/test_cli_pin_bump.py
+++ b/tests/test_cli_pin_bump.py
@@ -30,6 +30,22 @@ pytestmark = pytest.mark.skipif(
 )
 
 
+@pytest.fixture(autouse=True)
+def _neutralize_243_guards(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Default the #243 guards off so pre-existing tests don't pick up
+    the real ``shipyard --version`` / ``origin/main`` state from the
+    developer's machine.
+
+    Guard-specific tests override these patches explicitly.
+    """
+    monkeypatch.setattr(
+        "shipyard.cli._current_global_shipyard_version", lambda: None,
+    )
+    monkeypatch.setattr(
+        "shipyard.cli._main_pinned_version_at_origin", lambda _root: None,
+    )
+
+
 def _setup_consumer_repo(
     tmp_path: Path,
     *,
@@ -347,3 +363,176 @@ def test_pin_bump_normalizes_missing_v_prefix(
     # Version string must be prefixed with v even though the user
     # passed a bare number.
     assert 'version = "v0.44.0"' in rewritten
+
+
+# ---------------------------------------------------------------------------
+# #243: worktree-safety guards
+# ---------------------------------------------------------------------------
+
+
+def test_pin_bump_refuses_downgrade_of_global_binary(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Stale worktree: pin says v0.20.0, user asks for --to v0.26.0,
+    # but the globally-installed binary is v0.47.0. Running
+    # install-shipyard.sh with v0.26.0 would regress the global
+    # install, so we refuse and tell them to rebase.
+    repo = _setup_consumer_repo(tmp_path, pinned_version="v0.20.0")
+    monkeypatch.chdir(repo)
+    monkeypatch.setattr(
+        "shipyard.cli._current_global_shipyard_version", lambda: "0.47.0",
+    )
+    # Neutralize the redundant-branch guard — we're testing downgrade
+    # only, and origin/main won't exist in this tmp repo anyway.
+    monkeypatch.setattr(
+        "shipyard.cli._main_pinned_version_at_origin", lambda _root: None,
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main, ["pin", "bump", "--to", "v0.26.0", "--no-pr", "--skip-verify"],
+    )
+    assert result.exit_code != 0
+    assert "downgrade" in result.output.lower()
+    assert "--allow-downgrade" in result.output
+    # Pin file must NOT be rewritten on refusal.
+    toml_text = (repo / "tools" / "shipyard.toml").read_text()
+    assert 'version = "v0.20.0"' in toml_text
+
+
+def test_pin_bump_allow_downgrade_escape_hatch(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Same setup as above but with --allow-downgrade, the bump
+    # proceeds and rewrites the pin.
+    repo = _setup_consumer_repo(tmp_path, pinned_version="v0.20.0")
+    monkeypatch.chdir(repo)
+    monkeypatch.setattr(
+        "shipyard.cli._current_global_shipyard_version", lambda: "0.47.0",
+    )
+    monkeypatch.setattr(
+        "shipyard.cli._main_pinned_version_at_origin", lambda _root: None,
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "pin", "bump", "--to", "v0.26.0",
+            "--allow-downgrade", "--no-pr", "--skip-verify",
+        ],
+    )
+    _assert_cli_ok(result)
+    assert 'version = "v0.26.0"' in (
+        repo / "tools" / "shipyard.toml"
+    ).read_text()
+
+
+def test_pin_bump_skips_downgrade_guard_when_binary_unreachable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # If `shipyard --version` can't be reached (returns None), the
+    # downgrade guard is skipped — we'd rather proceed than refuse
+    # on a missing binary.
+    repo = _setup_consumer_repo(tmp_path, pinned_version="v0.20.0")
+    monkeypatch.chdir(repo)
+    monkeypatch.setattr(
+        "shipyard.cli._current_global_shipyard_version", lambda: None,
+    )
+    monkeypatch.setattr(
+        "shipyard.cli._main_pinned_version_at_origin", lambda _root: None,
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main, ["pin", "bump", "--to", "v0.26.0", "--no-pr", "--skip-verify"],
+    )
+    _assert_cli_ok(result)
+
+
+def test_pin_bump_refuses_redundant_branch(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Branch behind main: origin/main pins v0.47.0, this worktree
+    # pins v0.40.0, user asks to bump to v0.47.0. The bump is
+    # redundant with what main already has — refuse.
+    repo = _setup_consumer_repo(tmp_path, pinned_version="v0.40.0")
+    monkeypatch.chdir(repo)
+    monkeypatch.setattr(
+        "shipyard.cli._current_global_shipyard_version", lambda: None,
+    )
+    monkeypatch.setattr(
+        "shipyard.cli._main_pinned_version_at_origin",
+        lambda _root: "v0.47.0",
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main, ["pin", "bump", "--to", "v0.47.0", "--no-pr", "--skip-verify"],
+    )
+    assert result.exit_code != 0
+    assert "redundant" in result.output.lower() or \
+           "origin/main" in result.output.lower()
+    assert "--allow-redundant" in result.output
+
+
+def test_pin_bump_allow_redundant_escape_hatch(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # --allow-redundant lets the same redundant bump proceed.
+    repo = _setup_consumer_repo(tmp_path, pinned_version="v0.40.0")
+    monkeypatch.chdir(repo)
+    monkeypatch.setattr(
+        "shipyard.cli._current_global_shipyard_version", lambda: None,
+    )
+    monkeypatch.setattr(
+        "shipyard.cli._main_pinned_version_at_origin",
+        lambda _root: "v0.47.0",
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "pin", "bump", "--to", "v0.47.0",
+            "--allow-redundant", "--no-pr", "--skip-verify",
+        ],
+    )
+    _assert_cli_ok(result)
+    assert 'version = "v0.47.0"' in (
+        repo / "tools" / "shipyard.toml"
+    ).read_text()
+
+
+def test_pin_bump_skips_redundant_guard_when_origin_main_unreachable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Offline / no origin remote / no main branch: guard B returns
+    # None and we proceed. Covers the 'tmp-repo has no origin'
+    # case as well as real offline operation.
+    repo = _setup_consumer_repo(tmp_path, pinned_version="v0.40.0")
+    monkeypatch.chdir(repo)
+    monkeypatch.setattr(
+        "shipyard.cli._current_global_shipyard_version", lambda: None,
+    )
+    monkeypatch.setattr(
+        "shipyard.cli._main_pinned_version_at_origin", lambda _root: None,
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main, ["pin", "bump", "--to", "v0.47.0", "--no-pr", "--skip-verify"],
+    )
+    _assert_cli_ok(result)
+
+
+def test_parse_version_tuple_edge_cases() -> None:
+    # Non-semver inputs return None so guards no-op instead of
+    # false-triggering. Regression-guard against a future refactor
+    # that tries to compare 'v0.47.0-rc1' and hits a TypeError.
+    from shipyard.cli import _parse_version_tuple
+    assert _parse_version_tuple("v0.47.0") == (0, 47, 0)
+    assert _parse_version_tuple("0.47.0") == (0, 47, 0)
+    assert _parse_version_tuple("0.47.0-rc1") is None
+    assert _parse_version_tuple("latest") is None
+    assert _parse_version_tuple("") is None


### PR DESCRIPTION
Two refuse-by-default guards on `shipyard pin bump` so consumer-repo
users don't have to remember which worktree is stale before running
the command:

1. Guard A — refuse to downgrade the currently-installed global
   `shipyard` binary. Fires when target < `shipyard --version`.
   Common trigger: running the command in a stale worktree whose
   pin is older than the globally-installed binary. Escape:
   --allow-downgrade.

2. Guard B — refuse when `origin/main:tools/shipyard.toml` already
   pins >= the target. Trigger: branch is behind main; the PR
   would be redundant or conflict-prone at merge time. Escape:
   --allow-redundant.

Both guards fail open when their inputs are unavailable (no
shipyard on PATH, offline, no origin/main) — advisory, not
load-bearing. Guard order places refusals before the pin-file
rewrite so a refused run leaves the working tree clean.

Also added `skills/ci/SKILL.md` section covering the
multi-worktree / multi-consumer mental model so agents pick the
right flow.

Pulp-side port tracked in #244.