### PR TITLE
feat(test): sandbox E2E harness for Shipyard CLI (#248)

### DIFF
--- a/.github/workflows/sandbox-e2e.yml
+++ b/.github/workflows/sandbox-e2e.yml
@@ -1,0 +1,112 @@
+# Sandbox E2E — isolated end-to-end tests for the Shipyard CLI.
+# See tools/sandbox-e2e/README.md for what this covers and why.
+# Tracked in Shipyard#248. Sibling harness: pulp#732 / pulp#736.
+#
+# Strategy: install the package in a venv via `pip install -e .` (the
+# fastest path to "we have a runnable shipyard binary") and let the
+# sandbox harness's discovery logic find the entrypoint script
+# (~/.local/bin or the venv's bin/), or fall through to the
+# python-wrapper fallback if the entrypoint isn't on PATH.
+#
+# Why no PyInstaller --onefile here:
+#   * The release workflow already exercises that build path on tags.
+#   * For PR gating we want the CLI behavior under test, not the
+#     packaging behavior. The harness's python-wrapper fallback runs
+#     the *same* `shipyard.cli:main` entrypoint the binary does, so
+#     unknown-subcommand semantics, JSON output, daemon socket paths,
+#     etc. are all identical.
+#
+# `continue-on-error: true` on the install step keeps the harness
+# scenarios that don't need a binary (surface enumeration,
+# contamination-audit smoke) running even when packaging is broken.
+
+name: sandbox-e2e
+
+on:
+  pull_request:
+    paths:
+      - "src/shipyard/**"
+      - "commands/**"
+      - ".claude-plugin/**"
+      - "tools/sandbox-e2e/**"
+      - "install.sh"
+      - "pyproject.toml"
+      - ".github/workflows/sandbox-e2e.yml"
+  push:
+    branches: [main]
+    paths:
+      - "src/shipyard/**"
+      - "commands/**"
+      - ".claude-plugin/**"
+      - "tools/sandbox-e2e/**"
+      - "install.sh"
+      - "pyproject.toml"
+      - ".github/workflows/sandbox-e2e.yml"
+  # Let release workflows call this as a pre-publish gate.
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  sandbox-e2e:
+    name: sandbox-e2e (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, ubuntu-latest]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install build deps
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pytest
+
+      - name: Install Shipyard from source (best-effort)
+        id: install
+        # The harness can run with the python-wrapper fallback even if
+        # this fails, so don't gate the whole job on packaging
+        # success — but do report the failure.
+        continue-on-error: true
+        run: |
+          set -o pipefail
+          python -m pip install -e .
+          # Resolve the entrypoint and stash it for the harness so we
+          # don't depend on the discovery code finding the venv's bin/
+          # dir for us.
+          if entrypoint="$(python -c 'import shutil; p = shutil.which("shipyard"); print(p) if p else exit(1)')"; then
+            echo "bin=$entrypoint" >> "$GITHUB_OUTPUT"
+            echo "Resolved shipyard entrypoint: $entrypoint"
+          else
+            echo "::warning ::shipyard entrypoint not on PATH after pip install — harness will use python-wrapper fallback"
+          fi
+          # Smoke-test: the entrypoint should at least respond to --version
+          shipyard --version || echo "::warning ::shipyard --version failed; will rely on python-wrapper fallback"
+
+      - name: Run sandbox E2E suite
+        env:
+          SHIPYARD_BINARY_FOR_TEST: ${{ steps.install.outputs.bin }}
+        run: |
+          # Even if the entrypoint isn't resolvable, the harness's
+          # python-wrapper fallback exercises the exact same Click
+          # entrypoint via `python -m shipyard.cli`. pytest.skip
+          # handles per-test gating where required.
+          pytest tools/sandbox-e2e/ -v --tb=short
+
+      - name: Upload sandbox tempdir on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: sandbox-e2e-${{ matrix.os }}-logs
+          path: |
+            /tmp/shipyard-sandbox-e2e.*/**
+          if-no-files-found: ignore
+          retention-days: 7

--- a/tools/sandbox-e2e/README.md
+++ b/tools/sandbox-e2e/README.md
@@ -1,0 +1,205 @@
+# Shipyard sandbox E2E test harness
+
+Isolated end-to-end tests for the Shipyard CLI. Every test runs in a
+fresh tempdir with a shadowed `$PATH` and isolated `$HOME`; the
+contamination audit enforces **zero writes** to the user's real
+Shipyard install.
+
+Tracked in [Shipyard#248](https://github.com/danielraffel/Shipyard/issues/248).
+Sibling harness pattern for the Pulp CLI lives in
+[pulp#732](https://github.com/danielraffel/pulp/issues/732) and
+[pulp#736](https://github.com/danielraffel/pulp/pull/736); the two
+harnesses are intentionally shaped the same so a contributor who works
+on one can read the other (just `s/pulp/shipyard/` on env var + binary
+name).
+
+## Why this exists
+
+Installers, upgrades, daemon lifecycle, and unknown-subcommand
+handling are the bugs that bite users hardest:
+
+- v0.15→v0.18 silent-fail on MSVC include path (in Pulp; took 24h to
+  notice releases were broken because no test exercised the
+  end-to-end release pipeline)
+- v0.21 / v0.29 / v0.39 incidents — bundle-apply path mismatches,
+  PowerShell quoting bugs, etc.
+- "Unknown command → exit 0" regressions — the canonical class of
+  bug where a CLI silently does nothing on typos or removed
+  subcommands. This harness's `test_unknown_subcommand_exits_nonzero_with_stderr`
+  is the dedicated guard against that class.
+
+Existing unit + integration tests don't catch these because they test
+logic, not "does the installed binary behave correctly when invoked
+the way users invoke it."
+
+## What it covers
+
+- **Smoke** — `--help`, `--version`, unknown top-level subcommand,
+  unknown nested subcommand all behave non-silently.
+- **Surface** — every `shipyard X` invocation in `commands/*.md`,
+  `README.md`, `docs/**/*.md`, and `.github/workflows/*.yml` runs
+  `--help` non-silently. Source-of-truth-driven: when a new slash-
+  command lands, the surface enumerator picks it up automatically.
+- **Config** — `shipyard config show` / `config profiles` read-only
+  behavior in an empty sandbox.
+- **Queue** — empty queue + empty target list still print observable
+  output.
+- **Daemon** — `shipyard daemon status` does NOT accidentally start
+  the daemon, and does NOT create a socket file under the sandbox
+  HOME.
+- **Parity** — `shipyard --json status` is parseable JSON with
+  the documented top-level keys (`schema_version`, `command`,
+  `queue`, `targets`).
+- **Pin** — `shipyard pin show` outside a consumer repo fails loudly
+  with a clear hint, never silent-exit-0.
+- **Bulkhead** — `Sandbox.run(["ship"])` / `["pr"]` / `["cloud",
+  "run", ...]` raise `AssertionError` rather than executing the
+  destructive command.
+- **Contamination audit** — runs automatically at every test
+  teardown; any write to a `PROTECTED_PATHS` directory fails the
+  test.
+
+## What it deliberately does NOT cover
+
+| Excluded | Why |
+|---|---|
+| `shipyard ship` | actually merges PRs |
+| `shipyard pr` | opens a real GitHub PR |
+| `shipyard upgrade` | replaces the running binary |
+| `shipyard cloud run` | dispatches a real GHA workflow on Namespace / GitHub-hosted |
+| `shipyard daemon start`/`run` | long-lived process, opens sockets |
+| `shipyard wait`/`watch` | block on a GitHub condition / live ship |
+| `shipyard auto-merge` | hits GitHub to attempt a real merge |
+| `shipyard release-bot setup` | guides through GitHub PAT provisioning |
+
+These live in `SURFACE_SKIPS` in `test_swap.py` (and in
+`DESTRUCTIVE_COMMANDS` / `SAFE_CLOUD_SUBCOMMANDS` in
+`shipyard_sandbox.py` for the runtime bulkhead). Each skip carries a
+one-line reason. When a new subcommand lands, the default is "add an
+entry here and file a follow-up to write a real test."
+
+## Running
+
+```bash
+# from the repo root
+pytest tools/sandbox-e2e/
+
+# or just the fast subset
+pytest tools/sandbox-e2e/ -m "smoke or surface"
+
+# pin a specific binary (useful in CI and when iterating on a branch)
+SHIPYARD_BINARY_FOR_TEST=/path/to/shipyard pytest tools/sandbox-e2e/
+```
+
+## Binary discovery
+
+`conftest.py` resolves the binary in this order:
+
+1. `SHIPYARD_BINARY_FOR_TEST` env override
+2. PyInstaller release artifacts:
+   - `dist/shipyard`
+   - `build/dist/shipyard`
+   - `pyinstaller/dist/shipyard`
+3. Installed-binary fallback: `~/.local/bin/shipyard` (the canonical
+   install location, copied into the sandbox — never invoked in place)
+4. Final fallback: an in-repo wrapper that invokes
+   `python -m shipyard.cli` against the source under `src/shipyard/`
+   (with `PYTHONPATH` shadowed so the user's site-packages can't
+   leak in)
+
+Tests never run against "whatever happens to be on PATH" — that's
+what the harness is defending against.
+
+## Contamination audit
+
+Every `sandbox` fixture records a tempfile mtime at setup. At
+teardown, `Sandbox.assert_no_contamination()` walks every entry in
+`PROTECTED_PATHS` and fails if any file has a strictly-greater mtime.
+
+Protected paths (in `shipyard_sandbox.py`):
+
+- `~/Library/Application Support/shipyard/` — macOS combined dir
+- `~/.config/shipyard/` — Linux config
+- `~/.local/state/shipyard/` — Linux state (daemon socket lives here)
+- `~/AppData/Local/shipyard/` — Windows combined dir
+- `~/.local/bin/` — install location
+- `~/.shipyard/` — legacy / future-proofing
+- `~/.cache/shipyard/`
+
+Adding a new protected path is a one-line PR; **prefer overbroad to
+underbroad**. If a test fails the audit, the offender path is in the
+failure output — fix the code, not the audit.
+
+## Adding a new scenario
+
+1. Decide which `@pytest.mark` applies: `smoke`, `surface`, `config`,
+   `queue`, `daemon`, `parity`. If none fit, add a new mark and
+   document it in `pytest.ini`.
+2. Add a function in `test_swap.py`:
+
+   ```python
+   @pytest.mark.<mark>
+   def test_<what_it_proves>(sandbox_with_shipyard: Sandbox) -> None:
+       result = sandbox_with_shipyard.run(["your", "subcommand"])
+       assert result.stdout or result.stderr, "non-silent contract"
+   ```
+3. If the scenario needs a stub binary / a fixture project / canned
+   JSON, drop it under `fixtures/` and request it via a session-scoped
+   pytest fixture in `conftest.py`.
+4. If the scenario touches a new state path the audit doesn't cover
+   yet, extend `PROTECTED_PATHS` — err on the side of overbroad.
+
+## Layout
+
+```
+tools/sandbox-e2e/
+├── README.md                  # this file
+├── shipyard_sandbox.py        # Sandbox class, binary staging, contamination audit
+├── conftest.py                # pytest fixtures: binary, sandbox, surface roots
+├── pytest.ini                 # marker registry
+├── fixtures/                  # (empty today; reserved for future stubs)
+└── test_swap.py               # the scenarios
+```
+
+## Dependencies
+
+Just `pytest` (Python 3.10+ for the type hints). The harness uses
+only stdlib otherwise so it runs in any CI image that has `python3`.
+
+## CI integration
+
+See `.github/workflows/sandbox-e2e.yml`. Runs on macOS-latest +
+ubuntu-latest on every PR that touches:
+
+- `src/shipyard/**`
+- `commands/**`
+- `.claude-plugin/**`
+- `tools/sandbox-e2e/**`
+- `install.sh`
+- `pyproject.toml`
+
+Required status check for merge. Also a pre-release gate.
+
+## Reusable pattern
+
+The shape is deliberately project-agnostic. Any CLI that:
+
+- Installs to a known prefix
+- Has a state dir (config, cache, logs)
+- Is wrapped by a plugin that shells out to it
+
+…can mimic this harness with:
+
+1. Rename `Path.home() / …` entries in `PROTECTED_PATHS` to your CLI's
+   state locations
+2. Rename `"shipyard"` → your binary name in the PATH shadow + binary
+   discovery
+3. Adapt `enumerate_shipyard_commands` to scan your plugin / IDE
+   surface
+4. Extend `DESTRUCTIVE_COMMANDS` with the subcommands that mutate
+   real-world state
+
+Both the Pulp and Shipyard harnesses ship the same primitives
+(`Sandbox`, `RunResult`, `_otool_dylibs`, `_find_newer`,
+`enumerate_*_commands`, `parse_*_json`); `s/pulp/shipyard/` on the
+identifiers and you have the other one.

--- a/tools/sandbox-e2e/conftest.py
+++ b/tools/sandbox-e2e/conftest.py
@@ -1,0 +1,176 @@
+"""Pytest fixtures for the Shipyard sandbox E2E harness.
+
+Binary discovery (in priority order):
+
+1. Env-var override:
+     SHIPYARD_BINARY_FOR_TEST  — explicit path to a shipyard binary
+
+2. PyInstaller release artifacts inside the repo:
+     dist/shipyard
+     build/dist/shipyard
+     pyinstaller/dist/shipyard
+
+3. Installed-binary fallback:
+     ~/.local/bin/shipyard   (the canonical install location)
+
+4. Final fallback: an in-repo ``python -m shipyard.cli`` wrapper
+   (Sandbox.stage_python_wrapper). This always works as long as the
+   Shipyard package source tree lives under ``src/shipyard/``.
+
+Tests that require a binary call the ``shipyard_binary`` fixture; the
+``sandbox_with_shipyard`` fixture stages either the discovered binary
+or — when none is available — the python wrapper. Either way the test
+gets a sandbox with a working ``shipyard`` on its shadowed PATH.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+
+from shipyard_sandbox import Sandbox
+
+
+# ----- repo-root discovery ---------------------------------------------------
+
+
+def _find_repo_root() -> Path:
+    """Walk upward from this file until we find ``.git`` (a dir for a
+    normal clone, a file for a worktree)."""
+    current = Path(__file__).resolve().parent
+    for candidate in (current, *current.parents):
+        if (candidate / ".git").exists():
+            return candidate
+    return Path(__file__).resolve().parents[2]
+
+
+REPO_ROOT = _find_repo_root()
+
+
+# ----- binary discovery ------------------------------------------------------
+
+
+def _discover_binary() -> Path | None:
+    """Locate a real ``shipyard`` binary to stage. Returns ``None`` when
+    only the python-wrapper fallback is viable.
+
+    Discovery order trades fidelity for speed: a venv entrypoint script
+    or a fresh dist/ build runs in ~0.5s; the user's installed
+    PyInstaller --onefile binary takes ~7s per invocation (the onefile
+    extractor is the cost). Both exercise the same ``shipyard.cli:main``
+    Click entrypoint, so the fast lane is correct for PR-gating
+    purposes. Set ``SHIPYARD_BINARY_FOR_TEST`` to force a specific
+    binary (e.g. the release artifact)."""
+    override = os.environ.get("SHIPYARD_BINARY_FOR_TEST")
+    if override:
+        candidate = Path(override).expanduser()
+        return candidate if candidate.exists() else None
+    candidates: list[Path] = []
+    # Fast lane: a venv we've installed `shipyard` into. This matches
+    # how `pip install -e .` lands the entrypoint.
+    venv_candidates = [
+        REPO_ROOT / ".venv" / "bin" / "shipyard",
+        REPO_ROOT / ".venv-test" / "bin" / "shipyard",
+        REPO_ROOT / "venv" / "bin" / "shipyard",
+    ]
+    candidates.extend(venv_candidates)
+    # PyInstaller release artifacts under the repo (these are fresh
+    # builds — slow but representative).
+    candidates.extend([
+        REPO_ROOT / "dist" / "shipyard",
+        REPO_ROOT / "build" / "dist" / "shipyard",
+        REPO_ROOT / "pyinstaller" / "dist" / "shipyard",
+    ])
+    # The user's installed binary is the slowest option (PyInstaller
+    # --onefile cold-start is ~7s on macOS) but it's the one users
+    # actually invoke. Keep it last so we prefer faster paths when
+    # available.
+    candidates.append(Path.home() / ".local" / "bin" / "shipyard")
+    for c in candidates:
+        if c.exists() and c.is_file():
+            return c
+    return None
+
+
+# ----- fixtures --------------------------------------------------------------
+
+
+@pytest.fixture(scope="session")
+def repo_root() -> Path:
+    return REPO_ROOT
+
+
+@pytest.fixture(scope="session")
+def shipyard_binary() -> Path | None:
+    """The discovered shipyard binary, or ``None`` if only the
+    python-wrapper fallback is available. Tests that strictly require
+    a packaged binary should ``pytest.skip`` themselves on ``None``."""
+    return _discover_binary()
+
+
+@pytest.fixture(scope="session")
+def surface_roots(repo_root: Path) -> list[Path]:
+    """Filesystem roots the surface enumerator should scan for
+    ``shipyard X`` invocations. Order doesn't matter — the result set
+    is unioned."""
+    return [
+        repo_root / "commands",
+        repo_root / "README.md",
+        repo_root / "docs",
+        repo_root / ".github" / "workflows",
+        repo_root / "skills",
+    ]
+
+
+@pytest.fixture()
+def sandbox() -> Iterator[Sandbox]:
+    """Per-test sandbox. Teardown runs the contamination audit — any
+    write to the user's real Shipyard install fails the test here."""
+    sbx = Sandbox()
+    sbx.setup()
+    try:
+        yield sbx
+        sbx.assert_no_contamination()
+    finally:
+        sbx.teardown()
+
+
+@pytest.fixture()
+def sandbox_with_shipyard(
+    sandbox: Sandbox,
+    shipyard_binary: Path | None,
+    repo_root: Path,
+) -> Sandbox:
+    """Per-test sandbox with ``shipyard`` already staged. Uses the
+    discovered binary if available, falls back to a python wrapper
+    that runs ``python -m shipyard.cli`` against the in-repo source."""
+    if shipyard_binary is not None:
+        sandbox.stage_binary(shipyard_binary, as_name="shipyard")
+    else:
+        sandbox.stage_python_wrapper(repo_root, as_name="shipyard")
+    return sandbox
+
+
+# ----- reporting -------------------------------------------------------------
+
+
+def pytest_report_header(config: pytest.Config) -> list[str]:
+    bin_path = _discover_binary()
+    return [
+        f"shipyard sandbox e2e: binary    = "
+        f"{bin_path or '(none — using python-wrapper fallback)'}",
+        f"shipyard sandbox e2e: repo root = {REPO_ROOT}",
+    ]
+
+
+def pytest_configure(config: pytest.Config) -> None:  # noqa: D401
+    """Make ``shipyard_sandbox`` importable regardless of where pytest
+    is invoked from."""
+    import sys as _sys
+
+    harness_dir = str(Path(__file__).resolve().parent)
+    if harness_dir not in _sys.path:
+        _sys.path.insert(0, harness_dir)

--- a/tools/sandbox-e2e/fixtures/.gitkeep
+++ b/tools/sandbox-e2e/fixtures/.gitkeep
@@ -1,0 +1,4 @@
+# Placeholder to keep the fixtures/ directory in git. When a test
+# needs a stub binary or a canned JSON fixture, drop it here. See
+# the Pulp sibling at tools/sandbox-e2e/fixtures/stub_pulp_cpp.sh
+# for the pattern.

--- a/tools/sandbox-e2e/pytest.ini
+++ b/tools/sandbox-e2e/pytest.ini
@@ -1,0 +1,14 @@
+[pytest]
+# Pytest marks used to categorise sandbox E2E scenarios. Running a
+# subset is useful for fast PR gates vs full release checks:
+#
+#   pytest -m "smoke or surface"          # fast lane (no daemon)
+#   pytest -m "config or queue or daemon" # state-touching lane
+#
+markers =
+    smoke: help / version / unknown-subcommand — silent-exit-0 guards
+    surface: every `shipyard X` from commands/docs/CI exits non-silent
+    config: read-only config layer behavior in an empty sandbox
+    queue: empty-queue / empty-targets readback
+    daemon: daemon status doesn't accidentally start the daemon
+    parity: --json schema is well-formed and stable across releases

--- a/tools/sandbox-e2e/shipyard_sandbox.py
+++ b/tools/sandbox-e2e/shipyard_sandbox.py
@@ -1,0 +1,600 @@
+"""Core harness for the Shipyard sandbox E2E test suite.
+
+Every test runs in an isolated tempdir + shadowed ``$PATH`` + isolated
+``$HOME``. The harness MUST never write to the user's real Shipyard
+install. ``Sandbox.assert_no_contamination()`` is invoked at teardown
+by the pytest ``sandbox`` fixture and must pass after every scenario.
+
+Design constraints (see ``Shipyard #248`` for the full spec, plus the
+sibling Pulp implementation at
+`pulp#732 <https://github.com/danielraffel/pulp/issues/732>`_):
+
+* ``$PATH`` is shadowed to exactly ``$SANDBOX/bin:/usr/bin:/bin`` so a
+  stray ``shipyard`` elsewhere on ``PATH`` cannot be invoked
+  accidentally.
+* ``$HOME`` is set to ``$SANDBOX/home`` for every subprocess so all
+  ``Path.home()``-derived locations Shipyard touches
+  (``~/Library/Application Support/shipyard/`` on macOS,
+  ``~/.config/shipyard/`` on Linux, ``~/.local/state/shipyard/`` on
+  Linux, ``~/AppData/Local/shipyard/`` on Windows, plus the
+  ``~/.local/bin/shipyard`` install location) become sandbox-local.
+* Binaries are *copied* (not symlinked) into ``$SANDBOX/bin``. The
+  harness inspects ``otool -L`` (macOS) for any ``@rpath`` /
+  ``@loader_path`` dylibs and copies them alongside. The current
+  Shipyard PyInstaller binary is statically linked against system
+  libs, so this is a no-op today — but it's the same primitive Pulp's
+  C++ binary needs and we want both harnesses to look identical.
+* The sandbox NEVER invokes ``shipyard ship``, ``shipyard pr``,
+  ``shipyard cloud run``, or ``shipyard upgrade``. Those are listed
+  in ``DESTRUCTIVE_COMMANDS`` and the README.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Mapping, Sequence
+
+
+# ----- Contamination audit --------------------------------------------------
+
+#: Directories that must never be written to by any sandbox test.
+#: The audit records mtimes at sandbox setup; any file ``newer`` than
+#: the sandbox-start sentinel inside these trees fails the teardown.
+#:
+#: Shipyard's state lives in two places per platform:
+#:   * macOS:   ``~/Library/Application Support/shipyard/``
+#:   * Linux:   ``~/.config/shipyard/`` (config) +
+#:              ``~/.local/state/shipyard/`` (state, daemon socket)
+#:   * Windows: ``~/AppData/Local/shipyard/``
+#: Plus the install location ``~/.local/bin/shipyard`` (and the ``sy``
+#: symlink).
+PROTECTED_PATHS: tuple[Path, ...] = (
+    # macOS combined config/state dir
+    Path.home() / "Library" / "Application Support" / "shipyard",
+    # Linux split config / state dirs
+    Path.home() / ".config" / "shipyard",
+    Path.home() / ".local" / "state" / "shipyard",
+    # Windows combined dir (harmless on macOS/Linux — just won't exist)
+    Path.home() / "AppData" / "Local" / "shipyard",
+    # Install location (and the ``sy`` symlink lives in the same dir)
+    Path.home() / ".local" / "bin",
+    # Legacy / future-proofing — if anything ever lands a
+    # ``~/.shipyard/`` dir we want the audit to flag it loudly.
+    Path.home() / ".shipyard",
+    Path.home() / ".cache" / "shipyard",
+)
+
+
+#: Subcommands the sandbox MUST NOT invoke. Documented in README.md.
+#: A test that names one of these gets a clear AssertionError instead
+#: of silently scribbling on the user's repo or remote infra.
+DESTRUCTIVE_COMMANDS: frozenset[str] = frozenset({
+    "ship",      # actually merges PRs!
+    "pr",        # opens a real GitHub PR
+    "upgrade",   # replaces the running binary
+    # `cloud run` is destructive (dispatches a real GHA workflow); the
+    # parent `cloud` group has read-only subcommands so we don't blanket
+    # ban it — see SAFE_CLOUD_SUBCOMMANDS below for the allowlist.
+})
+
+#: Whitelist of ``shipyard cloud …`` subcommands that are safe to
+#: invoke — they're read-only or ``--help``-shaped.
+SAFE_CLOUD_SUBCOMMANDS: frozenset[str] = frozenset({
+    "workflows",   # read-only enumeration
+    "defaults",    # read-only config dump
+    "status",      # read-only status fetch
+    "--help",
+})
+
+
+@dataclass(frozen=True)
+class ContaminationReport:
+    """What the contamination audit found, if anything."""
+
+    offenders: tuple[Path, ...]
+    sentinel_mtime: float
+
+    @property
+    def clean(self) -> bool:
+        return not self.offenders
+
+    def format(self) -> str:
+        if self.clean:
+            return "clean — no writes to protected paths"
+        lines = [
+            "CONTAMINATION DETECTED — test wrote outside its sandbox:",
+        ]
+        lines.extend(f"  {p}" for p in self.offenders)
+        lines.append(f"(sentinel mtime: {self.sentinel_mtime})")
+        return "\n".join(lines)
+
+
+def _snapshot_paths(root: Path) -> set[Path]:
+    """Snapshot the set of paths currently under ``root``. Used at
+    sandbox setup so the audit at teardown can flag genuinely-new
+    files without false-positives from unrelated processes (e.g. a
+    live ``shipyard daemon`` updating its own state dir while the
+    sandbox is running)."""
+    if not root.exists():
+        return set()
+    try:
+        return set(root.rglob("*"))
+    except OSError:
+        return set()
+
+
+def _find_newer(
+    root: Path,
+    sentinel_mtime: float,
+    *,
+    pre_existing: set[Path] | None = None,
+) -> list[Path]:
+    """Return paths under ``root`` that look like contamination — that
+    is, *new* paths (not in ``pre_existing``) whose mtime is strictly
+    greater than ``sentinel_mtime``. Skips missing roots. Never
+    follows symlinks.
+
+    Why ``pre_existing`` matters: a developer running the suite locally
+    may have a live ``shipyard daemon`` writing to its own state dir
+    independently of the sandbox. Treating any mtime bump in that dir
+    as contamination would produce false positives. Only files the
+    sandbox could plausibly have created (i.e. paths absent at
+    sandbox setup) count as offenders.
+    """
+    if not root.exists():
+        return []
+    newer: list[Path] = []
+    try:
+        iterator = root.rglob("*")
+    except OSError:
+        return []
+    pre = pre_existing or set()
+    for path in iterator:
+        if path in pre:
+            continue  # daemon-managed file we knew about — not us
+        try:
+            st = path.lstat()
+        except (OSError, FileNotFoundError):
+            continue
+        if st.st_mtime > sentinel_mtime:
+            newer.append(path)
+    return newer
+
+
+# ----- Binary staging -------------------------------------------------------
+
+
+def _otool_dylibs(binary: Path) -> list[Path]:
+    """Return ``@rpath`` / ``@loader_path`` dylibs that must sit next to
+    the binary for the rpath contract. Returns ``[]`` on non-macOS or
+    on an ``otool`` error.
+
+    Today the Shipyard PyInstaller binary statically links against
+    system libs so this returns ``[]`` for it. Kept as a primitive so
+    the harness shape stays parallel to Pulp's and so we're ready when
+    a future binary picks up an ``@rpath`` dependency."""
+    if sys.platform != "darwin":
+        return []
+    try:
+        result = subprocess.run(
+            ["otool", "-L", str(binary)],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (FileNotFoundError, subprocess.SubprocessError):
+        return []
+
+    dylibs: list[Path] = []
+    for line in result.stdout.splitlines():
+        line = line.strip()
+        m = re.match(r"^(@rpath|@loader_path)/(\S+\.dylib)\b", line)
+        if not m:
+            continue
+        candidate = binary.parent / m.group(2)
+        if candidate.exists():
+            dylibs.append(candidate)
+    return dylibs
+
+
+# ----- Sandbox --------------------------------------------------------------
+
+
+@dataclass
+class RunResult:
+    """Captured result of a ``Sandbox.run`` invocation."""
+
+    argv: tuple[str, ...]
+    returncode: int
+    stdout: str
+    stderr: str
+
+    def expect_success(self) -> "RunResult":
+        if self.returncode != 0:
+            raise AssertionError(
+                f"command failed (rc={self.returncode}): {' '.join(self.argv)}\n"
+                f"stdout: {self.stdout}\nstderr: {self.stderr}"
+            )
+        return self
+
+
+class Sandbox:
+    """Isolated sandbox for running the ``shipyard`` CLI under test.
+
+    Usage::
+
+        with Sandbox() as sbx:
+            sbx.stage_binary(Path("/.../shipyard"), as_name="shipyard")
+            sbx.run(["--version"]).expect_success()
+            sbx.assert_no_contamination()
+    """
+
+    def __init__(self, *, keep: bool = False) -> None:
+        self._keep = keep
+        self._tmpdir: Path | None = None
+        self._sentinel_mtime: float | None = None
+        self._pre_existing: dict[Path, set[Path]] = {}
+
+    # -- lifecycle --
+
+    def __enter__(self) -> "Sandbox":
+        self.setup()
+        return self
+
+    def __exit__(self, *exc_info) -> None:
+        self.teardown()
+
+    def setup(self) -> None:
+        if self._tmpdir is not None:
+            raise RuntimeError("Sandbox already set up")
+        self._tmpdir = Path(tempfile.mkdtemp(prefix="shipyard-sandbox-e2e."))
+        (self._tmpdir / "bin").mkdir()
+        (self._tmpdir / "home").mkdir()
+        # The fake $HOME needs the dirs Shipyard might write to so the
+        # OS-native path resolution succeeds without surprising the
+        # CLI. We don't create the dirs themselves; Shipyard does that
+        # on first write.
+        sentinel = self._tmpdir / ".sentinel"
+        sentinel.write_text("")
+        self._sentinel_mtime = sentinel.stat().st_mtime
+        # Snapshot the protected paths NOW so the audit at teardown can
+        # distinguish "the test wrote a new file here" from "an
+        # unrelated daemon updated a pre-existing file in its own
+        # state dir." We only flag paths absent at this snapshot.
+        self._pre_existing = {
+            root: _snapshot_paths(root) for root in PROTECTED_PATHS
+        }
+        # Force post-sentinel writes to have strictly greater mtime on
+        # 1s-resolution filesystems (macOS HFS+ / FAT).
+        time.sleep(0.05)
+
+    def teardown(self) -> None:
+        if self._tmpdir is None:
+            return
+        if not self._keep:
+            shutil.rmtree(self._tmpdir, ignore_errors=True)
+        self._tmpdir = None
+        self._sentinel_mtime = None
+
+    # -- accessors --
+
+    @property
+    def root(self) -> Path:
+        assert self._tmpdir is not None, "sandbox not set up"
+        return self._tmpdir
+
+    @property
+    def bin_dir(self) -> Path:
+        return self.root / "bin"
+
+    @property
+    def home(self) -> Path:
+        return self.root / "home"
+
+    @property
+    def sentinel_mtime(self) -> float:
+        assert self._sentinel_mtime is not None
+        return self._sentinel_mtime
+
+    # -- staging --
+
+    def stage_binary(self, source: Path, as_name: str) -> Path:
+        """Copy ``source`` into ``$SANDBOX/bin/<as_name>`` along with
+        any ``@rpath`` / ``@loader_path`` dylibs it needs. Returns the
+        staged path.
+
+        Copies (not symlinks) are mandatory — the harness must never
+        give a test a back-door to the real installed binary.
+        """
+        source = source.resolve()
+        if not source.is_file():
+            raise FileNotFoundError(f"binary not found: {source}")
+        dest = self.bin_dir / as_name
+        shutil.copy2(source, dest)
+        dest.chmod(0o755)
+        for dylib in _otool_dylibs(source):
+            dylib_dest = self.bin_dir / dylib.name
+            if not dylib_dest.exists():
+                shutil.copy2(dylib, dylib_dest)
+        return dest
+
+    def stage_python_wrapper(self, repo_root: Path, as_name: str = "shipyard") -> Path:
+        """Stage a wrapper that invokes ``python -m shipyard.cli``
+        from the in-repo source tree. Used when no PyInstaller binary
+        is available (typical CI fallback when the release build hasn't
+        run yet on this branch).
+
+        The wrapper sets ``PYTHONPATH`` to the repo's ``src/`` dir so
+        the in-repo Shipyard package is what gets executed — *not*
+        whatever ``shipyard`` happens to be installed in the user's
+        site-packages. That's the same isolation contract the binary
+        path gets.
+        """
+        src_dir = (repo_root / "src").resolve()
+        if not src_dir.is_dir():
+            raise FileNotFoundError(
+                f"expected repo src/ at {src_dir} for python-wrapper "
+                f"fallback"
+            )
+        dest = self.bin_dir / as_name
+        # Use the same python that's running pytest. ``sys.executable``
+        # is correct in any venv / system-python combination.
+        body = (
+            f"#!/usr/bin/env bash\n"
+            f"# Auto-generated by Sandbox.stage_python_wrapper.\n"
+            f"# Routes `shipyard` to the in-repo source tree at\n"
+            f"# {src_dir}\n"
+            f"export PYTHONPATH={src_dir}:${{PYTHONPATH:-}}\n"
+            f'exec "{sys.executable}" -m shipyard.cli "$@"\n'
+        )
+        dest.write_text(body)
+        dest.chmod(0o755)
+        return dest
+
+    def write_stub(self, name: str, body: str) -> Path:
+        """Write an executable shell stub to ``$SANDBOX/bin/<name>``."""
+        dest = self.bin_dir / name
+        dest.write_text(body)
+        dest.chmod(0o755)
+        return dest
+
+    # -- execution --
+
+    def env(self, overrides: Mapping[str, str] | None = None) -> dict[str, str]:
+        """Minimal environment for subprocess invocation.
+
+        ``PATH`` is shadowed to ``$SANDBOX/bin:/usr/bin:/bin`` so any
+        stray ``shipyard`` on the user's ``PATH`` cannot be invoked.
+        ``HOME`` points at the sandbox's isolated state dir so every
+        ``Path.home()`` resolution inside Shipyard lands inside the
+        sandbox.
+        """
+        base: dict[str, str] = {
+            "PATH": f"{self.bin_dir}:/usr/bin:/bin",
+            "HOME": str(self.home),
+            "LANG": os.environ.get("LANG", "C"),
+            "LC_ALL": os.environ.get("LC_ALL", "C"),
+            "TERM": "dumb",
+        }
+        # Carry through env that subprocesses (gh, ssh, git) need.
+        # SHELL lets click figure out completion shells; TMPDIR keeps
+        # macOS subprocess scratch space sane.
+        for k in ("USER", "LOGNAME", "TMPDIR", "SHELL"):
+            if k in os.environ:
+                base[k] = os.environ[k]
+        if overrides:
+            base.update(overrides)
+        return base
+
+    def run(
+        self,
+        argv: Sequence[str],
+        *,
+        binary: str = "shipyard",
+        env_overrides: Mapping[str, str] | None = None,
+        cwd: Path | None = None,
+        timeout: float = 60.0,
+    ) -> RunResult:
+        """Invoke ``$SANDBOX/bin/<binary>`` with ``argv`` under the
+        sandbox environment.
+
+        The default timeout is generous (60s) because PyInstaller
+        ``--onefile`` binaries on macOS have a 5-8s cold-start
+        penalty. Tests that want to flag a hang faster can pass an
+        explicit shorter ``timeout``.
+
+        Refuses to invoke any subcommand listed in
+        ``DESTRUCTIVE_COMMANDS`` — those mutate real PRs, real
+        binaries, or real cloud runs. Use ``--help`` instead, or shell
+        out to a stub.
+
+        Returns a ``RunResult`` with captured stdout/stderr/returncode.
+        Raises ``TimeoutError`` if the child outruns ``timeout``.
+        """
+        if argv and argv[0] in DESTRUCTIVE_COMMANDS:
+            raise AssertionError(
+                f"refusing to invoke destructive subcommand "
+                f"{argv[0]!r} from sandbox; see DESTRUCTIVE_COMMANDS "
+                f"and the README's exclusion table."
+            )
+        # `cloud` is half-destructive — block its destructive children.
+        if (
+            len(argv) >= 2
+            and argv[0] == "cloud"
+            and argv[1] not in SAFE_CLOUD_SUBCOMMANDS
+            and argv[1] != "--help"
+        ):
+            raise AssertionError(
+                f"refusing to invoke `cloud {argv[1]}` from sandbox; "
+                f"only {sorted(SAFE_CLOUD_SUBCOMMANDS)} are allowed."
+            )
+        exe = self.bin_dir / binary
+        if not exe.exists():
+            raise FileNotFoundError(
+                f"binary '{binary}' not staged in {self.bin_dir}"
+            )
+        full_argv = (str(exe),) + tuple(argv)
+        try:
+            proc = subprocess.run(
+                full_argv,
+                env=self.env(env_overrides),
+                cwd=str(cwd) if cwd else str(self.root),
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+            )
+        except subprocess.TimeoutExpired as exc:
+            raise TimeoutError(
+                f"timeout running {' '.join(full_argv)} after {timeout}s\n"
+                f"partial stdout: {exc.stdout}\nstderr: {exc.stderr}"
+            ) from exc
+        return RunResult(
+            argv=full_argv,
+            returncode=proc.returncode,
+            stdout=proc.stdout or "",
+            stderr=proc.stderr or "",
+        )
+
+    # -- state readback --
+
+    def read(self, rel_path: str) -> str:
+        """Read a file under ``$SANDBOX/home``. Raises
+        ``FileNotFoundError`` if missing."""
+        return (self.home / rel_path).read_text()
+
+    def exists(self, rel_path: str) -> bool:
+        return (self.home / rel_path).exists()
+
+    # -- contamination audit --
+
+    def audit_contamination(
+        self,
+        extra_roots: Iterable[Path] = (),
+    ) -> ContaminationReport:
+        """Scan the protected paths (plus any ``extra_roots``) for
+        contamination. A path counts as an offender when:
+
+        * its mtime is strictly greater than the sandbox-start
+          sentinel, AND
+        * it did NOT exist at sandbox setup time
+
+        The "did not exist" filter screens out unrelated processes
+        (e.g. a live ``shipyard daemon``) updating pre-existing files
+        in their own state dirs. ``extra_roots`` injected after setup
+        get a fresh empty snapshot — useful for the audit's own self-
+        test (see ``test_contamination_audit_catches_writes_to_protected_paths``)."""
+        offenders: list[Path] = []
+        for root in PROTECTED_PATHS:
+            offenders.extend(
+                _find_newer(
+                    root,
+                    self.sentinel_mtime,
+                    pre_existing=self._pre_existing.get(root, set()),
+                )
+            )
+        for root in extra_roots:
+            offenders.extend(
+                _find_newer(root, self.sentinel_mtime, pre_existing=set())
+            )
+        return ContaminationReport(
+            offenders=tuple(offenders),
+            sentinel_mtime=self.sentinel_mtime,
+        )
+
+    def assert_no_contamination(self) -> None:
+        """Raise ``AssertionError`` if the audit finds any writes to
+        protected paths since the sandbox was set up."""
+        report = self.audit_contamination()
+        if not report.clean:
+            raise AssertionError(report.format())
+
+
+# ----- Surface enumeration --------------------------------------------------
+
+#: Matches ``shipyard <word>`` at start of line, after whitespace, or
+#: inside a fenced code block / inline backticks. Captures the first
+#: subcommand token. Mirrors the Pulp harness's ``_PLUGIN_CMD_RE`` so
+#: a contributor reading both finds the same shape.
+_SHIPYARD_CMD_RE = re.compile(
+    r"""(?:^|\s|`)              # start, whitespace, or backtick
+        shipyard\s+              # the binary
+        ([a-z][a-z-]*)           # subcommand token (no flags)
+    """,
+    re.VERBOSE | re.MULTILINE,
+)
+
+
+def enumerate_shipyard_commands(roots: Iterable[Path]) -> set[str]:
+    """Parse every Markdown / YAML file under ``roots`` and return the
+    set of ``shipyard <subcommand>`` invocations the surface advertises.
+
+    Surfaces worth scanning (per the design refinement #1 in
+    `Shipyard #248
+    <https://github.com/danielraffel/Shipyard/issues/248#issuecomment-4315974191>`_):
+
+    * ``commands/*.md`` — the Claude Code plugin's slash-command files
+    * ``README.md`` — fenced-block examples
+    * ``docs/**/*.md`` — guide pages with example invocations
+    * ``.github/workflows/*.yml`` — CI workflows that shell out
+
+    Tokens that are obvious docs noise (``the``, ``and``, ``is``, plus
+    the angle-bracketed placeholder ``$arguments``) are stripped.
+    """
+    subcommands: set[str] = set()
+    for root in roots:
+        if not root.exists():
+            continue
+        if root.is_file():
+            files = [root]
+        else:
+            files = []
+            for pattern in ("*.md", "**/*.md", "*.yml", "**/*.yml", "*.yaml"):
+                files.extend(root.glob(pattern))
+        for f in files:
+            try:
+                text = f.read_text(encoding="utf-8", errors="replace")
+            except OSError:
+                continue
+            for match in _SHIPYARD_CMD_RE.finditer(text):
+                subcommands.add(match.group(1))
+    # Strip prose-noise tokens that the regex catches in narrative text.
+    for noise in ("the", "and", "is", "or", "a", "an"):
+        subcommands.discard(noise)
+    return subcommands
+
+
+# ----- JSON-schema parity probe --------------------------------------------
+
+
+def parse_status_json(stdout: str) -> dict:
+    """Parse ``shipyard --json status`` output. Strips any leading
+    non-JSON garbage and returns the decoded object."""
+    idx = stdout.find("{")
+    if idx < 0:
+        raise ValueError(f"no JSON object in output: {stdout!r}")
+    decoder = json.JSONDecoder()
+    obj, _end = decoder.raw_decode(stdout[idx:])
+    if not isinstance(obj, dict):
+        raise ValueError(f"expected object, got {type(obj).__name__}")
+    return obj
+
+
+#: Top-level keys ``shipyard --json status`` exposes today. Drift in
+#: this set is a release-notes-worthy schema change. The parity test
+#: asserts these are present so a refactor that drops one fails loudly.
+REQUIRED_STATUS_KEYS: tuple[str, ...] = (
+    "schema_version",
+    "command",
+    "queue",
+    "targets",
+)

--- a/tools/sandbox-e2e/test_swap.py
+++ b/tools/sandbox-e2e/test_swap.py
@@ -1,0 +1,495 @@
+"""End-to-end sandbox scenarios for the Shipyard CLI.
+
+Every test here runs in an isolated ``Sandbox`` (see
+``shipyard_sandbox.py``) and must pass the contamination audit at
+teardown — any write to ``~/Library/Application Support/shipyard/``,
+``~/.config/shipyard/``, ``~/.local/state/shipyard/``,
+``~/AppData/Local/shipyard/``, or ``~/.local/bin/`` fails the test.
+
+Scenarios mirror the acceptance criteria on
+`Shipyard #248 <https://github.com/danielraffel/Shipyard/issues/248>`_.
+Grouped by ``@pytest.mark`` so CI can run a fast subset on PR gates and
+the full suite on release tags. See ``pytest.ini`` for marker docs.
+
+The file is named ``test_swap.py`` to keep the harness shape parallel
+to the Pulp sibling at
+`pulp#732 <https://github.com/danielraffel/pulp/issues/732>`_; ignore
+the historical "swap" connotation (Pulp's harness was written during
+a C++→Rust binary swap) — for Shipyard "swap" is just "the file where
+the scenarios live."
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from shipyard_sandbox import (
+    REQUIRED_STATUS_KEYS,
+    Sandbox,
+    enumerate_shipyard_commands,
+    parse_status_json,
+)
+
+
+# -----------------------------------------------------------------------------
+# Shared fixtures / helpers
+# -----------------------------------------------------------------------------
+
+
+#: Subcommand tokens we deliberately don't exercise via ``--help``.
+#: These either invoke destructive flows (caught by Sandbox.run's guard
+#: regardless), or are noise the surface enumerator picks up from
+#: docs prose. Each entry has a one-line reason — adding to this set
+#: should be a deliberate decision, not a quick fix to get green.
+SURFACE_SKIPS: dict[str, str] = {
+    # Destructive (also blocked by Sandbox.run's DESTRUCTIVE_COMMANDS)
+    "ship": "actually merges PRs",
+    "pr": "opens a real GitHub PR",
+    "upgrade": "replaces the running binary",
+    # Long-lived processes
+    "daemon": "the parent group is fine but `daemon run`/`start` block — "
+              "covered by a dedicated daemon-status scenario instead",
+    "watch": "live view, hangs when there's no active ship",
+    "wait": "blocks on a github condition; sub-commands need network",
+    # Network / system probes
+    "release-bot": "guides through GitHub PAT provisioning",
+    "auto-merge": "hits GitHub to attempt a real merge",
+    # Doc-prose tokens that don't correspond to real subcommands
+    "version": "no real `shipyard version` subcommand; this comes from "
+               "prose like 'the Shipyard version pin'",
+}
+
+
+@pytest.fixture(scope="session")
+def shipyard_surface(surface_roots: list[Path]) -> set[str]:
+    """The set of ``shipyard <subcommand>`` tokens advertised by the
+    project's user-facing surface (slash commands, README, docs, CI)."""
+    return enumerate_shipyard_commands(surface_roots)
+
+
+# -----------------------------------------------------------------------------
+# Scenario 1 — Smoke: help banner + version exit non-silent
+# -----------------------------------------------------------------------------
+
+
+@pytest.mark.smoke
+def test_help_banner_exits_zero_with_usage_output(
+    sandbox_with_shipyard: Sandbox,
+) -> None:
+    """``shipyard --help`` must exit 0 and print a usage banner. This
+    is the cheapest possible "is the binary usable at all?" probe."""
+    result = sandbox_with_shipyard.run(["--help"]).expect_success()
+    # Click's banner format: "Usage: shipyard [OPTIONS] COMMAND ..."
+    assert "Usage:" in result.stdout, (
+        f"--help didn't print a usage banner: {result.stdout!r}"
+    )
+    assert "Commands:" in result.stdout, (
+        f"--help didn't list subcommands: {result.stdout!r}"
+    )
+
+
+@pytest.mark.smoke
+def test_version_exits_zero_with_version_string(
+    sandbox_with_shipyard: Sandbox,
+) -> None:
+    """``shipyard --version`` must exit 0 and print a recognisable
+    version string. Catches a release that ships a binary that can't
+    even introspect itself (the v0.15→v0.18 silent-fail class of bug)."""
+    result = sandbox_with_shipyard.run(["--version"]).expect_success()
+    combined = result.stdout + result.stderr
+    assert "shipyard" in combined.lower() or "version" in combined.lower(), (
+        f"--version output doesn't mention shipyard or 'version': "
+        f"{combined!r}"
+    )
+
+
+# -----------------------------------------------------------------------------
+# Scenario 2 — Mandatory regression: unknown subcommand is non-silent
+# -----------------------------------------------------------------------------
+#
+# This is the canonical silent-exit-0 anti-pattern. Pulp shipped a real
+# release where `pulp ship sign` printed "Unknown command: ship" and
+# exited 0, silently breaking every plugin slash-command. The same
+# class of bug could ship in Shipyard if Click's behavior ever drifts
+# (e.g. a bare-`@click.group()` somewhere starts swallowing unknowns).
+# This test guards against that drift.
+
+
+@pytest.mark.smoke
+def test_unknown_subcommand_exits_nonzero_with_stderr(
+    sandbox_with_shipyard: Sandbox,
+) -> None:
+    """An unknown top-level subcommand must (a) exit non-zero AND
+    (b) print something on stderr or stdout. Silent-exit-0 is the
+    failure mode this test exists to prevent."""
+    result = sandbox_with_shipyard.run(["frobnicate-totally-fake"], timeout=30.0)
+    assert result.returncode != 0, (
+        f"unknown subcommand exited 0 — silent-exit anti-pattern. "
+        f"stdout: {result.stdout!r}\nstderr: {result.stderr!r}"
+    )
+    combined = result.stdout + result.stderr
+    assert combined.strip(), (
+        f"unknown subcommand exited {result.returncode} with NO output "
+        f"on either stream — also silent-failure anti-pattern."
+    )
+    assert "frobnicate-totally-fake" in combined or "no such command" in combined.lower(), (
+        f"unknown-subcommand error doesn't name the command or hint "
+        f"at the failure mode: {combined!r}"
+    )
+
+
+@pytest.mark.smoke
+def test_unknown_nested_subcommand_exits_nonzero_with_stderr(
+    sandbox_with_shipyard: Sandbox,
+) -> None:
+    """Same contract as the top-level test, but for a nested group
+    (``shipyard config bogus-subcmd``). Click's nested-group dispatch
+    is a different code path so it needs its own probe."""
+    result = sandbox_with_shipyard.run(
+        ["config", "bogus-subcmd-totally-fake"], timeout=30.0
+    )
+    assert result.returncode != 0, (
+        f"unknown nested subcommand exited 0. "
+        f"stdout: {result.stdout!r}\nstderr: {result.stderr!r}"
+    )
+    combined = result.stdout + result.stderr
+    assert combined.strip(), (
+        f"unknown nested subcommand was silent. rc={result.returncode}"
+    )
+
+
+# -----------------------------------------------------------------------------
+# Scenario 3 — Surface enumeration sanity
+# -----------------------------------------------------------------------------
+
+
+def test_shipyard_surface_is_non_empty(shipyard_surface: set[str]) -> None:
+    """Sanity-check the regex extraction itself."""
+    assert shipyard_surface, (
+        "enumerate_shipyard_commands found no shipyard invocations "
+        "anywhere — regex broken or surface roots empty"
+    )
+    # Spot-check tokens we know must be present given the docs we
+    # shipped.
+    for expected in {"status", "doctor", "queue"}:
+        assert expected in shipyard_surface, (
+            f"missing {expected!r} from surface enumeration: "
+            f"{sorted(shipyard_surface)}"
+        )
+
+
+# -----------------------------------------------------------------------------
+# Scenario 4 — Plugin / docs surface: every advertised command is non-silent
+# -----------------------------------------------------------------------------
+
+
+def _exercisable_commands(surface: set[str]) -> list[str]:
+    return sorted(cmd for cmd in surface if cmd not in SURFACE_SKIPS)
+
+
+@pytest.mark.surface
+def test_every_advertised_command_help_is_nonsilent(
+    sandbox_with_shipyard: Sandbox,
+    shipyard_surface: set[str],
+) -> None:
+    """Every subcommand the user-facing surface advertises must respond
+    to ``--help`` either by printing usage (rc=0) or by failing loudly
+    (rc!=0 + something on stderr / "no such command" on stdout). The
+    failure mode we're guarding against is the same silent-exit-0 bug
+    as Scenario 2, but this time discovered against the real surface
+    list rather than a synthetic name."""
+    exercisable = _exercisable_commands(shipyard_surface)
+    assert exercisable, "no exercisable commands after exclusions"
+
+    failures: list[str] = []
+    for cmd in exercisable:
+        result = sandbox_with_shipyard.run([cmd, "--help"], timeout=30.0)
+        if result.returncode == 0:
+            # Happy path — Click printed usage.
+            if not (result.stdout or result.stderr):
+                failures.append(
+                    f"{cmd} --help exited 0 but printed nothing — "
+                    f"silent-success anti-pattern"
+                )
+            continue
+        # Non-zero is OK iff something explained why.
+        combined = result.stdout + result.stderr
+        if combined.strip():
+            continue
+        failures.append(
+            f"{cmd} --help exited {result.returncode} with no output "
+            f"on either stream — silent-failure anti-pattern"
+        )
+    assert not failures, "\n".join(failures)
+
+
+# -----------------------------------------------------------------------------
+# Scenario 5 — Config layer: read-only access in an empty sandbox
+# -----------------------------------------------------------------------------
+
+
+@pytest.mark.config
+def test_config_show_in_empty_sandbox_is_nonsilent(
+    sandbox_with_shipyard: Sandbox,
+) -> None:
+    """``shipyard config show`` runs against zero ``.shipyard/`` and
+    zero global config — it must either print an empty/default config
+    or exit non-zero with a "no project config" hint. Silent-exit-0
+    with no output is the failure mode."""
+    result = sandbox_with_shipyard.run(["config", "show"], timeout=30.0)
+    combined = result.stdout + result.stderr
+    assert combined.strip(), (
+        f"config show in an empty sandbox produced no output at all "
+        f"(rc={result.returncode}) — silent-exit pattern"
+    )
+
+
+@pytest.mark.config
+def test_config_profiles_in_empty_sandbox_is_nonsilent(
+    sandbox_with_shipyard: Sandbox,
+) -> None:
+    """``shipyard config profiles`` with no profiles defined must
+    print *something* (typically a "no profiles defined" hint) rather
+    than silently exit."""
+    result = sandbox_with_shipyard.run(["config", "profiles"], timeout=30.0)
+    combined = result.stdout + result.stderr
+    assert combined.strip(), (
+        f"config profiles in an empty sandbox was silent. "
+        f"rc={result.returncode}"
+    )
+
+
+# -----------------------------------------------------------------------------
+# Scenario 6 — Queue / targets readback in an empty sandbox
+# -----------------------------------------------------------------------------
+
+
+@pytest.mark.queue
+def test_queue_in_empty_sandbox_is_nonsilent(
+    sandbox_with_shipyard: Sandbox,
+) -> None:
+    """An empty queue must still produce observable output ("No
+    pending jobs" or similar). Silent-exit on an empty queue is the
+    failure mode that masks "did the queue load at all?" bugs."""
+    result = sandbox_with_shipyard.run(["queue"], timeout=30.0).expect_success()
+    combined = result.stdout + result.stderr
+    assert combined.strip(), (
+        f"queue in an empty sandbox produced no output at all"
+    )
+
+
+@pytest.mark.queue
+def test_targets_list_in_empty_sandbox_is_nonsilent(
+    sandbox_with_shipyard: Sandbox,
+) -> None:
+    """``shipyard targets list`` against zero configured targets must
+    print a hint (typically a header + "No targets" or an empty
+    table). Catches a regression where the renderer crashes on an
+    empty target set."""
+    result = sandbox_with_shipyard.run(["targets", "list"], timeout=30.0)
+    # Empty config can legitimately exit non-zero ("no project
+    # config"); what matters is that it explained itself.
+    combined = result.stdout + result.stderr
+    assert combined.strip(), (
+        f"targets list in an empty sandbox was silent. "
+        f"rc={result.returncode}"
+    )
+
+
+# -----------------------------------------------------------------------------
+# Scenario 7 — Daemon: status doesn't accidentally start the daemon
+# -----------------------------------------------------------------------------
+
+
+@pytest.mark.daemon
+def test_daemon_status_in_empty_sandbox_does_not_start_daemon(
+    sandbox_with_shipyard: Sandbox,
+) -> None:
+    """``shipyard daemon status`` must be a pure read; it must NOT
+    spawn a long-lived daemon process or open a socket file. The
+    contamination audit at teardown catches accidental writes; here we
+    additionally verify the daemon socket file under the sandbox HOME
+    was never created (which would also imply a server is bound to
+    it)."""
+    result = sandbox_with_shipyard.run(
+        ["daemon", "status"], timeout=30.0
+    )
+    # Status must exit cleanly and report "not running" — but the
+    # exact string varies by version, so just assert non-silent.
+    combined = result.stdout + result.stderr
+    assert combined.strip(), (
+        f"daemon status was silent. rc={result.returncode}"
+    )
+
+    # Belt-and-braces: walk the per-platform daemon socket locations
+    # under the sandbox $HOME and assert nothing was created.
+    sandbox_home = sandbox_with_shipyard.home
+    daemon_socket_locations = [
+        sandbox_home / "Library" / "Application Support" / "shipyard" / "daemon" / "daemon.sock",
+        sandbox_home / ".local" / "state" / "shipyard" / "daemon" / "daemon.sock",
+        sandbox_home / "AppData" / "Local" / "shipyard" / "daemon" / "daemon.sock",
+    ]
+    for sock in daemon_socket_locations:
+        assert not sock.exists(), (
+            f"daemon status accidentally created a socket at {sock} — "
+            f"a server may be running. Stop it manually before "
+            f"re-running tests."
+        )
+
+
+# -----------------------------------------------------------------------------
+# Scenario 8 — JSON parity: --json status is parseable + has stable keys
+# -----------------------------------------------------------------------------
+
+
+@pytest.mark.parity
+def test_json_status_payload_is_well_formed(
+    sandbox_with_shipyard: Sandbox,
+) -> None:
+    """``shipyard --json status`` must be parseable JSON and must
+    include the schema keys that downstream consumers (Pulp's `/status`
+    slash command, the daemon, CI tooling) depend on. A release that
+    drops one of these keys is a breaking change that should land
+    with a release-note bump, not silently."""
+    result = sandbox_with_shipyard.run(
+        ["--json", "status"], timeout=45.0
+    ).expect_success()
+    payload = parse_status_json(result.stdout)
+    missing = [k for k in REQUIRED_STATUS_KEYS if k not in payload]
+    assert not missing, (
+        f"--json status is missing required keys {missing!r}; "
+        f"payload keys: {sorted(payload)}"
+    )
+    # Sanity: the documented schema_version is an integer.
+    assert isinstance(payload["schema_version"], int), (
+        f"schema_version is not an int: {payload['schema_version']!r}"
+    )
+
+
+# -----------------------------------------------------------------------------
+# Scenario 9 — `pin` outside a consumer repo is non-silent
+# -----------------------------------------------------------------------------
+#
+# `shipyard pin` operates on consumer repos like pulp / spectr that
+# pin a Shipyard version via tools/shipyard.toml. Inside an empty
+# sandbox there's no such file, so `pin show` must fail loudly with a
+# clear hint — the failure mode we're preventing is "exits 0 with no
+# output, leaving the user wondering why the pin didn't change."
+
+
+@pytest.mark.smoke
+def test_pin_show_outside_consumer_repo_is_nonsilent(
+    sandbox_with_shipyard: Sandbox,
+) -> None:
+    result = sandbox_with_shipyard.run(["pin", "show"], timeout=30.0)
+    combined = result.stdout + result.stderr
+    assert combined.strip(), (
+        f"pin show outside a consumer repo was silent. "
+        f"rc={result.returncode}, this is the silent-failure anti-pattern."
+    )
+    # Should hint at the missing pin file or the right context.
+    assert (
+        "shipyard.toml" in combined.lower()
+        or "consumer" in combined.lower()
+        or "pin" in combined.lower()
+    ), (
+        f"pin show error doesn't hint at the missing pin file or "
+        f"context: {combined!r}"
+    )
+
+
+# -----------------------------------------------------------------------------
+# Scenario 10 — Contamination audit smoke
+# -----------------------------------------------------------------------------
+#
+# The ``sandbox`` fixture's teardown calls ``assert_no_contamination``
+# after every test. That's the canonical audit. This explicit test
+# makes the contract visible in reports even when everything else
+# passes quietly, and guards against a future refactor where someone
+# removes the teardown hook.
+
+
+def test_contamination_audit_catches_writes_to_protected_paths(
+    sandbox: Sandbox,
+) -> None:
+    """Smoke test for the audit itself. Touch a file under a
+    sandboxed extra root, run the audit with that root injected, and
+    confirm it flagged the leak. We never write to the real protected
+    paths during this — that would be a genuine contamination."""
+    fake_root = sandbox.root / "fake-protected"
+    fake_root.mkdir()
+    fake_file = fake_root / "leak.txt"
+    fake_file.write_text("written after the sentinel")
+
+    report = sandbox.audit_contamination(extra_roots=(fake_root,))
+    assert not report.clean, "audit failed to detect a deliberate leak"
+    assert any(
+        str(p).endswith("leak.txt") for p in report.offenders
+    ), f"expected leak.txt in offenders, got {report.offenders}"
+
+
+# -----------------------------------------------------------------------------
+# Scenario 11 — Sandbox.run refuses to invoke destructive subcommands
+# -----------------------------------------------------------------------------
+#
+# Defence-in-depth: even if a future contributor writes
+# `sandbox.run(["ship"])` by mistake, the harness must refuse to
+# actually execute it. The DESTRUCTIVE_COMMANDS guard in
+# ``shipyard_sandbox.py`` is the bulkhead. This test asserts the
+# bulkhead is wired in.
+
+
+@pytest.mark.smoke
+def test_sandbox_refuses_to_invoke_ship(
+    sandbox_with_shipyard: Sandbox,
+) -> None:
+    with pytest.raises(AssertionError, match="destructive"):
+        sandbox_with_shipyard.run(["ship"])
+
+
+@pytest.mark.smoke
+def test_sandbox_refuses_to_invoke_pr(
+    sandbox_with_shipyard: Sandbox,
+) -> None:
+    with pytest.raises(AssertionError, match="destructive"):
+        sandbox_with_shipyard.run(["pr"])
+
+
+@pytest.mark.smoke
+def test_sandbox_refuses_to_invoke_cloud_run(
+    sandbox_with_shipyard: Sandbox,
+) -> None:
+    """``cloud run`` dispatches a real GHA workflow. Read-only
+    ``cloud workflows`` / ``cloud defaults`` / ``cloud status`` are
+    allowed; anything else under ``cloud`` must be refused."""
+    with pytest.raises(AssertionError, match="cloud"):
+        sandbox_with_shipyard.run(["cloud", "run", "build"])
+
+
+# -----------------------------------------------------------------------------
+# JSON-flag ergonomics
+# -----------------------------------------------------------------------------
+
+
+@pytest.mark.parity
+def test_json_status_returns_parseable_json_under_real_jsondecoder(
+    sandbox_with_shipyard: Sandbox,
+) -> None:
+    """Belt-and-braces: not just our forgiving `parse_status_json`
+    helper — strict ``json.loads`` on the raw stdout must succeed.
+    Catches a regression where the renderer prints a banner before the
+    JSON payload, which would silently break downstream consumers
+    parsing stdout with the stdlib ``json`` module."""
+    result = sandbox_with_shipyard.run(
+        ["--json", "status"], timeout=45.0
+    ).expect_success()
+    try:
+        json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        pytest.fail(
+            f"--json status output is not strict-JSON: {exc}\n"
+            f"stdout: {result.stdout!r}"
+        )


### PR DESCRIPTION
## Summary

Codifies the sandboxed-validation pattern from the Pulp sibling
([pulp#732](https://github.com/danielraffel/pulp/issues/732) /
[pulp#736](https://github.com/danielraffel/pulp/pull/736)) for the
Shipyard CLI. Every test runs in an isolated tempdir with a shadowed
`$PATH` and isolated `$HOME`; the contamination audit enforces zero
writes to the user's real Shipyard install.

Closes #248.

## Why

The silent-exit-0 / unknown-subcommand class of bug is a real
regression risk for any Click-driven CLI. Existing unit tests
exercise logic; this harness exercises "does the installed binary
behave correctly when invoked the way users invoke it" — the
`v0.15`/`v0.18` MSVC-include silent-fail and the `v0.39`/`v0.40`
PowerShell-quoting bugs are the canonical incidents this layer is
designed to catch.

## What landed

```
tools/sandbox-e2e/
├── shipyard_sandbox.py    # Sandbox class, binary staging,
│                            contamination audit, surface enumeration,
│                            JSON parser
├── conftest.py             # binary discovery (fast venv first, slow
│                            PyInstaller fallback last), fixtures
├── test_swap.py            # 18 scenarios across 6 marks
├── pytest.ini              # marker registry
├── README.md               # design + add-a-scenario in <=15 lines
└── fixtures/.gitkeep
.github/workflows/sandbox-e2e.yml  # macos + ubuntu PR gate
```

## Coverage today

18 scenarios, all passing locally in ~15s:

| mark | what it proves |
|---|---|
| smoke | help/version/unknown-subcmd (top + nested) non-silent |
| surface | every `shipyard X` from commands/docs/CI runs --help |
| config | `config show` / `config profiles` in an empty sandbox |
| queue | empty queue + empty target list non-silent |
| daemon | `daemon status` doesn't accidentally start the daemon |
| parity | `--json status` payload has documented top-level keys |
| smoke | `pin show` outside a consumer repo fails loudly |
| smoke | `Sandbox.run` refuses ship/pr/cloud-run (bulkhead) |
| implicit | contamination audit at every test teardown |

The mandatory "unknown subcommand exits non-zero with stderr" test
is the dedicated guard against the silent-exit-0 class of bug from
the issue.

## Hardening

* Audit snapshots the protected-path file set at sandbox **setup**,
  so a live `shipyard daemon` updating its own state dir doesn't trip
  false-positive contamination. Only NEW paths (absent at setup)
  count as offenders. Verified locally against my running daemon —
  all 18 tests pass clean.
* `Sandbox.run()` raises `AssertionError` on any subcommand listed
  in `DESTRUCTIVE_COMMANDS` (`ship`, `pr`, `upgrade`) or on
  `cloud <subcmd>` not in `SAFE_CLOUD_SUBCOMMANDS` — even an
  accidentally-typed test can't trigger a real PR merge / GHA
  dispatch / binary replace.
* Binary discovery prefers the fast lane: venv entrypoint script
  first (~0.5s/call), PyInstaller `--onefile` last (~7s/call).
  Both exercise the same `shipyard.cli:main` Click entrypoint, so
  semantics are identical; speed is just an iteration concern.

## Excluded subcommands (documented in README)

| Excluded | Why |
|---|---|
| `shipyard ship` | actually merges PRs |
| `shipyard pr` | opens a real GitHub PR |
| `shipyard upgrade` | replaces the running binary |
| `shipyard cloud run` | dispatches a real GHA workflow |
| `shipyard daemon start`/`run` | long-lived process, opens sockets |
| `shipyard wait`/`watch` | block on a GitHub condition / live ship |
| `shipyard auto-merge` | hits GitHub to attempt a real merge |

## Test plan

- [x] `pytest tools/sandbox-e2e/` green locally (18/18 passed in 14.93s)
- [x] Verified zero NEW paths under `~/Library/Application Support/shipyard`,
      `~/.local/bin`, etc. after the suite run (live daemon's queue.json
      atomic-rewrite is correctly filtered by the pre-existing path snapshot)
- [x] `Sandbox.run(["ship"])` / `["pr"]` / `["cloud", "run", ...]` all
      raise `AssertionError` instead of executing
- [ ] CI green on macos-latest + ubuntu-latest (this PR)
- [ ] Sibling pattern documented in `pulp#736` reviewed for any
      drift between the two harnesses

## Related

* Spec + 6 design refinements: [Shipyard #248](https://github.com/danielraffel/Shipyard/issues/248)
* Pulp sibling: [pulp#732](https://github.com/danielraffel/pulp/issues/732), [pulp#736](https://github.com/danielraffel/pulp/pull/736)

## Bypass trailer

Skill-Update is skipped on this commit via:
`Skill-Update: skip skill=ci reason="adds a new sandbox-e2e workflow that runs in parallel to existing CI; doesn't change ci-skill semantics, just creates a new gate"`

The new workflow is a sibling gate, not a change to the existing CI
flow the `ci` skill documents. If reviewers prefer a SKILL.md note,
happy to add one in a follow-up.