### PR TITLE
release: CI-signing experiment scaffolding (#226)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -350,3 +350,78 @@ jobs:
           # release-macos-local.sh's final step flips draft=false
           # once the dmg passes the end-to-end install check.
           draft: true
+
+  # ── #226: CI-signing experiment ───────────────────────────────────
+  # Gated on repo variable `CI_MACOS_SIGNING_ENABLED == 'true'`.
+  # Absent / false → this job is a no-op (conditional skips the whole
+  # job, no minutes burned). When enabled, runs the full sign +
+  # notarize + staple + upload pipeline on a Namespace macOS runner
+  # and attaches the dmg to the draft release. Does NOT flip the
+  # release public — the maintainer's local invocation remains the
+  # load-bearing cross-machine verification gate per #219/CLAUDE.md.
+  # The hypothesis (#226): CI-signing failed pre-v0.44 because we
+  # shipped bare Mach-O that depended on Apple's flaky online
+  # notarization check; stapled .dmg verifies offline so that failure
+  # mode shouldn't recur. Two consecutive healthy releases confirm or
+  # disprove it.
+  sign-and-upload-macos:
+    needs: [resolve-runners, release]
+    if: startsWith(github.ref, 'refs/tags/v') && vars.CI_MACOS_SIGNING_ENABLED == 'true'
+    runs-on: ${{ fromJSON(needs.resolve-runners.outputs.macos_arm) }}
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install uv + PyInstaller
+        run: |
+          curl -LsSf https://astral.sh/uv/install.sh | sh
+          export PATH="$HOME/.local/bin:$PATH"
+          uv sync --frozen
+          echo "$(pwd)/.venv/bin" >> "$GITHUB_PATH"
+
+      - name: Import Developer ID signing identity
+        env:
+          SIGN_P12_B64: ${{ secrets.MACOS_SIGN_P12_BASE64 }}
+          SIGN_P12_PASSWORD: ${{ secrets.MACOS_SIGN_P12_PASSWORD }}
+        run: |
+          # Create an ephemeral keychain that only this job can see,
+          # import the cert, unlock, add key-partition ACL so codesign
+          # can use it non-interactively. Kept in a unique-named
+          # keychain so concurrent runs + the cleanup step don't race.
+          KEYCHAIN="ci-sign-$GITHUB_RUN_ID.keychain-db"
+          security create-keychain -p ci "$KEYCHAIN"
+          security list-keychains -d user -s "$KEYCHAIN" $(security list-keychains -d user | tr -d '"')
+          security default-keychain -s "$KEYCHAIN"
+          security unlock-keychain -p ci "$KEYCHAIN"
+          # 6h timeout so a long notarization step doesn't hit a lock.
+          security set-keychain-settings -t 21600 -u "$KEYCHAIN"
+          echo "$SIGN_P12_B64" | base64 -d > /tmp/cert.p12
+          security import /tmp/cert.p12 -k "$KEYCHAIN" \
+            -P "$SIGN_P12_PASSWORD" -T /usr/bin/codesign -T /usr/bin/security
+          rm -f /tmp/cert.p12
+          security set-key-partition-list -S apple-tool:,apple: -s -k ci "$KEYCHAIN"
+          IDENTITY_SHA=$(security find-identity -p codesigning -v "$KEYCHAIN" \
+            | awk '/Developer ID Application/ {print $2; exit}')
+          if [ -z "$IDENTITY_SHA" ]; then
+            echo "ERROR: no Developer ID Application identity in keychain." >&2
+            exit 1
+          fi
+          echo "IDENTITY_SHA=$IDENTITY_SHA" >> "$GITHUB_ENV"
+          echo "SIGNING_KEYCHAIN=$KEYCHAIN" >> "$GITHUB_ENV"
+
+      - name: Sign + notarize + staple + upload
+        env:
+          SHIPYARD_NOTARIZE_APPLE_ID: ${{ secrets.MACOS_NOTARIZE_APPLE_ID }}
+          SHIPYARD_NOTARIZE_APP_PASSWORD: ${{ secrets.MACOS_NOTARIZE_APP_PASSWORD }}
+          SHIPYARD_NOTARIZE_TEAM_ID: ${{ secrets.MACOS_NOTARIZE_TEAM_ID }}
+          SHIPYARD_SIGNING_IDENTITY: ${{ env.IDENTITY_SHA }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          ./scripts/release-macos-local.sh \
+            --tag ${{ github.ref_name }} \
+            --upload \
+            --ci-mode
+
+      - name: Delete ephemeral signing keychain
+        if: always() && env.SIGNING_KEYCHAIN != ''
+        run: |
+          security delete-keychain "$SIGNING_KEYCHAIN" || true

--- a/scripts/release-macos-local.sh
+++ b/scripts/release-macos-local.sh
@@ -23,7 +23,7 @@
 # this we'd have caught v0.42.0 before it shipped.
 #
 # Usage:
-#   ./scripts/release-macos-local.sh [--tag vX.Y.Z] [--upload]
+#   ./scripts/release-macos-local.sh [--tag vX.Y.Z] [--upload] [--ci-mode]
 #
 # Env vars required for notarization:
 #   SHIPYARD_NOTARIZE_APPLE_ID           (Apple ID email)
@@ -37,6 +37,15 @@
 #   --upload       Upload the signed+tested asset to the GitHub release
 #                  for --tag. Without this, the script only builds and
 #                  verifies — useful for diagnosing without shipping.
+#   --ci-mode      Run in the GH Actions CI-signing experiment path
+#                  (#226). Mount-test becomes a warning instead of a
+#                  hard fail (hosted macOS runners sometimes can't
+#                  mount a freshly-signed dmg from the same process).
+#                  Draft-flip + end-to-end install.sh check are both
+#                  skipped; the maintainer's local (non-ci-mode)
+#                  invocation is the gate that flips public after
+#                  cross-machine verify.
+#
 #   (Intel Mac support was dropped in v0.50.0 per #256; arm64 only.)
 #
 # Exit codes:
@@ -56,6 +65,7 @@ set -euo pipefail
 ARCH="arm64"
 TAG=""
 DO_UPLOAD=0
+CI_MODE=0
 
 while [ $# -gt 0 ]; do
     case "$1" in
@@ -73,6 +83,20 @@ while [ $# -gt 0 ]; do
             fi
             shift 2 ;;
         --upload) DO_UPLOAD=1; shift ;;
+        --ci-mode)
+            # #226: CI-signing experiment. When set:
+            #   - Step 6 (mount + launch test) runs but doesn't fail
+            #     the run on mount errors — CI macOS runners sometimes
+            #     can't mount freshly-signed dmgs from the same process.
+            #   - Step 8 (draft flip) is SKIPPED — CI runs don't have
+            #     the authoritative "E2E passed on a different Mac"
+            #     signal that the local flow gets. Publishing is the
+            #     maintainer's decision after a cross-machine verify.
+            #   - Step 9 (e2e install.sh) is SKIPPED — meaningless on
+            #     the same runner that just produced the dmg. A
+            #     separate workflow / local invocation does this on a
+            #     different machine.
+            CI_MODE=1; shift ;;
         -h|--help)
             sed -n '/^# Usage:/,/^$/p' "$0" | sed 's/^# //; s/^#//'
             exit 0
@@ -228,11 +252,25 @@ MOUNT_POINT="$(mktemp -d)/mnt"
 # /Volumes/ looking for the right volume.
 if ! hdiutil attach -nobrowse -readonly \
         -mountpoint "$MOUNT_POINT" "$DIST_DMG" >/dev/null; then
-    echo "ERROR: could not mount DMG." >&2
-    exit 1
+    # #226: in --ci-mode, a mount failure on the same runner that
+    # just signed the dmg is a known-limitation of hosted macOS
+    # environments rather than a broken artifact. The proper
+    # verification happens on a different Mac post-upload; surface
+    # the mount-fail as a warning and proceed to upload.
+    if [ "$CI_MODE" -eq 1 ]; then
+        echo "  ⚠ DMG mount failed on CI runner (known hosted-runner limitation);" >&2
+        echo "    skipping launch test. The real verification happens on a" >&2
+        echo "    different Mac via install.sh after upload." >&2
+        MOUNT_POINT=""
+    else
+        echo "ERROR: could not mount DMG." >&2
+        exit 1
+    fi
 fi
-trap 'hdiutil detach "$MOUNT_POINT" >/dev/null 2>&1 || true' EXIT
-if ! OUTPUT=$("$MOUNT_POINT/shipyard" --version 2>&1); then
+if [ -n "$MOUNT_POINT" ]; then
+    trap 'hdiutil detach "$MOUNT_POINT" >/dev/null 2>&1 || true' EXIT
+fi
+if [ -n "$MOUNT_POINT" ] && ! OUTPUT=$("$MOUNT_POINT/shipyard" --version 2>&1); then
     echo "" >&2
     echo "ERROR: LOCAL LAUNCH TEST FAILED from mounted DMG." >&2
     echo "       DMG: $DIST_DMG" >&2
@@ -257,12 +295,16 @@ if ! OUTPUT=$("$MOUNT_POINT/shipyard" --version 2>&1); then
     hdiutil detach "$MOUNT_POINT" >/dev/null 2>&1 || true
     exit 3
 fi
-echo "  ✓ --version printed: ${OUTPUT}"
+if [ -n "$MOUNT_POINT" ]; then
+    echo "  ✓ --version printed: ${OUTPUT}"
+fi
 
 # Detach the DMG before further work — the mount is no longer
 # needed and leaving it attached confuses the later e2e step
 # which mounts a freshly-downloaded copy.
-hdiutil detach "$MOUNT_POINT" >/dev/null 2>&1 || true
+if [ -n "$MOUNT_POINT" ]; then
+    hdiutil detach "$MOUNT_POINT" >/dev/null 2>&1 || true
+fi
 trap - EXIT
 
 # ── Upload (opt-in) ────────────────────────────────────────────────
@@ -349,7 +391,18 @@ if [ "$DO_UPLOAD" -eq 1 ]; then
         exit 0
     fi
 
-    if [ "$WAS_DRAFT" -eq 1 ]; then
+    # #226: --ci-mode never flips the release to public. The CI
+    # runner can verify its own build, but can't verify a fresh
+    # install.sh download on an independent Mac — which is the
+    # load-bearing rule per #219/CLAUDE.md. Publishing stays with
+    # the maintainer's hand-run of the script in --local mode.
+    if [ "$CI_MODE" -eq 1 ]; then
+        echo "Step 8/9: Skipping draft flip (--ci-mode)."
+        echo "         Release $TAG stays draft; maintainer's local"
+        echo "         invocation of this script (no --ci-mode) is"
+        echo "         the gate that flips it public after verifying"
+        echo "         the CI-signed dmg on a different Mac."
+    elif [ "$WAS_DRAFT" -eq 1 ]; then
         echo "Step 8/9: All expected macOS dmgs present; flipping release"
         echo "         $TAG from draft to published..."
         gh release edit "$TAG" --draft=false >/dev/null
@@ -357,6 +410,22 @@ if [ "$DO_UPLOAD" -eq 1 ]; then
         echo "  ✓ Release $TAG is now public."
     else
         echo "Step 8/9: Release $TAG is already public (skipping draft flip)."
+    fi
+
+    # #226: skip E2E in CI mode. Running install.sh on the runner
+    # that just produced the dmg tests nothing meaningful — the
+    # whole point of E2E is "does a fresh, different machine
+    # succeed." A separate local invocation (no --ci-mode) is
+    # what actually exercises that path.
+    if [ "$CI_MODE" -eq 1 ]; then
+        echo "Step 9/9: E2E verification SKIPPED (--ci-mode)."
+        echo ""
+        echo "═══ CI build done. Run scripts/release-macos-local.sh"
+        echo "    --tag $TAG  (no --ci-mode) on a different Mac to"
+        echo "    flip the release public after the cross-machine"
+        echo "    install.sh check. ═══"
+        echo ""
+        exit 0
     fi
 
     # ── End-to-end verification (#55 codification) ─────────────────

--- a/tests/test_release_macos_local.py
+++ b/tests/test_release_macos_local.py
@@ -246,6 +246,64 @@ def test_install_sh_rejects_intel_mac_cleanly() -> None:
     assert '$OS" = "macos"' in content and '$ARCH" = "x64"' in content
 
 
+def test_ci_mode_skips_publish_and_e2e() -> None:
+    # #226: the CI-signing experiment workflow invokes this script
+    # with --ci-mode. That mode MUST NOT flip the release public and
+    # MUST skip the E2E install.sh check — the load-bearing rule
+    # per #219/CLAUDE.md is cross-machine verification (the dmg runs
+    # cleanly on a Mac OTHER than the one that signed it), and that
+    # only exists via the maintainer's local invocation.
+    content = SCRIPT.read_text()
+    # --ci-mode flag must exist and parse into a CI_MODE variable.
+    assert "--ci-mode)" in content
+    assert "CI_MODE=1" in content
+    # Step 8 must have a CI_MODE branch that skips the draft flip.
+    # Grep the logical block to avoid brittle string matching.
+    step8_pos = content.find("# #226: --ci-mode never flips")
+    assert step8_pos != -1, (
+        "step 8 must have an explicit #226 branch that keeps the "
+        "release in draft under --ci-mode"
+    )
+    # Step 9 must also have a CI_MODE branch that skips E2E.
+    assert 'CI_MODE" -eq 1' in content
+    # Help text must describe --ci-mode so operators/wrappers can
+    # discover it.
+    assert "CI-signing experiment path" in content
+
+
+def test_release_yml_has_ci_signing_job() -> None:
+    # #226: a sign-and-upload-macos job must exist, gated on the
+    # CI_MACOS_SIGNING_ENABLED repo variable so it's opt-in during
+    # the experiment. Don't accidentally enable it by default — the
+    # 3-condition verification (two different Macs) has to land first.
+    release_yml = REPO_ROOT / ".github" / "workflows" / "release.yml"
+    content = release_yml.read_text()
+    assert "sign-and-upload-macos:" in content, (
+        "release.yml must define the #226 CI-signing job"
+    )
+    assert "vars.CI_MACOS_SIGNING_ENABLED == 'true'" in content, (
+        "CI-signing must be gated on the repo variable so it's "
+        "opt-in, not default"
+    )
+    # Job must invoke the script with --ci-mode so publish/E2E are
+    # skipped (cross-machine gate stays with maintainer).
+    assert "--ci-mode" in content
+    # Must use the ephemeral-keychain + delete-keychain pattern so
+    # the cert isn't persisted on the runner past the job.
+    assert "security create-keychain" in content
+    assert "security delete-keychain" in content
+    # Secret names documented in #226's experiment plan must all be
+    # referenced so a typo can't silently pass the gate.
+    for secret in (
+        "MACOS_SIGN_P12_BASE64",
+        "MACOS_SIGN_P12_PASSWORD",
+        "MACOS_NOTARIZE_APPLE_ID",
+        "MACOS_NOTARIZE_APP_PASSWORD",
+        "MACOS_NOTARIZE_TEAM_ID",
+    ):
+        assert secret in content, f"secret {secret} not referenced"
+
+
 def test_intel_guard_runs_after_version_resolution() -> None:
     # Codex P1 on #257: if the Intel guard fires BEFORE version
     # resolution, users who explicitly pinned to a pre-drop tag that


### PR DESCRIPTION
Adds the workflow + script surface for the #226 CI-signing
experiment. Dormant by default — the new
\`sign-and-upload-macos\` job is gated on
\`vars.CI_MACOS_SIGNING_ENABLED == 'true'\`, so absent or false
makes it a no-op (no CI minutes burned, no behavior change).

When enabled, the job runs on a Namespace macOS runner:

1. Imports Developer ID cert from \`MACOS_SIGN_P12_BASE64\` +
   \`MACOS_SIGN_P12_PASSWORD\` into an ephemeral keychain scoped
   to the run ID, set up for non-interactive codesign access.
2. Invokes \`release-macos-local.sh --tag X --upload --ci-mode\`.
3. Deletes the keychain on job exit.

\`--ci-mode\` is the new flag that adapts the release script for
the CI path:

- Step 6 (mount + launch test): mount failure becomes a warning
  rather than a hard exit. Hosted macOS runners sometimes can't
  mount a freshly-signed dmg from the same process; the real
  verification happens on a different Mac post-upload.
- Step 8 (draft-flip): SKIPPED. The load-bearing rule per
  #219/CLAUDE.md is cross-machine verification; only the
  maintainer's local invocation gets to flip public.
- Step 9 (E2E install.sh): SKIPPED. Running install.sh on the
  runner that just produced the dmg tests nothing meaningful.

Hypothesis being tested: the v0.42.0 / v0.43.0 CI-signing
failures were caused by bare Mach-O + Apple's flaky online
notarization check, not by the signing environment per se.
Since v0.44.0 we ship stapled .dmg which verifies offline —
that failure mode shouldn't recur. The experiment will confirm
or disprove this across two consecutive releases before we'd
consider retiring the local-sign step.

Required GitHub Secrets (maintainer provisions; none committed
to the repo):

- \`MACOS_SIGN_P12_BASE64\` — Developer ID Application cert
- \`MACOS_SIGN_P12_PASSWORD\` — P12 password
- \`MACOS_NOTARIZE_APPLE_ID\` — Apple ID email
- \`MACOS_NOTARIZE_APP_PASSWORD\` — app-specific password
- \`MACOS_NOTARIZE_TEAM_ID\` — Apple Developer Team ID

Required repo variable: \`CI_MACOS_SIGNING_ENABLED=true\` to
enable. Ships false / absent so this PR landing is behavior-
preserving.

Tests in \`tests/test_release_macos_local.py\`:

- \`test_ci_mode_skips_publish_and_e2e\` pins the --ci-mode
  behavior so a refactor can't silently re-enable publish.
- \`test_release_yml_has_ci_signing_job\` pins the job name,
  the opt-in gate, the ephemeral-keychain pattern, and every
  secret name. Catches typos at PR time, not at release time.

Skill-Update: skip skill=ci reason="CI-signing scaffolding is opt-in experiment, dormant until CI_MACOS_SIGNING_ENABLED is set; no shape change to the default dispatch/target flow."