### PR TITLE
sandbox-e2e: address #260 Codex P1 + P2

### DIFF
--- a/.github/workflows/sandbox-e2e.yml
+++ b/.github/workflows/sandbox-e2e.yml
@@ -106,7 +106,15 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: sandbox-e2e-${{ matrix.os }}-logs
+          # Codex P2 on #260: sandbox tempdirs are created via
+          # `tempfile.mkdtemp(...)`, which honors `TMPDIR` /
+          # platform default — on GitHub macOS runners that's
+          # `/private/var/folders/...`, NOT `/tmp/...`. Cover both
+          # locations so failure artifacts actually upload on
+          # macOS instead of silently `if-no-files-found: ignore`.
           path: |
             /tmp/shipyard-sandbox-e2e.*/**
+            /private/var/folders/**/shipyard-sandbox-e2e.*/**
+            /var/folders/**/shipyard-sandbox-e2e.*/**
           if-no-files-found: ignore
           retention-days: 7

--- a/tools/sandbox-e2e/shipyard_sandbox.py
+++ b/tools/sandbox-e2e/shipyard_sandbox.py
@@ -78,9 +78,13 @@ PROTECTED_PATHS: tuple[Path, ...] = (
 #: A test that names one of these gets a clear AssertionError instead
 #: of silently scribbling on the user's repo or remote infra.
 DESTRUCTIVE_COMMANDS: frozenset[str] = frozenset({
-    "ship",      # actually merges PRs!
-    "pr",        # opens a real GitHub PR
-    "upgrade",   # replaces the running binary
+    "ship",        # actually merges PRs!
+    "pr",          # opens a real GitHub PR
+    "upgrade",     # replaces the running binary
+    # Codex P1 on #260: `auto-merge` reaches `merge_pr(...)` in
+    # cli.py and merges the named PR if checks are green — exactly
+    # the kind of real-world mutation the bulkhead exists to prevent.
+    "auto-merge",
     # `cloud run` is destructive (dispatches a real GHA workflow); the
     # parent `cloud` group has read-only subcommands so we don't blanket
     # ban it — see SAFE_CLOUD_SUBCOMMANDS below for the allowlist.

--- a/tools/sandbox-e2e/test_swap.py
+++ b/tools/sandbox-e2e/test_swap.py
@@ -469,6 +469,18 @@ def test_sandbox_refuses_to_invoke_cloud_run(
         sandbox_with_shipyard.run(["cloud", "run", "build"])
 
 
+@pytest.mark.smoke
+def test_sandbox_refuses_to_invoke_auto_merge(
+    sandbox_with_shipyard: Sandbox,
+) -> None:
+    """Codex P1 on #260: ``auto-merge`` reaches ``merge_pr(...)`` in
+    cli.py and merges the named PR if checks are green. A test that
+    accidentally calls it would mutate real GitHub state, exactly
+    what the bulkhead exists to prevent. Pin the refusal."""
+    with pytest.raises(AssertionError, match="destructive"):
+        sandbox_with_shipyard.run(["auto-merge", "999"])
+
+
 # -----------------------------------------------------------------------------
 # JSON-flag ergonomics
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
**P1 — auto-merge missing from DESTRUCTIVE_COMMANDS**

The sandbox's bulkhead exists to prevent tests from accidentally
mutating real-world state. \`auto-merge\` reaches \`merge_pr(...)\`
in cli.py and merges the named PR if checks are green — exactly
the failure mode the bulkhead is designed to prevent. A test that
called \`sandbox.run(["auto-merge", "<pr>"])\` would have actually
merged a real PR.

Added \`auto-merge\` to \`DESTRUCTIVE_COMMANDS\` and a smoke test
(\`test_sandbox_refuses_to_invoke_auto_merge\`) that pins the
refusal so a future refactor of the set can't silently regress.

**P2 — failure-artifact path missed macOS tempdirs**

\`Sandbox\` creates its tempdir via \`tempfile.mkdtemp(...)\`,
which honors \`TMPDIR\` / platform default. On GitHub macOS
runners that resolves to \`/private/var/folders/...\`, NOT
\`/tmp/...\`. The workflow's failure-artifact \`path\` only
listed \`/tmp/shipyard-sandbox-e2e.*/**\`, so a failed run on
macOS uploaded zero forensic artifacts (silently — \`if-no-files-
found: ignore\` is set).

Added the macOS tempdir patterns alongside the existing /tmp
glob: \`/private/var/folders/**/shipyard-sandbox-e2e.*/**\` and
\`/var/folders/**/...\` for completeness.

Tests: 19/19 sandbox harness tests pass including the new bulkhead
guard. Tested locally on macOS — the workflow path change is
yaml-only, exercised on the next CI run.

Skill-Update: skip skill=ci reason="sandbox-harness destructive-list + workflow artifact-path tweak; ci skill describes dispatch flow not test-harness internals"