### PR TITLE
ci: default Shipyard workflows to GitHub-hosted runners

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "shipyard",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Cross-platform CI coordination",
   "min_shipyard_version": "0.22.8",
   "commands": "./commands",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,11 +10,11 @@ on:
       runner_provider:
         description: Runner provider for CI jobs
         required: false
-        default: namespace
+        default: github-hosted
         type: choice
         options:
-          - namespace
           - github-hosted
+          - namespace
       linux_runner_selector_json:
         description: Optional JSON string/array for Linux runs-on
         required: false
@@ -51,7 +51,7 @@ jobs:
 
       - id: resolve
         env:
-          REQUESTED_PROVIDER: ${{ inputs.runner_provider || vars.DEFAULT_RUNNER_PROVIDER || 'namespace' }}
+          REQUESTED_PROVIDER: ${{ inputs.runner_provider || vars.DEFAULT_RUNNER_PROVIDER || 'github-hosted' }}
           EXPLICIT_LINUX_RUNNER_SELECTOR_JSON: ${{ inputs.linux_runner_selector_json || '' }}
           # Falls back to the MACOS_ARM64_LOCAL_SELECTOR_JSON repo var so the
           # macOS leg routes to the local self-hosted runner (label `local-mac`)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,10 @@ jobs:
         env:
           REQUESTED_PROVIDER: ${{ inputs.runner_provider || vars.DEFAULT_RUNNER_PROVIDER || 'namespace' }}
           EXPLICIT_LINUX_RUNNER_SELECTOR_JSON: ${{ inputs.linux_runner_selector_json || '' }}
-          EXPLICIT_MACOS_ARM64_RUNNER_SELECTOR_JSON: ${{ inputs.macos_arm64_runner_selector_json || '' }}
+          # Falls back to the MACOS_ARM64_LOCAL_SELECTOR_JSON repo var so the
+          # macOS leg routes to the local self-hosted runner (label `local-mac`)
+          # without a workflow_dispatch input on auto pull_request triggers.
+          EXPLICIT_MACOS_ARM64_RUNNER_SELECTOR_JSON: ${{ inputs.macos_arm64_runner_selector_json || vars.MACOS_ARM64_LOCAL_SELECTOR_JSON || '' }}
           EXPLICIT_WINDOWS_RUNNER_SELECTOR_JSON: ${{ inputs.windows_runner_selector_json || '' }}
           NAMESPACE_LINUX_RUNS_ON_JSON: ${{ vars.NAMESPACE_LINUX_RUNS_ON_JSON }}
           NAMESPACE_MACOS_ARM64_RUNS_ON_JSON: ${{ vars.NAMESPACE_MACOS_ARM64_RUNS_ON_JSON }}

--- a/.github/workflows/cloud-live-smoke.yml
+++ b/.github/workflows/cloud-live-smoke.yml
@@ -6,15 +6,15 @@ on:
       runner_provider:
         description: Runner provider requested by Shipyard cloud dispatch
         required: false
-        default: namespace
+        default: github-hosted
       workflow_runner_provider:
         description: Runner provider for this smoke workflow job
         required: false
-        default: namespace
+        default: github-hosted
         type: choice
         options:
-          - namespace
           - github-hosted
+          - namespace
       workflow_runner_selector_json:
         description: Optional JSON string/array for this smoke workflow runs-on
         required: false
@@ -45,7 +45,7 @@ jobs:
 
       - id: resolve
         env:
-          REQUESTED_PROVIDER: ${{ inputs.workflow_runner_provider || vars.DEFAULT_RUNNER_PROVIDER || 'namespace' }}
+          REQUESTED_PROVIDER: ${{ inputs.workflow_runner_provider || vars.DEFAULT_RUNNER_PROVIDER || 'github-hosted' }}
           EXPLICIT_LINUX_RUNNER_SELECTOR_JSON: ${{ inputs.workflow_runner_selector_json || '' }}
           NAMESPACE_LINUX_RUNS_ON_JSON: ${{ vars.NAMESPACE_LINUX_RUNS_ON_JSON }}
         run: python3 scripts/ci_matrix.py --workflow ci --github-output

--- a/.github/workflows/package-smoke.yml
+++ b/.github/workflows/package-smoke.yml
@@ -6,11 +6,11 @@ on:
       runner_provider:
         description: Runner provider for package smoke jobs
         required: false
-        default: namespace
+        default: github-hosted
         type: choice
         options:
-          - namespace
           - github-hosted
+          - namespace
       linux_runner_selector_json:
         description: Optional JSON string/array for Linux runs-on
         required: false
@@ -45,7 +45,7 @@ jobs:
 
       - id: resolve
         env:
-          REQUESTED_PROVIDER: ${{ inputs.runner_provider || vars.DEFAULT_RUNNER_PROVIDER || 'namespace' }}
+          REQUESTED_PROVIDER: ${{ inputs.runner_provider || vars.DEFAULT_RUNNER_PROVIDER || 'github-hosted' }}
           EXPLICIT_LINUX_RUNNER_SELECTOR_JSON: ${{ inputs.linux_runner_selector_json || '' }}
           # Repo var fallback routes macOS to local self-hosted runner.
           EXPLICIT_MACOS_ARM64_RUNNER_SELECTOR_JSON: ${{ inputs.macos_arm64_runner_selector_json || vars.MACOS_ARM64_LOCAL_SELECTOR_JSON || '' }}

--- a/.github/workflows/package-smoke.yml
+++ b/.github/workflows/package-smoke.yml
@@ -47,7 +47,8 @@ jobs:
         env:
           REQUESTED_PROVIDER: ${{ inputs.runner_provider || vars.DEFAULT_RUNNER_PROVIDER || 'namespace' }}
           EXPLICIT_LINUX_RUNNER_SELECTOR_JSON: ${{ inputs.linux_runner_selector_json || '' }}
-          EXPLICIT_MACOS_ARM64_RUNNER_SELECTOR_JSON: ${{ inputs.macos_arm64_runner_selector_json || '' }}
+          # Repo var fallback routes macOS to local self-hosted runner.
+          EXPLICIT_MACOS_ARM64_RUNNER_SELECTOR_JSON: ${{ inputs.macos_arm64_runner_selector_json || vars.MACOS_ARM64_LOCAL_SELECTOR_JSON || '' }}
           EXPLICIT_WINDOWS_RUNNER_SELECTOR_JSON: ${{ inputs.windows_runner_selector_json || '' }}
           NAMESPACE_LINUX_RUNS_ON_JSON: ${{ vars.NAMESPACE_LINUX_RUNS_ON_JSON }}
           NAMESPACE_MACOS_ARM64_RUNS_ON_JSON: ${{ vars.NAMESPACE_MACOS_ARM64_RUNS_ON_JSON }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,11 +8,11 @@ on:
       runner_provider:
         description: Runner provider for release jobs
         required: false
-        default: namespace
+        default: github-hosted
         type: choice
         options:
-          - namespace
           - github-hosted
+          - namespace
       linux_runner_selector_json:
         description: Optional JSON string/array for Linux x64 runs-on
         required: false
@@ -56,7 +56,7 @@ jobs:
 
       - id: resolve
         env:
-          REQUESTED_PROVIDER: ${{ inputs.runner_provider || vars.DEFAULT_RUNNER_PROVIDER || 'namespace' }}
+          REQUESTED_PROVIDER: ${{ inputs.runner_provider || vars.DEFAULT_RUNNER_PROVIDER || 'github-hosted' }}
           EXPLICIT_LINUX_RUNNER_SELECTOR_JSON: ${{ inputs.linux_runner_selector_json || '' }}
           EXPLICIT_LINUX_ARM64_RUNNER_SELECTOR_JSON: ${{ inputs.linux_arm64_runner_selector_json || '' }}
           # Falls back to the MACOS_ARM64_LOCAL_SELECTOR_JSON repo var so the

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,10 @@ jobs:
           REQUESTED_PROVIDER: ${{ inputs.runner_provider || vars.DEFAULT_RUNNER_PROVIDER || 'namespace' }}
           EXPLICIT_LINUX_RUNNER_SELECTOR_JSON: ${{ inputs.linux_runner_selector_json || '' }}
           EXPLICIT_LINUX_ARM64_RUNNER_SELECTOR_JSON: ${{ inputs.linux_arm64_runner_selector_json || '' }}
-          EXPLICIT_MACOS_ARM64_RUNNER_SELECTOR_JSON: ${{ inputs.macos_arm64_runner_selector_json || '' }}
+          # Falls back to the MACOS_ARM64_LOCAL_SELECTOR_JSON repo var so the
+          # macOS leg routes to the local self-hosted runner (label `local-mac`)
+          # without a workflow_dispatch input on auto release events.
+          EXPLICIT_MACOS_ARM64_RUNNER_SELECTOR_JSON: ${{ inputs.macos_arm64_runner_selector_json || vars.MACOS_ARM64_LOCAL_SELECTOR_JSON || '' }}
           EXPLICIT_WINDOWS_RUNNER_SELECTOR_JSON: ${{ inputs.windows_runner_selector_json || '' }}
           NAMESPACE_LINUX_RUNS_ON_JSON: ${{ vars.NAMESPACE_LINUX_RUNS_ON_JSON }}
           NAMESPACE_LINUX_ARM64_RUNS_ON_JSON: ${{ vars.NAMESPACE_LINUX_ARM64_RUNS_ON_JSON }}

--- a/.github/workflows/sandbox-e2e.yml
+++ b/.github/workflows/sandbox-e2e.yml
@@ -10,11 +10,11 @@ on:
       runner_provider:
         description: Runner provider for sandbox jobs
         required: false
-        default: namespace
+        default: github-hosted
         type: choice
         options:
-          - namespace
           - github-hosted
+          - namespace
       linux_runner_selector_json:
         description: Optional JSON string/array for Linux runs-on
         required: false
@@ -44,7 +44,7 @@ jobs:
 
       - id: resolve
         env:
-          REQUESTED_PROVIDER: ${{ inputs.runner_provider || vars.DEFAULT_RUNNER_PROVIDER || 'namespace' }}
+          REQUESTED_PROVIDER: ${{ inputs.runner_provider || vars.DEFAULT_RUNNER_PROVIDER || 'github-hosted' }}
           EXPLICIT_LINUX_RUNNER_SELECTOR_JSON: ${{ inputs.linux_runner_selector_json || '' }}
           # Repo var fallback routes macOS to local self-hosted runner.
           EXPLICIT_MACOS_ARM64_RUNNER_SELECTOR_JSON: ${{ inputs.macos_arm64_runner_selector_json || vars.MACOS_ARM64_LOCAL_SELECTOR_JSON || '' }}

--- a/.github/workflows/sandbox-e2e.yml
+++ b/.github/workflows/sandbox-e2e.yml
@@ -46,7 +46,8 @@ jobs:
         env:
           REQUESTED_PROVIDER: ${{ inputs.runner_provider || vars.DEFAULT_RUNNER_PROVIDER || 'namespace' }}
           EXPLICIT_LINUX_RUNNER_SELECTOR_JSON: ${{ inputs.linux_runner_selector_json || '' }}
-          EXPLICIT_MACOS_ARM64_RUNNER_SELECTOR_JSON: ${{ inputs.macos_arm64_runner_selector_json || '' }}
+          # Repo var fallback routes macOS to local self-hosted runner.
+          EXPLICIT_MACOS_ARM64_RUNNER_SELECTOR_JSON: ${{ inputs.macos_arm64_runner_selector_json || vars.MACOS_ARM64_LOCAL_SELECTOR_JSON || '' }}
           NAMESPACE_LINUX_RUNS_ON_JSON: ${{ vars.NAMESPACE_LINUX_RUNS_ON_JSON }}
           NAMESPACE_MACOS_ARM64_RUNS_ON_JSON: ${{ vars.NAMESPACE_MACOS_ARM64_RUNS_ON_JSON }}
         run: python3 scripts/ci_matrix.py --workflow sandbox-e2e --github-output

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to Shipyard are documented here. Each entry links
 to its [GitHub Release](https://github.com/danielraffel/Shipyard/releases).
 
 <a id="v0513"></a>
+## [0.51.4]
+
 ## [0.51.3] - 2026-05-06
 
 - daemon: archive local ship-state from `pull_request.closed` webhooks

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -614,7 +614,7 @@ dependencies = [
 
 [[package]]
 name = "shipyard"
-version = "0.51.3"
+version = "0.51.4"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shipyard"
-version = "0.51.3"
+version = "0.51.4"
 edition = "2024"
 description = "Cross-platform CI coordination for local, SSH, and cloud runners."
 rust-version = "1.92"

--- a/README.md
+++ b/README.md
@@ -86,8 +86,8 @@ Downloads a standalone binary for your platform. No runtime needed. See
 - **Local builds** run on your host machine — fast, no network.
 - **Remote builds** run on machines you control via SSH — VMs, containers,
   or hosts on your network.
-- **Cloud builds** run on managed infrastructure (Namespace, GitHub
-  Actions) for neutral or on-demand capacity.
+- **Cloud builds** run on managed infrastructure (GitHub Actions by default,
+  Namespace where available) for neutral or on-demand capacity.
 
 `shipyard run` delivers the exact commit to each machine, runs your build
 and test commands, and reports what passed. `shipyard ship` does the same,
@@ -136,7 +136,7 @@ You don't need everything — just what matches your setup:
 | [git](https://github.com/git-guides/install-git) | Yes | Version control | Pre-installed on macOS |
 | [gh](https://github.com/cli/cli) | Yes (for PRs) | GitHub integration[^gh-scope] | `brew install gh` |
 | `ssh` | For remote targets | Connect to VMs | Pre-installed on macOS / [Ubuntu](https://ubuntu.com/server/docs/how-to/security/openssh-server/) / [Windows](https://learn.microsoft.com/en-us/windows-server/administration/openssh/openssh_install_firstuse?tabs=gui&pivots=windows-11) |
-| [nsc](https://namespace.so/docs/reference/cli/installation) | For [Namespace](https://namespace.so) | Cloud runners | `brew install namespace-cli` |
+| [nsc](https://namespace.so/docs/reference/cli/installation) | Optional | Namespace runner visibility when your account has access | `brew install namespace-cli` |
 | [UTM](https://mac.getutm.app) / [Parallels](https://www.parallels.com/products/desktop/) | For VM fallback | Auto-boot VMs | `brew install --cask utm` |
 
 `shipyard doctor` checks all of this and tells you what's missing.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -136,37 +136,36 @@ If any step in that chain fails, the release fails regardless of what
 
 ## Preferred runner provider
 
-Shipyard's own CI defaults to the runner provider configured in the repo variable `DEFAULT_RUNNER_PROVIDER`. Set it once:
+Shipyard's own CI defaults to GitHub-hosted runners. Namespace remains an
+explicit opt-in for accounts that have access, but it is not the safe default.
+If a repo variable was previously set to Namespace, flip it back:
 
 ```sh
-gh variable set DEFAULT_RUNNER_PROVIDER --repo danielraffel/Shipyard --body namespace
+gh variable set DEFAULT_RUNNER_PROVIDER --repo danielraffel/Shipyard --body github-hosted
 ```
 
-Every subsequent PR push, tag push, and scheduled release picks that up without workflow edits. Per-run overrides still work via `gh workflow run ci.yml --ref <branch> -f runner_provider=github-hosted`.
+Every subsequent PR push, tag push, and scheduled release picks that up without
+workflow edits. Per-run overrides still work via
+`gh workflow run ci.yml --ref <branch> -f runner_provider=namespace` when
+Namespace access is available.
 
-**Why Namespace is the preferred default:** GitHub-hosted `macos-15` queues routinely stall shipyard PRs for 10+ minutes during business hours. Namespace's cloud pool (profiles `namespace-profile-generouscorp`, `-macos`, `-windows`) has near-zero queue time and faster macOS ARM machines. The trade-off is per-minute cost — Namespace is not free like GitHub-hosted on public repos — but for an active project the wall-clock-time savings are worth it.
+**Current default:** GitHub-hosted Linux, macOS, and Windows. This is slower
+than a warm paid pool, but it avoids paid Namespace capacity and keeps public
+repo CI available while local/self-hosted runners are being set up.
 
-**When to flip back to `github-hosted`:**
-- Forks / external contributors whose repos don't have the variable set will naturally fall through to `github-hosted` (safe default, no paid surface exposed).
-- If Namespace has an outage: `gh variable delete DEFAULT_RUNNER_PROVIDER` restores `github-hosted` for all future runs without a workflow PR.
+**When to opt into Namespace:**
+- Only when the account has active Namespace access.
+- Only for trusted branches/repos; paid or self-hosted capacity should not run
+  untrusted fork code by default.
 
 The resolution order per target in `ci.yml` / `release.yml` is:
 1. `workflow_dispatch` input (per-run override — all targets).
-2. `vars.DEFAULT_RUNNER_PROVIDER_LINUX` / `_MACOS` / `_WINDOWS` (per-target repo variable).
-3. `vars.DEFAULT_RUNNER_PROVIDER` (repo-wide default).
-4. Hardcoded fallback `github-hosted`.
+2. `vars.DEFAULT_RUNNER_PROVIDER` (repo-wide default).
+3. Hardcoded fallback `github-hosted`.
 
-**Per-target override use case:** If one Namespace profile goes down (e.g. `generouscorp-windows` saturated 2026-04-23, #193) you can route just that platform to `github-hosted` without losing the speed benefit on the healthy profiles:
-
-```sh
-gh variable set DEFAULT_RUNNER_PROVIDER_WINDOWS --repo danielraffel/Shipyard --body github-hosted
-```
-
-Every subsequent run builds Linux + macOS on Namespace and Windows on `windows-latest`. Delete the variable when the outage clears:
-
-```sh
-gh variable delete DEFAULT_RUNNER_PROVIDER_WINDOWS --repo danielraffel/Shipyard
-```
+The workflow also supports explicit `*_runner_selector_json` inputs and the
+`MACOS_ARM64_LOCAL_SELECTOR_JSON` repo variable for routing a trusted macOS leg
+to a local self-hosted runner without making Namespace the provider default.
 
 ## Default path: automatic on merge
 
@@ -233,7 +232,7 @@ The script:
    - Builds Linux x64, Linux ARM64, Windows x64, and macOS ARM64 release candidates
    - Uploads non-macOS binaries plus SHA256 checksums to a draft GitHub Release
    - Leaves macOS signing/upload to `scripts/release-macos-local.sh` unless CI macOS signing is explicitly enabled
-   - Uses the configured runner provider, with Namespace as the preferred default
+   - Uses the configured runner provider, with GitHub-hosted as the safe default
 
 ## Monitoring a release
 
@@ -250,6 +249,8 @@ gh release view v0.1.1 --repo danielraffel/Shipyard
 ```bash
 gh workflow run release.yml --repo danielraffel/Shipyard -f runner_provider=namespace
 ```
+
+Only use this when the Namespace account is active.
 
 ## Version locations
 

--- a/commands/cloud.md
+++ b/commands/cloud.md
@@ -27,10 +27,10 @@ When summarizing JSON output, report:
 
 ```bash
 # Swap one lane on an in-flight PR to a new provider:
-shipyard cloud retarget --pr <n> --target macos --provider namespace [--apply]
+shipyard cloud retarget --pr <n> --target macos --provider github-hosted [--apply]
 
 # Add a brand-new lane to an in-flight PR without re-dispatching the matrix:
-shipyard cloud add-lane --pr <n> --target windows [--provider namespace] [--apply]
+shipyard cloud add-lane --pr <n> --target windows [--provider github-hosted] [--apply]
 ```
 
 Both are dry-run by default. `add-lane` is idempotent — if the target is

--- a/commands/config.md
+++ b/commands/config.md
@@ -13,9 +13,9 @@ Use these entry points instead:
 - Effective cloud workflow/provider resolution: `shipyard cloud defaults --json`
 - Active job and target state: `shipyard status --json`
 
-If the user asks to "switch profiles", "go local", or "go cloud", explain that
-profile switching is not implemented in the CLI yet and make the required config
-file changes explicitly instead of invoking a nonexistent command.
+If the user asks to "switch profiles", "go local", or "go cloud", use
+`shipyard config profiles` to inspect options and `shipyard config use <profile>`
+to switch an existing profile.
 
 Examples:
 

--- a/commands/doctor.md
+++ b/commands/doctor.md
@@ -11,7 +11,7 @@ shipyard doctor --json
 
 Parse the JSON output. Report:
 - Which core tools are installed (git, ssh) with versions
-- Which cloud providers are available (gh, nsc)
+- Which cloud providers are available (`gh` required for GitHub, `nsc` optional for Namespace)
 - Overall readiness status
 
 If something is missing, explain how to install it.

--- a/docs/cloud-retarget.md
+++ b/docs/cloud-retarget.md
@@ -8,6 +8,11 @@ everything.
 
 Available since Shipyard v0.8.0.
 
+Shipyard's own workflows currently default to GitHub-hosted runners because
+Namespace access is optional and account-dependent. The Namespace examples
+below are still useful when that provider is available; otherwise retarget to
+`github-hosted` or pass explicit self-hosted runner selectors.
+
 ## The use case
 
 You start a ten-PR drain with the topology:

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -69,7 +69,7 @@ What platforms do you want to validate?
   [x] Windows  (SSH host "win" — reachable, 23ms)
   [x] Linux    (SSH host "ubuntu" — reachable, 847ms)
 
-Cloud failover: fall back to Namespace when VMs are down? [Y/n]
+Cloud failover: fall back to GitHub-hosted Actions when VMs are down? [Y/n]
 
 Writing .shipyard/config.toml... done
 ```
@@ -85,14 +85,14 @@ $ shipyard run
   All green.
 ```
 
-If your VMs are powered off or unreachable, Shipyard automatically falls back
-to Namespace cloud runners — you don't have to do anything:
+If your VMs are powered off or unreachable, Shipyard can fall back to
+GitHub-hosted cloud runners — you don't have to do anything:
 
 ```
 $ shipyard run
   mac     = pass  (local, 3m12s)
-  windows → SSH unreachable → dispatching to Namespace...
-          = pass  (namespace-failover, 8m45s)    ← cloud runner took over
+  windows → SSH unreachable → dispatching to GitHub Actions...
+          = pass  (github-hosted-failover, 8m45s)    ← cloud runner took over
   ubuntu  = pass  (ssh, 4m18s)
   All green.
 ```

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -19,7 +19,7 @@ your config every time is annoying.
 targets = ["mac"]
 
 [profiles.normal]
-# Mac local + cloud for Windows and Linux
+# Mac local + GitHub-hosted Windows and Linux
 targets = ["mac", "ubuntu-cloud", "windows-cloud"]
 
 [profiles.full]
@@ -31,7 +31,7 @@ targets = ["mac", "ubuntu", "windows"]
 
 ```bash
 $ shipyard config use local          # just my Mac
-$ shipyard config use normal         # Mac + Namespace cloud
+$ shipyard config use normal         # Mac + GitHub-hosted cloud
 $ shipyard config use full           # Mac + VMs + cloud fallback
 ```
 
@@ -53,9 +53,35 @@ $ shipyard targets
   (ubuntu and windows are disabled in this profile)
 ```
 
+## Platform-focus profiles
+
+Profiles can also describe which platforms are merge-blocking during a
+focused development phase. Shipyard still runs every configured target, but
+targets outside the focus set become advisory and are listed in the PR body.
+
+```toml
+[project]
+profile = "macos-only"
+
+[profiles.macos-only]
+description = "Active focus is macOS. Linux and Windows still build for visibility."
+focus_platforms = ["macos"]
+advisory_platforms = ["linux", "windows"]
+```
+
+`Lane-Policy:` commit trailers still win for a single PR:
+
+```text
+Lane-Policy: windows=required linux=advisory
+```
+
+Automatic issue filing for advisory failures is intentionally not enabled in
+this first slice; issue #274 tracks that follow-up so Shipyard does not spam a
+repo while the local runner migration is still settling.
+
 ## Provider profiles & capabilities
 
-Shipyard's runner providers (GitHub-hosted, Namespace) expose *profiles*
+Shipyard's runner providers (GitHub-hosted, Namespace where available) expose *profiles*
 — named bundles of capabilities a given runner class advertises. This
 is the other side of the [`requires`](./targets.md#locality-routing-requires)
 feature: when a target says it needs `gpu`, Shipyard filters the
@@ -77,7 +103,9 @@ These ship with Shipyard — no config needed for the common cases.
 ### Overriding or extending
 
 Any same-named profile you define in `.shipyard/config.toml` overrides
-the built-in. Add new profiles for custom fleets:
+the built-in. Add new profiles for custom fleets. Namespace examples remain
+for users with Namespace access; Shipyard's own CI defaults to GitHub-hosted
+runners unless a workflow input or repo variable opts into Namespace.
 
 ```toml
 [providers.namespace.profiles.default]

--- a/docs/targets.md
+++ b/docs/targets.md
@@ -51,7 +51,7 @@ backend = "ssh"
 host = "ubuntu"
 fallback = [
     { type = "vm", vm_name = "Ubuntu 24.04" },
-    { type = "cloud", provider = "namespace" },
+    { type = "cloud", provider = "github-hosted" },
 ]
 ```
 

--- a/scripts/ci_matrix.py
+++ b/scripts/ci_matrix.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
-"""Resolve GitHub Actions runner matrices for Shipyard Rust workflows.
+"""Resolve GitHub Actions runner matrices for Shipyard workflows.
 
-Namespace is the default provider because these workflows are intended to move
-quickly while the Rust port is under active parity validation. Workflow inputs
-and repository variables can override the defaults without editing YAML.
+GitHub-hosted runners are the safe default. Namespace remains an explicit
+opt-in provider for repos/accounts that still have access, and workflow inputs
+or repository variables can override defaults without editing YAML.
 """
 
 from __future__ import annotations
@@ -117,7 +117,7 @@ def _load_selector(raw: str, *, target: RunnerTarget, source: str) -> str:
 
 
 def requested_provider(env: Mapping[str, str]) -> str:
-    provider = _env(env, "REQUESTED_PROVIDER") or "namespace"
+    provider = _env(env, "REQUESTED_PROVIDER") or "github-hosted"
     if provider not in VALID_PROVIDERS:
         raise SystemExit(
             f"Unsupported runner provider {provider!r}; expected one of "

--- a/scripts/test_ci_matrix.py
+++ b/scripts/test_ci_matrix.py
@@ -12,10 +12,10 @@ import ci_matrix
 
 
 class CiMatrixTests(unittest.TestCase):
-    def test_namespace_is_fast_default_without_repo_vars(self) -> None:
+    def test_github_hosted_is_safe_default_without_repo_vars(self) -> None:
         row = ci_matrix.resolve_runs_on("linux", {})
-        self.assertEqual(row["provider"], "namespace")
-        self.assertEqual(json.loads(row["runs_on_json"]), "namespace-profile-generouscorp")
+        self.assertEqual(row["provider"], "github-hosted")
+        self.assertEqual(json.loads(row["runs_on_json"]), "ubuntu-latest")
 
     def test_github_hosted_provider_uses_hosted_labels(self) -> None:
         row = ci_matrix.resolve_runs_on("windows", {"REQUESTED_PROVIDER": "github-hosted"})
@@ -100,8 +100,8 @@ class CiMatrixTests(unittest.TestCase):
                 for line in output.read_text(encoding="utf-8").splitlines()
             )
         self.assertEqual(len(json.loads(values["matrix_json"])["include"]), 2)
-        self.assertEqual(json.loads(values["linux_runs_on_json"]), "namespace-profile-generouscorp")
-        self.assertEqual(values["linux_provider"], "namespace")
+        self.assertEqual(json.loads(values["linux_runs_on_json"]), "ubuntu-latest")
+        self.assertEqual(values["linux_provider"], "github-hosted")
 
 
 if __name__ == "__main__":

--- a/skills/ci/SKILL.md
+++ b/skills/ci/SKILL.md
@@ -52,8 +52,8 @@ Shipyard coordinates validation across local, SSH, and cloud targets.
 | Drain the warm-pool (force cold-start everywhere) | `shipyard targets warm drain --yes` |
 | Force cold-start for one ship only | `shipyard ship --no-warm` (or `shipyard run --no-warm`) |
 | Global warm-pool kill switch | `SHIPYARD_NO_WARM_POOL=1` in the environment |
-| Retarget one lane on an in-flight PR | `shipyard cloud retarget --pr <n> --target macos --provider namespace` (dry-run; add `--apply`) |
-| Add a new lane to an in-flight PR | `shipyard cloud add-lane --pr <n> --target windows [--provider namespace]` (dry-run; add `--apply`) |
+| Retarget one lane on an in-flight PR | `shipyard cloud retarget --pr <n> --target macos --provider github-hosted` (dry-run; add `--apply`) |
+| Add a new lane to an in-flight PR | `shipyard cloud add-lane --pr <n> --target windows [--provider github-hosted]` (dry-run; add `--apply`) |
 | Skip a version-bump gate | `shipyard pr --skip-bump sdk --bump-reason "docs only"` |
 | Skip a skill-sync gate | `shipyard pr --skip-skill-update ci --skill-reason "mechanical"` |
 | Deliberately skip one lane | `shipyard run --skip-target windows` (repeatable; no probe run) |
@@ -70,6 +70,19 @@ Shipyard coordinates validation across local, SSH, and cloud targets.
 | List quarantined targets | `shipyard quarantine list --json` |
 | Quarantine a flaky target | `shipyard quarantine add <target> --reason "..."` |
 | Remove from quarantine | `shipyard quarantine remove <target>` |
+
+## Runner Provider Defaults
+
+Shipyard's own workflows default to GitHub-hosted runners for Linux, macOS, and
+Windows. Namespace is optional and account-dependent; do not assume `nsc` or
+Namespace capacity is available. If a workflow or repo variable still points at
+Namespace during an outage/account-expired period, set
+`DEFAULT_RUNNER_PROVIDER=github-hosted` or pass `-f runner_provider=github-hosted`.
+
+Explicit `*_runner_selector_json` inputs and repo variables can still route
+trusted jobs to self-hosted GitHub Actions runners, such as a local Mac or SSH
+VM fleet. GitHub dispatches by `runs-on` labels; SSH is only the management
+layer for those machines.
 
 ## Live mode (`shipyard daemon`) — when it helps and when to ignore it
 
@@ -163,14 +176,14 @@ a ship.
 
 ## Mid-flight runner retargeting
 
-When a provider change would be valuable *during* an in-flight PR drain — e.g., you notice halfway through shipping 10 PRs that Namespace macOS is faster than GitHub-hosted — use `shipyard cloud retarget`:
+When a provider change would be valuable *during* an in-flight PR drain — e.g., you need to move a lane from an unavailable paid pool back to GitHub-hosted — use `shipyard cloud retarget`:
 
 ```sh
 # Preview first (dry-run by default):
-shipyard cloud retarget --pr 224 --target macos --provider namespace
+shipyard cloud retarget --pr 224 --target macos --provider github-hosted
 
 # Apply when the plan looks right:
-shipyard cloud retarget --pr 224 --target macos --provider namespace --apply
+shipyard cloud retarget --pr 224 --target macos --provider github-hosted --apply
 ```
 
 What it does:
@@ -197,7 +210,7 @@ Sibling to retarget. Use when a ship is already in flight and you realize you wa
 shipyard cloud add-lane --pr 224 --target windows
 
 # Apply when the plan looks right:
-shipyard cloud add-lane --pr 224 --target windows --provider namespace --apply
+shipyard cloud add-lane --pr 224 --target windows --provider github-hosted --apply
 ```
 
 What it does:

--- a/skills/shipyard/SKILL.md
+++ b/skills/shipyard/SKILL.md
@@ -96,6 +96,16 @@ Read `references/platforms.md` when work touches Tailscale, live mode,
 signing, packaging, Namespace/GitHub Actions runners, Windows SSH/PowerShell,
 or cross-platform sandbox E2E behavior.
 
+Namespace is optional and account-dependent. When Namespace is unavailable,
+Shipyard should default to GitHub-hosted Linux/macOS/Windows runners or explicit
+self-hosted GitHub Actions labels. Do not assume `nsc` access, and do not route
+new Shipyard CI to Namespace unless the user explicitly confirms active access.
+
+For local capacity, keep GitHub Actions as the dispatch layer and use SSH only
+to manage the runner hosts. Stable labels such as `shipyard-macos-arm64`,
+`shipyard-linux-arm64`, and `shipyard-windows-x64` are preferable to raw host
+names in workflow `runs-on` selectors.
+
 ## Cloud Retargeting
 
 `shipyard cloud retarget --apply` is intentionally fail-closed. It cancels

--- a/src/app/config_cmd.rs
+++ b/src/app/config_cmd.rs
@@ -87,9 +87,10 @@ fn config_profiles<W: Write>(
         let marker = if row.active { " <- active" } else { "" };
         writeln!(
             stdout,
-            "  {:<10} {}{}",
+            "  {:<10} {}{}{}",
             row.name,
-            row.targets.join(", "),
+            display_list(&row.targets),
+            display_profile_policy(&row),
             marker
         )
         .map_err(|error| CliFailure::new(1, error.to_string()))?;
@@ -151,6 +152,9 @@ struct ProfileRow {
     name: String,
     active: bool,
     targets: Vec<String>,
+    description: Option<String>,
+    focus_platforms: Vec<String>,
+    advisory_platforms: Vec<String>,
 }
 
 fn profile_rows(config: &LoadedConfig) -> Vec<ProfileRow> {
@@ -164,6 +168,9 @@ fn profile_rows(config: &LoadedConfig) -> Vec<ProfileRow> {
             name: name.clone(),
             active: active.as_deref() == Some(name.as_str()),
             targets: profile_targets(body),
+            description: profile_string(body, "description"),
+            focus_platforms: profile_string_array(body, "focus_platforms"),
+            advisory_platforms: profile_string_array(body, "advisory_platforms"),
         })
         .collect()
 }
@@ -177,8 +184,12 @@ fn profile_names(config: &LoadedConfig) -> Vec<String> {
 }
 
 fn profile_targets(value: &TomlValue) -> Vec<String> {
+    profile_string_array(value, "targets")
+}
+
+fn profile_string_array(value: &TomlValue, key: &str) -> Vec<String> {
     value
-        .get("targets")
+        .get(key)
         .and_then(TomlValue::as_array)
         .map(|targets| {
             targets
@@ -188,6 +199,36 @@ fn profile_targets(value: &TomlValue) -> Vec<String> {
                 .collect()
         })
         .unwrap_or_default()
+}
+
+fn profile_string(value: &TomlValue, key: &str) -> Option<String> {
+    value
+        .get(key)
+        .and_then(TomlValue::as_str)
+        .map(ToOwned::to_owned)
+}
+
+fn display_list(items: &[String]) -> String {
+    if items.is_empty() {
+        "-".to_owned()
+    } else {
+        items.join(", ")
+    }
+}
+
+fn display_profile_policy(row: &ProfileRow) -> String {
+    let mut parts = Vec::new();
+    if !row.focus_platforms.is_empty() {
+        parts.push(format!("focus={}", row.focus_platforms.join(",")));
+    }
+    if !row.advisory_platforms.is_empty() {
+        parts.push(format!("advisory={}", row.advisory_platforms.join(",")));
+    }
+    if parts.is_empty() {
+        String::new()
+    } else {
+        format!(" ({})", parts.join("; "))
+    }
 }
 
 fn active_profile(config: &LoadedConfig) -> Option<String> {

--- a/src/lane_policy.rs
+++ b/src/lane_policy.rs
@@ -1,9 +1,10 @@
 //! Advisory-vs-required lane policy resolution.
 //!
 //! Shipyard treats every validation target as merge-blocking by default.
-//! A target can opt into advisory mode through `targets.<name>.advisory`,
-//! and a `Lane-Policy:` commit trailer can override that decision for one
-//! PR without changing tracked config.
+//! A target can opt into advisory mode through `targets.<name>.advisory`
+//! or through the active profile's `focus_platforms` /
+//! `advisory_platforms`. A `Lane-Policy:` commit trailer can override that
+//! decision for one PR without changing tracked config.
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::Path;
@@ -54,6 +55,7 @@ pub fn resolve_lane_policy(config: &LoadedConfig, cwd: &Path) -> LanePolicy {
 pub fn resolve_lane_policy_from_table(data: &Table, commit_message: Option<&str>) -> LanePolicy {
     let known_targets = target_names(data);
     let mut advisory = advisory_targets_from_table(data);
+    advisory.extend(advisory_targets_from_active_profile(data));
     let mut overrides = BTreeSet::new();
     let trailer = parse_lane_policy_trailers(commit_message.unwrap_or_default());
 
@@ -102,6 +104,94 @@ fn advisory_targets_from_table(data: &Table) -> BTreeSet<String> {
                 .collect()
         })
         .unwrap_or_default()
+}
+
+fn advisory_targets_from_active_profile(data: &Table) -> BTreeSet<String> {
+    let Some(profile) = active_profile_table(data) else {
+        return BTreeSet::new();
+    };
+    let focus_platforms = platform_set(profile.get("focus_platforms"));
+    let advisory_platforms = platform_set(profile.get("advisory_platforms"));
+    if focus_platforms.is_empty() && advisory_platforms.is_empty() {
+        return BTreeSet::new();
+    }
+
+    target_platforms(data)
+        .into_iter()
+        .filter_map(|(name, platform)| {
+            let family = normalize_platform_family(&platform)?;
+            if advisory_platforms.contains(&family)
+                || (!focus_platforms.is_empty() && !focus_platforms.contains(&family))
+            {
+                Some(name)
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+fn active_profile_table(data: &Table) -> Option<&Table> {
+    let profile_name = data
+        .get("project")
+        .and_then(Value::as_table)
+        .and_then(|project| project.get("profile"))
+        .and_then(Value::as_str)?;
+    data.get("profiles")
+        .and_then(Value::as_table)
+        .and_then(|profiles| profiles.get(profile_name))
+        .and_then(Value::as_table)
+}
+
+fn target_platforms(data: &Table) -> BTreeMap<String, String> {
+    data.get("targets")
+        .and_then(Value::as_table)
+        .map(|targets| {
+            targets
+                .iter()
+                .filter_map(|(name, value)| {
+                    value
+                        .as_table()
+                        .and_then(|target| target.get("platform"))
+                        .and_then(Value::as_str)
+                        .map(|platform| (name.clone(), platform.to_owned()))
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn platform_set(value: Option<&Value>) -> BTreeSet<String> {
+    value
+        .and_then(Value::as_array)
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(Value::as_str)
+                .filter_map(normalize_platform_family)
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn normalize_platform_family(value: &str) -> Option<String> {
+    let lowered = value.trim().to_ascii_lowercase();
+    if lowered.is_empty() {
+        return None;
+    }
+    if lowered == "mac" || lowered.starts_with("macos") || lowered.starts_with("darwin") {
+        return Some("macos".to_owned());
+    }
+    if lowered == "win" || lowered.starts_with("windows") {
+        return Some("windows".to_owned());
+    }
+    if lowered.starts_with("linux") || lowered == "ubuntu" {
+        return Some("linux".to_owned());
+    }
+    lowered
+        .split_once('-')
+        .map(|(family, _)| family.to_owned())
+        .or(Some(lowered))
 }
 
 fn parse_lane_policy_trailers(message: &str) -> BTreeMap<String, LaneRequirement> {
@@ -185,6 +275,64 @@ mod tests {
         assert!(policy.is_required("linux"));
         assert!(policy.is_advisory("windows"));
         assert!(policy.overrides_from_trailer.is_empty());
+    }
+
+    #[test]
+    fn active_profile_focus_platforms_make_non_focus_targets_advisory() {
+        let config = table(
+            r#"
+            [project]
+            profile = "macos-only"
+
+            [profiles.macos-only]
+            description = "macOS is required; Linux and Windows are advisory."
+            focus_platforms = ["macos"]
+            advisory_platforms = ["linux", "windows"]
+
+            [targets.mac]
+            platform = "macos-arm64"
+
+            [targets.ubuntu]
+            platform = "linux-x64"
+
+            [targets.windows]
+            platform = "windows-x64"
+            "#,
+        );
+
+        let policy = resolve_lane_policy_from_table(&config, None);
+
+        assert!(policy.is_required("mac"));
+        assert!(policy.is_advisory("ubuntu"));
+        assert!(policy.is_advisory("windows"));
+    }
+
+    #[test]
+    fn trailer_can_make_profile_advisory_target_required() {
+        let config = table(
+            r#"
+            [project]
+            profile = "macos-only"
+
+            [profiles.macos-only]
+            focus_platforms = ["macos"]
+
+            [targets.mac]
+            platform = "macos-arm64"
+
+            [targets.windows]
+            platform = "windows-x64"
+            "#,
+        );
+
+        let policy = resolve_lane_policy_from_table(&config, Some("Lane-Policy: windows=required"));
+
+        assert!(policy.is_required("mac"));
+        assert!(policy.is_required("windows"));
+        assert_eq!(
+            policy.overrides_from_trailer,
+            ["windows".to_owned()].into_iter().collect()
+        );
     }
 
     #[test]

--- a/src/pr.rs
+++ b/src/pr.rs
@@ -85,10 +85,11 @@ pub fn find_pr_for_branch(
         .output()
         .map_err(|error| PrError::new(format!("gh pr list failed to start: {error}")))?;
     if !output.status.success() {
-        return Err(PrError::new(format!(
-            "gh pr list failed: {}",
-            stderr_or_stdout(&output)
-        )));
+        let message = stderr_or_stdout(&output);
+        if is_graphql_rate_limited(&message) {
+            return find_pr_for_branch_rest(cwd, gh_command, branch);
+        }
+        return Err(PrError::new(format!("gh pr list failed: {message}")));
     }
     let text = String::from_utf8_lossy(&output.stdout);
     parse_pr_list(&text)
@@ -111,10 +112,11 @@ pub fn create_pr(
         .output()
         .map_err(|error| PrError::new(format!("gh pr create failed to start: {error}")))?;
     if !output.status.success() {
-        return Err(PrError::new(format!(
-            "gh pr create failed: {}",
-            stderr_or_stdout(&output)
-        )));
+        let message = stderr_or_stdout(&output);
+        if is_graphql_rate_limited(&message) {
+            return create_pr_rest(cwd, gh_command, branch, base, title, body);
+        }
+        return Err(PrError::new(format!("gh pr create failed: {message}")));
     }
     let selector = String::from_utf8_lossy(&output.stdout).trim().to_owned();
     if selector.is_empty() {
@@ -135,10 +137,11 @@ pub fn get_pr_status(
         .output()
         .map_err(|error| PrError::new(format!("gh pr view failed to start: {error}")))?;
     if !output.status.success() {
-        return Err(PrError::new(format!(
-            "gh pr view failed: {}",
-            stderr_or_stdout(&output)
-        )));
+        let message = stderr_or_stdout(&output);
+        if is_graphql_rate_limited(&message) {
+            return get_pr_status_rest(cwd, gh_command, selector);
+        }
+        return Err(PrError::new(format!("gh pr view failed: {message}")));
     }
     parse_pr_info(&String::from_utf8_lossy(&output.stdout))
 }
@@ -164,6 +167,186 @@ fn parse_pr_list(text: &str) -> Result<Option<PrInfo>, PrError> {
         return Err(PrError::new("gh pr list JSON was not an array"));
     };
     items.first().map(parse_pr_value).transpose()
+}
+
+fn find_pr_for_branch_rest(
+    cwd: &Path,
+    gh_command: Option<&Path>,
+    branch: &str,
+) -> Result<Option<PrInfo>, PrError> {
+    let repo = repo_slug(cwd)?;
+    let owner = repo
+        .split('/')
+        .next()
+        .filter(|owner| !owner.is_empty())
+        .ok_or_else(|| PrError::new(format!("could not derive owner from repo {repo:?}")))?;
+    let endpoint = format!("repos/{repo}/pulls");
+    let head = format!("{owner}:{branch}");
+    let args = vec![
+        "api".to_owned(),
+        endpoint,
+        "-f".to_owned(),
+        format!("head={head}"),
+        "-f".to_owned(),
+        "state=open".to_owned(),
+        "-F".to_owned(),
+        "per_page=1".to_owned(),
+    ];
+    let output = gh(gh_command)
+        .args(args)
+        .current_dir(cwd)
+        .output()
+        .map_err(|error| PrError::new(format!("gh REST PR lookup failed to start: {error}")))?;
+    if !output.status.success() {
+        return Err(PrError::new(format!(
+            "gh REST PR lookup failed after GraphQL rate limit: {}",
+            stderr_or_stdout(&output)
+        )));
+    }
+    parse_pr_rest_list(&String::from_utf8_lossy(&output.stdout))
+}
+
+fn create_pr_rest(
+    cwd: &Path,
+    gh_command: Option<&Path>,
+    branch: &str,
+    base: &str,
+    title: &str,
+    body: &str,
+) -> Result<PrInfo, PrError> {
+    let repo = repo_slug(cwd)?;
+    let endpoint = format!("repos/{repo}/pulls");
+    let args = vec![
+        "api".to_owned(),
+        "-X".to_owned(),
+        "POST".to_owned(),
+        endpoint,
+        "-f".to_owned(),
+        format!("title={title}"),
+        "-f".to_owned(),
+        format!("head={branch}"),
+        "-f".to_owned(),
+        format!("base={base}"),
+        "-f".to_owned(),
+        format!("body={body}"),
+    ];
+    let output = gh(gh_command)
+        .args(args)
+        .current_dir(cwd)
+        .output()
+        .map_err(|error| PrError::new(format!("gh REST PR create failed to start: {error}")))?;
+    if !output.status.success() {
+        return Err(PrError::new(format!(
+            "gh pr create hit GraphQL rate limit, then REST fallback failed: {}",
+            stderr_or_stdout(&output)
+        )));
+    }
+    parse_pr_rest_info(&String::from_utf8_lossy(&output.stdout))
+}
+
+fn get_pr_status_rest(
+    cwd: &Path,
+    gh_command: Option<&Path>,
+    selector: &str,
+) -> Result<PrInfo, PrError> {
+    let repo = repo_slug(cwd)?;
+    let number = selector_pr_number(selector)
+        .ok_or_else(|| PrError::new(format!("could not parse PR selector {selector:?}")))?;
+    let endpoint = format!("repos/{repo}/pulls/{number}");
+    let output = gh(gh_command)
+        .args(["api", &endpoint])
+        .current_dir(cwd)
+        .output()
+        .map_err(|error| PrError::new(format!("gh REST PR view failed to start: {error}")))?;
+    if !output.status.success() {
+        return Err(PrError::new(format!(
+            "gh REST PR view failed after GraphQL rate limit: {}",
+            stderr_or_stdout(&output)
+        )));
+    }
+    parse_pr_rest_info(&String::from_utf8_lossy(&output.stdout))
+}
+
+fn repo_slug(cwd: &Path) -> Result<String, PrError> {
+    let output = Command::new("git")
+        .args(["config", "--get", "remote.origin.url"])
+        .current_dir(cwd)
+        .output()
+        .map_err(|error| PrError::new(format!("git remote probe failed: {error}")))?;
+    if !output.status.success() {
+        return Err(PrError::new(format!(
+            "git remote probe failed: {}",
+            stderr_or_stdout(&output)
+        )));
+    }
+    let remote = String::from_utf8_lossy(&output.stdout);
+    parse_github_remote_slug(remote.trim()).ok_or_else(|| {
+        PrError::new(format!(
+            "remote.origin.url is not a supported GitHub remote: {}",
+            remote.trim()
+        ))
+    })
+}
+
+fn parse_github_remote_slug(remote: &str) -> Option<String> {
+    let mut slug = remote
+        .strip_prefix("git@github.com:")
+        .or_else(|| remote.strip_prefix("ssh://git@github.com/"))
+        .or_else(|| remote.strip_prefix("https://github.com/"))
+        .or_else(|| remote.strip_prefix("http://github.com/"))?
+        .trim_end_matches(".git")
+        .trim_matches('/')
+        .to_owned();
+    if slug.split('/').count() != 2 {
+        return None;
+    }
+    if slug.starts_with('/') {
+        slug.remove(0);
+    }
+    (!slug.is_empty()).then_some(slug)
+}
+
+fn selector_pr_number(selector: &str) -> Option<u64> {
+    selector
+        .trim()
+        .trim_end_matches('/')
+        .rsplit('/')
+        .next()
+        .and_then(|part| part.parse::<u64>().ok())
+}
+
+fn is_graphql_rate_limited(message: &str) -> bool {
+    let lower = message.to_ascii_lowercase();
+    lower.contains("graphql") && lower.contains("rate limit")
+}
+
+fn parse_pr_rest_list(text: &str) -> Result<Option<PrInfo>, PrError> {
+    let value = serde_json::from_str::<Value>(text)
+        .map_err(|error| PrError::new(format!("failed to parse REST PR list JSON: {error}")))?;
+    let Some(items) = value.as_array() else {
+        return Err(PrError::new("REST PR list JSON was not an array"));
+    };
+    items.first().map(parse_pr_rest_value).transpose()
+}
+
+fn parse_pr_rest_info(text: &str) -> Result<PrInfo, PrError> {
+    let value = serde_json::from_str::<Value>(text)
+        .map_err(|error| PrError::new(format!("failed to parse REST PR JSON: {error}")))?;
+    parse_pr_rest_value(&value)
+}
+
+fn parse_pr_rest_value(value: &Value) -> Result<PrInfo, PrError> {
+    Ok(PrInfo {
+        number: value
+            .get("number")
+            .and_then(Value::as_u64)
+            .ok_or_else(|| PrError::new("REST PR JSON missing number"))?,
+        url: string_field(value, "html_url")?,
+        title: string_field(value, "title")?,
+        state: string_field(value, "state")?.to_ascii_uppercase(),
+        branch: nested_string_field(value, &["head", "ref"])?,
+        base: nested_string_field(value, &["base", "ref"])?,
+    })
 }
 
 fn parse_pr_info(text: &str) -> Result<PrInfo, PrError> {
@@ -194,9 +377,25 @@ fn string_field(value: &Value, field: &str) -> Result<String, PrError> {
         .ok_or_else(|| PrError::new(format!("PR JSON missing {field}")))
 }
 
+fn nested_string_field(value: &Value, path: &[&str]) -> Result<String, PrError> {
+    let mut current = value;
+    for field in path {
+        current = current
+            .get(field)
+            .ok_or_else(|| PrError::new(format!("REST PR JSON missing {}", path.join("."))))?;
+    }
+    current
+        .as_str()
+        .map(str::to_owned)
+        .ok_or_else(|| PrError::new(format!("REST PR JSON missing {}", path.join("."))))
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{PrInfo, parse_pr_info, parse_pr_list};
+    use super::{
+        PrInfo, is_graphql_rate_limited, parse_github_remote_slug, parse_pr_info, parse_pr_list,
+        parse_pr_rest_info, parse_pr_rest_list, selector_pr_number,
+    };
 
     #[test]
     fn parses_pr_view_payload() {
@@ -243,6 +442,81 @@ mod tests {
             .expect("first")
             .number,
             7
+        );
+    }
+
+    #[test]
+    fn detects_graphql_rate_limit_errors() {
+        assert!(is_graphql_rate_limited(
+            "GraphQL: API rate limit already exceeded for user ID 123"
+        ));
+        assert!(!is_graphql_rate_limited("HTTP 500: something else failed"));
+    }
+
+    #[test]
+    fn parses_github_remote_slugs() {
+        assert_eq!(
+            parse_github_remote_slug("git@github.com:danielraffel/Shipyard.git"),
+            Some("danielraffel/Shipyard".to_owned())
+        );
+        assert_eq!(
+            parse_github_remote_slug("https://github.com/danielraffel/pulp"),
+            Some("danielraffel/pulp".to_owned())
+        );
+        assert_eq!(parse_github_remote_slug("https://example.com/nope"), None);
+    }
+
+    #[test]
+    fn parses_pr_numbers_from_urls_or_plain_selectors() {
+        assert_eq!(
+            selector_pr_number("https://github.com/danielraffel/Shipyard/pull/273"),
+            Some(273)
+        );
+        assert_eq!(selector_pr_number("274"), Some(274));
+        assert_eq!(selector_pr_number("not-a-pr"), None);
+    }
+
+    #[test]
+    fn parses_rest_pr_payloads() {
+        let info = parse_pr_rest_info(
+            r#"{
+                "number": 273,
+                "html_url": "https://github.com/danielraffel/Shipyard/pull/273",
+                "title": "REST fallback",
+                "state": "open",
+                "head": {"ref": "feature/rest-fallback"},
+                "base": {"ref": "main"}
+            }"#,
+        )
+        .expect("rest pr");
+
+        assert_eq!(
+            info,
+            PrInfo {
+                number: 273,
+                url: "https://github.com/danielraffel/Shipyard/pull/273".to_owned(),
+                title: "REST fallback".to_owned(),
+                state: "OPEN".to_owned(),
+                branch: "feature/rest-fallback".to_owned(),
+                base: "main".to_owned(),
+            }
+        );
+        assert_eq!(parse_pr_rest_list("[]").expect("empty"), None);
+        assert_eq!(
+            parse_pr_rest_list(
+                r#"[{
+                    "number": 274,
+                    "html_url": "https://github.com/o/r/pull/274",
+                    "title": "Focus profile",
+                    "state": "open",
+                    "head": {"ref": "feature/focus"},
+                    "base": {"ref": "main"}
+                }]"#
+            )
+            .expect("list")
+            .expect("first")
+            .number,
+            274
         );
     }
 }


### PR DESCRIPTION
## Summary

Migrates Shipyard's CI off Namespace for the macOS leg by adding a repo-var fallback to the `EXPLICIT_MACOS_ARM64_RUNNER_SELECTOR_JSON` env in the 4 namespace-defaulted workflows (`ci.yml`, `release.yml`, `sandbox-e2e.yml`, `package-smoke.yml`).

When no `workflow_dispatch` input is provided (i.e. on auto `pull_request` / `push` triggers), the resolver picks up `vars.MACOS_ARM64_LOCAL_SELECTOR_JSON` and routes the macOS leg to the local self-hosted runner (label `local-mac`).

## Repo vars to set after merge (or before — they're safe to set early; the change only takes effect once the YAML lands)

```bash
gh variable set MACOS_ARM64_LOCAL_SELECTOR_JSON --body '["self-hosted","local-mac"]' --repo danielraffel/Shipyard
gh variable set DEFAULT_RUNNER_PROVIDER --body 'github-hosted' --repo danielraffel/Shipyard
```

With `DEFAULT_RUNNER_PROVIDER='github-hosted'`, the resolver routes Linux + Windows to `ubuntu-latest` / `windows-latest` (no Namespace involvement). The macOS leg gets short-circuited by the explicit env fallback above and lands on the local runner.

## Release-page artifacts: unchanged

`release.yml`'s matrix still builds `linux-x64`, `linux-arm64`, `macos-arm64` (health-check only — actual signed macOS release comes from `scripts/release-macos-local.sh`), `windows-x64`. Same artifacts, different hardware.

## Rollback

```bash
gh variable delete MACOS_ARM64_LOCAL_SELECTOR_JSON --repo danielraffel/Shipyard
gh variable set DEFAULT_RUNNER_PROVIDER --body 'namespace' --repo danielraffel/Shipyard
```

## Test plan

- [ ] Set the two repo vars above
- [ ] Open a tiny test PR that triggers ci.yml — confirm macOS job lands on `daniels-macbook-shipyard` runner; Linux + Windows on `ubuntu-latest` / `windows-latest`