### PR TITLE
release: drop unset-var reference in partial-arch exit path (#254 Codex P1)

### DIFF
--- a/scripts/release-macos-local.sh
+++ b/scripts/release-macos-local.sh
@@ -327,12 +327,15 @@ if [ "$DO_UPLOAD" -eq 1 ]; then
         echo "         is attached."
         # With dmgs still missing, skip the E2E check — it would
         # only exercise one arch and doesn't tell us whether the
-        # combined release is ready to go public.
+        # combined release is ready to go public. E2E_TMPDIR isn't
+        # created until step 9, so no cleanup needed here (Codex P1
+        # on #254 — referencing an unset var with `set -u` active
+        # would crash and defeat the "exit 0 on partial arch"
+        # contract).
         echo "Step 9/9: E2E verification SKIPPED (waiting for other arch)."
         echo ""
         echo "═══ Partial done. Re-run for the missing arch(es). ═══"
         echo ""
-        rm -rf "$E2E_TMPDIR" 2>/dev/null || true
         exit 0
     fi
 

--- a/tests/test_release_macos_local.py
+++ b/tests/test_release_macos_local.py
@@ -180,6 +180,37 @@ def test_release_yml_creates_draft_release_until_dmg_uploaded() -> None:
     assert "softprops/action-gh-release" in content
 
 
+def test_partial_arch_exit_path_does_not_reference_unset_vars() -> None:
+    # Codex P1 on #254: the partial-arch exit path (only one of
+    # arm64/x64 dmgs present) must not reference $E2E_TMPDIR — it's
+    # only created later in step 9, and `set -u` is active, so
+    # expanding it here raises an unbound-variable error and the
+    # script exits non-zero instead of returning the intended "exit
+    # 0, re-run for the other arch" contract.
+    #
+    # Doc-check rather than a runtime exercise because the partial
+    # path is reached only via a real `gh release view` call; that
+    # needs auth + a real release. Grep the source.
+    content = SCRIPT.read_text()
+    # Find the partial-arch block (starts at "Keeping release $TAG
+    # as draft" and ends at "exit 0"). The block must NOT reference
+    # any variable that's only created in step 9. E2E_TMPDIR is the
+    # canonical one per #254; broaden the check if others surface.
+    start = content.find("Keeping release $TAG as draft")
+    assert start != -1, "partial-arch message block not found"
+    end = content.find("exit 0", start)
+    assert end != -1, "partial-arch exit 0 not found"
+    partial_block = content[start:end]
+    # Match actual variable expansions (`$E2E_TMPDIR` or
+    # `${E2E_TMPDIR}`), not the word appearing inside a comment.
+    import re
+    matches = re.findall(r"\$\{?E2E_TMPDIR", partial_block)
+    assert not matches, (
+        "partial-arch exit path must not expand $E2E_TMPDIR — "
+        "it's only set in step 9 and `set -u` would crash the script"
+    )
+
+
 def test_publish_waits_for_both_macos_arches() -> None:
     # Codex P1 on #253: running this script for only arm64 previously
     # flipped the release public while the x64 dmg was still missing,


### PR DESCRIPTION
The partial-arch exit path added in #254 (first-arch run where the
other arch's dmg isn't on the release yet) called
`rm -rf "$E2E_TMPDIR"` as a cleanup step. But E2E_TMPDIR is only
created inside step 9's E2E block, which this exit path skips —
and `set -u` is active, so the unbound expansion crashed the
script. The intended "exit 0, re-run for the other arch" contract
never fired; the script exited non-zero with a cryptic
\`unbound variable\` error instead.

Fix: drop the rm -rf line. Nothing was created on this path, so
there's nothing to clean up. Comment explains the gotcha for
the next maintainer.

Regression test parses the partial-arch block out of the script
source and asserts no \`\$E2E_TMPDIR\` expansion is left. Anchored
via regex on the variable sigil, not the bare word, so code
comments mentioning the variable name don't trip the check.

Skill-Update: skip skill=ci reason="bash set-u hygiene in release script; no dispatch/target/workflow shape change."