### PR TITLE
daemon: surface webhook registration warnings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -614,7 +614,7 @@ dependencies = [
 
 [[package]]
 name = "shipyard"
-version = "0.51.1"
+version = "0.51.2"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shipyard"
-version = "0.51.1"
+version = "0.51.2"
 edition = "2024"
 description = "Cross-platform CI coordination for local, SSH, and cloud runners."
 rust-version = "1.92"

--- a/src/daemon_ipc.rs
+++ b/src/daemon_ipc.rs
@@ -44,6 +44,8 @@ pub struct IpcState {
     pub registered_repos: Vec<String>,
     /// Rate-limit snapshot if known.
     pub rate_limit: Option<Value>,
+    /// Last recoverable daemon warning/error, if any.
+    pub last_error: Option<String>,
 }
 
 #[cfg(unix)]
@@ -259,6 +261,7 @@ fn handle_client(
                     std::io::ErrorKind::WouldBlock | std::io::ErrorKind::TimedOut
                 ) =>
             {
+                thread::sleep(Duration::from_millis(50));
                 continue;
             }
             Err(_) => break,
@@ -366,6 +369,7 @@ fn status_frame(state: &IpcState) -> Value {
         "last_event_at": state.last_event_at,
         "registered_repos": state.registered_repos,
         "rate_limit": state.rate_limit,
+        "last_error": state.last_error,
         "shipyard_version": env!("CARGO_PKG_VERSION"),
         "protocol": IPC_PROTOCOL_VERSION,
     })
@@ -483,6 +487,7 @@ mod tests {
             last_event_at: None,
             registered_repos: vec!["org/repo".to_owned()],
             rate_limit: None,
+            last_error: None,
         }
     }
 

--- a/src/daemon_runtime.rs
+++ b/src/daemon_runtime.rs
@@ -33,7 +33,7 @@ use crate::reconcile::{
     reconcile_active_ship_states,
 };
 #[cfg(unix)]
-use crate::registrar::Registrar;
+use crate::registrar::{Registrar, RegistrarError, WEBHOOK_SCOPE_COMMAND};
 use crate::ship_state::ShipStateStore;
 #[cfg(unix)]
 use crate::ship_state::{DispatchedRun, ShipState};
@@ -44,6 +44,9 @@ use crate::tunnel::{
 };
 #[cfg(unix)]
 use crate::webhook::{decode_webhook_event, is_valid_signature};
+
+#[cfg(unix)]
+const SHIP_STATE_SCAN_INTERVAL: Duration = Duration::from_secs(1);
 
 /// Foreground daemon runtime configuration.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -165,33 +168,21 @@ pub fn run_blocking(config: DaemonRunConfig) -> Result<(), DaemonRunError> {
     )?;
     let repos = normalize_repos(config.repos);
     let registrar = Arc::new(Mutex::new(Registrar::new(&config.state_dir)));
-    let registrar_for_status = Arc::clone(&registrar);
+    let registration_error = Arc::new(Mutex::new(None::<String>));
     let ship_dir = config.state_dir.join("ship");
     let ship_dir_for_list = ship_dir.clone();
-    let last_event_at_for_status = Arc::clone(&last_event_at);
-    let tunnel_for_status = Arc::clone(&tunnel_runtime.snapshot);
 
-    let mut server = IpcServer::new(daemon_dir.join("daemon.sock"), move || {
-        let tunnel = tunnel_for_status
-            .lock()
-            .map_or_else(|_| TunnelSnapshot::inactive(), |guard| guard.clone());
-        IpcState {
-            tunnel_backend: tunnel.backend,
-            tunnel_url: tunnel.url,
-            tunnel_verified_at: tunnel.verified_at,
-            subscribers: 0,
-            last_event_at: last_event_at_for_status
-                .lock()
-                .ok()
-                .and_then(|guard| *guard),
-            registered_repos: registered_repos_snapshot(&registrar_for_status),
-            rate_limit: None,
-        }
-    })
-    .with_stop_request(move || {
-        stop_flag.store(false, Ordering::Release);
-    })
-    .with_ship_state_list_provider(move || ship_state_values(&ship_dir_for_list));
+    let status_provider = daemon_status_provider(
+        Arc::clone(&registrar),
+        Arc::clone(&registration_error),
+        Arc::clone(&last_event_at),
+        Arc::clone(&tunnel_runtime.snapshot),
+    );
+    let mut server = IpcServer::new(daemon_dir.join("daemon.sock"), status_provider)
+        .with_stop_request(move || {
+            stop_flag.store(false, Ordering::Release);
+        })
+        .with_ship_state_list_provider(move || ship_state_values(&ship_dir_for_list));
 
     server
         .start()
@@ -201,13 +192,15 @@ pub fn run_blocking(config: DaemonRunConfig) -> Result<(), DaemonRunError> {
     let mut reconcile_window = ReconcileWindow::default();
     let mut reconcile_in_flight = false;
     let mut next_reconcile_at = Instant::now() + initial_reconcile_delay();
-    let mut previous_states = BTreeMap::new();
+    let mut previous_states = ship_state_map(&ship_dir);
+    let mut next_ship_state_scan_at = Instant::now() + SHIP_STATE_SCAN_INTERVAL;
     let mut active_registration_url = None;
     while running.load(Ordering::Acquire) {
         drain_webhook_events(&webhook_rx, &server, &last_event_at);
         sync_tunnel_registration(
             &tunnel_runtime,
             &registrar,
+            &registration_error,
             &repos,
             &mut active_registration_url,
         );
@@ -218,9 +211,10 @@ pub fn run_blocking(config: DaemonRunConfig) -> Result<(), DaemonRunError> {
             publish_reconcile_events(&server, &last_event_at, &result.report);
         }
 
-        if !reconcile_in_flight && Instant::now() >= next_reconcile_at {
+        let now = Instant::now();
+        if !reconcile_in_flight && now >= next_reconcile_at {
             reconcile_in_flight = true;
-            next_reconcile_at = Instant::now() + Duration::from_secs(RECONCILE_INTERVAL_SECONDS);
+            next_reconcile_at = now + Duration::from_secs(RECONCILE_INTERVAL_SECONDS);
             start_reconcile_worker(
                 config.state_dir.clone(),
                 reconcile_window.clone(),
@@ -228,15 +222,18 @@ pub fn run_blocking(config: DaemonRunConfig) -> Result<(), DaemonRunError> {
             );
         }
 
-        let current_states = ship_state_map(&ship_dir);
-        for event in ship_state_delta_events(&previous_states, &current_states) {
-            let timestamp = daemon_timestamp();
-            if let Ok(mut last_event_at) = last_event_at.lock() {
-                *last_event_at = Some(timestamp);
+        if now >= next_ship_state_scan_at {
+            next_ship_state_scan_at = now + SHIP_STATE_SCAN_INTERVAL;
+            let current_states = ship_state_map(&ship_dir);
+            for event in ship_state_delta_events(&previous_states, &current_states) {
+                let timestamp = daemon_timestamp();
+                if let Ok(mut last_event_at) = last_event_at.lock() {
+                    *last_event_at = Some(timestamp);
+                }
+                server.broadcast_event(event);
             }
-            server.broadcast_event(event);
+            previous_states = current_states;
         }
-        previous_states = current_states;
         thread::sleep(Duration::from_millis(100));
     }
 
@@ -246,6 +243,33 @@ pub fn run_blocking(config: DaemonRunConfig) -> Result<(), DaemonRunError> {
         .stop()
         .map_err(|error| DaemonRunError::Protocol(error.to_string()))?;
     Ok(())
+}
+
+#[cfg(unix)]
+fn daemon_status_provider(
+    registrar: Arc<Mutex<Registrar>>,
+    registration_error: Arc<Mutex<Option<String>>>,
+    last_event_at: Arc<Mutex<Option<f64>>>,
+    tunnel_snapshot: Arc<Mutex<TunnelSnapshot>>,
+) -> impl Fn() -> IpcState + Send + Sync + 'static {
+    move || {
+        let tunnel = tunnel_snapshot
+            .lock()
+            .map_or_else(|_| TunnelSnapshot::inactive(), |guard| guard.clone());
+        IpcState {
+            tunnel_backend: tunnel.backend,
+            tunnel_url: tunnel.url,
+            tunnel_verified_at: tunnel.verified_at,
+            subscribers: 0,
+            last_event_at: last_event_at.lock().ok().and_then(|guard| *guard),
+            registered_repos: registered_repos_snapshot(&registrar),
+            rate_limit: None,
+            last_error: registration_error
+                .lock()
+                .ok()
+                .and_then(|guard| guard.clone()),
+        }
+    }
 }
 
 #[cfg(unix)]
@@ -267,6 +291,7 @@ fn drain_webhook_events(
 fn sync_tunnel_registration(
     tunnel_runtime: &TunnelRuntime,
     registrar: &Arc<Mutex<Registrar>>,
+    registration_error: &Arc<Mutex<Option<String>>>,
     repos: &[String],
     active_registration_url: &mut Option<String>,
 ) {
@@ -278,7 +303,9 @@ fn sync_tunnel_registration(
         current_registration_url.as_deref(),
         tunnel_runtime.webhook_secret.as_deref(),
     ) {
-        register_webhooks(registrar, repos, url, secret);
+        register_webhooks(registrar, registration_error, repos, url, secret);
+    } else if let Ok(mut status_error) = registration_error.lock() {
+        *status_error = None;
     }
     *active_registration_url = current_registration_url;
 }
@@ -1004,6 +1031,7 @@ fn public_webhook_url_for_snapshot(snapshot: &TunnelSnapshot) -> Option<String> 
 #[cfg(unix)]
 fn register_webhooks(
     registrar: &Arc<Mutex<Registrar>>,
+    registration_error: &Arc<Mutex<Option<String>>>,
     repos: &[String],
     public_url: &str,
     secret: &str,
@@ -1011,10 +1039,29 @@ fn register_webhooks(
     let Ok(mut registrar) = registrar.lock() else {
         return;
     };
+    let mut first_error = None;
     for repo in repos {
         if let Err(error) = registrar.ensure_registered(repo, public_url, secret) {
-            eprintln!("shipyard daemon: failed to register webhook for {repo}: {error}");
+            let message = registration_error_message(repo, &error);
+            eprintln!("shipyard daemon: failed to register webhook for {repo}: {message}");
+            if first_error.is_none() {
+                first_error = Some(message);
+            }
         }
+    }
+    if let Ok(mut status_error) = registration_error.lock() {
+        *status_error = first_error;
+    }
+}
+
+#[cfg(unix)]
+fn registration_error_message(repo: &str, error: &RegistrarError) -> String {
+    if error.is_missing_webhook_scope() {
+        format!(
+            "GitHub webhook management for {repo} needs one-time authorization. Polling continues; live webhooks need: {WEBHOOK_SCOPE_COMMAND}"
+        )
+    } else {
+        error.to_string()
     }
 }
 

--- a/src/registrar.rs
+++ b/src/registrar.rs
@@ -25,6 +25,9 @@ pub const SUBSCRIBED_EVENTS: [&str; 6] = [
     "release",
 ];
 
+/// One-time GitHub CLI remediation for managing repository webhooks.
+pub const WEBHOOK_SCOPE_COMMAND: &str = "gh auth refresh -h github.com -s admin:repo_hook";
+
 const GH_API_TIMEOUT: Duration = Duration::from_secs(15);
 
 /// Durable repo-to-hook mapping.
@@ -52,6 +55,13 @@ pub enum RegistrarError {
         /// Combined stdout/stderr from `gh`.
         output: String,
     },
+    /// GitHub CLI lacks the admin scope required to manage repo hooks.
+    MissingWebhookScope {
+        /// Registrar operation being attempted.
+        action: &'static str,
+        /// Combined stdout/stderr from `gh`.
+        output: String,
+    },
     /// GitHub CLI returned a successful response without a hook ID.
     MissingHookId(String),
     /// Persisted registration state could not be serialized or parsed.
@@ -67,6 +77,13 @@ impl std::fmt::Display for RegistrarError {
             Self::GhFailed { action, output } => {
                 write!(formatter, "{action} hook failed: {}", output.trim())
             }
+            Self::MissingWebhookScope { action, output } => {
+                write!(
+                    formatter,
+                    "{action} hook failed: {}. Run `{WEBHOOK_SCOPE_COMMAND}` and restart Shipyard.",
+                    output.trim()
+                )
+            }
             Self::MissingHookId(output) => {
                 write!(
                     formatter,
@@ -80,6 +97,14 @@ impl std::fmt::Display for RegistrarError {
 }
 
 impl std::error::Error for RegistrarError {}
+
+impl RegistrarError {
+    /// True when remediation is the GitHub webhook management scope refresh.
+    #[must_use]
+    pub fn is_missing_webhook_scope(&self) -> bool {
+        matches!(self, Self::MissingWebhookScope { .. })
+    }
+}
 
 impl From<std::io::Error> for RegistrarError {
     fn from(value: std::io::Error) -> Self {
@@ -254,10 +279,7 @@ fn create_hook(
         Some(&body.to_string()),
     )?;
     if output.status != 0 {
-        return Err(RegistrarError::GhFailed {
-            action: "create",
-            output: output.combined_output(),
-        });
+        return Err(classify_gh_failure("create", output.combined_output()));
     }
     let parsed = serde_json::from_str::<serde_json::Value>(&output.stdout)
         .map_err(|_| RegistrarError::MissingHookId(output.stdout.clone()))?;
@@ -300,10 +322,7 @@ fn update_hook(
     if output.status == 0 {
         return Ok(());
     }
-    Err(RegistrarError::GhFailed {
-        action: "patch",
-        output: output.combined_output(),
-    })
+    Err(classify_gh_failure("patch", output.combined_output()))
 }
 
 fn delete_hook(gh_binary: &Path, repo: &str, hook_id: u64) -> Result<(), RegistrarError> {
@@ -325,10 +344,20 @@ fn delete_hook(gh_binary: &Path, repo: &str, hook_id: u64) -> Result<(), Registr
     if lowered.contains("404") || lowered.contains("not found") {
         return Ok(());
     }
-    Err(RegistrarError::GhFailed {
-        action: "delete",
-        output: combined,
-    })
+    Err(classify_gh_failure("delete", combined))
+}
+
+fn classify_gh_failure(action: &'static str, output: String) -> RegistrarError {
+    if mentions_webhook_scope(&output) {
+        RegistrarError::MissingWebhookScope { action, output }
+    } else {
+        RegistrarError::GhFailed { action, output }
+    }
+}
+
+fn mentions_webhook_scope(output: &str) -> bool {
+    let lowered = output.to_ascii_lowercase();
+    lowered.contains("admin:repo_hook") || lowered.contains("repo_hook")
 }
 
 #[derive(Debug)]
@@ -450,7 +479,7 @@ mod tests {
 
     use super::Registrar;
     #[cfg(unix)]
-    use super::{RegistrarError, SUBSCRIBED_EVENTS};
+    use super::{RegistrarError, SUBSCRIBED_EVENTS, WEBHOOK_SCOPE_COMMAND};
 
     #[test]
     fn corrupt_state_loads_as_empty() {
@@ -572,6 +601,22 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
+    fn create_missing_webhook_scope_is_actionable() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let gh = write_gh_stub(temp.path(), GhStubMode::MissingWebhookScope);
+        let mut registrar = Registrar::new(temp.path());
+
+        let error = registrar
+            .ensure_registered_with_gh("owner/repo", "https://example.test/webhook", "secret", &gh)
+            .expect_err("missing scope");
+
+        assert!(error.is_missing_webhook_scope());
+        assert!(error.to_string().contains(WEBHOOK_SCOPE_COMMAND));
+        assert!(registrar.all().is_empty());
+    }
+
+    #[cfg(unix)]
+    #[test]
     fn unregister_without_gh_removes_local_state() {
         let temp = tempfile::tempdir().expect("tempdir");
         let gh = write_gh_stub(temp.path(), GhStubMode::Ok);
@@ -592,6 +637,7 @@ mod tests {
         Ok,
         Delete404,
         MissingId,
+        MissingWebhookScope,
     }
 
     #[cfg(unix)]
@@ -599,13 +645,25 @@ mod tests {
         let gh = temp.join("gh");
         let create_response = match mode {
             GhStubMode::MissingId => "{}",
-            GhStubMode::Ok | GhStubMode::Delete404 => "{\"id\":4242}",
+            GhStubMode::Ok | GhStubMode::Delete404 | GhStubMode::MissingWebhookScope => {
+                "{\"id\":4242}"
+            }
         };
         let delete_branch = match mode {
             GhStubMode::Delete404 => {
                 "  *\" -X DELETE \"*) printf '404 not found\\n' >&2; exit 1 ;;"
             }
-            GhStubMode::Ok | GhStubMode::MissingId => "  *\" -X DELETE \"*) exit 0 ;;",
+            GhStubMode::Ok | GhStubMode::MissingId | GhStubMode::MissingWebhookScope => {
+                "  *\" -X DELETE \"*) exit 0 ;;"
+            }
+        };
+        let create_branch = match mode {
+            GhStubMode::MissingWebhookScope => String::from(
+                "  *\" -X POST \"*) printf 'missing scope: admin:repo_hook\\n' >&2; exit 1 ;;",
+            ),
+            GhStubMode::Ok | GhStubMode::Delete404 | GhStubMode::MissingId => {
+                format!("  *\" -X POST \"*) printf '%s\\n' '{create_response}' ;;")
+            }
         };
         let script = format!(
             r#"#!/bin/sh
@@ -618,14 +676,14 @@ printf '%s' "$COUNT" > "$COUNT_FILE"
 printf '%s\n' "$*" > "$LOG_DIR/args-$COUNT"
 cat > "$LOG_DIR/stdin-$COUNT" || true
 case " $* " in
-  *" -X POST "*) printf '%s\n' '{create_response}' ;;
+{create_branch}
   *" -X PATCH "*) printf '%s\n' '{{}}' ;;
 {delete_branch}
   *) printf 'unexpected gh args: %s\n' "$*" >&2; exit 2 ;;
 esac
 "#,
             log_dir = shell_quote(temp),
-            create_response = create_response,
+            create_branch = create_branch,
             delete_branch = delete_branch,
         );
         fs::write(&gh, script).expect("write gh stub");

--- a/src/wait_transport.rs
+++ b/src/wait_transport.rs
@@ -458,6 +458,7 @@ mod tests {
             last_event_at: None,
             registered_repos: Vec::new(),
             rate_limit: None,
+            last_error: None,
         }
     }
 


### PR DESCRIPTION
## Summary
- expose recoverable daemon registration warnings as `last_error` in IPC status
- classify missing GitHub webhook admin scope and surface the exact `gh auth refresh -h github.com -s admin:repo_hook` remediation
- reduce daemon ship-state scan churn while preserving event broadcasts
- bump CLI to `0.51.2` so release automation publishes the hardening build

## Validation
- `cargo fmt --all -- --check`
- `cargo test --all-targets --locked` (587 passed)
- `cargo clippy --all-targets --locked -- -D warnings`