### PR TITLE
[codex] Refresh Rust release runbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,9 +117,9 @@ It calls your build commands and cares about one thing: did they pass?
 - [Release automation](RELEASING.md) — `shipyard release-bot setup`,
   `doctor --release-chain`, and the PAT + secret setup for the auto-
   release tag → binaries chain.
-- [Rust cutover and rollback](docs/cutover.md) — final go/no-go gates,
-  signed-artifact rehearsal, GUI validation, webhook/Funnel validation,
-  and rollback steps for the Rust migration.
+- [Rust release and rollback](docs/cutover.md) — post-cutover release
+  validation, signed macOS packaging, webhook/Funnel validation, GUI and
+  consumer notes, and rollback steps.
 - [Mid-flight runner retargeting](docs/cloud-retarget.md) — switch one
   target's runner provider on an open PR without tearing down the
   other targets' jobs.
@@ -150,7 +150,9 @@ Shipyard validates and ships itself. The config is in
 [`.github/workflows/ci.yml`](.github/workflows/ci.yml) runs tests on
 macOS, Linux, and Windows on every push. The release workflow at
 [`.github/workflows/release.yml`](.github/workflows/release.yml) builds
-binaries on 5 platforms when a version is tagged.
+Linux, Windows, and macOS ARM64 release candidates when a version is
+tagged; the macOS DMG is signed/notarized and published through the
+release runbook.
 
 ## FAQ
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -73,47 +73,12 @@ Run that after the auto-tag appears. The release workflow will pick up the exist
 
 ### How to cut a macOS release
 
-CI handles Linux + Windows. For the macOS `.dmg`:
-
-```bash
-# One-time setup — either .env or shell rc.
-export SHIPYARD_NOTARIZE_APPLE_ID=<apple-id-email>
-export SHIPYARD_NOTARIZE_TEAM_ID=<team-id>              # 10-char from developer.apple.com/account
-export SHIPYARD_NOTARIZE_APP_PASSWORD=<app-specific>    # appleid.apple.com → Sign-In and Security
-export SHIPYARD_SIGNING_IDENTITY=<SHA1-or-CN>           # `security find-identity -v -p codesigning`
-
-# After release.yml workflow publishes non-macOS assets:
-./scripts/release-macos-local.sh --tag vX.Y.Z --upload
-```
-
-The script is 8 steps:
-
-1. Fail fast on missing env vars (before the Rust release build).
-2. Build via `cargo build --release --locked --bin shipyard`.
-3. Re-sign outer Mach-O with `--options runtime --timestamp`.
-4. Package the signed Mach-O into a `.dmg` (`hdiutil create`, volname "Shipyard").
-5. Sign the DMG itself.
-6. Submit to Apple, wait for `status: Accepted`, then `xcrun stapler staple` and `xcrun stapler validate`.
-7. **Local launch test** — mount the stapled DMG read-only, run `<binary> --version`. Refuses to upload if this fails. Distinguishes exit 3 (local launch broke) from exit 4 (download path broke).
-8. **End-to-end verification after upload** — runs the local `install.sh` against the just-uploaded tag. Downloads the dmg, mounts, extracts, launches. Exit 4 if this fails, with a warning that the upload already happened and needs manual deletion.
-
-### Lesson codified
-
-We shipped v0.42.0 and v0.43.0 with the same class of breakage because we declared "works" based on partial verification. The release script now enforces what we should have been doing all along: **the only success criterion is `--version` printing after a fresh install.sh → mount → extract → launch flow**. If any step in that chain fails, the release fails, regardless of what `codesign --verify` or `spctl --assess` say.
-
-### Why the repo secrets stay
-
-The five secrets below are kept in the repo even though CI doesn't use them today — they're needed for:
-
-- ~~Future Rosetta-hosted local cross-builds for x64~~ (retired by #256 — Intel dropped as of v0.50.0; arm64 only)
-- Forks that may re-enable CI signing for their own environments (tracked in #226)
-- The `.dmg` pipeline above reuses `SHIPYARD_SIGNING_IDENTITY` conceptually (the cert is in the local keychain rather than a GH secret, but the same cert)
-
-Five secrets on the repo (all `gh secret set NAME`):
-
-### How to cut a macOS release
-
-CI still handles Linux + Windows. For the macOS binary:
+Tag pushes create a draft GitHub release with Linux and Windows
+artifacts. The macOS job builds and launch-smokes the Rust binary, but
+does not upload an unsigned artifact unless the optional CI signing
+experiment is explicitly enabled. The maintainer-local path remains the
+primary macOS release path because it proves the exact DMG on the Mac
+that will use it.
 
 ```bash
 # One-time setup — either .env file or shell rc.
@@ -122,8 +87,8 @@ export SHIPYARD_NOTARIZE_TEAM_ID=<team-id>              # 10-char from developer
 export SHIPYARD_NOTARIZE_APP_PASSWORD=<app-specific>    # appleid.apple.com → Sign-In and Security
 export SHIPYARD_SIGNING_IDENTITY=<SHA1-or-CN>           # `security find-identity -v -p codesigning`
 
-# After the release.yml workflow publishes the non-macOS assets:
-./scripts/release-macos-local.sh --tag vX.Y.Z --upload
+# After release.yml creates the draft release:
+./scripts/release-macos-local.sh --tag vX.Y.Z --upload --rollback-tag vPREVIOUS
 ```
 
 The script runs the full pipeline on the local Mac:
@@ -134,34 +99,40 @@ The script runs the full pipeline on the local Mac:
 4. Packages the signed binary into a `.dmg`, signs the DMG, submits it via `xcrun notarytool submit --wait`, and staples the accepted ticket.
 5. **Runs `<binary> --version` from the mounted DMG locally.** If this fails, the script exits and does NOT upload. This is the whole point — the Mac running the script is the same Mac that will need to launch the binary tomorrow.
 6. On launch success: uploads via `gh release upload --clobber`, updates `checksums.sha256`, verifies public asset visibility, and runs the `install.sh` E2E.
+7. With `--rollback-tag`, verifies baseline install, upgrade to the new release, and rollback to the previous release in an isolated temp install directory.
 
 Running without `--upload` is the diagnostic mode (used to confirm the local signing path actually works on a given Mac). Script-helper tests under `scripts/test_*.py` ensure missing creds / bad flags / bash syntax errors all surface before the expensive build step.
 
-### Why the repo secrets are still listed below
+### Optional CI macOS signing
 
-The CI signing steps have been removed from `.github/workflows/release.yml` (build-only for macOS, no signing / notarizing / uploading). The five secrets below are kept in the repo for:
+CI signing is dormant unless the repository variable
+`CI_MACOS_SIGNING_ENABLED=true` is set. When enabled, the macOS release
+job imports a Developer ID identity into an ephemeral keychain, resolves
+the identity by Team ID, and runs `scripts/release-macos-local.sh
+--ci-mode --upload`.
 
-- ~~The x64 slice once we add Rosetta-hosted local cross-builds~~ (retired; see above)
-- Future `.dmg` stapling pipeline (task #52 — the long-term answer that eliminates Apple's online-check dependency entirely)
-- Forks that might want to re-enable CI signing for their own environments
-
-Five secrets on the repo (all `gh secret set NAME`):
+Required CI secret names:
 
 | Secret | What |
 |---|---|
-| `APPLE_ID` | Apple ID email (same one used for Developer ID certificate) |
-| `TEAM_ID` | 10-char Team ID from [developer.apple.com/account](https://developer.apple.com/account) |
-| `APP_SPECIFIC_PASSWORD` | App-specific password generated at [appleid.apple.com](https://appleid.apple.com) → Sign-In and Security → App-Specific Passwords |
-| `SIGNING_CERT_P12_BASE64` | `base64 -i DeveloperID.p12` of your exported Developer ID Application cert + private key |
-| `SIGNING_CERT_PASSWORD` | Export password for the .p12 |
+| `MACOS_NOTARIZE_APPLE_ID` | Apple ID email used for notarization |
+| `MACOS_NOTARIZE_TEAM_ID` | 10-char Team ID from developer.apple.com/account |
+| `MACOS_NOTARIZE_APP_PASSWORD` | App-specific Apple ID password |
+| `MACOS_SIGN_P12_BASE64` | Base64-encoded Developer ID Application cert + private key |
+| `MACOS_SIGN_P12_PASSWORD` | Export password for the `.p12` |
 
-When the CI signing experiment is enabled, the release workflow's macOS job imports the cert into a temp keychain, resolves the Developer ID Application identity by **Team ID**, builds the Rust binary, signs and notarizes the `.dmg`, and uploads it to the draft release. The maintainer's local `scripts/release-macos-local.sh` path remains the primary verification path because it performs the same install.sh E2E on the Mac that will use the binary.
+If the variable is unset, the macOS CI job is build-health-only. Forks
+and pull requests from external contributors are not blocked by signing
+credentials.
 
-The gate is all-five-present (not just `APPLE_ID`). A partial rotation — say a new `APPLE_ID` pasted in but the new `SIGNING_CERT_P12_BASE64` not yet uploaded — used to run the signing path and fail mid-release on `base64 -d`. Now the step cleanly no-ops in that state and the ad-hoc fallback publishes normally.
+### Lesson codified
 
-When the secrets aren't set, the CI sign+notarize job is skipped. Forks and pull requests from external contributors aren't blocked.
-
-A bare Mach-O can't be `stapler staple`'d — Gatekeeper verifies notarization online at first launch instead. That requires network, which every CI / user machine has. Accepted tradeoff vs wrapping the CLI in a no-op `.app` bundle just for stapling.
+We shipped v0.42.0 and v0.43.0 with the same class of breakage because
+we declared "works" based on partial verification. The release script
+now enforces the actual success criterion: `install.sh` downloads the
+DMG, mounts it, extracts the binary, and `shipyard --version` launches.
+If any step in that chain fails, the release fails regardless of what
+`codesign --verify` or `spctl --assess` said earlier.
 
 ## Preferred runner provider
 
@@ -199,12 +170,17 @@ gh variable delete DEFAULT_RUNNER_PROVIDER_WINDOWS --repo danielraffel/Shipyard
 
 ## Default path: automatic on merge
 
-Normal releases are automatic. You don't call any script.
+Normal releases are automatic through draft creation. The macOS DMG
+publish step still follows the signed release runbook above unless CI
+macOS signing is explicitly enabled.
 
 1. Open a PR via `shipyard pr` (or `shipyard ship`).
 2. CI runs `.github/workflows/version-skill-check.yml`, which confirms the right bump(s) are present via `scripts/version_bump_check.py` + `scripts/skill_sync_check.py`. Merge on green.
 3. On push to `main`, `.github/workflows/auto-release.yml` diffs `Cargo.toml`'s package version against the previous push. If it moved, the workflow creates a `v<x.y.z>` tag.
-4. The existing tag-triggered `release.yml` builds binaries on 5 platforms and publishes the GitHub Release.
+4. The existing tag-triggered `release.yml` builds Linux, Windows, and
+   macOS ARM64 release candidates, creates a draft GitHub Release, and
+   leaves macOS signing/upload to the runbook unless CI macOS signing is
+   explicitly enabled.
 
 Plugin-version bumps (`.claude-plugin/plugin.json`) are intentionally **not** tagged — plugin files are delivered from git, not from the binary. Bumping the plugin version still requires a PR and goes through the same gate, but it doesn't cut a binary release.
 
@@ -254,9 +230,10 @@ The script:
 3. Tags the commit (`v0.1.1`)
 4. Pushes the tag
 5. The tag push triggers `.github/workflows/release.yml` which:
-   - Builds binaries on macOS ARM64, Windows x64, Linux x64, and Linux ARM64
-   - Creates a GitHub Release with binaries + SHA256 checksums
-   - Uses GitHub-hosted runners by default; Namespace via manual dispatch
+   - Builds Linux x64, Linux ARM64, Windows x64, and macOS ARM64 release candidates
+   - Uploads non-macOS binaries plus SHA256 checksums to a draft GitHub Release
+   - Leaves macOS signing/upload to `scripts/release-macos-local.sh` unless CI macOS signing is explicitly enabled
+   - Uses the configured runner provider, with Namespace as the preferred default
 
 ## Monitoring a release
 

--- a/docs/cutover.md
+++ b/docs/cutover.md
@@ -1,210 +1,202 @@
-# Rust Cutover And Rollback
+# Rust Shipyard Release And Rollback
 
-This page records the operational checklist for the first Rust-backed
-Shipyard release. It is intentionally conservative: do not replace a
-working Python install, publish a release, or update consumer pins until
-the final go/no-go has been approved.
+Shipyard is Rust-backed by default as of `v0.51.0`. The current
+post-cutover release is `v0.51.1`, which includes the `cloud retarget`
+cancellation-denial diagnostics from issue `#265`.
 
-## Current Cutover Candidate
+This page is now an operator runbook: how to validate the installed
+binary, how release artifacts are produced, how to test live webhook
+delivery safely, and how to roll back if the Rust CLI or daemon
+regresses.
 
-- Migration worktree: `/Users/danielraffel/Code/shipyard-mainline-rust-cutover`
-- Branch: `rust-mainline-cutover`
-- Prepared commits: `f368a22` (`Migrate Shipyard CLI to Rust`) and
-  `66b2dcd` (`Document Rust cutover runbook`)
-- Python parity baseline: `d1999c69085f5b8c8c8672cb3943be3ccc59ed66`
-- Rust version: `shipyard 0.51.0`
+## Current Release Shape
 
-The daily fallback remains the installed Python binary until cutover:
+- `shipyard` and `sy` install to `~/.local/bin`.
+- Current macOS releases are Apple Silicon only:
+  `shipyard-macos-arm64.dmg`.
+- Linux x64, Linux arm64, and Windows x64 ship as native standalone
+  binaries.
+- macOS artifacts must be Developer-ID signed, notarized, stapled into
+  a DMG, mounted, extracted, and launch-tested before the GitHub release
+  is published.
+- The release stays draft until all expected public assets and
+  `checksums.sha256` are present and install E2E has passed.
 
-```sh
-/Users/danielraffel/.local/bin/shipyard --version
-```
+## Validate The Installed CLI
 
-Expected pre-cutover output:
-
-```text
-shipyard, version 0.46.0
-```
-
-## Required Go/No-Go Gates
-
-Run these before opening or merging the migration PR:
+Run these after install, upgrade, rollback, or daemon refresh:
 
 ```sh
-python3 scripts/compare_cli_surface.py \
-  --python-bin /Users/danielraffel/Code/shipyard/.venv/bin/shipyard \
-  --rust-bin target/release/shipyard \
-  --allow-rust-only paths
+shipyard --version
+sy --version
+shipyard --json doctor
+shipyard --json doctor --release-chain
+shipyard wait release v0.51.1 --repo danielraffel/Shipyard --timeout 60 --json
+codesign --verify --deep --strict "$(command -v shipyard)"
+```
 
+Expected healthy state:
+
+- `shipyard --version` and `sy --version` report the same release.
+- `doctor.ready` is `true`.
+- `daemon-version` says the daemon and CLI versions match.
+- `doctor --release-chain` reports `release_chain.version:
+  checkout-ok` when `RELEASE_BOT_TOKEN` is configured.
+- `wait release` observes the expected release assets from
+  `danielraffel/Shipyard`, not from the current checkout's inferred
+  repo. Pass `--repo` explicitly when running from a sidecar repo.
+
+## Release Gates
+
+Before publishing a new Shipyard CLI release, run the local gates that
+match the change:
+
+```sh
 python3 -m unittest discover -s scripts -p 'test_*.py'
 cargo fmt -- --check
 cargo clippy --all-targets --locked -- -D warnings
 cargo test --all-targets --locked
 cargo llvm-cov --locked --summary-only --fail-under-lines 75
+python3 -m pytest tools/sandbox-e2e/ -q
+```
 
+For release candidates, also validate the package/install path in an
+isolated sandbox:
+
+```sh
 SHIPYARD_BINARY_FOR_TEST="$PWD/target/release/shipyard" \
-SHIPYARD_PYTHON_REPO_FOR_TEST=/Users/danielraffel/Code/shipyard \
-SHIPYARD_PYTHON_FOR_TEST=/Users/danielraffel/Code/shipyard/.venv/bin/python \
-  /Users/danielraffel/Code/shipyard/.venv/bin/python -m pytest tools/sandbox-e2e/ -q
+  python3 -m pytest tools/sandbox-e2e/ -q
 ```
 
-Expected result from the latest rehearsal:
+The Rust cutover rehearsal passed CLI surface parity, 82%+ line
+coverage, local unit/script gates, sandbox E2E, signed macOS rehearsal,
+GUI validation, release-chain doctor, and live webhook validation before
+`v0.51.0` was merged.
 
-- CLI surface compare: `missing_from_rust: []`
-- Rust tests: `583` passing
-- Coverage: `82.44%` line coverage
-- Script tests: `63` passing
-- Sandbox E2E: `38` passing with Python parity enabled
+## macOS Release
 
-## Release Rehearsal
+The default tag push creates a draft release with non-macOS artifacts.
+The macOS DMG is then produced by either the local maintainer path or
+the optional CI signing path.
 
-Build and sign a no-upload macOS artifact:
-
-```sh
-cargo build --release --locked --bin shipyard
-
-scripts/release-macos-local.sh \
-  --tag v0.51.0-rust-finalwindow-20260505-0550 \
-  --skip-build \
-  --binary target/release/shipyard \
-  --dist-dir target/release-rehearsal \
-  --env-file /Users/danielraffel/Code/PlunderTube/.env
-```
-
-The latest rehearsal produced:
-
-```text
-target/release-rehearsal/v0.51.0-rust-finalwindow-20260505-0550/shipyard-macos-arm64.dmg
-```
-
-The DMG was signed, notarized, stapled, validated, mounted, and
-launch-smoked as `shipyard 0.51.0`. No upload was performed.
-
-## Release-Chain Doctor
-
-The Rust migration branch adds `workflow_dispatch` to
-`.github/workflows/auto-release.yml` so `shipyard doctor --release-chain`
-can verify the release-bot checkout path.
-
-Before this migration is merged, live Python `main` does not have that
-trigger. A pre-merge run can therefore fail with GitHub HTTP `422`
-(`Workflow does not have 'workflow_dispatch' trigger`) even though the
-prepared migration branch contains the required workflow change. Treat
-that as a pre-merge validation limitation, not as a Rust runtime failure.
-
-After the migration lands on `main`, run:
-
-```sh
-shipyard --json doctor --release-chain
-```
-
-Expected result after merge: `ready: true`, `release_chain.ok: true`,
-and `RELEASE_BOT_TOKEN` configured.
-
-## GUI Validation
-
-Validate the macOS GUI against the exact Rust artifact selected for
-cutover:
-
-```sh
-SHIPYARD_GUI_TEST_RUST_BINARY=/tmp/shipyard-gui-finalwindow-XfMulU/shipyard \
-  xcodebuildmcp macos test \
-  --project-path ShipyardMenuBar.xcodeproj \
-  --scheme ShipyardMenuBar
-```
-
-Latest result against the signed final-window artifact: `19` passed,
-`1` skipped, `0` failed on My Mac macOS `26.4.1`.
-
-If Xcode stalls before test execution in `SWBBuildService` or `clang`,
-record that as an Xcode build-system caveat. Do not classify it as a
-Rust runtime failure unless the Rust binary is actually executed and
-fails.
-
-## Webhook And Funnel Gate
-
-Non-mutating preflight is safe anytime:
-
-```sh
-python3 scripts/validate_webhook_tunnel_live.py \
-  --binary target/release/shipyard \
-  --json
-```
-
-Full live delivery is a machine-level Tailscale Funnel takeover. Run it
-only in an approved window:
-
-```sh
-python3 scripts/validate_webhook_tunnel_live.py \
-  --binary target/release/shipyard \
-  --apply \
-  --allow-funnel-reset \
-  --json
-```
-
-The validator resets Serve/Funnel only for an owned validation run and
-cleans up transient GitHub hooks. If the daily Python daemon currently
-owns Funnel, stop it deliberately, run the Rust gate, then either restore
-Python or proceed with the approved cutover.
-
-## Release And Install
-
-Do not use `--upload` until the release tag, rollback tag, and monitoring
-window are agreed:
+Local signing remains the primary release path:
 
 ```sh
 scripts/release-macos-local.sh \
   --tag vX.Y.Z \
   --upload \
   --rollback-tag vPREVIOUS \
-  --env-file /Users/danielraffel/Code/PlunderTube/.env
+  --env-file /path/to/release.env
 ```
 
-The release script keeps GitHub releases draft until expected assets are
-present and install E2E succeeds. A failed install E2E returns a just-
-published release to draft.
+Required environment:
 
-## Rollback
+- `SHIPYARD_NOTARIZE_APPLE_ID`
+- `SHIPYARD_NOTARIZE_TEAM_ID`
+- `SHIPYARD_NOTARIZE_APP_PASSWORD`
+- `SHIPYARD_SIGNING_IDENTITY`
 
-Rollback if Rust doctor, GUI selected-CLI resolution, daemon IPC,
-webhook/Funnel, installer E2E, or a consumer gate fails.
+The script builds or accepts a supplied binary, signs the Mach-O,
+packages a DMG, signs and notarizes the DMG, staples the ticket,
+mounts the DMG, runs `shipyard --version`, uploads the macOS artifact,
+merges checksums, verifies public asset visibility, and runs
+install/upgrade/rollback E2E when a rollback tag is provided.
 
-1. Stop the Rust daemon:
+The optional CI path is gated by `CI_MACOS_SIGNING_ENABLED=true` and
+requires the `MACOS_SIGN_*` / `MACOS_NOTARIZE_*` secret set. CI signing
+uses an ephemeral keychain and the same `release-macos-local.sh
+--ci-mode` orchestration. If CI signing is not enabled, the macOS job is
+build-health-only and does not upload an unsigned artifact.
 
-   ```sh
-   shipyard daemon stop
-   ```
+## Webhook And Funnel Validation
 
-2. Reinstall the recorded previous Python Shipyard release.
-3. Confirm the fallback binary:
+Non-mutating preflight is safe anytime:
 
-   ```sh
-   /Users/danielraffel/.local/bin/shipyard --version
-   shipyard --json doctor
-   ```
+```sh
+python3 scripts/validate_webhook_tunnel_live.py \
+  --repo danielraffel/Shipyard \
+  --binary "$(command -v shipyard)" \
+  --json
+```
 
-4. Point the GUI selected CLI path back to the Python binary if needed.
-5. Revert or supersede consumer pin PRs targeting the Rust release.
-6. If release upload already happened and install E2E failed, keep the
-   release in draft until the failure is understood.
+Full live validation creates a temporary GitHub webhook and may reset the
+machine-global Tailscale Serve/Funnel route. Run it only when that short
+interruption is acceptable:
 
-## Consumer Pin Updates
+```sh
+python3 scripts/validate_webhook_tunnel_live.py \
+  --repo danielraffel/Shipyard \
+  --binary "$(command -v shipyard)" \
+  --apply \
+  --allow-funnel-reset \
+  --json
+```
 
-Do not update Pulp or other consumers until the Rust release is published
-and stable.
+The validator understands the App Store Tailscale build and probes
+`/Applications/Tailscale.app/Contents/MacOS/Tailscale` when PATH shims
+are unavailable. A healthy non-mutating pass proves `gh`, `curl`,
+GitHub hook read access, DNS, Funnel permission, and current Funnel
+status without changing the route.
 
-When approved, update consumers through the CLI rather than hand-editing:
+## GUI And Consumers
+
+The macOS GUI should use the selected CLI path as the source of truth.
+When the selected CLI supports `shipyard --json paths`, the GUI can
+derive daemon socket, pid, and state paths from that response. Older
+Python binaries without `paths` need the legacy production socket
+fallback.
+
+Do not update Pulp or other consumer pins as part of a Shipyard release
+PR. After the release is published and stable, update consumers through:
 
 ```sh
 shipyard pin show
 shipyard pin bump --to vX.Y.Z
 ```
 
-Keep those PRs isolated and validate each consumer with its normal
-Shipyard gate.
+Keep consumer pin PRs isolated from unrelated docs or source changes.
+
+## Rollback
+
+Rollback if the new release fails doctor, daemon IPC, GUI selected-CLI
+resolution, webhook/Funnel validation, installer E2E, or a consumer
+gate.
+
+1. Stop the daemon:
+
+   ```sh
+   shipyard daemon stop
+   ```
+
+2. Reinstall the last known-good release, or restore a preserved local
+   backup binary:
+
+   ```sh
+   SHIPYARD_VERSION=vPREVIOUS \
+     curl -fsSL https://generouscorp.com/Shipyard/install.sh | bash
+   ```
+
+3. Confirm the restored binary:
+
+   ```sh
+   shipyard --version
+   shipyard --json doctor
+   ```
+
+4. Restart the daemon only after the restored CLI is healthy.
+5. Point the GUI selected CLI path back to the restored binary if needed.
+6. Revert or supersede any consumer pin PRs that targeted the bad
+   release.
+7. If a just-published GitHub release failed install E2E, return it to
+   draft or delete the bad asset before users can install it.
 
 ## Deferred Features
 
-Issue `#265` and issue `#266` are intentionally post-cutover unless they
-land in Python before merge. The cutover goal is parity and stability,
-not new feature scope.
+Issue `#265` shipped in `v0.51.1`. Its additive-dispatch extension is
+still intentionally not implemented because a standalone dispatch may
+not satisfy the same stale PR-event required check context.
+
+Issue `#266` remains the next deferred post-cutover candidate:
+`SHIPYARD_PR_RUNNING=1` for supervised `shipyard pr` child processes and
+clean GraphQL rate-limit backoff. Keep it separate from release
+stability work.

--- a/skills/shipyard/SKILL.md
+++ b/skills/shipyard/SKILL.md
@@ -7,20 +7,21 @@ description: Shipyard operations guardrails. Use when working in /Users/danielra
 
 ## Core Rule
 
-Preserve the user's active Shipyard install until they explicitly approve a
-replacement or release install. Do not replace
-`/Users/danielraffel/.local/bin/shipyard`, change Pulp pins, reset Tailscale
-Funnel, or merge GUI cutover support without a clear go/no-go.
+Preserve the user's active Shipyard install and rollback path. Rust Shipyard is
+the daily implementation as of `v0.51.0` / `v0.51.1`, but do not replace
+`/Users/danielraffel/.local/bin/shipyard`, remove preserved backups, change
+Pulp pins, reset Tailscale Funnel, or merge GUI cutover support without a clear
+go/no-go for that operation.
 
 ## First Steps
 
 1. Confirm the active repo and dirty state with `git status --short`.
 2. Use RepoPrompt for code analysis across Shipyard, historical shipyard-rust,
    and the macOS GUI before declaring parity or implementation gaps.
-3. Read the current planning packet before making cutover claims:
-   `planning/cutover-go-no-go.md`, `planning/parity-matrix.md`,
-   `planning/feature-audit.md`, `planning/quality-gates.md`,
-   `planning/mainline-migration-plan.md`, and `docs/plan/README.md`.
+3. Read the current planning packet before making release/cutover claims:
+   `planning/post-cutover-status.md`, `planning/go-no-go-completion-audit.md`,
+   `planning/upstream-drift.md`, `planning/documentation-backlog.md`, and
+   `docs/plan/README.md`.
 4. Use `--mode isolated`, temporary install directories, and sandbox HOME/PATH
    roots for rehearsals that must not touch the active production state.
 
@@ -68,11 +69,19 @@ The live webhook gate is intentionally dangerous because it resets the local
 Funnel config:
 
 ```sh
-scripts/validate_webhook_tunnel_live.py --apply --allow-funnel-reset --json
+scripts/validate_webhook_tunnel_live.py \
+  --repo danielraffel/Shipyard \
+  --binary "$(command -v shipyard)" \
+  --apply \
+  --allow-funnel-reset \
+  --json
 ```
 
-Run that only in an approved window where interrupting the current Python
-Shipyard live mode is acceptable.
+Run that only in an approved window where briefly taking over the
+machine-global Tailscale Serve/Funnel route is acceptable. The validator knows
+about the App Store Tailscale binary at
+`/Applications/Tailscale.app/Contents/MacOS/Tailscale`; do not assume a
+`tailscale` PATH shim exists.
 
 ## macOS GUI
 
@@ -101,8 +110,8 @@ permission trouble.
 
 ## Cutover Discipline
 
-Cutover is a human decision, not an implementation side effect. Before asking
-for go/no-go, ensure:
+Release/cutover is a human decision, not an implementation side effect. Before
+asking for go/no-go, ensure:
 
 - Drift tracker has no untriaged upstream changes.
 - CLI surface comparison is clean.


### PR DESCRIPTION
## Summary

Refresh post-cutover Shipyard docs now that Rust is the default implementation:

- convert `docs/cutover.md` from a pre-merge cutover checklist into the current Rust release, validation, webhook/Funnel, GUI/consumer, and rollback runbook
- update the README docs link and release workflow summary to match the Rust `v0.51.1` release shape
- clean up stale duplicated macOS release guidance in `RELEASING.md`, including the local signing path, optional CI signing gate, and current secret names

## Validation

- `git diff --check`
- stale-doc grep for pre-cutover/Python fallback wording
- current installed CLI/release checks from the sidecar audit: `shipyard --json doctor`, `doctor --release-chain`, explicit `wait release v0.51.1 --repo danielraffel/Shipyard`, codesign verification, and non-mutating webhook preflight