### PR TITLE
install.sh: Intel guard runs after version resolution (#257 Codex P1)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -59,18 +59,6 @@ case "$(uname -m)" in
         ;;
 esac
 
-# #256: Intel Macs (x86_64) are no longer supported as of v0.50.0.
-# Surface a clean message rather than letting the user hit a 404 on
-# a missing asset. Exit 2 distinguishes "this platform is
-# unsupported" from exit 1 ("something went wrong").
-if [ "$OS" = "macos" ] && [ "$ARCH" = "x64" ]; then
-    echo "Intel Macs (x86_64) are not supported by Shipyard v0.50.0 and later." >&2
-    echo "Apple Silicon (arm64) Macs only. If you're pinned to an older tag" >&2
-    echo "(SHIPYARD_VERSION=vX.Y.Z) that still has an Intel dmg, that install" >&2
-    echo "remains functional — the cutover only affects new releases." >&2
-    exit 2
-fi
-
 ARTIFACT="shipyard-${OS}-${ARCH}"
 if [ "${SHIPYARD_DRY_RUN:-0}" != "1" ]; then
     echo "Detected platform: ${OS}-${ARCH}"
@@ -93,6 +81,43 @@ else
     esac
     API_PATH="releases/tags/${TAG}"
     VERSION_LABEL="${TAG}"
+fi
+
+# #256: Intel Macs (x86_64) are no longer supported as of v0.50.0.
+# Surface a clean message rather than letting the user hit a 404 on
+# the missing asset. Runs AFTER version resolution (Codex P1 on #257)
+# so pinning SHIPYARD_VERSION to a pre-drop tag that still has an
+# Intel dmg (v0.44.0-v0.49.0) is still installable. The refusal
+# fires when:
+#   - no explicit version → `latest` resolves to v0.50.0+
+#   - the pinned tag is v0.50.0 or newer (strict semver compare)
+# Exit 2 distinguishes "this platform is unsupported" from exit 1.
+if [ "$OS" = "macos" ] && [ "$ARCH" = "x64" ]; then
+    _intel_blocked=0
+    if [ "${VERSION_LABEL}" = "latest" ]; then
+        _intel_blocked=1
+    else
+        # Strip leading `v` and extract major.minor.patch; compare
+        # to 0.50.0 as a lexicographic-safe tuple compare.
+        _ver="${VERSION_LABEL#v}"
+        _major="${_ver%%.*}"
+        _rest="${_ver#*.}"
+        _minor="${_rest%%.*}"
+        if [ -n "$_major" ] && [ -n "$_minor" ] \
+                && { [ "$_major" -gt 0 ] \
+                     || { [ "$_major" -eq 0 ] && [ "$_minor" -ge 50 ]; }; } 2>/dev/null; then
+            _intel_blocked=1
+        fi
+    fi
+    if [ "$_intel_blocked" -eq 1 ]; then
+        echo "Intel Macs (x86_64) are not supported by Shipyard v0.50.0 and later." >&2
+        echo "Apple Silicon (arm64) Macs only." >&2
+        echo "" >&2
+        echo "If you have an Intel Mac, pin to a pre-drop version that" >&2
+        echo "still ships an Intel dmg (v0.44.0–v0.49.0):" >&2
+        echo "  SHIPYARD_VERSION=v0.49.0 bash install.sh" >&2
+        exit 2
+    fi
 fi
 
 # Dry-run short-circuit — print the resolved config and exit before

--- a/tests/test_release_macos_local.py
+++ b/tests/test_release_macos_local.py
@@ -232,19 +232,46 @@ def test_publish_gate_covers_arm64_only_after_intel_drop() -> None:
 
 def test_install_sh_rejects_intel_mac_cleanly() -> None:
     # #256: install.sh on Intel Mac must surface a clear "unsupported"
-    # message and exit non-zero BEFORE attempting the asset fetch.
-    # Letting it fall through to the 404 on a missing dmg is exactly
-    # the UX regression this drop was meant to clean up.
+    # message and exit non-zero rather than fall through to a 404 on
+    # the missing asset.
     install_sh = REPO_ROOT / "install.sh"
     content = install_sh.read_text()
     assert "Intel Macs (x86_64) are not supported" in content, (
         "install.sh must surface a clean unsupported-platform message "
         "for Intel Macs, not fall through to a 404 on a missing asset"
     )
-    # Refusal must happen on OS=macos + ARCH=x64, not on Linux x64.
+    # Refusal must key on OS=macos + ARCH=x64, not on Linux x64.
     # Anchor to both so a future simplification of the condition
     # doesn't accidentally nuke Linux x64 installs.
     assert '$OS" = "macos"' in content and '$ARCH" = "x64"' in content
+
+
+def test_intel_guard_runs_after_version_resolution() -> None:
+    # Codex P1 on #257: if the Intel guard fires BEFORE version
+    # resolution, users who explicitly pinned to a pre-drop tag that
+    # still ships an Intel dmg (v0.44.0–v0.49.0) get wrongly refused.
+    # The guard must be positioned AFTER the REQUESTED_VERSION →
+    # VERSION_LABEL resolution block, and must gate on the resolved
+    # version (latest OR >= v0.50.0) rather than unconditionally.
+    install_sh = REPO_ROOT / "install.sh"
+    content = install_sh.read_text()
+    # Find both anchors and assert order.
+    ver_resolution = content.find("# ── version resolution")
+    intel_guard = content.find("Intel Macs (x86_64) are not supported")
+    assert ver_resolution != -1, "version resolution block not found"
+    assert intel_guard != -1, "Intel guard not found"
+    assert ver_resolution < intel_guard, (
+        "Intel guard must come AFTER version resolution — Codex P1 on "
+        "#257: pre-drop pinned tags that still have Intel dmgs must "
+        "still be installable via SHIPYARD_VERSION=vX.Y.Z"
+    )
+    # Guard must be version-conditional (latest or >= 0.50), not
+    # unconditional for all macOS x64 invocations.
+    assert "VERSION_LABEL" in content[intel_guard - 500:intel_guard]
+    # Escape hatch (pinned older version) must be discoverable from
+    # the message so operators know the workaround.
+    assert "SHIPYARD_VERSION=v0.49.0" in content
+    assert "v0.44.0" in content or "v0.49.0" in content
 
 
 def test_release_yml_drops_macos_x64_matrix_row() -> None:


### PR DESCRIPTION
My initial #256 position put the Intel-Mac refusal BEFORE the
SHIPYARD_VERSION → VERSION_LABEL resolution block, so it fired
unconditionally for every macOS x64 invocation. That broke the
back-compat story the commit message itself promised: pre-drop
tags (v0.44.0–v0.49.0) that still ship Intel dmgs should remain
installable via \`SHIPYARD_VERSION=v0.49.0 bash install.sh\`.
Codex P1 on #257 caught this.

Fix: defer the Intel guard until after version resolution. Gate
fires when:
  - \`VERSION_LABEL == "latest"\` (unbounded, will resolve to
    v0.50.0+ which has no Intel dmg), OR
  - the pinned tag parses to major.minor where (major,minor) >=
    (0, 50).

For earlier pins (v0.44.0–v0.49.0), install.sh proceeds and
resolves the existing Intel dmg asset — exactly the back-compat
story the Intel-drop docs claim.

Error message also now names the escape hatch explicitly
(\`SHIPYARD_VERSION=v0.49.0 bash install.sh\`) so operators see the
workaround inline.

New test \`test_intel_guard_runs_after_version_resolution\` pins
both the position (guard AFTER version resolution block) and the
conditional (must reference VERSION_LABEL, not run
unconditionally). A refactor that moves the guard back above
version resolution trips the test immediately.

Skill-Update: skip skill=ci reason="install.sh intel guard position fix; no workflow/dispatch shape change."