### PR TITLE
ssh-windows: post-upload bundle probe (#247)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "shipyard"
-version = "0.48.0"
+version = "0.49.0"
 description = "Cross-platform CI coordination — local VMs, SSH hosts, cloud runners"
 readme = "README.md"
 license = "MIT"

--- a/src/shipyard/__init__.py
+++ b/src/shipyard/__init__.py
@@ -1,3 +1,3 @@
 """Shipyard — Cross-platform CI coordination."""
 
-__version__ = "0.48.0"
+__version__ = "0.49.0"

--- a/src/shipyard/executor/ssh_windows.py
+++ b/src/shipyard/executor/ssh_windows.py
@@ -225,6 +225,47 @@ class SSHWindowsExecutor:
                         f"{upload_result.message}",
                     )
 
+                # #247: verify the upload actually landed before
+                # handing off to git. upload_bundle's success can
+                # be reported even when scp closes cleanly with zero
+                # bytes actually on disk — in that failure mode git
+                # emits "error: could not open '...'" which PowerShell
+                # wraps in a CLIXML envelope + progress records, and
+                # the operator sees pulp#728-shaped garbage instead
+                # of a clean "bundle missing after upload" message.
+                # The probe also records size+mtime in the target log
+                # on success, so every future apply failure has
+                # forensic upload state alongside the error.
+                probe = _probe_remote_bundle(
+                    host=host,
+                    bundle_path=remote_bundle,
+                    ssh_options=ssh_options,
+                )
+                try:
+                    with log_file.open("a", encoding="utf-8") as lf:
+                        lf.write(f"bundle post-upload probe: {probe.detail}\n")
+                except OSError:
+                    pass
+                if not probe.exists:
+                    return _error_result(
+                        target_name, platform, started_at, start_time,
+                        str(log_file),
+                        f"Bundle upload completed but remote file is "
+                        f"missing: {probe.detail}. This is the failure "
+                        f"mode from #247 (scp closed cleanly but the "
+                        f"file isn't on the remote). Re-run should "
+                        f"trigger a fresh upload.",
+                    )
+                if probe.size == 0:
+                    return _error_result(
+                        target_name, platform, started_at, start_time,
+                        str(log_file),
+                        f"Bundle upload completed but remote file is "
+                        f"0 bytes: {probe.detail}. This is a silent "
+                        f"truncation (#247). Re-run should trigger a "
+                        f"fresh upload.",
+                    )
+
                 # Apply bundle via PowerShell on the remote. Pass
                 # the per-target log_file through so the raw stderr
                 # (including any CLIXML envelope) gets persisted
@@ -581,6 +622,122 @@ def _remote_has_sha_windows(
         return result.returncode == 0
     except (subprocess.SubprocessError, OSError):
         return False
+
+
+class _BundleProbe:
+    """Result of a post-upload bundle-on-remote check (#247).
+
+    ``exists`` reflects the result of ``Test-Path -LiteralPath``.
+    ``size`` is the file's length in bytes (0 when the file is
+    missing or we couldn't parse the Get-Item output).
+    ``detail`` is a short human-readable summary suitable for logs
+    and error messages.
+    """
+
+    def __init__(self, exists: bool, size: int, detail: str) -> None:
+        self.exists = exists
+        self.size = size
+        self.detail = detail
+
+
+def _probe_remote_bundle(
+    host: str,
+    bundle_path: str,
+    ssh_options: list[str],
+    *,
+    timeout: int = 30,
+) -> _BundleProbe:
+    """Check that the uploaded bundle actually landed on the remote
+    host, and capture its size + mtime as a forensic artifact (#247).
+
+    ``upload_bundle`` returns success when scp/ssh closes cleanly —
+    but a cleanly-closed channel can still end up with zero bytes on
+    disk (session dropout, remote-side write failure the SFTP server
+    didn't surface). Without this probe the next diagnostic signal
+    is git's ``error: could not open '...'``, which gets wrapped by
+    PowerShell's CLIXML envelope and interleaved with progress
+    records — so the user sees the Spectr / pulp#728 failure shape
+    instead of a clean "bundle missing after upload" message.
+
+    Runs a single SSH command (Test-Path + Get-Item if present) and
+    returns an opaque probe object the caller decides what to do
+    with. Any SSH/PowerShell failure returns ``exists=False`` with a
+    diagnostic ``detail`` string — the caller treats that as "upload
+    verification failed, bail" rather than guessing.
+    """
+    safe_bundle = _ps_single_quote(bundle_path)
+    resolved = (
+        f"'{safe_bundle}'"
+        if _is_windows_absolute_path(bundle_path)
+        else f"(Join-Path $HOME '{safe_bundle}')"
+    )
+    script = (
+        f"{_WINDOWS_UTF8_PRELUDE}"
+        f"$Bundle = {resolved}; "
+        f"if (Test-Path -LiteralPath $Bundle) {{ "
+        f"$i = Get-Item -LiteralPath $Bundle; "
+        # One-line, whitespace-separated; easy to parse and easy to
+        # eyeball in the log. mtime in ISO-8601 UTC.
+        f"Write-Output (\"OK size=\" + $i.Length + "
+        f"\" mtime=\" + $i.LastWriteTimeUtc.ToString('o') + "
+        f"\" path=\" + $Bundle) "
+        f"}} else {{ "
+        f"Write-Output (\"MISSING path=\" + $Bundle) "
+        f"}}"
+    )
+    cmd = ["ssh"] + list(ssh_options) + _powershell_encoded_argv(host, script)
+    try:
+        result = subprocess.run(
+            cmd, capture_output=True, text=True, timeout=timeout,
+        )
+    except subprocess.TimeoutExpired:
+        return _BundleProbe(
+            exists=False, size=0,
+            detail=f"probe timed out after {timeout}s",
+        )
+    except (subprocess.SubprocessError, OSError) as exc:
+        return _BundleProbe(
+            exists=False, size=0, detail=f"probe error: {exc}",
+        )
+    if result.returncode != 0:
+        stderr_snip = (result.stderr or "").strip()[:200]
+        return _BundleProbe(
+            exists=False, size=0,
+            detail=(
+                f"probe exited {result.returncode}"
+                + (f": {stderr_snip}" if stderr_snip else "")
+            ),
+        )
+    stdout = (result.stdout or "").strip()
+    # Scan for our sentinel lines anywhere in stdout rather than
+    # requiring them at the start. Some users configure a PowerShell
+    # profile that prints a banner on session open; requiring our
+    # line to be position-0 would false-positive fail on those hosts
+    # and regress them relative to pre-#247 behavior.
+    import re
+    ok_match = re.search(
+        r"OK\s+size=(\d+)\s+mtime=(\S+)\s+path=(.+)", stdout,
+    )
+    if ok_match:
+        size = int(ok_match.group(1))
+        # Keep `detail` as the matched line only, not the whole
+        # stdout — makes the log readable even when a banner runs
+        # long.
+        detail = (
+            f"OK size={size} mtime={ok_match.group(2)} "
+            f"path={ok_match.group(3).strip()}"
+        )
+        return _BundleProbe(exists=True, size=size, detail=detail)
+    missing_match = re.search(r"MISSING\s+path=(.+)", stdout)
+    if missing_match:
+        detail = f"MISSING path={missing_match.group(1).strip()}"
+        return _BundleProbe(exists=False, size=0, detail=detail)
+    # Neither sentinel found — treat as "can't verify" and surface
+    # the snippet so the operator can diagnose.
+    return _BundleProbe(
+        exists=False, size=0,
+        detail=f"probe unexpected output: {stdout[:200]!r}",
+    )
 
 
 def _apply_bundle_windows(

--- a/tests/executor/test_247_bundle_post_upload_probe.py
+++ b/tests/executor/test_247_bundle_post_upload_probe.py
@@ -1,0 +1,181 @@
+"""Tests for ssh-windows post-upload bundle probe (#247).
+
+Context: Pulp PR #728 reproduced a persistent ssh-windows bundle-apply
+failure against a reachable Windows host. The operator saw a CLIXML-
+wrapped `error: could not open 'C:/Users/.../shipyard.bundle'`
+interleaved with a PowerShell progress record — i.e. `git` failing
+to read a file that `upload_bundle` had just reported as delivered.
+The user's suggested fix: verify the uploaded bundle actually landed
+(Test-Path + size) before handing off to git.
+
+`_probe_remote_bundle` implements that verification. Tests here drive
+it with mocked subprocess output covering every branch the helper has
+to return a clean `_BundleProbe` for so `validate()` can distinguish
+"upload silently failed" from "apply itself broke."
+"""
+
+from __future__ import annotations
+
+import subprocess
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest  # noqa: TC002 — MonkeyPatch fixture
+
+from shipyard.executor.ssh_windows import _BundleProbe, _probe_remote_bundle
+
+
+def _proc(
+    returncode: int = 0,
+    stdout: str = "",
+    stderr: str = "",
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        returncode=returncode, stdout=stdout, stderr=stderr,
+    )
+
+
+def test_probe_reports_size_and_mtime_on_success(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Happy path: remote PowerShell says OK with size + mtime. The
+    # probe returns exists=True with the parsed size and the full
+    # detail line preserved for forensic logging.
+    stdout = (
+        "OK size=452837 mtime=2026-04-24T18:12:03.1234567Z "
+        "path=C:\\Users\\ci\\shipyard.bundle"
+    )
+    with patch(
+        "shipyard.executor.ssh_windows.subprocess.run",
+        return_value=_proc(stdout=stdout),
+    ):
+        result = _probe_remote_bundle(
+            host="win", bundle_path="shipyard.bundle",
+            ssh_options=["-o", "ConnectTimeout=5"],
+        )
+    assert isinstance(result, _BundleProbe)
+    assert result.exists is True
+    assert result.size == 452837
+    assert "size=452837" in result.detail
+    assert "mtime=" in result.detail
+
+
+def test_probe_detects_missing_file(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The exact #247 failure mode: upload_bundle claimed success,
+    # but PowerShell's Test-Path says the file is not there.
+    stdout = "MISSING path=C:\\Users\\ci\\shipyard.bundle"
+    with patch(
+        "shipyard.executor.ssh_windows.subprocess.run",
+        return_value=_proc(stdout=stdout),
+    ):
+        result = _probe_remote_bundle(
+            host="win", bundle_path="shipyard.bundle", ssh_options=[],
+        )
+    assert result.exists is False
+    assert result.size == 0
+    assert "MISSING" in result.detail
+
+
+def test_probe_handles_subprocess_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Timeouts during the probe itself are treated as "can't verify".
+    # The caller bails rather than handing off to git on a state it
+    # couldn't confirm — otherwise we just reintroduce the #247
+    # CLIXML-wrapped garbage on a slower / less-responsive host.
+    def raise_timeout(*_args, **_kw):
+        raise subprocess.TimeoutExpired(cmd=["ssh"], timeout=30)
+
+    with patch(
+        "shipyard.executor.ssh_windows.subprocess.run",
+        side_effect=raise_timeout,
+    ):
+        result = _probe_remote_bundle(
+            host="win", bundle_path="shipyard.bundle", ssh_options=[],
+        )
+    assert result.exists is False
+    assert result.size == 0
+    assert "timed out" in result.detail.lower()
+
+
+def test_probe_handles_subprocess_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # OSError (e.g. ssh binary gone) returns exists=False with a
+    # diagnostic so validate() can surface a clean error message.
+    def raise_os_error(*_args, **_kw):
+        raise OSError("ssh: command not found")
+
+    with patch(
+        "shipyard.executor.ssh_windows.subprocess.run",
+        side_effect=raise_os_error,
+    ):
+        result = _probe_remote_bundle(
+            host="win", bundle_path="shipyard.bundle", ssh_options=[],
+        )
+    assert result.exists is False
+    assert "probe error" in result.detail
+
+
+def test_probe_nonzero_exit_preserves_stderr_snippet(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # PowerShell exited non-zero (e.g. auth broke, PowerShell
+    # unavailable on the remote). The probe surfaces exit code +
+    # stderr snippet so the operator has something to grep.
+    with patch(
+        "shipyard.executor.ssh_windows.subprocess.run",
+        return_value=_proc(
+            returncode=255,
+            stderr="Permission denied (publickey).",
+        ),
+    ):
+        result = _probe_remote_bundle(
+            host="win", bundle_path="shipyard.bundle", ssh_options=[],
+        )
+    assert result.exists is False
+    assert "exited 255" in result.detail
+    assert "Permission denied" in result.detail
+
+
+def test_probe_treats_unparseable_stdout_as_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Neither the OK sentinel nor MISSING is present (garbled
+    # output, e.g. PowerShell crashed mid-pipe). The probe must
+    # NOT default to exists=True — that'd reintroduce the #247
+    # failure mode where a missing-file state sneaks past.
+    with patch(
+        "shipyard.executor.ssh_windows.subprocess.run",
+        return_value=_proc(stdout="welcome banner\nsomething else"),
+    ):
+        result = _probe_remote_bundle(
+            host="win", bundle_path="shipyard.bundle", ssh_options=[],
+        )
+    assert result.exists is False
+    assert "unexpected output" in result.detail
+
+
+def test_probe_tolerates_powershell_profile_banner(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Real-world: operator's PowerShell profile prints a banner on
+    # session open. Our OK line ends up on line 2+, not line 1.
+    # Requiring our sentinel at stdout position 0 would false-
+    # positive fail on those hosts, so we scan anywhere in stdout
+    # for the sentinel. This test pins the tolerance.
+    stdout = (
+        "Welcome to PowerShell 7.4, Administrator.\n"
+        "Loading user profile from $PROFILE...\n"
+        "OK size=12345 mtime=2026-04-24T18:12:03.0Z "
+        "path=C:\\Users\\ci\\shipyard.bundle"
+    )
+    with patch(
+        "shipyard.executor.ssh_windows.subprocess.run",
+        return_value=_proc(stdout=stdout),
+    ):
+        result = _probe_remote_bundle(
+            host="win", bundle_path="shipyard.bundle", ssh_options=[],
+        )
+    assert result.exists is True
+    assert result.size == 12345

--- a/tests/executor/test_ssh.py
+++ b/tests/executor/test_ssh.py
@@ -10,9 +10,21 @@ from shipyard.core.job import TargetStatus
 from shipyard.executor.ssh import SSHExecutor
 from shipyard.executor.ssh_windows import (
     SSHWindowsExecutor,
+    _BundleProbe,
     decode_encoded_ssh_argv,
 )
 from shipyard.executor.streaming import StreamingCommandResult
+
+
+def _ok_probe() -> _BundleProbe:
+    # Default passing probe for ssh_windows validate() tests. Real
+    # subprocess-level coverage lives in test_247_bundle_post_upload_probe.py;
+    # existing validate-flow tests only need a "probe said the file
+    # is there" stub so they don't make real SSH calls to mock hosts.
+    return _BundleProbe(
+        exists=True, size=1024,
+        detail="OK size=1024 mtime=2026-01-01T00:00:00Z path=test.bundle",
+    )
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -96,6 +108,10 @@ def _mock_windows_bundle_success():
         patch(
             "shipyard.executor.ssh_windows.upload_bundle",
             return_value=BundleResult(success=True, message="ok", path="/tmp/b"),
+        ),
+        patch(
+            "shipyard.executor.ssh_windows._probe_remote_bundle",
+            return_value=_ok_probe(),
         ),
         patch(
             "shipyard.executor.ssh_windows._apply_bundle_windows",
@@ -693,7 +709,6 @@ class TestSSHResumeFrom:
         assert result is None
 
     def test_validate_passes_resume_from_through(self, tmp_path) -> None:
-        from shipyard.bundle.git_bundle import BundleResult
 
         executor = SSHExecutor()
         log_path = str(tmp_path / "log.txt")
@@ -763,6 +778,9 @@ class TestSSHWindowsExecutorValidate:
             "shipyard.executor.ssh_windows.upload_bundle",
             return_value=BundleResult(success=True, message="ok", path="/tmp/b"),
         ), patch(
+            "shipyard.executor.ssh_windows._probe_remote_bundle",
+            return_value=_ok_probe(),
+        ), patch(
             "shipyard.executor.ssh_windows._apply_bundle_windows",
             return_value=type("R", (), {"success": True, "message": "ok"})(),
         ), patch(
@@ -792,6 +810,9 @@ class TestSSHWindowsExecutorValidate:
             "shipyard.executor.ssh_windows.upload_bundle",
             return_value=BundleResult(success=True, message="ok", path="/tmp/b"),
         ), patch(
+            "shipyard.executor.ssh_windows._probe_remote_bundle",
+            return_value=_ok_probe(),
+        ), patch(
             "shipyard.executor.ssh_windows._apply_bundle_windows",
             return_value=type("R", (), {"success": True, "message": "ok"})(),
         ), patch(
@@ -819,6 +840,9 @@ class TestSSHWindowsExecutorValidate:
         ), patch(
             "shipyard.executor.ssh_windows.upload_bundle",
             return_value=BundleResult(success=True, message="ok", path="/tmp/b"),
+        ), patch(
+            "shipyard.executor.ssh_windows._probe_remote_bundle",
+            return_value=_ok_probe(),
         ), patch(
             "shipyard.executor.ssh_windows._apply_bundle_windows",
             return_value=type("R", (), {"success": True, "message": "ok"})(),
@@ -865,6 +889,9 @@ class TestSSHWindowsExecutorValidate:
             "shipyard.executor.ssh_windows.upload_bundle",
             return_value=BundleResult(success=True, message="ok", path="/tmp/b"),
         ), patch(
+            "shipyard.executor.ssh_windows._probe_remote_bundle",
+            return_value=_ok_probe(),
+        ), patch(
             "shipyard.executor.ssh_windows._apply_bundle_windows",
             return_value=type("R", (), {"success": True, "message": "ok"})(),
         ), patch(
@@ -904,6 +931,9 @@ class TestSSHWindowsExecutorValidate:
         ), patch(
             "shipyard.executor.ssh_windows.upload_bundle",
             return_value=BundleResult(success=True, message="ok", path="/tmp/b"),
+        ), patch(
+            "shipyard.executor.ssh_windows._probe_remote_bundle",
+            return_value=_ok_probe(),
         ), patch(
             "shipyard.executor.ssh_windows._apply_bundle_windows",
             return_value=type("R", (), {"success": True, "message": "ok"})(),
@@ -949,6 +979,9 @@ class TestSSHWindowsExecutorValidate:
             "shipyard.executor.ssh_windows.upload_bundle",
             return_value=BundleResult(success=True, message="ok", path="/tmp/b"),
         ), patch(
+            "shipyard.executor.ssh_windows._probe_remote_bundle",
+            return_value=_ok_probe(),
+        ), patch(
             "shipyard.executor.ssh_windows._apply_bundle_windows",
             return_value=type("R", (), {"success": True, "message": "ok"})(),
         ), patch(
@@ -992,6 +1025,9 @@ class TestSSHWindowsExecutorValidate:
         ), patch(
             "shipyard.executor.ssh_windows.upload_bundle",
             return_value=BundleResult(success=True, message="ok", path="/tmp/b"),
+        ), patch(
+            "shipyard.executor.ssh_windows._probe_remote_bundle",
+            return_value=_ok_probe(),
         ), patch(
             "shipyard.executor.ssh_windows._apply_bundle_windows",
             return_value=type("R", (), {"success": True, "message": "ok"})(),


### PR DESCRIPTION
Pulp PR #728 reproduced a persistent ssh-windows failure in v0.46.0:
`upload_bundle` reported success, but `git bundle verify` on the
remote emitted `error: could not open 'C:/Users/.../shipyard.bundle'`
wrapped in a PowerShell CLIXML envelope interleaved with a progress
record. The failure mode is upload-returned-success-but-file-missing
— scp/ssh closed cleanly with zero bytes actually on disk.

Fix: a new `_probe_remote_bundle()` helper runs Test-Path +
Get-Item on the uploaded bundle between the upload-success check
and the apply handoff. On success it logs size + mtime as a
forensic artifact (so every future apply failure has upload state
alongside the error), and on missing/zero-byte it returns a clean
"Bundle upload completed but remote file is missing: ..." error
instead of handing off to git and getting the CLIXML-wrapped
garbage surface.

Parser scans anywhere in stdout for the `OK size=... mtime=... path=...`
sentinel rather than requiring it at position 0, so operators
whose PowerShell profile prints a banner don't regress from
pre-#247 behavior. Unparseable output is treated as "can't verify"
and fails closed — same as a probe timeout or SSH error — so a
silently-empty remote never sneaks past.

Existing validate-flow tests in test_ssh.py now mock
`_probe_remote_bundle` alongside `upload_bundle` and
`_apply_bundle_windows`, otherwise they'd make real SSH calls to
mock hosts and take 30-60s per test to time out (this is why the
executor suite was running 10+ min before; now back to ~4 min).

Tests: 7 new probe-level tests in
tests/executor/test_247_bundle_post_upload_probe.py covering the
full decision matrix (success with size/mtime, MISSING sentinel,
subprocess timeout, OSError, nonzero exit with stderr snippet,
unparseable stdout, PowerShell-banner tolerance).