### PR TITLE
release: draft-until-complete gate (#252)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -344,8 +344,17 @@ jobs:
           done
           cd release && sha256sum * > checksums.sha256
 
-      - name: Create GitHub Release
+      - name: Create GitHub Release (draft until macOS dmg attached)
         uses: softprops/action-gh-release@v2
         with:
           files: release/*
           generate_release_notes: true
+          # #252: keep the release in draft until the macOS .dmg has
+          # been uploaded + verified by the maintainer's local script.
+          # install.sh's `releases/latest` resolution automatically
+          # excludes drafts, so end users on macOS degrade to the
+          # previous published release during the gap window instead
+          # of hitting a 404 on the missing dmg asset.
+          # release-macos-local.sh's final step flips draft=false
+          # once the dmg passes the end-to-end install check.
+          draft: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,7 +163,9 @@ After any new tag lands and the release workflow publishes non-macOS assets, run
 ./scripts/release-macos-local.sh --tag vX.Y.Z --upload
 ```
 
-The script is 8 steps: build, re-sign, package-to-dmg, sign-dmg, notarize+staple, **mount + launch test** (exit 3 if it fails), upload, **end-to-end install.sh → launch test** (exit 4 if it fails). Refuses to upload a dmg that doesn't mount-and-launch cleanly; refuses to declare success after upload if the download+install chain doesn't end in a working `--version`.
+The script is 9 steps: build, re-sign, package-to-dmg, sign-dmg, notarize+staple, **mount + launch test** (exit 3 if it fails), upload, **flip release from draft to public** (#252), **end-to-end install.sh → launch test** (exit 4 if it fails — reverts release to draft). Refuses to upload a dmg that doesn't mount-and-launch cleanly; refuses to declare success after upload if the download+install chain doesn't end in a working `--version`.
+
+**Draft-until-complete (#252):** `release.yml` now creates the GitHub Release as **draft**. `install.sh`'s `releases/latest` resolution excludes drafts by default — so during the build/upload gap window, macOS users degrade to the previous published tag instead of hitting a 404 on the missing dmg. Step 8 of the local release script flips `draft=false` once the dmg is uploaded; step 9's E2E failure reverts to draft so broken releases disappear from `releases/latest` automatically. This is why shipping is a manual-on-Mac step today, not an auto-release: the maintainer's local script is the gate that flips the release public.
 
 **Load-bearing rule:** the success criterion is a working `--version` after fresh install.sh → mount → extract → launch. Not `codesign --verify`, not `spctl --assess`, not the on-runner launch gate in isolation. We shipped v0.42.0 and v0.43.0 with the same breakage because we declared victory on partial verification. Don't do that again.
 

--- a/scripts/release-macos-local.sh
+++ b/scripts/release-macos-local.sh
@@ -43,10 +43,15 @@
 #
 # Exit codes:
 #   0   Build + sign + notarize + local-launch test all passed.
-#       Asset was uploaded if --upload was passed.
+#       Asset was uploaded if --upload was passed. When --upload is
+#       set, the GitHub Release is flipped from draft to public after
+#       the end-to-end install.sh verification passes.
 #   1   One of the steps failed. Diagnostics on stderr.
 #   2   Missing required env var.
 #   3   --version smoke test FAILED on this Mac. Do NOT ship this binary.
+#   4   End-to-end install.sh test FAILED after upload. Release is
+#       reverted to draft so install.sh's `releases/latest` degrades
+#       to the previous good release (#252).
 
 set -euo pipefail
 
@@ -100,7 +105,7 @@ echo ""
 # so the resulting binary is byte-identical to what CI would produce
 # on the same commit (modulo signing timestamp). If this binary
 # launches but the CI-signed one doesn't, the delta is signing.
-echo "Step 1/5: PyInstaller build..."
+echo "Step 1/9: PyInstaller build..."
 if ! command -v pyinstaller >/dev/null 2>&1; then
     echo "ERROR: pyinstaller not on PATH. pip install pyinstaller." >&2
     exit 1
@@ -117,7 +122,7 @@ if [ ! -f "$DIST_BINARY" ]; then
 fi
 
 # ── Re-sign with hardened runtime + timestamp ──────────────────────
-echo "Step 2/5: Re-sign with hardened runtime + secure timestamp..."
+echo "Step 2/9: Re-sign with hardened runtime + secure timestamp..."
 codesign --force --options runtime --timestamp \
     --sign "$SHIPYARD_SIGNING_IDENTITY" \
     "$DIST_BINARY"
@@ -134,7 +139,7 @@ codesign -dv --verbose=4 "$DIST_BINARY" 2>&1 | grep -E "Authority|TeamIdentifier
 # offline. Gatekeeper + taskgated verify against that ticket
 # instead of calling Apple, so per-Mac network/CDN/provenance
 # state stops mattering.
-echo "Step 3/6: Package signed Mach-O into .dmg..."
+echo "Step 3/9: Package signed Mach-O into .dmg..."
 DMG_NAME="${ARTIFACT}.dmg"
 DIST_DMG="dist/${DMG_NAME}"
 DMG_STAGING="$(mktemp -d)/stage"
@@ -155,7 +160,7 @@ hdiutil create -volname "Shipyard" \
 # notarytool can match + return a staple-able ticket. Without this
 # the DMG ships unsigned and notarize fails with "package is not
 # signed".
-echo "Step 4/6: Sign the DMG..."
+echo "Step 4/9: Sign the DMG..."
 codesign --force --sign "$SHIPYARD_SIGNING_IDENTITY" "$DIST_DMG"
 codesign -dv --verbose=2 "$DIST_DMG" 2>&1 | grep -E "Authority|TeamIdentifier" | head -3
 
@@ -165,7 +170,7 @@ codesign -dv --verbose=2 "$DIST_DMG" 2>&1 | grep -E "Authority|TeamIdentifier" |
 # After acceptance, `stapler staple` embeds the ticket in the DMG
 # so first-launch verification is OFFLINE — the entire point of
 # task #52.
-echo "Step 5/6: Submit DMG to Apple notarization service (~30-90s)..."
+echo "Step 5/9: Submit DMG to Apple notarization service (~30-90s)..."
 NOTARIZE_LOG="$(mktemp)"
 if ! xcrun notarytool submit "$DIST_DMG" \
         --apple-id "$SHIPYARD_NOTARIZE_APPLE_ID" \
@@ -207,7 +212,7 @@ echo "  ✓ Ticket stapled and validated"
 # Gatekeeper-verifies-offline flow end users will hit after
 # install.sh extracts. If it fails here, the dmg is broken —
 # refuse to upload.
-echo "Step 6/6: Local launch test via mounted DMG..."
+echo "Step 6/9: Local launch test via mounted DMG..."
 MOUNT_POINT="$(mktemp -d)/mnt"
 # -nobrowse: don't show the volume in Finder. -readonly: prevent
 # accidental writes. Explicit mountpoint so we don't scrape
@@ -253,7 +258,7 @@ trap - EXIT
 
 # ── Upload (opt-in) ────────────────────────────────────────────────
 if [ "$DO_UPLOAD" -eq 1 ]; then
-    echo "Step 7/8: Uploading $DIST_DMG to release $TAG..."
+    echo "Step 7/9: Uploading $DIST_DMG to release $TAG..."
     gh release upload "$TAG" "$DIST_DMG" --clobber
     # Update the checksum line for this artifact. Keyed on the
     # full asset filename (e.g. shipyard-macos-arm64.dmg) so an
@@ -279,6 +284,26 @@ if [ "$DO_UPLOAD" -eq 1 ]; then
     rm -rf "$CHECKSUMS_DIR"
     echo "  ✓ Uploaded to release $TAG"
 
+    # ── Publish (flip draft → public) ─────────────────────────────
+    # #252: `release.yml` creates the release as draft so end users
+    # on macOS don't 404 on the missing dmg during the build/upload
+    # window. Now that the dmg is uploaded (and the mount test at
+    # step 6 proved it launches), flip draft=false so install.sh can
+    # resolve this tag as latest. If step 8's E2E check fails below,
+    # we revert to draft so the broken release disappears from
+    # install.sh's `releases/latest` resolution.
+    WAS_DRAFT=0
+    if [ "$(gh release view "$TAG" --json isDraft --jq '.isDraft')" = "true" ]; then
+        WAS_DRAFT=1
+    fi
+    if [ "$WAS_DRAFT" -eq 1 ]; then
+        echo "Step 8/9: Flipping release $TAG from draft to published..."
+        gh release edit "$TAG" --draft=false >/dev/null
+        echo "  ✓ Release $TAG is now public."
+    else
+        echo "Step 8/9: Release $TAG is already public (skipping draft flip)."
+    fi
+
     # ── End-to-end verification (#55 codification) ─────────────────
     # Test the same install.sh → launch path end users hit. The
     # local launch test above proved the DMG works when mounted
@@ -291,11 +316,17 @@ if [ "$DO_UPLOAD" -eq 1 ]; then
     # merge + release, the tag's install.sh and this checkout's
     # install.sh are the same file, so the test remains honest.
     #
-    # If this fails, the upload already happened: operator must
-    # manually delete the uploaded asset or re-run after fixing.
-    # Exit 4 distinguishes this from the local mounted-launch test
-    # failure (exit 3).
-    echo "Step 8/8: End-to-end verification (local install.sh → launch)..."
+    # On failure, we revert the release to draft (so install.sh's
+    # `releases/latest` degrades to the previous good release) and
+    # exit 4.
+    revert_to_draft_on_failure() {
+        if [ "$WAS_DRAFT" -eq 1 ]; then
+            echo "  → Reverting release $TAG to draft so end users" >&2
+            echo "    don't see the broken dmg." >&2
+            gh release edit "$TAG" --draft=true >/dev/null 2>&1 || true
+        fi
+    }
+    echo "Step 9/9: End-to-end verification (local install.sh → launch)..."
     E2E_TMPDIR="$(mktemp -d)"
     E2E_INSTALL_DIR="$E2E_TMPDIR/bin"
     LOCAL_INSTALL_SH="$(cd "$(dirname "$0")/.." && pwd)/install.sh"
@@ -305,29 +336,30 @@ if [ "$DO_UPLOAD" -eq 1 ]; then
             >"$E2E_TMPDIR/install.log" 2>&1; then
         echo "" >&2
         echo "ERROR: E2E install.sh FAILED for $TAG." >&2
-        echo "       Upload already happened — this DMG is live but" >&2
-        echo "       end-users won't be able to install it cleanly." >&2
         echo "       Install log:" >&2
         sed 's/^/         /' "$E2E_TMPDIR/install.log" >&2
+        revert_to_draft_on_failure
         rm -rf "$E2E_TMPDIR"
         exit 4
     fi
     if ! E2E_OUTPUT=$("$E2E_INSTALL_DIR/shipyard" --version 2>&1); then
         echo "" >&2
         echo "ERROR: E2E installed binary FAILED to launch." >&2
-        echo "       Upload already happened. The DMG mounts + verifies" >&2
-        echo "       but the extracted binary does not survive the" >&2
-        echo "       install.sh download + post-processing path." >&2
+        echo "       The DMG mounts + verifies but the extracted" >&2
+        echo "       binary does not survive the install.sh download" >&2
+        echo "       + post-processing path." >&2
         echo "       Install log:" >&2
         sed 's/^/         /' "$E2E_TMPDIR/install.log" >&2
+        revert_to_draft_on_failure
         rm -rf "$E2E_TMPDIR"
         exit 4
     fi
     echo "  ✓ End-to-end install.sh + launch passed: ${E2E_OUTPUT}"
     rm -rf "$E2E_TMPDIR"
 else
-    echo "Step 7/8: SKIPPED (--upload not passed)."
-    echo "Step 8/8: E2E verification SKIPPED (requires upload)."
+    echo "Step 7/9: SKIPPED (--upload not passed)."
+    echo "Step 8/9: Draft-flip SKIPPED (requires upload)."
+    echo "Step 9/9: E2E verification SKIPPED (requires upload)."
     echo ""
     echo "Signed + notarized + stapled DMG at: $DIST_DMG"
     echo "Re-run with --upload to ship it to release $TAG."

--- a/tests/test_release_macos_local.py
+++ b/tests/test_release_macos_local.py
@@ -148,3 +148,33 @@ def test_all_env_vars_missing_names_first_missing_one_clearly() -> None:
     assert len(error_lines) == 1, (
         f"expected exactly one missing-env error line; got {error_lines}"
     )
+
+
+def test_script_documents_draft_until_complete_exit_4() -> None:
+    # #252: script now flips the release from draft to public after
+    # upload, and reverts to draft on E2E failure. Help text must
+    # document exit 4 so operators + wrappers know what it means.
+    content = SCRIPT.read_text()
+    assert "4 " in content and "reverted to draft" in content, (
+        "Exit code 4 must be documented in the script header"
+    )
+    # All nine step labels must be present — proxy test for the new
+    # step 8 (publish) and step 9 (e2e) landing together. If someone
+    # renumbers to 10 steps or drops a step this fires first.
+    for n in range(1, 10):
+        assert f"Step {n}/9" in content, f"missing Step {n}/9 label"
+
+
+def test_release_yml_creates_draft_release_until_dmg_uploaded() -> None:
+    # #252: release.yml must create the GitHub Release as a draft so
+    # install.sh's `releases/latest` degrades to the previous
+    # published release during the build/upload gap window.
+    release_yml = REPO_ROOT / ".github" / "workflows" / "release.yml"
+    content = release_yml.read_text()
+    assert "draft: true" in content, (
+        "release.yml must create new tag releases as draft — "
+        "release-macos-local.sh flips draft=false after upload"
+    )
+    # Anchor the draft:true line to the softprops action block,
+    # not a comment or stray YAML, by requiring both in the file.
+    assert "softprops/action-gh-release" in content


### PR DESCRIPTION
Today's two back-to-back releases (v0.48.0, v0.49.0) exposed the
gap window between CI publishing Linux/Windows assets and the
maintainer running release-macos-local.sh on their Mac for the
stapled .dmg. During that window, macOS users' install.sh 404s on
the missing dmg asset.

Fix uses GitHub's draft-release semantics: install.sh's
`releases/latest` endpoint excludes drafts by default, so if the
current tag's release stays in draft until the dmg lands,
install.sh automatically resolves to the previous published tag
during the gap. No 404s, no user-visible breakage.

Changes:

- `.github/workflows/release.yml`: `softprops/action-gh-release@v2`
  now sets `draft: true`. Linux + Windows + checksums land on a
  draft release that's invisible to install.sh's latest resolution.

- `scripts/release-macos-local.sh`: after upload (step 7) flips
  the release `draft=false` (new step 8), then runs the e2e
  install.sh verification (step 9). If the e2e check fails, the
  script reverts the release to draft so the broken dmg disappears
  from `releases/latest` and install.sh continues degrading to
  the previous good release. Exit 4 is now specifically documented
  as "release reverted to draft."

- Step labels renumbered 1/5→9/9 consistently across the script
  (previously had 1/5 + 3/6 + 7/8 mix).

- CLAUDE.md updated to describe draft-until-complete as the reason
  the manual-on-Mac step is load-bearing rather than a wart.

Pairs cleanly with the #226 CI-signing experiment: if CI signing
comes back, the CI macOS job would do the same thing — upload dmg,
flip to published, on e2e failure revert to draft. Same gate,
different signer.

Tests:

- `test_release_yml_creates_draft_release_until_dmg_uploaded`
  pins `draft: true` in release.yml so a future yaml edit can't
  silently drop the gate.
- `test_script_documents_draft_until_complete_exit_4` pins the
  exit-code doc + the 9-step structure.

What this does NOT do:

- Retroactively fix v0.48.0 and v0.49.0. Both were created with
  the old (non-draft) flow and are already public-without-dmg.
  The existing manual `release-macos-local.sh --tag v0.48.0/49.0`
  invocations still need to happen on your Mac. Only v0.50.0+
  get the draft-until-complete treatment.

Skill-Update: skip skill=ci reason="release workflow draft-flag change; the ci skill describes dispatch/target flow, not GH Release lifecycle. Draft-until-complete is release-script internal."