### PR TITLE
shipyard run: scope drift-guard banner to enforceable targets (#262 Codex P2)

### DIFF
--- a/src/shipyard/cli.py
+++ b/src/shipyard/cli.py
@@ -239,34 +239,62 @@ def run(
         render_error("Not in a git repository")
         sys.exit(1)
 
-    # #238 → #249: working-tree quiescence advisory + drift-detect
-    # status banner. The drift guard catches mid-run edits between
-    # stage boundaries (TREE_DRIFT failure class, exit 3); this
-    # banner just tells the operator that's the contract so they
-    # don't bake in old "feel free to edit, ignore failures" muscle
-    # memory. Quiet in --json mode — agents parse envelopes, they
-    # don't need human-readable banners.
-    if not ctx.json_mode:
-        if allow_tree_drift:
-            render_message(
-                "→ --allow-tree-drift active: working-tree drift "
-                "guard suppressed for this run. Mid-run edits will "
-                "NOT be caught.",
-                style="bold yellow",
-            )
-        else:
-            render_message(
-                "→ Drift guard active (#249): mid-run edits abort "
-                "the run with TREE_DRIFT (exit 3). Use a separate "
-                "worktree for parallel work.",
-                style="dim",
-            )
-
     # Resolve targets
     target_names = targets.split(",") if targets else list(config.targets.keys())
     if not target_names:
         render_error("No targets configured. Run 'shipyard init' first.")
         sys.exit(1)
+
+    # #238 → #249: working-tree quiescence advisory + drift-detect
+    # status banner.
+    #
+    # Codex P2 on #262: the drift guard only fires inside
+    # LocalExecutor (#249's implementation) and only when a tree
+    # signature can be computed (git repo). SSH / cloud / non-git
+    # targets get NO drift detection. So the banner has to be scoped
+    # to the actual targets in this run — claiming "Drift guard
+    # active" when every target is ssh would be a lie.
+    #
+    # Quiet in --json mode — agents parse envelopes, they don't need
+    # human-readable banners.
+    local_targets = [
+        n for n in target_names
+        if str(
+            (config.targets.get(n) or {}).get("type")
+            or (config.targets.get(n) or {}).get("backend")
+            or "local"
+        ).strip().lower() == "local"
+    ]
+    if not ctx.json_mode:
+        if not local_targets:
+            # No local targets → drift guard doesn't apply anywhere;
+            # don't promise it. Surface the bare advisory only.
+            render_message(
+                "→ Avoid editing source files mid-run on remote "
+                "targets — drift detection only fires for local "
+                "targets (#249). Use a separate worktree for "
+                "parallel work.",
+                style="dim",
+            )
+        elif allow_tree_drift:
+            render_message(
+                "→ --allow-tree-drift active: working-tree drift "
+                "guard suppressed for this run. Mid-run edits will "
+                "NOT be caught on local targets.",
+                style="bold yellow",
+            )
+        else:
+            scope = (
+                "all targets are local"
+                if len(local_targets) == len(target_names)
+                else f"local targets ({', '.join(local_targets)})"
+            )
+            render_message(
+                f"→ Drift guard active (#249) for {scope}: mid-run "
+                "edits abort the run with TREE_DRIFT (exit 3). "
+                "Remote targets (ssh / cloud) are NOT covered.",
+                style="dim",
+            )
 
     dispatcher = _make_dispatcher(config)
     try:

--- a/tests/test_run_tree_quiescence_warning.py
+++ b/tests/test_run_tree_quiescence_warning.py
@@ -59,3 +59,38 @@ def test_run_docstring_mentions_concrete_failure_shape() -> None:
     doc = (run_cmd.__doc__ or "").lower()
     assert "concurrent" in doc or "quiescent" in doc or "edit" in doc
     assert "cmake" in doc or "configure" in doc or "source" in doc
+
+
+def test_drift_banner_only_promises_what_is_actually_enforced() -> None:
+    # Codex P2 on #262: the drift guard fires only inside
+    # LocalExecutor on git-capable trees. The banner must NOT
+    # unconditionally promise drift detection on a run whose targets
+    # are SSH / cloud only — that's misleading users about what's
+    # actually being enforced.
+    #
+    # Pin the source so a future refactor can't silently re-introduce
+    # the unscoped banner. Three branches of the conditional must
+    # exist: no-local-targets, --allow-tree-drift, default(local).
+    from pathlib import Path
+    cli_path = Path(__file__).resolve().parent.parent \
+        / "src" / "shipyard" / "cli.py"
+    content = cli_path.read_text()
+
+    # The banner code must reference the resolved target list to
+    # compute scope, not just blindly fire.
+    banner_idx = content.find("Drift guard active (#249)")
+    assert banner_idx != -1, "drift guard banner must exist"
+    # Window of ~2KB around the banner — should contain the
+    # local_targets computation.
+    window = content[max(0, banner_idx - 1500):banner_idx + 500]
+    assert "local_targets" in window, (
+        "drift banner must compute target-set scope before "
+        "rendering — Codex P2 on #262"
+    )
+    # The "no local targets" branch must exist so SSH-only / cloud-
+    # only runs see a NON-promising message.
+    assert "remote targets" in content.lower() or \
+           "drift detection only fires for local" in content.lower(), (
+        "must have a non-promising banner for runs whose targets "
+        "are all remote — drift guard doesn't fire there"
+    )


### PR DESCRIPTION
The banner I introduced in #262 said "Drift guard active (#249):
mid-run edits abort the run with TREE_DRIFT (exit 3)"
unconditionally, but #249's enforcement lives only in
LocalExecutor and only runs when a tree signature can be computed
(git repo). Runs that include SSH / cloud targets (or local
targets whose cwd isn't a git repo) get NO drift detection on
those targets — the banner was overpromising.

Codex P2 caught this on #262 post-merge.

Fix: compute the local-target subset before rendering, then pick
one of three messages:

- All-remote run (no local targets): bare advisory, no
  "guard active" claim. Says drift detection only fires for
  local targets and points at separate-worktree as the workaround.
- --allow-tree-drift active: bold-yellow callout, qualified to
  "NOT be caught on local targets" (was just "NOT be caught").
- Default (at least one local target): qualifies the scope —
  "for all targets are local" or "for local targets (mac, ubuntu)"
  — and explicitly notes "Remote targets (ssh / cloud) are NOT
  covered."

Banner is moved AFTER target resolution so the local_targets
computation has the resolved set to filter on.

New test `test_drift_banner_only_promises_what_is_actually_enforced`
greps the cli.py source for the local_targets computation + the
"remote targets" / "drift detection only fires for local" branch.
A future refactor that goes back to an unscoped banner trips the
test.

Skill-Update: skip skill=ci reason="banner-text scoping fix; ci skill describes dispatch flow not user-facing run-banner copy"