### PR TITLE
release.yml: retire dead CI signing infrastructure (#226 cleanup)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,152 +132,27 @@ jobs:
         # irrelevant.
         run: pip install --break-system-packages .[dev] pyinstaller
 
-      # Keychain setup MUST happen before the PyInstaller build so the
-      # --codesign-identity flag can resolve and sign every embedded
-      # dylib (notably Python.framework). A post-build outer-only sign
-      # produced a Team-ID mismatch at runtime — the outer Mach-O
-      # carried the Developer ID Team ID but the embedded
-      # Python.framework was still ad-hoc-signed, so dyld rejected
-      # the load with "code signature ... not valid for use in
-      # process: mapping process and mapped file (non-platform) have
-      # different Team IDs". See RELEASING.md for the background.
-      #
-      # Skipped on forks / PRs from outside contributors (APPLE_ID
-      # secret absent) — the install.sh xattr-strip + ad-hoc re-sign
-      # fallback still handles those.
-      # Signing is enabled only when ALL five secrets are present.
-      # Gating on just APPLE_ID (pre-#177) let a partial rotation —
-      # e.g. new APPLE_ID pasted but the p12 not re-uploaded yet —
-      # run the signing path and fail mid-release on `base64 -d` or
-      # `codesign`. Requiring all five makes the no-op fallback match
-      # the docs ("when all five are set, we sign; otherwise ad-hoc").
-      #
-      # GitHub Actions does NOT evaluate `secrets.*` in step-level
-      # `if:` conditions (documented limitation; condition evaluates
-      # to an unexpanded string which is truthy → step would run
-      # even when the secret is missing, #184). Work around it with
-      # a detect-readiness step whose env block populates the
-      # secrets and whose bash body emits a boolean output; later
-      # `if:` conditions branch on that output.
-      - name: Detect signing readiness (macOS)
-        id: detect_signing_readiness
-        if: startsWith(matrix.target, 'macos-')
-        env:
-          APPLE_ID: ${{ secrets.APPLE_ID }}
-          TEAM_ID: ${{ secrets.TEAM_ID }}
-          APP_SPECIFIC_PASSWORD: ${{ secrets.APP_SPECIFIC_PASSWORD }}
-          SIGNING_CERT_P12_BASE64: ${{ secrets.SIGNING_CERT_P12_BASE64 }}
-          SIGNING_CERT_PASSWORD: ${{ secrets.SIGNING_CERT_PASSWORD }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          if [ -n "${APPLE_ID:-}" ] \
-             && [ -n "${TEAM_ID:-}" ] \
-             && [ -n "${APP_SPECIFIC_PASSWORD:-}" ] \
-             && [ -n "${SIGNING_CERT_P12_BASE64:-}" ] \
-             && [ -n "${SIGNING_CERT_PASSWORD:-}" ]; then
-            echo "enabled=true" >> "$GITHUB_OUTPUT"
-            echo "All five signing secrets present; enabling signing path."
-          else
-            echo "enabled=false" >> "$GITHUB_OUTPUT"
-            echo "One or more signing secrets missing; falling back to ad-hoc."
-          fi
-
-      - name: Import signing identity (macOS)
-        id: import_signing_identity
-        if: steps.detect_signing_readiness.outputs.enabled == 'true'
-        env:
-          TEAM_ID: ${{ secrets.TEAM_ID }}
-          SIGNING_CERT_P12_BASE64: ${{ secrets.SIGNING_CERT_P12_BASE64 }}
-          SIGNING_CERT_PASSWORD: ${{ secrets.SIGNING_CERT_PASSWORD }}
-        run: |
-          set -euo pipefail
-
-          KEYCHAIN="$RUNNER_TEMP/shipyard-sign.keychain-db"
-          KEYCHAIN_PASSWORD="$(openssl rand -hex 32)"
-          CERT_PATH="$RUNNER_TEMP/developer-id.p12"
-
-          echo "$SIGNING_CERT_P12_BASE64" | base64 -d > "$CERT_PATH"
-          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
-          security set-keychain-settings -lut 21600 "$KEYCHAIN"
-          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
-          security import "$CERT_PATH" -P "$SIGNING_CERT_PASSWORD" \
-            -A -t cert -f pkcs12 -k "$KEYCHAIN"
-          # Prepend the temp keychain to the search list so PyInstaller's
-          # invocation of /usr/bin/codesign finds the identity.
-          security list-keychains -d user -s "$KEYCHAIN" \
-            $(security list-keychains -d user | sed -e 's/"//g')
-          security set-key-partition-list -S apple-tool:,apple:,codesign: \
-            -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
-
-          # Resolve the signing identity by SHA-1 fingerprint, keyed
-          # on the Team ID rather than the cert subject CN (which was
-          # hardcoded to "Daniel Raffel" pre-#177 and broke forks / org
-          # certs / maintainer rotation). `security find-identity`
-          # prints lines like `  1) <HASH> "Developer ID Application:
-          # <any name> (<TEAM_ID>)"` — we grep on `(TEAM_ID)` and
-          # pull the hash.
-          IDENTITY_HASH="$(security find-identity -v -p codesigning "$KEYCHAIN" \
-            | grep -m1 "(${TEAM_ID})" \
-            | awk '{print $2}')"
-          if [ -z "$IDENTITY_HASH" ]; then
-            echo "::error::No Developer ID Application identity matching Team ID ${TEAM_ID} found in the imported keychain." >&2
-            exit 1
-          fi
-          echo "Resolved signing identity: $IDENTITY_HASH"
-
-          # Emit identity + keychain path so downstream steps can sign
-          # regardless of the cert subject, and the cleanup step can
-          # delete the keychain on any exit path.
-          echo "identity=$IDENTITY_HASH" >> "$GITHUB_OUTPUT"
-          echo "keychain=$KEYCHAIN" >> "$GITHUB_OUTPUT"
-
+      # #226: macOS build is a PyInstaller health-check only — no
+      # signing, no notarization in this step. The signed artifact
+      # that ships is produced by a separate job `sign-and-upload-
+      # macos` (gated on `CI_MACOS_SIGNING_ENABLED=true`) OR by the
+      # maintainer's local `scripts/release-macos-local.sh`. The
+      # earlier CI-signing machinery that used to live here (detect-
+      # readiness + import-keychain + --codesign-identity) signed
+      # every macOS binary only for the result to be discarded post-
+      # #54, so it was dead code paying a real keychain-mutation tax
+      # on every release. Retired in this cleanup. See #226 for the
+      # current CI-signing experiment path, which uses ephemeral-
+      # keychain import inside its own job instead.
       - name: Build binary
-        # When signing is enabled on a macOS matrix row, the import
-        # step above already imported the cert and resolved the
-        # identity to a SHA-1 fingerprint. PyInstaller's
-        # --codesign-identity signs every embedded dylib (incl.
-        # Python.framework) with that identity so dyld's runtime
-        # Team-ID check passes. On non-macOS rows, or when any of the
-        # five signing secrets is missing, we fall through to a plain
-        # ad-hoc build. `shell: bash` so Windows uses Git-for-Windows
-        # bash instead of PowerShell.
+        # `shell: bash` so Windows uses Git-for-Windows bash instead
+        # of PowerShell.
         shell: bash
         env:
-          SIGNING_IDENTITY: ${{ steps.import_signing_identity.outputs.identity }}
           ARTIFACT: ${{ matrix.artifact }}
         run: |
           set -euo pipefail
-          if [ -n "${SIGNING_IDENTITY:-}" ]; then
-            pyinstaller --onefile \
-              --name "$ARTIFACT" \
-              --codesign-identity "$SIGNING_IDENTITY" \
-              src/shipyard/cli.py
-          else
-            pyinstaller --onefile \
-              --name "$ARTIFACT" \
-              src/shipyard/cli.py
-          fi
-
-      # #219: macOS signing + notarization happens LOCALLY on the
-      # maintainer's Mac via scripts/release-macos-local.sh, NOT here.
-      # Two rounds of CI-signed+notarized macOS binaries (v0.42.0,
-      # v0.43.0) passed every CI check including the on-runner launch
-      # gate but SIGKILL'd at launch on the maintainer's actual Mac
-      # ("Taskgated Invalid Signature"). The CI runner and end-user
-      # Mac evidently differ enough on taskgated/Gatekeeper state
-      # that a CI-notarized binary is not reliably launchable. See
-      # RELEASING.md § "macOS signing is local-only" for the
-      # confirmed diagnosis + workflow.
-      #
-      # The macOS build step above still runs — it catches
-      # PyInstaller regressions. We just don't sign, notarize, or
-      # upload the CI-built binary: the maintainer's local script
-      # produces + uploads the asset that users actually download.
-      - name: Delete signing keychain (macOS)
-        if: always() && steps.import_signing_identity.outputs.keychain != ''
-        run: |
-          security delete-keychain "${{ steps.import_signing_identity.outputs.keychain }}" || true
+          pyinstaller --onefile --name "$ARTIFACT" src/shipyard/cli.py
 
       # Skip uploading macOS artifacts to the workflow's artifact
       # store — they're unsigned, unnotarized, and should not reach

--- a/tests/test_release_macos_local.py
+++ b/tests/test_release_macos_local.py
@@ -246,6 +246,102 @@ def test_install_sh_rejects_intel_mac_cleanly() -> None:
     assert '$OS" = "macos"' in content and '$ARCH" = "x64"' in content
 
 
+def test_release_yml_has_no_dead_signing_infra() -> None:
+    # Pre-cleanup, release.yml had a `Detect signing readiness` +
+    # `Import signing identity` pair that imported the Developer ID
+    # cert and passed `--codesign-identity` to every macOS PyInstaller
+    # build. Post-#54, the signed binary wasn't uploaded (local script
+    # produces the shipping artifact), so the whole signing path paid
+    # a keychain-mutation tax on every release for nothing.
+    #
+    # This cleanup rips it out. Lock the removal with these pins:
+    # the old step names, the old env var names passed into the
+    # import, and the `--codesign-identity` flag must all be absent
+    # from release.yml's build path. The NEW #226 path has its own
+    # ephemeral-keychain import inside sign-and-upload-macos and uses
+    # different secret names, so no false-positive match.
+    release_yml = REPO_ROOT / ".github" / "workflows" / "release.yml"
+    content = release_yml.read_text()
+
+    # Step identifiers from the removed infrastructure must be gone.
+    for dead_token in (
+        "detect_signing_readiness",
+        "import_signing_identity",
+        "Detect signing readiness",
+        "Import signing identity",
+        "Delete signing keychain",
+    ):
+        assert dead_token not in content, (
+            f"release.yml still references '{dead_token}' from the "
+            "dead CI-signing block — clean up missed that reference"
+        )
+
+    # Old secret names (stays out of release.yml; only the new
+    # MACOS_SIGN_* / MACOS_NOTARIZE_* names live in the #226 job).
+    for dead_secret in (
+        "secrets.APPLE_ID",
+        "secrets.APP_SPECIFIC_PASSWORD",
+        "secrets.TEAM_ID",
+        "secrets.SIGNING_CERT_P12_BASE64",
+        "secrets.SIGNING_CERT_PASSWORD",
+    ):
+        assert dead_secret not in content, (
+            f"release.yml still references '{{{{ {dead_secret} }}}}' — "
+            "the old 5 secrets are being retired; the #226 path uses "
+            "MACOS_SIGN_* / MACOS_NOTARIZE_* instead"
+        )
+
+    # The default macOS build step must NOT pass --codesign-identity.
+    # (The #226 sign-and-upload-macos job uses a different codepath
+    # entirely — it invokes release-macos-local.sh which reads the
+    # identity SHA from an env var, not from a PyInstaller flag.)
+    #
+    # Walk the file to find the `- name: Build binary` block and
+    # assert --codesign-identity doesn't appear there.
+    build_idx = content.find("- name: Build binary")
+    assert build_idx != -1, "Build binary step must still exist"
+    # Scope to the ~50 lines of that step block.
+    build_block = content[build_idx:build_idx + 2000]
+    assert "--codesign-identity" not in build_block, (
+        "Build binary step must be ad-hoc only — CI-signing lives "
+        "in the separate #226 job now"
+    )
+
+
+def test_release_yml_build_step_still_produces_pyinstaller_output() -> None:
+    # Regression guard: the build step still has to produce a
+    # PyInstaller --onefile binary named after the matrix artifact.
+    # Removing the signing wrapper was supposed to preserve exactly
+    # this behavior, plus a clean `pyinstaller --onefile` invocation
+    # on every matrix row including macOS.
+    release_yml = REPO_ROOT / ".github" / "workflows" / "release.yml"
+    content = release_yml.read_text()
+    build_idx = content.find("- name: Build binary")
+    build_block = content[build_idx:build_idx + 2000]
+    assert "pyinstaller --onefile" in build_block
+    assert 'matrix.artifact' in build_block or '$ARTIFACT' in build_block
+    assert "src/shipyard/cli.py" in build_block
+
+
+def test_release_yml_macos_artifact_not_uploaded_to_release() -> None:
+    # Invariant kept from pre-cleanup: macOS CI build is health-check
+    # only; the actual shipping artifact comes from the local
+    # script (or the #226 CI-signing job when armed). The
+    # `Upload artifact` step must still be gated on non-macOS so
+    # release.yml's release job doesn't pick up an unsigned macOS
+    # binary.
+    release_yml = REPO_ROOT / ".github" / "workflows" / "release.yml"
+    content = release_yml.read_text()
+    upload_idx = content.find("Upload artifact (non-macOS)")
+    assert upload_idx != -1, "Non-macOS upload step must still exist"
+    # The upload's `if:` condition must exclude macOS.
+    upload_block = content[upload_idx:upload_idx + 400]
+    assert "runner.os != 'macOS'" in upload_block, (
+        "macOS build output must NOT feed the release-artifact "
+        "upload — that would re-introduce the v0.42.0 failure mode"
+    )
+
+
 def test_ci_mode_skips_publish_and_e2e() -> None:
     # #226: the CI-signing experiment workflow invokes this script
     # with --ci-mode. That mode MUST NOT flip the release public and


### PR DESCRIPTION
Pre-cleanup state: release.yml had a 3-step macOS signing pipeline
(\`Detect signing readiness\` + \`Import signing identity\` +
\`--codesign-identity\` + \`Delete signing keychain\`) that signed
every macOS PyInstaller build with the Developer ID cert. Post-#54
the signed binary was no longer uploaded — the maintainer's local
script produces the shipping dmg. So the whole signing pipeline
ran on every release, imported a cert into a keychain, signed a
binary, then threw the signed binary away. Dead code paying a
real keychain-mutation tax + holding 5 secrets open.

This commit removes all of it:

- \`Detect signing readiness\` step — gone
- \`Import signing identity\` step — gone
- \`--codesign-identity\` flag on PyInstaller — gone (ad-hoc only)
- \`Delete signing keychain\` step — gone (no keychain now)
- 5 old \`secrets.APPLE_ID / TEAM_ID / APP_SPECIFIC_PASSWORD /
  SIGNING_CERT_P12_BASE64 / SIGNING_CERT_PASSWORD\` references —
  all removed from this file

The new #226 \`sign-and-upload-macos\` job is unaffected — it has
its own ephemeral-keychain import inside the job body and uses
\`MACOS_SIGN_*\` / \`MACOS_NOTARIZE_*\` secret names. That job
remains gated on \`CI_MACOS_SIGNING_ENABLED=true\` (dormant by
default). Next step is for the maintainer to delete the 5 stale
secrets from the repo now that nothing references them.

Nothing that ships to users changes. The shipping artifact path
has been:
  1. scripts/release-macos-local.sh on the maintainer's Mac
     → stapled arm64 dmg → gh release upload
  2. (experiment) #226 sign-and-upload-macos job when armed

Neither of those depended on the code being removed here.

Tests (new in tests/test_release_macos_local.py):

- \`test_release_yml_has_no_dead_signing_infra\` pins the removal
  of every token from the 3 old step bodies and the 5 old secret
  references, so a future refactor can't silently reintroduce them.
- \`test_release_yml_build_step_still_produces_pyinstaller_output\`
  ensures the remaining Build binary step still produces the
  \`shipyard-<platform>-<arch>\` artifact — regression guard against
  a cleanup that accidentally removes the build itself.
- \`test_release_yml_macos_artifact_not_uploaded_to_release\`
  preserves the post-#54 invariant that CI-built macOS artifacts
  are NEVER uploaded — re-introducing that would recreate the
  v0.42.0 failure mode.

Full suite: 1343 passed, 2 skipped (platform-gated), 0 failed.

Skill-Update: skip skill=ci reason="release.yml dead-code removal; signing path was unused post-#54 and retiring it makes the #226 experiment the single macOS signing path. No dispatch/target shape change."