### PR TITLE
shipyard run: tree-hash drift detection at stage boundaries (#249)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to Shipyard are documented here. Each entry links
 to its [GitHub Release](https://github.com/danielraffel/Shipyard/releases).
 
 <a id="v0470"></a>
+## [0.48.0]
+
 ## [0.47.0] - 2026-04-24
 
 - #239 Phase A: ssh-windows bundle upload hardening ([#241](https://github.com/danielraffel/Shipyard/pull/241))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "shipyard"
-version = "0.47.0"
+version = "0.48.0"
 description = "Cross-platform CI coordination — local VMs, SSH hosts, cloud runners"
 readme = "README.md"
 license = "MIT"

--- a/src/shipyard/__init__.py
+++ b/src/shipyard/__init__.py
@@ -1,3 +1,3 @@
 """Shipyard — Cross-platform CI coordination."""
 
-__version__ = "0.47.0"
+__version__ = "0.48.0"

--- a/src/shipyard/cli.py
+++ b/src/shipyard/cli.py
@@ -28,6 +28,7 @@ from shipyard import __version__
 from shipyard.cloud.github import find_dispatched_run, run_view, workflow_dispatch
 from shipyard.cloud.records import CloudRecordStore, CloudRunRecord
 from shipyard.cloud.registry import default_workflow_key, discover_workflows, resolve_cloud_dispatch_plan
+from shipyard.core.classify import FailureClass
 from shipyard.core.config import Config
 from shipyard.core.evidence import EvidenceStore
 from shipyard.core.job import Job, JobStatus, TargetResult, TargetStatus, ValidationMode
@@ -189,6 +190,19 @@ def main(ctx: click.Context, json_mode: bool) -> None:
         "SHIPYARD_NO_WARM_POOL=1 for this invocation."
     ),
 )
+@click.option(
+    "--allow-tree-drift",
+    is_flag=True,
+    default=False,
+    help=(
+        "Suppress the #249 working-tree drift guard for this run. "
+        "By default, `shipyard run` fails fast if the working tree "
+        "changes between validation stages (mid-run edits in a "
+        "multi-agent workflow produce non-deterministic failures). "
+        "Pass this flag when a build step legitimately writes "
+        "generated files into the tree."
+    ),
+)
 @click.pass_obj
 def run(
     ctx: Context,
@@ -200,6 +214,7 @@ def run(
     allow_unreachable_targets: bool,
     skip_target: tuple[str, ...],
     no_warm: bool,
+    allow_tree_drift: bool,
 ) -> None:
     """Validate current HEAD on configured targets.
 
@@ -291,6 +306,7 @@ def run(
         fail_fast=fail_fast,
         resume_from=resume_from,
         warm_disabled=no_warm,
+        allow_tree_drift=allow_tree_drift,
     )
 
     if ctx.json_mode:
@@ -300,7 +316,16 @@ def run(
             render_message("All green.", style="bold green")
         else:
             render_message("Failed.", style="bold red")
-            sys.exit(1)
+    # Exit 3 when any target hit tree drift — distinct from validation
+    # failure (exit 1) so agents can distinguish "the build was correct
+    # but the tree moved under it" from "the code actually failed."
+    if any(
+        (r.failure_class or "") == FailureClass.TREE_DRIFT.value
+        for r in job.results.values()
+    ):
+        sys.exit(3)
+    if not job.passed:
+        sys.exit(1)
 
 
 @main.command()
@@ -5887,11 +5912,21 @@ def _execute_job(
     resume_from: str | None,
     ship_state: ShipState | None = None,
     warm_disabled: bool = False,
+    allow_tree_drift: bool = False,
 ) -> Job:
     job = job.start()
     ctx.queue.update(job)
 
     validation_config = _resolve_validation(config, mode)
+    # #249: thread the CLI `--allow-tree-drift` opt-out through as a
+    # private flag on validation_config. LocalExecutor reads this to
+    # decide whether to enforce drift detection; other executors
+    # (ssh, cloud) ignore it today. Using a leading underscore to
+    # mark this as a runtime-injected key, not a user-declared one.
+    validation_config = {
+        **validation_config,
+        "_allow_tree_drift": allow_tree_drift,
+    }
     had_failure = False
     warm_pool = WarmPool(default_pool_path(config.state_dir))
     # Global kill switch: env var disables everything for this process.

--- a/src/shipyard/core/classify.py
+++ b/src/shipyard/core/classify.py
@@ -44,6 +44,7 @@ class FailureClass(str, Enum):
     TIMEOUT = "TIMEOUT"
     CONTRACT = "CONTRACT"
     TEST = "TEST"
+    TREE_DRIFT = "TREE_DRIFT"
     UNKNOWN = "UNKNOWN"
 
 

--- a/src/shipyard/core/tree_drift.py
+++ b/src/shipyard/core/tree_drift.py
@@ -1,0 +1,166 @@
+"""Working-tree drift detection for `shipyard run` (#249).
+
+Context: `shipyard run` reads the live working tree through every
+validation stage (configure → build → test). Edits that land mid-run
+— whether from a parallel agent or a human — corrupt the run
+silently, then surface as an unrelated-looking compile error 20+
+minutes in. #238 shipped a doc-fix + one-liner warning (P3 scope);
+this module is the P2 follow-up that fails fast with a specific
+error instead.
+
+How it works: compute a content-addressed signature of the working
+tree at run start, re-compute at each stage boundary, abort with
+``FailureClass.TREE_DRIFT`` when the signature changes. ~milliseconds
+per check on a typical repo.
+
+What counts as the tree: git-tracked files with unstaged/staged
+modifications, plus all untracked files that aren't gitignored. That's
+the set `git ls-files -m -o --exclude-standard` reports. Ignored files
+don't count — build outputs and caches routinely change mid-run and
+aren't user edits.
+
+Kept in a dedicated module so LocalExecutor's `_run_stages` integration
+stays small and both surfaces (executor + future CLI probes) share the
+same signature function.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import subprocess
+from pathlib import Path
+
+
+def compute_signature(cwd: str | Path | None = None) -> str | None:
+    """Return a short opaque signature of the working-tree state.
+
+    The signature changes iff any tracked file's on-disk content
+    differs, any untracked non-ignored file appears/disappears/changes,
+    or HEAD moves. Returns ``None`` when git is unavailable or the
+    path isn't a git repo — callers treat that as "can't check, skip
+    the guard" so non-git projects aren't penalized.
+    """
+    cwd_str = str(cwd) if cwd else None
+
+    head = _git_output(["git", "rev-parse", "HEAD"], cwd_str, timeout=5)
+    if head is None:
+        return None
+
+    # `-m` = tracked files with unstaged modifications.
+    # `-o --exclude-standard` = untracked files that aren't gitignored.
+    # Staged-but-unmodified files don't show up here but still contribute
+    # via the diff hash below — so a `git add` between stages is caught.
+    listing = _git_output(
+        ["git", "ls-files", "-m", "-o", "--exclude-standard"],
+        cwd_str, timeout=30,
+    )
+    if listing is None:
+        return None
+
+    # Also capture the full diff against HEAD so staged changes (which
+    # `-m` doesn't list) and content-level edits show up in the hash.
+    # `--no-ext-diff` keeps user-configured external diff tools from
+    # making the signature non-deterministic.
+    diff = _git_output(
+        ["git", "diff", "--no-ext-diff", "HEAD"],
+        cwd_str, timeout=30,
+    )
+    if diff is None:
+        return None
+
+    h = hashlib.sha256()
+    h.update(head.encode())
+    h.update(b"\0LS\0")
+    h.update(listing.encode())
+    h.update(b"\0DIFF\0")
+    h.update(diff.encode())
+
+    # Untracked file contents aren't in `git diff HEAD`, so hash them
+    # directly. Sort for determinism.
+    base = Path(cwd_str) if cwd_str else Path.cwd()
+    for path in sorted(p for p in listing.splitlines() if p):
+        full = base / path
+        h.update(b"\0U\0")
+        h.update(path.encode())
+        try:
+            h.update(full.read_bytes())
+        except OSError:
+            # Path vanished between the listing and the read (race
+            # with a rename/delete). That *is* drift — fold a sentinel
+            # into the hash so a subsequent compute sees a different
+            # value.
+            h.update(b"<missing>")
+
+    return h.hexdigest()[:32]
+
+
+def list_dirty_paths(cwd: str | Path | None = None) -> list[str]:
+    """List paths currently dirty relative to HEAD.
+
+    Shape matches `git status --short` (status prefix + path) so the
+    error message surfaces the same view the user would see by running
+    git themselves. Empty list when clean or git is unavailable.
+    """
+    cwd_str = str(cwd) if cwd else None
+    output = _git_output(
+        ["git", "status", "--short", "--untracked-files=all"],
+        cwd_str, timeout=30,
+    )
+    if output is None:
+        return []
+    return [line for line in output.splitlines() if line.strip()]
+
+
+def format_drift_error(
+    stage: str,
+    initial_paths: list[str],
+    current_paths: list[str],
+) -> str:
+    """Format the user-facing drift error message (#249 acceptance).
+
+    Shows the stage that was about to run and what changed since the
+    run started — the initial dirty set vs the current one — so the
+    operator / agent knows exactly which files drifted without diffing
+    manually.
+    """
+    lines = [
+        f"working tree changed during `shipyard run` (stage={stage}).",
+        "mid-run edits produce non-deterministic failures (#238).",
+        "re-run after your other edits settle, or use separate "
+        "worktrees for parallel work.",
+    ]
+    initial_set = set(initial_paths)
+    current_set = set(current_paths)
+    added = sorted(current_set - initial_set)
+    removed = sorted(initial_set - current_set)
+    if added or removed:
+        lines.append("")
+        lines.append("what changed:")
+        for entry in added:
+            lines.append(f"  + {entry}")
+        for entry in removed:
+            lines.append(f"  - {entry}")
+    # Pass the `--allow-tree-drift` hint last so it's visible but not
+    # the first thing a reviewer sees — we don't want to advertise the
+    # escape hatch over the fix (rebase / separate worktree).
+    lines.append("")
+    lines.append(
+        "(pass --allow-tree-drift to suppress this guard when you "
+        "know a build step mutates the tree on purpose.)"
+    )
+    return "\n".join(lines)
+
+
+def _git_output(
+    cmd: list[str], cwd: str | None, *, timeout: float,
+) -> str | None:
+    """Run a git command, return stdout on success, None on any failure."""
+    try:
+        result = subprocess.run(
+            cmd, cwd=cwd, capture_output=True, text=True, timeout=timeout,
+        )
+    except (FileNotFoundError, subprocess.SubprocessError):
+        return None
+    if result.returncode != 0:
+        return None
+    return result.stdout

--- a/src/shipyard/executor/local.py
+++ b/src/shipyard/executor/local.py
@@ -26,6 +26,13 @@ from shipyard.core.prepared_state import (
     filter_stages_by_prepared_state,
     hash_stage_commands,
 )
+from shipyard.core.tree_drift import (
+    compute_signature as _tree_signature,
+)
+from shipyard.core.tree_drift import (
+    format_drift_error,
+    list_dirty_paths,
+)
 from shipyard.executor.contract import (
     evaluate_contract,
     required_markers,
@@ -109,6 +116,9 @@ class LocalExecutor:
             sha=sha,
             mode=mode,
             prepared_state_enabled=_prepared_state_enabled(validation_config),
+            allow_tree_drift=bool(
+                validation_config.get("_allow_tree_drift", False)
+            ),
         )
 
     def _run_single(
@@ -181,6 +191,7 @@ class LocalExecutor:
         sha: str = "",
         mode: str = "default",
         prepared_state_enabled: bool = False,
+        allow_tree_drift: bool = False,
     ) -> TargetResult:
         """Run validation as separate stages. Stop at first failure.
 
@@ -222,6 +233,22 @@ class LocalExecutor:
             if prepared_skipped:
                 stages = stages_to_run
 
+        # #249 — tree-drift detection. Capture a signature of the
+        # working tree before any stage runs, then re-check before
+        # each subsequent stage. Mid-run edits (common in multi-agent
+        # workflows) would otherwise silently corrupt the build and
+        # surface 20+ minutes later as unrelated-looking compile
+        # errors. Skipped entirely when the project / operator opts
+        # out via --allow-tree-drift, or when git isn't available
+        # (signature returns None → guard no-ops).
+        drift_cwd = target_config.get("cwd")
+        initial_signature: str | None = None
+        initial_dirty_paths: list[str] = []
+        if not allow_tree_drift:
+            initial_signature = _tree_signature(drift_cwd)
+            if initial_signature is not None:
+                initial_dirty_paths = list_dirty_paths(drift_cwd)
+
         try:
             log_file.write_text("")
             if prepared_skipped:
@@ -232,7 +259,37 @@ class LocalExecutor:
                         f"({', '.join(prepared_skipped)}) for sha={sha} "
                         f"target={target_name} mode={mode} ===\n"
                     )
-            for stage_name, command in stages:
+            for stage_index, (stage_name, command) in enumerate(stages):
+                # Drift check at every stage boundary AFTER the first
+                # — the first stage's check would compare the baseline
+                # to itself. By checking at the top of each subsequent
+                # stage we catch drift within seconds of the previous
+                # stage finishing, not the 20-min-deep compile error.
+                if (
+                    stage_index > 0
+                    and initial_signature is not None
+                ):
+                    current = _tree_signature(drift_cwd)
+                    if current is not None and current != initial_signature:
+                        current_dirty = list_dirty_paths(drift_cwd)
+                        error_msg = format_drift_error(
+                            stage_name, initial_dirty_paths, current_dirty,
+                        )
+                        with open(log_file, "a", encoding="utf-8") as log:
+                            log.write(f"\n=== TREE_DRIFT at {stage_name} ===\n")
+                            log.write(error_msg + "\n")
+                        return TargetResult(
+                            target_name=target_name, platform=platform,
+                            status=TargetStatus.ERROR, backend="local",
+                            duration_secs=time.monotonic() - start_time,
+                            started_at=started_at,
+                            completed_at=datetime.now(timezone.utc),
+                            log_path=str(log_file),
+                            error_message=error_msg,
+                            phase=stage_name,
+                            failure_class=FailureClass.TREE_DRIFT.value,
+                        )
+
                 stage_start = time.monotonic()
                 with open(log_file, "a", encoding="utf-8") as log:
                     log.write(f"\n=== {stage_name} ===\n")

--- a/tests/core/test_tree_drift.py
+++ b/tests/core/test_tree_drift.py
@@ -1,0 +1,149 @@
+"""Unit tests for `shipyard.core.tree_drift` (#249).
+
+Exercises the signature + dirty-path helpers directly against real
+git repos under `tmp_path`. Keeps executor-integration out of scope —
+that's covered separately in tests/executor/test_249_tree_drift.py.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path  # noqa: TC003 — tmp_path fixture type hint
+
+from shipyard.core.tree_drift import (
+    compute_signature,
+    format_drift_error,
+    list_dirty_paths,
+)
+
+
+def _init_repo(path: Path, *, seed_file: str = "seed.txt") -> None:
+    subprocess.run(["git", "init", "-q"], cwd=path, check=True)
+    subprocess.run(
+        ["git", "config", "user.email", "t@example.com"],
+        cwd=path, check=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test"], cwd=path, check=True,
+    )
+    (path / seed_file).write_text("seed\n")
+    subprocess.run(["git", "add", seed_file], cwd=path, check=True)
+    subprocess.run(
+        ["git", "commit", "-q", "-m", "initial"], cwd=path, check=True,
+    )
+
+
+def test_signature_stable_when_tree_unchanged(tmp_path: Path) -> None:
+    _init_repo(tmp_path)
+    sig_a = compute_signature(tmp_path)
+    sig_b = compute_signature(tmp_path)
+    assert sig_a is not None
+    assert sig_a == sig_b
+
+
+def test_signature_changes_on_tracked_file_edit(tmp_path: Path) -> None:
+    _init_repo(tmp_path)
+    baseline = compute_signature(tmp_path)
+    (tmp_path / "seed.txt").write_text("seed\nedit\n")
+    after = compute_signature(tmp_path)
+    assert baseline != after
+
+
+def test_signature_changes_on_untracked_file_create(tmp_path: Path) -> None:
+    _init_repo(tmp_path)
+    baseline = compute_signature(tmp_path)
+    (tmp_path / "new.txt").write_text("hello\n")
+    after = compute_signature(tmp_path)
+    assert baseline != after
+
+
+def test_signature_changes_on_untracked_file_content(
+    tmp_path: Path,
+) -> None:
+    _init_repo(tmp_path)
+    (tmp_path / "new.txt").write_text("v1\n")
+    baseline = compute_signature(tmp_path)
+    (tmp_path / "new.txt").write_text("v2\n")
+    after = compute_signature(tmp_path)
+    assert baseline != after
+
+
+def test_signature_ignores_gitignored_file(tmp_path: Path) -> None:
+    # Ignored paths shouldn't count — build caches / outputs are the
+    # classic false-positive source. This is load-bearing for real
+    # projects where cmake / ninja write to build/ mid-run.
+    _init_repo(tmp_path)
+    (tmp_path / ".gitignore").write_text("build/\n")
+    subprocess.run(
+        ["git", "add", ".gitignore"], cwd=tmp_path, check=True,
+    )
+    subprocess.run(
+        ["git", "commit", "-q", "-m", "ignore build"],
+        cwd=tmp_path, check=True,
+    )
+    baseline = compute_signature(tmp_path)
+    (tmp_path / "build").mkdir()
+    (tmp_path / "build" / "artifact.o").write_text("x")
+    after = compute_signature(tmp_path)
+    assert baseline == after
+
+
+def test_signature_changes_when_head_moves(tmp_path: Path) -> None:
+    _init_repo(tmp_path)
+    baseline = compute_signature(tmp_path)
+    (tmp_path / "seed.txt").write_text("seed\ncommit2\n")
+    subprocess.run(
+        ["git", "commit", "-aq", "-m", "second"], cwd=tmp_path, check=True,
+    )
+    after = compute_signature(tmp_path)
+    assert baseline != after
+
+
+def test_signature_returns_none_outside_git_repo(tmp_path: Path) -> None:
+    # Callers treat None as "can't check, skip the guard" so non-git
+    # projects aren't penalized. Regression guard against a refactor
+    # that raises instead.
+    assert compute_signature(tmp_path) is None
+
+
+def test_list_dirty_paths_clean_tree(tmp_path: Path) -> None:
+    _init_repo(tmp_path)
+    assert list_dirty_paths(tmp_path) == []
+
+
+def test_list_dirty_paths_reports_modifications(tmp_path: Path) -> None:
+    _init_repo(tmp_path)
+    (tmp_path / "seed.txt").write_text("seed\nedit\n")
+    (tmp_path / "new.txt").write_text("new\n")
+    paths = list_dirty_paths(tmp_path)
+    # Shape matches `git status --short` — status prefix + path.
+    assert any("seed.txt" in line for line in paths)
+    assert any("new.txt" in line for line in paths)
+
+
+def test_format_drift_error_shape() -> None:
+    # Exact wording is load-bearing for the #249 acceptance criteria:
+    # the stage name, the "what changed" header, and the escape-hatch
+    # hint must all be present so agents / operators see a useful
+    # diagnostic without parsing logs.
+    msg = format_drift_error(
+        stage="build",
+        initial_paths=[" M initial-dirty.txt"],
+        current_paths=[" M initial-dirty.txt", " M new-change.cpp"],
+    )
+    assert "stage=build" in msg
+    assert "what changed:" in msg
+    assert "new-change.cpp" in msg
+    # The before-set file must NOT be reported as changed.
+    assert "+ initial-dirty.txt" not in msg
+    assert "--allow-tree-drift" in msg
+
+
+def test_format_drift_error_no_paths_still_useful() -> None:
+    # Edge case: signature changed but list_dirty_paths returned empty
+    # (e.g. a HEAD move with matching tree state). Message must still
+    # be clear about what to do.
+    msg = format_drift_error(stage="configure", initial_paths=[], current_paths=[])
+    assert "stage=configure" in msg
+    assert "#238" in msg
+    assert "--allow-tree-drift" in msg

--- a/tests/executor/test_249_tree_drift.py
+++ b/tests/executor/test_249_tree_drift.py
@@ -1,0 +1,243 @@
+"""End-to-end tests for LocalExecutor tree-drift detection (#249).
+
+Concrete races we're guarding against (from the #249 brief):
+
+  2026-04-24, Spectr PR #20 — 30+ min burned on a mac build that
+  failed at 90%+ because a parallel edit on a different branch of
+  the same tree leaked a new SDK method call into the build step.
+  The compile error surfaced in the middle of build, ~20 minutes
+  into an otherwise-healthy run.
+
+The guard's job is to catch that drift at the first stage boundary
+after the edit and fail fast with a clear error, instead of letting
+the run burn another 15 minutes before surfacing an unrelated-
+looking compile error.
+
+Tests here drive real `shipyard.executor.local.LocalExecutor.validate`
+calls against real git repos under `tmp_path` with multi-stage
+validation configs, which is the integration shape #249 cares about.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from shipyard.core.classify import FailureClass
+from shipyard.core.job import TargetStatus
+from shipyard.executor.local import LocalExecutor
+
+
+@pytest.fixture
+def _drift_workspace() -> tuple[Path, Path]:
+    # Two sibling dirs: a git repo under repo/ and a log dir under
+    # logs/. In production the log path lives under state_dir
+    # (typically ~/.shipyard/logs/...), outside the working tree, so
+    # the log file's own writes can never be confused with drift.
+    # Keep that invariant in tests.
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_root = Path(tmp)
+        root = tmp_root / "repo"
+        root.mkdir()
+        logs = tmp_root / "logs"
+        logs.mkdir()
+        subprocess.run(["git", "init", "-q"], cwd=root, check=True)
+        subprocess.run(
+            ["git", "config", "user.email", "t@example.com"],
+            cwd=root, check=True,
+        )
+        subprocess.run(
+            ["git", "config", "user.name", "Test"], cwd=root, check=True,
+        )
+        (root / "src.txt").write_text("v1\n")
+        subprocess.run(["git", "add", "src.txt"], cwd=root, check=True)
+        subprocess.run(
+            ["git", "commit", "-q", "-m", "initial"], cwd=root, check=True,
+        )
+        yield root, logs
+
+
+@pytest.fixture
+def repo_dir(_drift_workspace: tuple[Path, Path]) -> Path:
+    return _drift_workspace[0]
+
+
+@pytest.fixture
+def log_path(_drift_workspace: tuple[Path, Path]) -> str:
+    return str(_drift_workspace[1] / "run.log")
+
+
+def _run(
+    executor: LocalExecutor,
+    repo_dir: Path,
+    log_path: str,
+    *,
+    stages: dict[str, str],
+    allow_tree_drift: bool = False,
+):
+    validation_config: dict = dict(stages)
+    validation_config["_allow_tree_drift"] = allow_tree_drift
+    return executor.validate(
+        sha="abc1234",
+        branch="test",
+        target_config={
+            "name": "test",
+            "platform": "macos-arm64",
+            "cwd": str(repo_dir),
+        },
+        validation_config=validation_config,
+        log_path=log_path,
+    )
+
+
+def test_clean_tree_passes(repo_dir: Path, log_path: str) -> None:
+    # Acceptance criterion: clean tree → no change from today.
+    # Every stage succeeds, no drift, PASS result.
+    executor = LocalExecutor()
+    result = _run(
+        executor, repo_dir, log_path,
+        stages={"setup": "true", "build": "true", "test": "true"},
+    )
+    assert result.status == TargetStatus.PASS, (
+        f"expected PASS, got {result.status} / {result.error_message!r}"
+    )
+    assert result.failure_class is None
+
+
+def test_edit_between_stages_aborts_with_tree_drift(
+    repo_dir: Path, log_path: str,
+) -> None:
+    # Acceptance criterion: edit a tracked file mid-run, next stage
+    # boundary detects drift and aborts with TREE_DRIFT failure class.
+    # The `setup` stage mutates a tracked file; the next stage
+    # (`build`) runs its drift check first, sees the new signature,
+    # and the run terminates before `build`'s command ever executes.
+    executor = LocalExecutor()
+    # Note: the setup command edits `src.txt` — that's the "parallel
+    # edit" in the real scenario, modeled here as an in-stage mutation
+    # so the test is deterministic.
+    edit_cmd = f"echo edit >> {repo_dir / 'src.txt'}"
+    result = _run(
+        executor, repo_dir, log_path,
+        stages={
+            "setup": edit_cmd,
+            "build": "echo build-would-have-run",
+            "test": "echo test-would-have-run",
+        },
+    )
+    assert result.status == TargetStatus.ERROR
+    assert result.failure_class == FailureClass.TREE_DRIFT.value
+    assert "working tree changed" in (result.error_message or "")
+    # The error must name the stage that was about to start.
+    assert "stage=build" in (result.error_message or "")
+    # Build's actual command must NOT have been run — the log should
+    # not mention `build-would-have-run`.
+    log_text = Path(log_path).read_text()
+    assert "build-would-have-run" not in log_text
+    assert "TREE_DRIFT" in log_text
+
+
+def test_allow_tree_drift_suppresses_guard(
+    repo_dir: Path, log_path: str,
+) -> None:
+    # Acceptance criterion: --allow-tree-drift tolerates mid-run edits.
+    # Same scenario as above, but with the escape hatch engaged — the
+    # build + test stages proceed normally and the run reaches PASS.
+    executor = LocalExecutor()
+    edit_cmd = f"echo edit >> {repo_dir / 'src.txt'}"
+    result = _run(
+        executor, repo_dir, log_path,
+        stages={
+            "setup": edit_cmd,
+            "build": "echo build-ran",
+            "test": "echo test-ran",
+        },
+        allow_tree_drift=True,
+    )
+    assert result.status == TargetStatus.PASS, (
+        f"expected PASS with --allow-tree-drift, got "
+        f"{result.status} / {result.error_message!r}"
+    )
+    log_text = Path(log_path).read_text()
+    assert "build-ran" in log_text
+    assert "test-ran" in log_text
+
+
+def test_edit_during_first_stage_not_caught(
+    repo_dir: Path, log_path: str,
+) -> None:
+    # Documented behavior: drift detection is stage-boundary-grained,
+    # not in-stage. An edit during the last stage won't be caught —
+    # there's no next boundary to check at. This test pins that
+    # behavior so a future refactor that claims "detects drift in
+    # every stage" gets called out for the missing check.
+    executor = LocalExecutor()
+    edit_cmd = f"echo edit >> {repo_dir / 'src.txt'}"
+    result = _run(
+        executor, repo_dir, log_path,
+        stages={"test": edit_cmd},
+    )
+    # Single-stage run → no boundary check fires → PASS despite
+    # mid-stage drift. This is the "acceptable granularity" trade-off
+    # the issue explicitly calls out.
+    assert result.status == TargetStatus.PASS
+
+
+def test_untracked_file_creation_between_stages_is_drift(
+    repo_dir: Path, log_path: str,
+) -> None:
+    # Creating an untracked non-ignored file mid-run counts as drift.
+    # This is the shape of a parallel agent that writes a new source
+    # file into the project root (e.g. a code generator or refactor
+    # agent). Should fail fast just like the tracked-file edit case.
+    executor = LocalExecutor()
+    create_cmd = f"echo new-src > {repo_dir / 'new_src.cpp'}"
+    result = _run(
+        executor, repo_dir, log_path,
+        stages={
+            "setup": create_cmd,
+            "build": "echo build",
+        },
+    )
+    assert result.status == TargetStatus.ERROR
+    assert result.failure_class == FailureClass.TREE_DRIFT.value
+
+
+def test_gitignored_file_not_drift(
+    repo_dir: Path, log_path: str,
+) -> None:
+    # Build outputs write to `build/` and similar. Those paths are
+    # gitignored in every real project and must NOT be flagged as
+    # drift — otherwise the guard false-positives on every real
+    # build and becomes useless.
+    (repo_dir / ".gitignore").write_text("build/\n")
+    subprocess.run(["git", "add", ".gitignore"], cwd=repo_dir, check=True)
+    subprocess.run(
+        ["git", "commit", "-q", "-m", "ignore build"],
+        cwd=repo_dir, check=True,
+    )
+
+    executor = LocalExecutor()
+    # The setup stage creates build/ and writes output into it. By
+    # the next stage boundary that's present on disk — but because
+    # it's gitignored the signature shouldn't change.
+    build_dir = repo_dir / "build"
+    write_cmd = (
+        f"mkdir -p {build_dir} && echo artifact > {build_dir / 'out.o'}"
+    )
+    result = _run(
+        executor, repo_dir, log_path,
+        stages={
+            "setup": write_cmd,
+            "build": "true",
+            "test": "true",
+        },
+    )
+    assert result.status == TargetStatus.PASS, (
+        f"gitignored writes must not false-positive; got "
+        f"{result.status} / {result.error_message!r}"
+    )
+    assert result.failure_class is None


### PR DESCRIPTION
Follow-up to #238 — that issue shipped with a doc + one-liner
warning only (P3 scope). The race mechanic was unchanged: `shipyard
run` still reads the live working tree through configure / build /
test, so mid-run edits corrupt the run silently and surface 20+
minutes later as unrelated-looking compile errors (Spectr PR #20 on
2026-04-24 burned 30+ min on a parallel-agent edit leak).

This lands the P2 prevention: a content-addressed signature of the
working tree is captured at run start (`compute_signature` hashes
git HEAD + `git diff HEAD` + untracked non-ignored file contents),
re-computed at each stage boundary, and a mismatch aborts the run
with `FailureClass.TREE_DRIFT` and exit code 3 (distinct from exit
1 validation failure). The error names the stage that was about to
run and lists the paths that changed since start.

Gitignored paths are excluded from the signature — build outputs
would otherwise false-positive every real run. Non-git projects
get None from the signature helper and the guard no-ops. A new
`--allow-tree-drift` CLI flag suppresses the guard for the rare
case where a build step writes generated files into the tree.

Wired via `validation_config["_allow_tree_drift"]` so other
executors (SSH, SSH-Windows, Cloud) ignore the flag today without
signature changes — local is where the Spectr race surfaced.

Tests: 11 unit tests on the signature + dirty-path + message
helpers in tests/core/test_tree_drift.py, plus 6 executor
integration tests in tests/executor/test_249_tree_drift.py covering
the full acceptance matrix (clean run passes, edit-between-stages
aborts, --allow-tree-drift suppresses, last-stage edit not caught
by design, untracked creation is drift, gitignored writes are not).