### PR TITLE
Release Shipyard 0.51.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -614,7 +614,7 @@ dependencies = [
 
 [[package]]
 name = "shipyard"
-version = "0.51.0"
+version = "0.51.1"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shipyard"
-version = "0.51.0"
+version = "0.51.1"
 edition = "2024"
 description = "Cross-platform CI coordination for local, SSH, and cloud runners."
 rust-version = "1.92"


### PR DESCRIPTION
## Summary

Patch release for the merged #265 cloud retarget cancellation diagnostics and documentation.

## Validation

- cargo fmt -- --check
- cargo test --all-targets --locked
- cargo clippy --all-targets --locked -- -D warnings
- python3 -m unittest discover -s scripts -p "test_*.py"
- SHIPYARD_ENFORCE_PREPUSH=1 python3 scripts/version_bump_check.py --base origin/main --config scripts/versioning.json --mode=report
- SHIPYARD_ENFORCE_PREPUSH=1 python3 scripts/doc_sync_check.py --base origin/main --map scripts/doc_sync_map.json --mode=report
- SHIPYARD_ENFORCE_PREPUSH=1 python3 scripts/skill_sync_check.py --base origin/main --config scripts/versioning.json --mode=report
- git diff --check
- cargo run --locked -- --version -> shipyard 0.51.1
