### PR TITLE
ci: remove hidden local macOS runner fallback

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "shipyard",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "Cross-platform CI coordination",
   "min_shipyard_version": "0.22.8",
   "commands": "./commands",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,10 +53,7 @@ jobs:
         env:
           REQUESTED_PROVIDER: ${{ inputs.runner_provider || vars.DEFAULT_RUNNER_PROVIDER || 'github-hosted' }}
           EXPLICIT_LINUX_RUNNER_SELECTOR_JSON: ${{ inputs.linux_runner_selector_json || '' }}
-          # Falls back to the MACOS_ARM64_LOCAL_SELECTOR_JSON repo var so the
-          # macOS leg routes to the local self-hosted runner (label `local-mac`)
-          # without a workflow_dispatch input on auto pull_request triggers.
-          EXPLICIT_MACOS_ARM64_RUNNER_SELECTOR_JSON: ${{ inputs.macos_arm64_runner_selector_json || vars.MACOS_ARM64_LOCAL_SELECTOR_JSON || '' }}
+          EXPLICIT_MACOS_ARM64_RUNNER_SELECTOR_JSON: ${{ inputs.macos_arm64_runner_selector_json || '' }}
           EXPLICIT_WINDOWS_RUNNER_SELECTOR_JSON: ${{ inputs.windows_runner_selector_json || '' }}
           NAMESPACE_LINUX_RUNS_ON_JSON: ${{ vars.NAMESPACE_LINUX_RUNS_ON_JSON }}
           NAMESPACE_MACOS_ARM64_RUNS_ON_JSON: ${{ vars.NAMESPACE_MACOS_ARM64_RUNS_ON_JSON }}

--- a/.github/workflows/package-smoke.yml
+++ b/.github/workflows/package-smoke.yml
@@ -47,8 +47,7 @@ jobs:
         env:
           REQUESTED_PROVIDER: ${{ inputs.runner_provider || vars.DEFAULT_RUNNER_PROVIDER || 'github-hosted' }}
           EXPLICIT_LINUX_RUNNER_SELECTOR_JSON: ${{ inputs.linux_runner_selector_json || '' }}
-          # Repo var fallback routes macOS to local self-hosted runner.
-          EXPLICIT_MACOS_ARM64_RUNNER_SELECTOR_JSON: ${{ inputs.macos_arm64_runner_selector_json || vars.MACOS_ARM64_LOCAL_SELECTOR_JSON || '' }}
+          EXPLICIT_MACOS_ARM64_RUNNER_SELECTOR_JSON: ${{ inputs.macos_arm64_runner_selector_json || '' }}
           EXPLICIT_WINDOWS_RUNNER_SELECTOR_JSON: ${{ inputs.windows_runner_selector_json || '' }}
           NAMESPACE_LINUX_RUNS_ON_JSON: ${{ vars.NAMESPACE_LINUX_RUNS_ON_JSON }}
           NAMESPACE_MACOS_ARM64_RUNS_ON_JSON: ${{ vars.NAMESPACE_MACOS_ARM64_RUNS_ON_JSON }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,10 +59,7 @@ jobs:
           REQUESTED_PROVIDER: ${{ inputs.runner_provider || vars.DEFAULT_RUNNER_PROVIDER || 'github-hosted' }}
           EXPLICIT_LINUX_RUNNER_SELECTOR_JSON: ${{ inputs.linux_runner_selector_json || '' }}
           EXPLICIT_LINUX_ARM64_RUNNER_SELECTOR_JSON: ${{ inputs.linux_arm64_runner_selector_json || '' }}
-          # Falls back to the MACOS_ARM64_LOCAL_SELECTOR_JSON repo var so the
-          # macOS leg routes to the local self-hosted runner (label `local-mac`)
-          # without a workflow_dispatch input on auto release events.
-          EXPLICIT_MACOS_ARM64_RUNNER_SELECTOR_JSON: ${{ inputs.macos_arm64_runner_selector_json || vars.MACOS_ARM64_LOCAL_SELECTOR_JSON || '' }}
+          EXPLICIT_MACOS_ARM64_RUNNER_SELECTOR_JSON: ${{ inputs.macos_arm64_runner_selector_json || '' }}
           EXPLICIT_WINDOWS_RUNNER_SELECTOR_JSON: ${{ inputs.windows_runner_selector_json || '' }}
           NAMESPACE_LINUX_RUNS_ON_JSON: ${{ vars.NAMESPACE_LINUX_RUNS_ON_JSON }}
           NAMESPACE_LINUX_ARM64_RUNS_ON_JSON: ${{ vars.NAMESPACE_LINUX_ARM64_RUNS_ON_JSON }}

--- a/.github/workflows/sandbox-e2e.yml
+++ b/.github/workflows/sandbox-e2e.yml
@@ -46,8 +46,7 @@ jobs:
         env:
           REQUESTED_PROVIDER: ${{ inputs.runner_provider || vars.DEFAULT_RUNNER_PROVIDER || 'github-hosted' }}
           EXPLICIT_LINUX_RUNNER_SELECTOR_JSON: ${{ inputs.linux_runner_selector_json || '' }}
-          # Repo var fallback routes macOS to local self-hosted runner.
-          EXPLICIT_MACOS_ARM64_RUNNER_SELECTOR_JSON: ${{ inputs.macos_arm64_runner_selector_json || vars.MACOS_ARM64_LOCAL_SELECTOR_JSON || '' }}
+          EXPLICIT_MACOS_ARM64_RUNNER_SELECTOR_JSON: ${{ inputs.macos_arm64_runner_selector_json || '' }}
           NAMESPACE_LINUX_RUNS_ON_JSON: ${{ vars.NAMESPACE_LINUX_RUNS_ON_JSON }}
           NAMESPACE_MACOS_ARM64_RUNS_ON_JSON: ${{ vars.NAMESPACE_MACOS_ARM64_RUNS_ON_JSON }}
         run: python3 scripts/ci_matrix.py --workflow sandbox-e2e --github-output

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to Shipyard are documented here. Each entry links
 to its [GitHub Release](https://github.com/danielraffel/Shipyard/releases).
 
 <a id="v0512"></a>
+## [0.51.5]
+
 ## [0.51.2] - 2026-05-05
 
 - daemon: surface webhook registration warnings ([#271](https://github.com/danielraffel/Shipyard/pull/271))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -614,7 +614,7 @@ dependencies = [
 
 [[package]]
 name = "shipyard"
-version = "0.51.4"
+version = "0.51.5"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shipyard"
-version = "0.51.4"
+version = "0.51.5"
 edition = "2024"
 description = "Cross-platform CI coordination for local, SSH, and cloud runners."
 rust-version = "1.92"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -163,9 +163,10 @@ The resolution order per target in `ci.yml` / `release.yml` is:
 2. `vars.DEFAULT_RUNNER_PROVIDER` (repo-wide default).
 3. Hardcoded fallback `github-hosted`.
 
-The workflow also supports explicit `*_runner_selector_json` inputs and the
-`MACOS_ARM64_LOCAL_SELECTOR_JSON` repo variable for routing a trusted macOS leg
-to a local self-hosted runner without making Namespace the provider default.
+The workflow also supports explicit `*_runner_selector_json` inputs for trusted
+manual runs. There is intentionally no hidden repo-variable fallback to a local
+macOS runner; if you want a self-hosted runner for one run, pass the selector
+explicitly via `workflow_dispatch`.
 
 ## Default path: automatic on merge
 

--- a/scripts/test_ci_matrix.py
+++ b/scripts/test_ci_matrix.py
@@ -103,6 +103,13 @@ class CiMatrixTests(unittest.TestCase):
         self.assertEqual(json.loads(values["linux_runs_on_json"]), "ubuntu-latest")
         self.assertEqual(values["linux_provider"], "github-hosted")
 
+    def test_workflows_do_not_implicitly_route_macos_to_local_runner(self) -> None:
+        root = Path(__file__).resolve().parents[1]
+        workflow_dir = root / ".github" / "workflows"
+        for path in workflow_dir.glob("*.yml"):
+            text = path.read_text(encoding="utf-8")
+            self.assertNotIn("MACOS_ARM64_LOCAL_SELECTOR_JSON", text, path.name)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/skills/ci/SKILL.md
+++ b/skills/ci/SKILL.md
@@ -79,10 +79,12 @@ Namespace capacity is available. If a workflow or repo variable still points at
 Namespace during an outage/account-expired period, set
 `DEFAULT_RUNNER_PROVIDER=github-hosted` or pass `-f runner_provider=github-hosted`.
 
-Explicit `*_runner_selector_json` inputs and repo variables can still route
+Explicit `*_runner_selector_json` workflow-dispatch inputs can still route
 trusted jobs to self-hosted GitHub Actions runners, such as a local Mac or SSH
-VM fleet. GitHub dispatches by `runs-on` labels; SSH is only the management
-layer for those machines.
+VM fleet. Do not add hidden repo-variable fallbacks that silently override the
+GitHub-hosted default; a trusted self-hosted run should be an explicit per-run
+choice. GitHub dispatches by `runs-on` labels; SSH is only the management layer
+for those machines.
 
 ## Live mode (`shipyard daemon`) — when it helps and when to ignore it
 

--- a/skills/shipyard/SKILL.md
+++ b/skills/shipyard/SKILL.md
@@ -100,6 +100,9 @@ Namespace is optional and account-dependent. When Namespace is unavailable,
 Shipyard should default to GitHub-hosted Linux/macOS/Windows runners or explicit
 self-hosted GitHub Actions labels. Do not assume `nsc` access, and do not route
 new Shipyard CI to Namespace unless the user explicitly confirms active access.
+Do not add hidden repo-variable fallbacks to local/self-hosted macOS runners:
+local runner use should be explicit via workflow-dispatch selector inputs so
+default GitHub-hosted runs cannot be stolen by stale local runner variables.
 
 For local capacity, keep GitHub Actions as the dispatch layer and use SSH only
 to manage the runner hosts. Stable labels such as `shipyard-macos-arm64`,


### PR DESCRIPTION
## Summary

- Remove the hidden `MACOS_ARM64_LOCAL_SELECTOR_JSON` workflow fallback so GitHub-hosted defaults stay GitHub-hosted for CI, package smoke, sandbox E2E, and release signing.
- Keep explicit `*_runner_selector_json` workflow-dispatch inputs for trusted manual self-hosted runs.
- Add a regression test that fails if workflow files reintroduce the hidden macOS local-runner fallback.

## Verification

- `python3 -m unittest discover -s scripts -p 'test_*.py'`
- `python3 scripts/ci_matrix.py --workflow release` resolves macOS to `"macos-15"`.
- `python3 scripts/version_bump_check.py --base origin/main --config scripts/versioning.json --mode=report`
- `python3 scripts/skill_sync_check.py --base origin/main --config scripts/versioning.json --mode=report`