### PR TITLE
release: drop Intel Mac (x86_64) support — arm64 only (#256)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,6 @@ jobs:
       linux: ${{ steps.resolve.outputs.linux }}
       linux_arm: ${{ steps.resolve.outputs.linux_arm }}
       macos_arm: ${{ steps.resolve.outputs.macos_arm }}
-      macos_x64: ${{ steps.resolve.outputs.macos_x64 }}
       windows: ${{ steps.resolve.outputs.windows }}
     steps:
       - id: resolve
@@ -77,7 +76,8 @@ jobs:
           else
             echo "macos_arm=\"macos-15\"" >> "$GITHUB_OUTPUT"
           fi
-          echo "macos_x64=\"macos-15\"" >> "$GITHUB_OUTPUT"
+          # #256: Intel Mac (x86_64) dropped. No macos_x64 output
+          # anymore — it's gone from the build matrix too.
 
           if [ "$P_WINDOWS" = "namespace" ]; then
             echo "windows=\"namespace-profile-generouscorp-windows\"" >> "$GITHUB_OUTPUT"
@@ -94,9 +94,10 @@ jobs:
           - target: macos-arm64
             artifact: shipyard-macos-arm64
             runs_on: ${{ needs.resolve-runners.outputs.macos_arm }}
-          - target: macos-x64
-            artifact: shipyard-macos-x64
-            runs_on: ${{ needs.resolve-runners.outputs.macos_x64 }}
+          # #256: Intel Mac (x86_64) dropped as of v0.50.0. Apple
+          # Silicon only. install.sh surfaces a clean
+          # "unsupported platform" message when an Intel Mac runs
+          # it, distinct from a 404 on a missing asset.
           - target: windows-x64
             artifact: shipyard-windows-x64
             runs_on: ${{ needs.resolve-runners.outputs.windows }}
@@ -297,31 +298,22 @@ jobs:
         # scripts/release-macos-local.sh to sign+notarize on their
         # Mac and upload the signed asset.
         #
-        # Codex P1 on #225: the reminder defaults to --arch arm64
-        # (what the script itself defaults to). For users on Intel
-        # Macs, install.sh resolves ARTIFACT=shipyard-macos-x64,
-        # which would 404 if only the arm64 dmg shipped. Emit both
-        # command lines so the maintainer doesn't silently drop
-        # Intel-Mac support for a release.
+        # #256: Intel (x86_64) support was dropped as of v0.50.0. The
+        # matrix only builds arm64 now; install.sh surfaces a clean
+        # "unsupported" message to anyone running it on Intel.
         run: |
           echo "✓ macOS build succeeded (${{ matrix.artifact }})."
           echo ""
           echo "This binary is NOT being uploaded to the release."
           echo "macOS signing + notarization is local-only (see #219)."
-          echo "Run BOTH on your Mac after the release tag appears —"
-          echo "Apple Silicon AND Intel — so install.sh resolves on"
-          echo "both architectures:"
+          echo "Run on your Mac after the release tag appears:"
           echo ""
-          echo "  # Apple Silicon (arm64):"
           echo "  ./scripts/release-macos-local.sh \\"
-          echo "    --tag ${{ github.ref_name }} --arch arm64 --upload"
+          echo "    --tag ${{ github.ref_name }} --upload"
           echo ""
-          echo "  # Intel (x64) — needs a Rosetta or Intel build host:"
-          echo "  ./scripts/release-macos-local.sh \\"
-          echo "    --tag ${{ github.ref_name }} --arch x64 --upload"
-          echo ""
-          echo "If you've dropped Intel support intentionally, remove"
-          echo "the macos-x64 matrix entry above and this reminder."
+          echo "The script signs, notarizes, staples, uploads the"
+          echo "arm64 dmg, flips the draft release to public (#252),"
+          echo "and runs the end-to-end install.sh verification."
           echo ""
 
   release:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,9 +153,11 @@ rather than stacking them.
 
 `./scripts/release.sh` remains as a break-glass manual path. The default is the automatic path above (auto-release workflow on merge). Do not call `release.sh` directly unless the automatic path is genuinely blocked.
 
-## macOS release is a stapled .dmg, built LOCALLY
+## macOS release is a stapled .dmg, built LOCALLY (arm64 only)
 
 As of #219 (2026-04-24 evening), macOS binaries ship as stapled **.dmg** artifacts built on the maintainer's Mac. CI handles Linux + Windows. The `.dmg` wrapper puts the notarization ticket **inside** the artifact so Gatekeeper verifies offline — no online notarization check, no per-Mac taskgated flakiness. Bare Mach-O binaries depend on an online check that proved unreliable (v0.42.0 and v0.43.0 both shipped bare Mach-O and both SIGKILL'd on the maintainer's Mac).
+
+As of #256 (v0.50.0+), **Apple Silicon (arm64) is the only supported macOS architecture.** Intel Macs (x86_64) were dropped — install.sh now prints a clean "unsupported" message on Intel rather than hitting a 404. This halved the release surface and retired the Rosetta/Intel-host branch of the local flow.
 
 After any new tag lands and the release workflow publishes non-macOS assets, run:
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -105,8 +105,8 @@ We shipped v0.42.0 and v0.43.0 with the same class of breakage because we declar
 
 The five secrets below are kept in the repo even though CI doesn't use them today — they're needed for:
 
-- Future Rosetta-hosted local cross-builds for x64
-- Forks that may re-enable CI signing for their own environments
+- ~~Future Rosetta-hosted local cross-builds for x64~~ (retired by #256 — Intel dropped as of v0.50.0; arm64 only)
+- Forks that may re-enable CI signing for their own environments (tracked in #226)
 - The `.dmg` pipeline above reuses `SHIPYARD_SIGNING_IDENTITY` conceptually (the cert is in the local keychain rather than a GH secret, but the same cert)
 
 Five secrets on the repo (all `gh secret set NAME`):
@@ -141,7 +141,7 @@ Running without `--upload` is the diagnostic mode (used to confirm the local sig
 
 The CI signing steps have been removed from `.github/workflows/release.yml` (build-only for macOS, no signing / notarizing / uploading). The five secrets below are kept in the repo for:
 
-- The x64 slice once we add Rosetta-hosted local cross-builds or move x64 to local too
+- ~~The x64 slice once we add Rosetta-hosted local cross-builds~~ (retired; see above)
 - Future `.dmg` stapling pipeline (task #52 — the long-term answer that eliminates Apple's online-check dependency entirely)
 - Forks that might want to re-enable CI signing for their own environments
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -104,11 +104,12 @@ SHIPYARD_INSTALL_DIR="${HOME}/mytools/bin" bash install.sh
 
 | OS | Architecture | Binary |
 |----|-------------|--------|
-| macOS | Apple Silicon (ARM64) | `shipyard-macos-arm64` |
-| macOS | Intel (x64) | `shipyard-macos-x64` |
+| macOS | Apple Silicon (ARM64) | `shipyard-macos-arm64.dmg` |
 | Windows | x64 | `shipyard-windows-x64.exe` |
 | Linux | x64 | `shipyard-linux-x64` |
 | Linux | ARM64 | `shipyard-linux-arm64` |
+
+Intel Macs (x86_64) are not supported from v0.50.0 onward. Apple Silicon only. Older releases (v0.44.0–v0.49.0) that shipped Intel dmgs remain installable by pinning `SHIPYARD_VERSION`; `install.sh` on an Intel Mac surfaces a clear "unsupported" message instead of a 404 on v0.50.0+.
 
 ## Build from source
 

--- a/install.sh
+++ b/install.sh
@@ -59,6 +59,18 @@ case "$(uname -m)" in
         ;;
 esac
 
+# #256: Intel Macs (x86_64) are no longer supported as of v0.50.0.
+# Surface a clean message rather than letting the user hit a 404 on
+# a missing asset. Exit 2 distinguishes "this platform is
+# unsupported" from exit 1 ("something went wrong").
+if [ "$OS" = "macos" ] && [ "$ARCH" = "x64" ]; then
+    echo "Intel Macs (x86_64) are not supported by Shipyard v0.50.0 and later." >&2
+    echo "Apple Silicon (arm64) Macs only. If you're pinned to an older tag" >&2
+    echo "(SHIPYARD_VERSION=vX.Y.Z) that still has an Intel dmg, that install" >&2
+    echo "remains functional — the cutover only affects new releases." >&2
+    exit 2
+fi
+
 ARTIFACT="shipyard-${OS}-${ARCH}"
 if [ "${SHIPYARD_DRY_RUN:-0}" != "1" ]; then
     echo "Detected platform: ${OS}-${ARCH}"

--- a/scripts/release-macos-local.sh
+++ b/scripts/release-macos-local.sh
@@ -23,7 +23,7 @@
 # this we'd have caught v0.42.0 before it shipped.
 #
 # Usage:
-#   ./scripts/release-macos-local.sh [--tag vX.Y.Z] [--upload] [--arch arm64|x64]
+#   ./scripts/release-macos-local.sh [--tag vX.Y.Z] [--upload]
 #
 # Env vars required for notarization:
 #   SHIPYARD_NOTARIZE_APPLE_ID           (Apple ID email)
@@ -37,9 +37,7 @@
 #   --upload       Upload the signed+tested asset to the GitHub release
 #                  for --tag. Without this, the script only builds and
 #                  verifies — useful for diagnosing without shipping.
-#   --arch         Build for arm64 (default) or x64. The host CPU is
-#                  what you'll actually get; x64 needs Rosetta or a
-#                  different host.
+#   (Intel Mac support was dropped in v0.50.0 per #256; arm64 only.)
 #
 # Exit codes:
 #   0   Build + sign + notarize + local-launch test all passed.
@@ -62,7 +60,18 @@ DO_UPLOAD=0
 while [ $# -gt 0 ]; do
     case "$1" in
         --tag) TAG="$2"; shift 2 ;;
-        --arch) ARCH="$2"; shift 2 ;;
+        --arch)
+            # #256: Intel dropped. Preserve the flag for back-compat
+            # so a muscle-memory `--arch arm64` invocation still works,
+            # but refuse any value other than arm64 so an accidental
+            # `--arch x64` fails fast instead of producing an unrelease-
+            # able build.
+            if [ "$2" != "arm64" ]; then
+                echo "Intel Mac (x86_64) support was dropped in v0.50.0 (#256)." >&2
+                echo "Re-run without --arch, or with --arch arm64." >&2
+                exit 2
+            fi
+            shift 2 ;;
         --upload) DO_UPLOAD=1; shift ;;
         -h|--help)
             sed -n '/^# Usage:/,/^$/p' "$0" | sed 's/^# //; s/^#//'
@@ -298,9 +307,10 @@ if [ "$DO_UPLOAD" -eq 1 ]; then
     # shipyard-macos-*.dmg assets release.yml's build matrix
     # produces today (arm64 + x64; keep in sync if the matrix
     # changes).
+    # #256: Intel Mac support dropped as of v0.50.0. Only arm64 is
+    # expected; the flip-to-public gate is satisfied by this one arch.
     EXPECTED_MACOS_DMGS=(
         "shipyard-macos-arm64.dmg"
-        "shipyard-macos-x64.dmg"
     )
     PRESENT_DMGS=$(gh release view "$TAG" --json assets \
         --jq '.assets[].name' 2>/dev/null | grep -E 'shipyard-macos-.*\.dmg$' || true)

--- a/tests/test_release_macos_local.py
+++ b/tests/test_release_macos_local.py
@@ -211,20 +211,53 @@ def test_partial_arch_exit_path_does_not_reference_unset_vars() -> None:
     )
 
 
-def test_publish_waits_for_both_macos_arches() -> None:
-    # Codex P1 on #253: running this script for only arm64 previously
-    # flipped the release public while the x64 dmg was still missing,
-    # leaving Intel-Mac users with a public release that still 404'd
-    # on install. The fix requires EVERY expected macOS dmg to be
-    # on the release before the flip. Pin the two current arches
-    # so a refactor can't silently drop the arch-completeness check.
+def test_publish_gate_covers_arm64_only_after_intel_drop() -> None:
+    # #256: Intel dropped as of v0.50.0. The arch-completeness gate
+    # now expects only arm64. Regression guard: if someone re-adds
+    # x64 to EXPECTED_MACOS_DMGS without also restoring the build
+    # matrix + install.sh resolution, the gate would wait forever.
     content = SCRIPT.read_text()
     assert "EXPECTED_MACOS_DMGS" in content, (
         "script must express which macOS dmgs are expected before publish"
     )
     assert "shipyard-macos-arm64.dmg" in content
-    assert "shipyard-macos-x64.dmg" in content
+    assert "shipyard-macos-x64.dmg" not in content, (
+        "x64 dropped in #256 — EXPECTED_MACOS_DMGS must be arm64 only"
+    )
     # Revert-on-failure must track DID_PUBLISH, not just WAS_DRAFT —
     # otherwise a failed E2E right after this run's flip wouldn't
     # revert (WAS_DRAFT is 0 post-flip).
     assert "DID_PUBLISH" in content
+
+
+def test_install_sh_rejects_intel_mac_cleanly() -> None:
+    # #256: install.sh on Intel Mac must surface a clear "unsupported"
+    # message and exit non-zero BEFORE attempting the asset fetch.
+    # Letting it fall through to the 404 on a missing dmg is exactly
+    # the UX regression this drop was meant to clean up.
+    install_sh = REPO_ROOT / "install.sh"
+    content = install_sh.read_text()
+    assert "Intel Macs (x86_64) are not supported" in content, (
+        "install.sh must surface a clean unsupported-platform message "
+        "for Intel Macs, not fall through to a 404 on a missing asset"
+    )
+    # Refusal must happen on OS=macos + ARCH=x64, not on Linux x64.
+    # Anchor to both so a future simplification of the condition
+    # doesn't accidentally nuke Linux x64 installs.
+    assert '$OS" = "macos"' in content and '$ARCH" = "x64"' in content
+
+
+def test_release_yml_drops_macos_x64_matrix_row() -> None:
+    # Pair with the script-side gate test above: the CI build matrix
+    # must stop producing a macos-x64 artifact. Keeping it around
+    # would waste CI minutes on an artifact that never gets signed
+    # and which install.sh now refuses to resolve anyway.
+    release_yml = REPO_ROOT / ".github" / "workflows" / "release.yml"
+    content = release_yml.read_text()
+    assert "target: macos-arm64" in content
+    assert "target: macos-x64" not in content, (
+        "#256: macos-x64 build matrix row must be gone; Intel dropped"
+    )
+    assert "macos_x64:" not in content, (
+        "#256: macos_x64 runner output must be gone too"
+    )


### PR DESCRIPTION
The local-sign release flow (#219 / #252) runs on the maintainer's
arm64 Mac. Producing an x64 dmg requires either a Rosetta-built
Intel Python stack or a separate Intel host — both fragile, both
double the release surface for a shrinking user segment. User
decision: skip Intel going forward, fewer headaches.

Changes:

- `.github/workflows/release.yml`: drop the `macos-x64` build matrix
  row and the `macos_x64` runner output. Simplify the post-build
  macOS reminder — no more "run for BOTH arches".
- `install.sh`: when the host is macOS + x86_64, print a clean
  "Intel Macs are not supported by v0.50.0+; older pins still work"
  message and exit 2. Distinct from 404 noise on a missing asset.
- `scripts/release-macos-local.sh`: `EXPECTED_MACOS_DMGS` shrinks to
  just `shipyard-macos-arm64.dmg`, so the draft→public gate is
  satisfied by the single arm64 run. `--arch x64` refuses with a
  fast exit 2 pointing at this change; `--arch arm64` still works
  for muscle memory.
- `CLAUDE.md` + `RELEASING.md` + `docs/install.md`: updated to
  reflect arm64-only. The platform binaries table no longer lists
  Intel; RELEASING.md's "Rosetta cross-build" note is retired.

Doesn't change:

- Linux arm64/x64, Windows x64 — all still built and uploaded by CI.
- The `.dmg` / stapled-notarization path from #219 — Apple Silicon
  still goes through the same local script.
- Existing Intel installs pinned to v0.44.0–v0.49.0 — those dmgs
  remain on the release, install.sh honors `SHIPYARD_VERSION=vX.Y.Z`
  if the asset exists. The Intel-refusal fires only on the
  auto-resolution path where ARTIFACT would have been
  `shipyard-macos-x64` and the asset is absent.

Test coverage: `test_publish_gate_covers_arm64_only_after_intel_drop`,
`test_install_sh_rejects_intel_mac_cleanly`,
`test_release_yml_drops_macos_x64_matrix_row` lock all three
surfaces (script, install.sh, release.yml) so a future refactor
can't regress one of them in isolation.

Skill-Update: skip skill=ci reason="Intel drop touches release workflow + release script; ci skill describes dispatch/target flow, not platform-support policy."