### PR TITLE
feat(runner): self-hosted runner watchdog + kill subcommand with recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to Shipyard are documented here. Each entry links
 to its [GitHub Release](https://github.com/danielraffel/Shipyard/releases).
 
 <a id="v0512"></a>
+## [0.52.0]
+
 ## [0.51.2] - 2026-05-05
 
 - daemon: surface webhook registration warnings ([#271](https://github.com/danielraffel/Shipyard/pull/271))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -614,7 +614,7 @@ dependencies = [
 
 [[package]]
 name = "shipyard"
-version = "0.51.8"
+version = "0.52.0"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shipyard"
-version = "0.51.8"
+version = "0.52.0"
 edition = "2024"
 description = "Cross-platform CI coordination for local, SSH, and cloud runners."
 rust-version = "1.92"

--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ shipyard changelog init    # opt in to post-release CHANGELOG auto-sync
 - **22 ecosystem detectors.** `shipyard init` recognises CMake, Swift,
   Xcode, Rust, Go, Node (pnpm/bun/yarn/npm), Python (uv/poetry/pip),
   Gradle, Maven, .NET, Flutter, Dart, Deno, Ruby, Elixir, PHP.
+- **Self-hosted runner watchdog.** `shipyard runner status` /
+  `cleanup --fix` / `watch --fix` detect and auto-recover the
+  stuck-runner failure mode (orphaned busy state, hung worker, stale
+  queued runs). See [docs/runner-watchdog.md](docs/runner-watchdog.md).
 
 ## Installation
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -51,7 +51,17 @@ shipyard cloud status          # tracked cloud runs
 
 # Branch protection (one-shot)
 shipyard branch apply [--create name] [--base branch] [target_branch]
+
+# Self-hosted runner watchdog
+shipyard runner status                    # one-shot health check (exit 0/1/2)
+shipyard runner cleanup                   # dry-run: list stale queued runs
+shipyard runner cleanup --fix             # cancel stale queued runs
+shipyard runner cleanup --stale-hours 4   # override threshold for this call
+shipyard runner watch                     # poll loop (default 5 min)
+shipyard runner watch --fix               # auto-cancel stale runs each tick
 ```
+
+See `docs/runner-watchdog.md` for the full reference.
 
 ## JSON output
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -59,6 +59,14 @@ shipyard runner cleanup --fix             # cancel stale queued runs
 shipyard runner cleanup --stale-hours 4   # override threshold for this call
 shipyard runner watch                     # poll loop (default 5 min)
 shipyard runner watch --fix               # auto-cancel stale runs each tick
+
+# Explicit Worker termination (snapshot + SIGTERM grace + SIGKILL + quarantine)
+shipyard runner kill --pid 59996 --reason "wedged on agentB/81"
+shipyard runner kill --pid 59996 --reason "..." --retrigger     # re-queue CI
+shipyard runner kill --pid 59996 --reason "..." --yes           # skip prompt
+shipyard runner kill --history                                  # review past kills
+shipyard runner kill --history --last 5
+shipyard runner kill --recover kill-59996-deadbeef              # restore quarantine
 ```
 
 See `docs/runner-watchdog.md` for the full reference.

--- a/docs/runner-watchdog.md
+++ b/docs/runner-watchdog.md
@@ -16,7 +16,7 @@ them, and offer a guarded recovery path.
 | Symptom | Detection | Default action |
 |---|---|---|
 | `orphaned_busy` | API reports `busy=true` but no `Runner.Worker` process is visible locally | Report only (clears in 1-5 min) |
-| `hung_worker` | A `Runner.Worker` has been running longer than `max_job_min` | Report only (auto-kill is intentionally opt-in twice) |
+| `hung_worker` | A `Runner.Worker` has been running longer than `max_job_min` | Report on `status`; terminate with full recovery via `runner kill --pid <pid>` |
 | `stale_queued_runs` | Queued runs older than `max_queue_age_hours` | Report on `status`; cancel on `cleanup --fix` |
 
 ## Subcommands
@@ -50,13 +50,110 @@ shipyard runner cleanup --stale-hours 4 --fix
 shipyard runner cleanup --json --fix                # structured cancel report
 ```
 
-`--force-kill` is reserved for terminating a hung `Runner.Worker`
-process. It requires `--fix` and two confirmation prompts (`y` then the
-literal word `KILL`). On non-TTY stdin it is ignored unless `--yes` is
-also passed. The current implementation **does not** actually terminate
-the process — it prints diagnostic guidance so the operator can decide
-how to kill it. This is deliberate: silent worker-kill can corrupt
-in-flight build artifacts.
+`--force-kill` is the original advisory flag and is retained for
+backwards compatibility. It requires `--fix` and two confirmation
+prompts (`y` then the literal word `KILL`); on non-TTY stdin it is
+ignored unless `--yes` is also passed. The current implementation **does
+not** actually terminate the process — it prints diagnostic guidance and
+points users at `shipyard runner kill` (below), which has a full
+recovery sequence baked in. Direct silent worker-kill from `cleanup`
+would still risk corrupting in-flight build artifacts; the explicit
+subcommand is the safe path.
+
+### `shipyard runner kill`
+
+Explicit `Runner.Worker` termination with a full recovery sequence.
+Unlike `cleanup --force-kill`, this subcommand actually sends signals
+— but every kill is preceded by a snapshot to
+`~/.shipyard/kill-recovery.jsonl`, escalates `SIGTERM` → `SIGKILL` only
+after a 10 s grace period, reaps orphaned `cmake`/`ninja`/`make`/`ctest`
+children, **moves** (does not delete) any matching partial `build*`
+directories from `_work/` to `/tmp/shipyard-killed-builds/<event-id>/`,
+verifies that `Runner.Listener` is still alive, and waits for GitHub to
+recognise that the run has flipped to `completed`. `--retrigger` then
+re-queues the killed PR's CI via
+`POST /actions/runs/<id>/rerun-failed-jobs`.
+
+```bash
+shipyard runner kill --pid 59996 --reason "wedged on agentB/81"
+shipyard runner kill --pid 59996 --reason "..." --retrigger
+shipyard runner kill --pid 59996 --reason "..." --yes       # skip prompt
+shipyard runner kill --history                              # review past kills
+shipyard runner kill --history --last 5
+shipyard runner kill --recover kill-59996-deadbeef          # restore quarantine
+```
+
+Required flags:
+
+- `--pid <pid>` — Worker PID. Sanity-checked against
+  `Runner.Worker` + the configured `runner_dir` before any signal is
+  sent. Refusing to kill an unrelated process is the first guardrail.
+- `--reason "<text>"` — free-text reason. Stored in the recovery log so
+  the audit trail tells future-you why you did this.
+
+Optional flags:
+
+- `--retrigger` — after the GitHub run flips to `completed/failure`,
+  call `rerun-failed-jobs` on the same run id so the killed PR's CI
+  starts immediately. The recovery log records `retriggered: true` (or
+  `retrigger_error` if the API call failed).
+- `--yes` — skip the typed `KILL` confirmation. Intended for scripted
+  use after a human has already invoked the command interactively at
+  least once.
+- `--history [--last N]` — print the recovery log as a human table,
+  most recent first.
+- `--recover <event-id>` — restore the quarantined build for a prior
+  kill event back to `_work/`. Skips destination paths that already
+  exist (so a re-run that produced a fresh build will not be
+  clobbered). If `--retrigger` was not used at kill time, `--recover`
+  will also issue `rerun-failed-jobs` so the recovered build has a CI
+  run to attach to.
+
+Hidden test hooks (`--grace-secs`, `--recovery-log`,
+`--quarantine-root`, `--no-wait-github`) exist so the integration test
+suite can drive the flow against a synthetic process and ephemeral
+filesystem paths.
+
+#### Recovery sequence (the 10-step flow)
+
+1. **Snapshot** — append a JSONL line to `~/.shipyard/kill-recovery.jsonl`
+   capturing pid, reason, PR, job, branch, etime, `_work` dir, GitHub
+   run id, and a per-kill `id` (`kill-<pid>-<unix-nanos-hex>`).
+2. **Confirmation** — require typed `KILL` (not `y`/`yes`) unless
+   `--yes` was passed.
+3. **SIGTERM** — send `kill -TERM <pid>` and poll `ps -p <pid>` every
+   500 ms for up to `--grace-secs` (default 10 s).
+4. **SIGKILL** — only if the worker is still alive after the grace
+   window. The recovery log records `signal: SIGKILL`.
+5. **Reap orphans** — `pkill -P <pid> -f 'cmake|ninja|make|ctest|build'`.
+6. **Quarantine partial builds** — move any `build*` directory under
+   `_work/` whose mtime is within `etime_min + 5` minutes of `now` to
+   `/tmp/shipyard-killed-builds/<event-id>/`. Never deletes.
+7. **Verify Runner.Listener** — `pgrep -f Runner.Listener`. If absent,
+   the summary prints restart guidance (`svc.sh restart` / `run.sh`).
+8. **Wait for GitHub status flip** — poll `GET /actions/runs/<id>`
+   every 2 s for up to 90 s, waiting for `status = completed`.
+9. **Optional retrigger** — `POST /actions/runs/<id>/rerun-failed-jobs`
+   if `--retrigger` is set.
+10. **Summary** — print a multi-line recovery summary that ends with the
+    `--recover` invocation needed to undo this kill.
+
+#### Manual recovery (without `--recover`)
+
+If `--recover` is unavailable for some reason, the quarantine path is
+deterministic:
+
+```bash
+ls /tmp/shipyard-killed-builds/<event-id>/
+# Move directories back manually:
+mv /tmp/shipyard-killed-builds/<event-id>/build* ~/actions-runner/_work/<repo>/<branch>/
+# Re-queue CI:
+gh api -X POST repos/<owner>/<repo>/actions/runs/<run_id>/rerun-failed-jobs
+```
+
+The recovery log entry stores `worker_dir`, `github_run_id`, and
+`quarantine_dir`, so the values are easy to recover via `jq` over the
+JSONL file.
 
 ### `shipyard runner watch`
 
@@ -105,9 +202,12 @@ defaults (`max_job_min=90`, `max_queue_age_hours=2`,
 - `concurrency: cancel-in-progress: true` on a workflow *should*
   auto-cancel duplicate runs on force-push, but doesn't always (see Pulp
   issue #1884).
-- Auto-killing the Worker process is too risky to wire silently;
-  `--force-kill` deliberately stops short of `kill -9` and prints
-  guidance instead.
+- Auto-killing the Worker process is too risky to wire silently from
+  `cleanup --fix`; `--force-kill` deliberately stops short of `kill -9`
+  and points at the explicit `shipyard runner kill` subcommand instead.
+- The kill subcommand never deletes work — partial builds move to
+  `/tmp/shipyard-killed-builds/<event-id>/` so a misclick is recoverable
+  with `--recover`.
 
 ## Implementation notes
 

--- a/docs/runner-watchdog.md
+++ b/docs/runner-watchdog.md
@@ -1,0 +1,122 @@
+# Runner watchdog
+
+`shipyard runner` detects and (optionally) auto-recovers a self-hosted
+GitHub Actions runner that has gotten itself stuck.
+
+## Why
+
+On 2026-05-12 a Pulp self-hosted runner sat busy on a UBSan job from a
+closed branch for >75 minutes while 17 stale queued runs piled up behind
+it. A critical-path PR was blocked for hours before a human noticed. The
+watchdog is the structural fix: detect the symptoms automatically, report
+them, and offer a guarded recovery path.
+
+## Symptoms it catches
+
+| Symptom | Detection | Default action |
+|---|---|---|
+| `orphaned_busy` | API reports `busy=true` but no `Runner.Worker` process is visible locally | Report only (clears in 1-5 min) |
+| `hung_worker` | A `Runner.Worker` has been running longer than `max_job_min` | Report only (auto-kill is intentionally opt-in twice) |
+| `stale_queued_runs` | Queued runs older than `max_queue_age_hours` | Report on `status`; cancel on `cleanup --fix` |
+
+## Subcommands
+
+### `shipyard runner status`
+
+One-shot health check. Exit codes:
+
+- `0` runner healthy, no symptoms
+- `1` runner online but at least one symptom detected
+- `2` runner offline / API unreachable
+
+```bash
+shipyard runner status                              # uses config defaults
+shipyard runner status --runner-id 1763             # explicit override
+shipyard runner status --max-queue-age-hours 4      # widen the queue cutoff
+shipyard runner status --json                       # structured output
+```
+
+### `shipyard runner cleanup`
+
+Lists stale queued runs. Default is `--dry-run`; pass `--fix` to actually
+cancel them via `POST /actions/runs/<id>/cancel`. Exits non-zero when
+stale runs are found in dry-run mode (matches the prototype script's
+contract, so cron consumers see drift).
+
+```bash
+shipyard runner cleanup                             # dry-run, prints stale ids
+shipyard runner cleanup --fix                       # cancel them
+shipyard runner cleanup --stale-hours 4 --fix
+shipyard runner cleanup --json --fix                # structured cancel report
+```
+
+`--force-kill` is reserved for terminating a hung `Runner.Worker`
+process. It requires `--fix` and two confirmation prompts (`y` then the
+literal word `KILL`). On non-TTY stdin it is ignored unless `--yes` is
+also passed. The current implementation **does not** actually terminate
+the process — it prints diagnostic guidance so the operator can decide
+how to kill it. This is deliberate: silent worker-kill can corrupt
+in-flight build artifacts.
+
+### `shipyard runner watch`
+
+Polling daemon. Defaults to the `runner.watchdog.watch_interval_seconds`
+config value (300 s). Logs one line per tick. With `--fix`, cancels stale
+queued runs every tick.
+
+```bash
+shipyard runner watch
+shipyard runner watch --interval 60 --fix
+shipyard runner watch --json   # NDJSON-style structured ticks
+```
+
+The loop never exits on its own; press Ctrl-C or run it under
+`launchd` / `systemd` for unattended operation. A hidden
+`--max-iterations N` flag exists for tests.
+
+## Configuration
+
+Defaults live in `.shipyard/config.toml`:
+
+```toml
+[runner.watchdog]
+runner_id = 1763
+runner_dir = "/Users/runner/actions-runner"
+max_job_min = 90
+max_queue_age_hours = 2
+watch_interval_seconds = 300
+auto_fix = false
+```
+
+Per-machine overrides go in `.shipyard.local/config.toml` and follow the
+standard Shipyard layered-config rules.
+
+Every command-line flag wins over config; config wins over the built-in
+defaults (`max_job_min=90`, `max_queue_age_hours=2`,
+`watch_interval_seconds=300`).
+
+## Lessons learned (from the prototype)
+
+- Stale queued runs from 5+ hours ago can sit forever and monopolize the
+  runner when they eventually get FIFO'd in.
+- A worker PID staying alive 1-5 min after `gh run cancel` is normal —
+  the runner takes time to honour graceful shutdown. Don't treat that as
+  a symptom on its own.
+- `concurrency: cancel-in-progress: true` on a workflow *should*
+  auto-cancel duplicate runs on force-push, but doesn't always (see Pulp
+  issue #1884).
+- Auto-killing the Worker process is too risky to wire silently;
+  `--force-kill` deliberately stops short of `kill -9` and prints
+  guidance instead.
+
+## Implementation notes
+
+- Pure detection logic lives in `src/runner_watchdog.rs` and has no I/O.
+- The CLI shell-out is contained in `src/app/runner_cmd.rs`. It uses the
+  existing `gh` invocation pattern from `src/cloud.rs`; no new HTTP
+  client dependency.
+- `crate::cloud::QueuedRun` and `GitHubActions::{list_queued_runs,
+  cancel_workflow_run}` are reused unchanged from the cloud-handoff
+  subcommand.
+- This subcommand intentionally does not touch any other Shipyard
+  subcommand.

--- a/skills/ci/SKILL.md
+++ b/skills/ci/SKILL.md
@@ -38,6 +38,13 @@ Shipyard coordinates validation across local, SSH, and cloud targets.
 | Show queue and status | `shipyard status --json` |
 | Show all queued jobs | `shipyard queue --json` |
 | Show run logs | `shipyard logs <job_id> --json` |
+| **Runner watchdog: health check** | `shipyard runner status --repo <r> --runner-id <id>` |
+| **Runner watchdog: list stale queued runs (dry-run)** | `shipyard runner cleanup --dry-run` |
+| **Runner watchdog: cancel stale queued runs** | `shipyard runner cleanup --fix` |
+| **Runner watchdog: daemon mode** | `shipyard runner watch --fix` |
+| **Stuck-runner: kill specific worker (with recovery)** | `shipyard runner kill --pid <pid> --reason "..." [--retrigger]` |
+| **Stuck-runner: review past kills** | `shipyard runner kill --history` |
+| **Stuck-runner: restore quarantined build after a misclick** | `shipyard runner kill --recover <event-id>` |
 | Show logs for one target | `shipyard logs <job_id> --target windows` |
 | Check merge readiness | `shipyard evidence --json` |
 | Bump job priority | `shipyard bump <job_id> high` |

--- a/skills/shipyard/SKILL.md
+++ b/skills/shipyard/SKILL.md
@@ -53,6 +53,77 @@ python3 scripts/finish_line_status.py \
   --json
 ```
 
+## Runner Watchdog (self-hosted runner recovery)
+
+Shipyard ships a `runner` subcommand family for detecting and recovering from
+stuck self-hosted GitHub Actions runner state. Built after the 2026-05-12
+incident where a UBSan job from a closed branch wedged Pulp's local runner for
+>75 min while 17 stale queued runs piled up behind it, blocking PR #1859 for
+hours.
+
+### When to reach for it
+
+- Runner reports `busy=true` to GitHub but no Worker process running locally
+- Worker process running >90 min on a job that should take ~20-30 min
+- Queue depth growing while runner appears stalled
+- Stale queued runs from closed/rebased branches monopolizing the runner
+
+### Safe commands (read-only or advisory)
+
+- `shipyard runner status` — one-shot health check, exit 0/1/2, `--json` supported
+- `shipyard runner cleanup --dry-run` — list stale queued runs without cancelling
+- `shipyard runner watch` — advisory daemon mode, polls every 5 min
+
+### Mutating commands (require explicit flags)
+
+- `shipyard runner cleanup --fix` — cancel stale queued runs (1s gap between cancels)
+- `shipyard runner watch --fix` — auto-recovery loop (cron-friendly)
+- `shipyard runner kill --pid X --reason "..."` — kill a specific Worker; requires typed `KILL` confirmation
+
+### `runner kill` recovery sequence
+
+10 steps, all reversible. **Nothing is destroyed.**
+
+1. Snapshot kill event to `~/.shipyard/kill-recovery.jsonl`
+2. Typed `KILL` confirmation (skip with `--yes`)
+3. SIGTERM with 10s grace (configurable via `--grace-secs`)
+4. SIGKILL only if still alive
+5. Reap orphaned children (`cmake|ninja|make|ctest|build`)
+6. **Move** (not delete) partial `build*` dirs to `/tmp/shipyard-killed-builds/<event-id>/`
+7. Verify `Runner.Listener` health via `pgrep`
+8. Poll GitHub for status flip to `completed`/`failure`
+9. Optional `--retrigger` re-queues the killed PR's CI
+10. Print recovery summary with `--recover` invocation hint
+
+A misclick costs ~2 min of cmake re-configure. To recover:
+`shipyard runner kill --recover <event-id>` walks the quarantined `build*` dir
+back to `_work/<repo>/` and re-queues the killed run.
+
+### Gotchas
+
+- The watchdog's `busy=true but no Worker process` check has a brief 1-5 min
+  false-positive window after `cleanup --fix` cancels a run — the runner needs
+  time to gracefully exit. Don't double-cancel.
+- `runner kill --pid` REFUSES non-Runner.Worker PIDs as a safety check. Override
+  via `--runner-dir` only if your install path is non-standard.
+- The `concurrency: cancel-in-progress: true` workflow setting SHOULD auto-cancel
+  on force-push but doesn't always (Pulp issue #1884). The watchdog's stale-queue
+  detection catches the consequences.
+
+### Config
+
+Per-machine overrides in `.shipyard.local/config.toml`:
+
+```toml
+[runner.watchdog]
+runner_id = 1763
+runner_dir = "/Users/me/actions-runner"
+max_job_min = 90
+max_queue_age_hours = 2
+watch_interval_seconds = 300
+auto_fix = false
+```
+
 ## Validation Gates
 
 Prefer non-mutating checks first:

--- a/src/app.rs
+++ b/src/app.rs
@@ -31,6 +31,7 @@ mod queue_cmd;
 mod release_bot_cmd;
 mod run_cmd;
 mod runner_cmd;
+mod runner_kill_cmd;
 mod ship_cmd;
 mod ship_state_cmd;
 mod targets_cmd;

--- a/src/app.rs
+++ b/src/app.rs
@@ -30,6 +30,7 @@ mod quarantine_cmd;
 mod queue_cmd;
 mod release_bot_cmd;
 mod run_cmd;
+mod runner_cmd;
 mod ship_cmd;
 mod ship_state_cmd;
 mod targets_cmd;
@@ -61,6 +62,7 @@ use self::run_cmd::{
     FailFastMode, ReachabilityPolicy, RootMismatchPolicy, RunCommandArgs, TreeDriftPolicy,
     WarmPolicy, run_command,
 };
+use self::runner_cmd::runner_command;
 use self::ship_cmd::{ShipCommandArgs, ship_command};
 use self::ship_state_cmd::{
     ship_state_discard, ship_state_list, ship_state_reconcile, ship_state_show,
@@ -256,6 +258,7 @@ fn handle_operational_variant<W: Write>(
             handle_ship_state_variant(&command, &runtime_paths.state_dir, json, stdout)?;
             Ok(ExitCode::SUCCESS)
         }
+        Command::Runner { command } => handle_runner_command(command, mode, cwd, json, stdout),
         Command::Paths
         | Command::Pin { .. }
         | Command::Config { .. }
@@ -396,6 +399,18 @@ fn handle_wait_command<W: Write>(
     stdout: &mut W,
 ) -> Result<ExitCode, CliFailure> {
     wait_command(command, mode, daemon_socket, cwd, json, stdout)
+}
+
+fn handle_runner_command<W: Write>(
+    command: self::cli::RunnerCommand,
+    mode: RuntimeMode,
+    cwd: &Path,
+    json: bool,
+    stdout: &mut W,
+) -> Result<ExitCode, CliFailure> {
+    let config = crate::config::LoadedConfig::load_from_cwd(mode, cwd)
+        .map_err(|error| CliFailure::new(1, error.to_string()))?;
+    runner_command(command, &config, cwd, json, stdout)
 }
 
 struct AutoMergeInvocation {

--- a/src/app/cli.rs
+++ b/src/app/cli.rs
@@ -376,6 +376,53 @@ pub(super) enum RunnerCommand {
         #[arg(long = "max-iterations", hide = true)]
         max_iterations: Option<u32>,
     },
+    /// Explicitly kill a hung `Runner.Worker` process with full recovery
+    /// sequence: snapshot, SIGTERM with grace, SIGKILL, reap children,
+    /// quarantine partial build, verify Runner.Listener, optional retrigger.
+    Kill {
+        /// Worker PID to kill. Required unless `--history` or `--recover`.
+        #[arg(long = "pid")]
+        pid: Option<u32>,
+        /// Free-text reason for the kill, recorded in the recovery log.
+        /// Required when `--pid` is set.
+        #[arg(long = "reason")]
+        reason: Option<String>,
+        /// After kill, immediately re-queue the killed PR's CI via
+        /// `gh api .../actions/runs/<id>/rerun-failed-jobs`.
+        #[arg(long = "retrigger")]
+        retrigger: bool,
+        /// Skip the typed "KILL" confirmation prompt. Scripted use only.
+        #[arg(long = "yes")]
+        yes: bool,
+        /// Owner/repo slug. Defaults to the current git repo.
+        #[arg(long)]
+        repo: Option<String>,
+        /// Local actions-runner directory. Defaults to
+        /// `runner.watchdog.runner_dir` or `$HOME/actions-runner`.
+        #[arg(long = "runner-dir")]
+        runner_dir: Option<PathBuf>,
+        /// Print recent kill events from the recovery log and exit.
+        #[arg(long = "history", conflicts_with_all = ["pid", "recover"])]
+        history: bool,
+        /// Limit history output to the most recent N entries.
+        #[arg(long = "last")]
+        last: Option<usize>,
+        /// Recover a previously-quarantined build by kill-event ID.
+        #[arg(long = "recover", conflicts_with_all = ["pid", "history"])]
+        recover: Option<String>,
+        /// Override the SIGTERM-to-SIGKILL grace window in seconds. Test hook.
+        #[arg(long = "grace-secs", hide = true)]
+        grace_secs: Option<u64>,
+        /// Override the recovery log path. Test hook.
+        #[arg(long = "recovery-log", hide = true)]
+        recovery_log: Option<PathBuf>,
+        /// Override the quarantine root directory. Test hook.
+        #[arg(long = "quarantine-root", hide = true)]
+        quarantine_root: Option<PathBuf>,
+        /// Skip the post-kill GitHub status-flip poll. Test hook.
+        #[arg(long = "no-wait-github", hide = true)]
+        no_wait_github: bool,
+    },
 }
 
 #[derive(Clone, Copy, Debug, Subcommand)]

--- a/src/app/cli.rs
+++ b/src/app/cli.rs
@@ -301,6 +301,81 @@ pub(super) enum Command {
         #[command(subcommand)]
         command: ShipStateCommand,
     },
+    /// Self-hosted runner watchdog: detect and recover stuck runner state.
+    Runner {
+        /// Runner subcommand.
+        #[command(subcommand)]
+        command: RunnerCommand,
+    },
+}
+
+#[derive(Debug, Subcommand)]
+pub(super) enum RunnerCommand {
+    /// One-shot health check. Exit 0 healthy, 1 stuck, 2 offline.
+    Status {
+        /// Self-hosted runner ID, e.g. 1763. Defaults to `runner.watchdog.runner_id`.
+        #[arg(long = "runner-id")]
+        runner_id: Option<u64>,
+        /// Owner/repo slug. Defaults to the current git repo.
+        #[arg(long)]
+        repo: Option<String>,
+        /// Local actions-runner directory. Defaults to `runner.watchdog.runner_dir`
+        /// or `$HOME/actions-runner`.
+        #[arg(long = "runner-dir")]
+        runner_dir: Option<PathBuf>,
+        /// Warn when a Worker has been running longer than this many minutes.
+        #[arg(long = "max-job-min")]
+        max_job_min: Option<i64>,
+        /// Flag queued runs older than this many hours.
+        #[arg(long = "max-queue-age-hours")]
+        max_queue_age_hours: Option<i64>,
+    },
+    /// Show or cancel stale queued runs older than the threshold.
+    Cleanup {
+        /// Show what would be cancelled without making changes.
+        #[arg(long = "dry-run", action = ArgAction::SetTrue, default_value_t = true)]
+        dry_run: bool,
+        /// Cancel stale queued runs (overrides --dry-run).
+        #[arg(long = "fix")]
+        fix: bool,
+        /// Stale-queue cutoff in hours.
+        #[arg(long = "stale-hours")]
+        stale_hours: Option<i64>,
+        /// Owner/repo slug. Defaults to the current git repo.
+        #[arg(long)]
+        repo: Option<String>,
+        /// Forcibly kill the oldest hung Worker process. Requires --fix and
+        /// two confirmation prompts; never honoured when stdin is not a TTY
+        /// unless --yes is also passed.
+        #[arg(long = "force-kill")]
+        force_kill: bool,
+        /// Bypass the two interactive confirmations for --force-kill. Intended
+        /// for tests; in production this still requires --force-kill.
+        #[arg(long = "yes", hide = true)]
+        yes: bool,
+    },
+    /// Watch loop. Polls every `watch_interval_seconds` until interrupted.
+    Watch {
+        /// Self-hosted runner ID. Defaults to `runner.watchdog.runner_id`.
+        #[arg(long = "runner-id")]
+        runner_id: Option<u64>,
+        /// Owner/repo slug. Defaults to the current git repo.
+        #[arg(long)]
+        repo: Option<String>,
+        /// Local actions-runner directory.
+        #[arg(long = "runner-dir")]
+        runner_dir: Option<PathBuf>,
+        /// Polling cadence in seconds.
+        #[arg(long)]
+        interval: Option<u64>,
+        /// Auto-cancel stale queued runs (still does NOT kill workers).
+        #[arg(long = "fix")]
+        fix: bool,
+        /// Maximum number of iterations to run before exiting. Defaults to
+        /// looping forever. Test hook.
+        #[arg(long = "max-iterations", hide = true)]
+        max_iterations: Option<u32>,
+    },
 }
 
 #[derive(Clone, Copy, Debug, Subcommand)]

--- a/src/app/runner_cmd.rs
+++ b/src/app/runner_cmd.rs
@@ -1,0 +1,896 @@
+//! `shipyard runner` subcommand — health check, stale-queue cleanup, watch
+//! daemon for the self-hosted GitHub Actions runner.
+//!
+//! Ports the Pulp planning watchdog prototype
+//! (`pulp-planning/scripts/runner-watchdog.sh`, commit c719482) into a
+//! first-class Shipyard subcommand. The pure detection logic lives in
+//! `crate::runner_watchdog`; this module is the thin shell that talks to
+//! `gh` and the local `ps` table.
+
+use std::collections::BTreeMap;
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+use std::process::{Command, ExitCode};
+use std::thread::sleep;
+use std::time::Duration;
+
+use chrono::Utc;
+use serde_json::Value;
+
+use super::CliFailure;
+use super::cli::RunnerCommand;
+use crate::cloud::{GitHubActions, QueuedRun};
+use crate::config::LoadedConfig;
+use crate::output::write_json_envelope;
+use crate::runner_watchdog::{
+    DEFAULT_MAX_JOB_MIN, DEFAULT_MAX_QUEUE_AGE_HOURS, DEFAULT_WATCH_INTERVAL_SECONDS, RunnerHealth,
+    RunnerReport, RunnerSnapshot, StaleQueuedRun, Symptom, WatchdogThresholds, assess_runner,
+    compute_stale_queued_runs, report_to_json,
+};
+
+const QUEUED_RUNS_LIMIT: u32 = 100;
+
+/// Entry point dispatched from `src/app.rs`.
+pub(super) fn runner_command<W: Write>(
+    command: RunnerCommand,
+    config: &LoadedConfig,
+    cwd: &Path,
+    json: bool,
+    stdout: &mut W,
+) -> Result<ExitCode, CliFailure> {
+    let actions = GitHubActions::new(cwd);
+    match command {
+        RunnerCommand::Status {
+            runner_id,
+            repo,
+            runner_dir,
+            max_job_min,
+            max_queue_age_hours,
+        } => status_command(
+            config,
+            cwd,
+            &actions,
+            runner_id,
+            repo,
+            runner_dir,
+            max_job_min,
+            max_queue_age_hours,
+            json,
+            stdout,
+        ),
+        RunnerCommand::Cleanup {
+            dry_run,
+            fix,
+            stale_hours,
+            repo,
+            force_kill,
+            yes,
+        } => cleanup_command(
+            config,
+            cwd,
+            &actions,
+            dry_run,
+            fix,
+            stale_hours,
+            repo,
+            force_kill,
+            yes,
+            json,
+            stdout,
+        ),
+        RunnerCommand::Watch {
+            runner_id,
+            repo,
+            runner_dir,
+            interval,
+            fix,
+            max_iterations,
+        } => watch_command(
+            config,
+            cwd,
+            &actions,
+            runner_id,
+            repo,
+            runner_dir,
+            interval,
+            fix,
+            max_iterations,
+            json,
+            stdout,
+        ),
+    }
+}
+
+// ---------- status ----------
+
+#[allow(clippy::too_many_arguments)]
+fn status_command<W: Write>(
+    config: &LoadedConfig,
+    cwd: &Path,
+    actions: &GitHubActions,
+    runner_id_override: Option<u64>,
+    repo_override: Option<String>,
+    runner_dir_override: Option<PathBuf>,
+    max_job_min_override: Option<i64>,
+    max_queue_age_hours_override: Option<i64>,
+    json: bool,
+    stdout: &mut W,
+) -> Result<ExitCode, CliFailure> {
+    let settings = resolve_watchdog_settings(
+        config,
+        cwd,
+        runner_id_override,
+        repo_override,
+        runner_dir_override,
+        max_job_min_override,
+        max_queue_age_hours_override,
+        None,
+    )?;
+    let snapshot = fetch_runner_snapshot(actions, &settings)?;
+    let queued_runs = fetch_queued_runs(actions, &settings.repo_slug)?;
+    let report = assess_runner(&snapshot, &queued_runs, settings.thresholds, Utc::now());
+
+    emit_status_report(stdout, &report, json)?;
+    Ok(ExitCode::from(report.health.exit_code()))
+}
+
+fn emit_status_report<W: Write>(
+    stdout: &mut W,
+    report: &RunnerReport,
+    json: bool,
+) -> Result<(), CliFailure> {
+    if json {
+        let data = report_to_json(report);
+        return write_json_envelope(stdout, "runner.status", data)
+            .map_err(|error| CliFailure::new(1, error.to_string()));
+    }
+
+    let writes = (|| -> std::io::Result<()> {
+        writeln!(
+            stdout,
+            "runner: {} (busy={}, workers={})",
+            report.status, report.busy, report.worker_count
+        )?;
+        match report.health {
+            RunnerHealth::Healthy => {
+                writeln!(stdout, "OK: no symptoms detected")?;
+            }
+            RunnerHealth::Offline => {
+                writeln!(
+                    stdout,
+                    "ERR: runner is not online; investigate before trusting CI."
+                )?;
+            }
+            RunnerHealth::Stuck => {
+                writeln!(stdout, "WARN: stuck-state symptoms detected:")?;
+                for symptom in &report.symptoms {
+                    writeln!(stdout, "  - {}", format_symptom_human(symptom))?;
+                }
+                if !report.stale_queued_runs.is_empty() {
+                    writeln!(stdout, "stale queued runs:")?;
+                    for run in &report.stale_queued_runs {
+                        writeln!(
+                            stdout,
+                            "  - run {} ({}, branch={}) queued for {}s",
+                            run.run_id, run.workflow, run.branch, run.queued_for_secs,
+                        )?;
+                    }
+                    writeln!(stdout, "fix with: shipyard runner cleanup --fix")?;
+                }
+            }
+        }
+        Ok(())
+    })();
+    writes.map_err(|error| CliFailure::new(1, error.to_string()))
+}
+
+fn format_symptom_human(symptom: &Symptom) -> String {
+    match symptom {
+        Symptom::OrphanedBusy => {
+            "orphaned_busy: runner.busy=true but no Runner.Worker process visible (usually clears in 1-5 min)".to_owned()
+        }
+        Symptom::HungWorker {
+            worker_age_min,
+            threshold_min,
+        } => format!(
+            "hung_worker: Runner.Worker has been running {worker_age_min} min (> {threshold_min} min threshold)"
+        ),
+        Symptom::StaleQueuedRuns { count } => {
+            format!("stale_queued_runs: {count} run(s) older than the queue-age cutoff")
+        }
+    }
+}
+
+// ---------- cleanup ----------
+
+#[allow(clippy::too_many_arguments, clippy::fn_params_excessive_bools)]
+fn cleanup_command<W: Write>(
+    config: &LoadedConfig,
+    cwd: &Path,
+    actions: &GitHubActions,
+    dry_run: bool,
+    fix: bool,
+    stale_hours_override: Option<i64>,
+    repo_override: Option<String>,
+    force_kill: bool,
+    yes: bool,
+    json: bool,
+    stdout: &mut W,
+) -> Result<ExitCode, CliFailure> {
+    let settings = resolve_watchdog_settings(
+        config,
+        cwd,
+        None,
+        repo_override,
+        None,
+        None,
+        stale_hours_override,
+        None,
+    )?;
+    let now = Utc::now();
+    let queued_runs = fetch_queued_runs(actions, &settings.repo_slug)?;
+    let stale = compute_stale_queued_runs(
+        &queued_runs,
+        settings.thresholds.max_queue_age_hours * 3_600,
+        now,
+    );
+
+    // `--fix` takes precedence over the default-true `--dry-run`.
+    let apply = fix && !dry_run_overridden_only(dry_run, fix);
+    let mut cancelled = Vec::new();
+    let mut failed = Vec::new();
+    if apply {
+        for run in &stale {
+            match actions.cancel_workflow_run(&settings.repo_slug, run.run_id) {
+                Ok(()) => cancelled.push(run.run_id),
+                Err(err) => failed.push((run.run_id, err.to_string())),
+            }
+        }
+    }
+
+    if force_kill {
+        if !apply {
+            return Err(CliFailure::new(
+                1,
+                "--force-kill requires --fix to acknowledge intent",
+            ));
+        }
+        let confirmed = confirm_force_kill(yes, stdout)?;
+        if confirmed {
+            // We intentionally do not implement Worker-process termination
+            // here. The prototype's lessons-learned section explicitly warned
+            // that auto-kill is too risky to wire silently. The CLI prints a
+            // diagnostic hint and exits without touching the local process
+            // table.
+            writeln!(
+                stdout,
+                "force-kill confirmed: refusing to terminate Runner.Worker automatically; \
+                 inspect with `ps -ef | grep Runner.Worker` and kill manually if it is \
+                 truly hung.",
+            )
+            .map_err(|error| CliFailure::new(1, error.to_string()))?;
+        }
+    }
+
+    emit_cleanup_report(stdout, &settings, &stale, &cancelled, &failed, apply, json)?;
+    if !failed.is_empty() {
+        return Ok(ExitCode::from(1));
+    }
+    if stale.is_empty() || apply {
+        Ok(ExitCode::SUCCESS)
+    } else {
+        // Found stale runs but did not fix; communicate via exit 1 just like
+        // the prototype script.
+        Ok(ExitCode::from(1))
+    }
+}
+
+// `--dry-run` defaults to true in clap; `--fix` is the explicit opt-in. The
+// two flags are not declared as a conflict pair (so `shipyard runner cleanup
+// --fix` works without needing to also pass `--no-dry-run`), so we only honour
+// dry-run when --fix is not present.
+fn dry_run_overridden_only(_dry_run: bool, fix: bool) -> bool {
+    !fix
+}
+
+fn confirm_force_kill<W: Write>(yes: bool, stdout: &mut W) -> Result<bool, CliFailure> {
+    if yes {
+        return Ok(true);
+    }
+    if !is_stdin_tty() {
+        writeln!(
+            stdout,
+            "--force-kill ignored: stdin is not a TTY and --yes was not passed",
+        )
+        .map_err(|error| CliFailure::new(1, error.to_string()))?;
+        return Ok(false);
+    }
+    let first = prompt_line(
+        stdout,
+        "Force-kill the oldest Runner.Worker process? This may corrupt in-flight artifacts. [y/N] ",
+    )?;
+    if !first.eq_ignore_ascii_case("y") && !first.eq_ignore_ascii_case("yes") {
+        return Ok(false);
+    }
+    let second = prompt_line(stdout, "Are you sure? Type the word KILL to confirm: ")?;
+    Ok(second == "KILL")
+}
+
+fn prompt_line<W: Write>(stdout: &mut W, prompt: &str) -> Result<String, CliFailure> {
+    write!(stdout, "{prompt}").map_err(|error| CliFailure::new(1, error.to_string()))?;
+    stdout
+        .flush()
+        .map_err(|error| CliFailure::new(1, error.to_string()))?;
+    let mut buf = String::new();
+    std::io::stdin()
+        .read_line(&mut buf)
+        .map_err(|error| CliFailure::new(1, error.to_string()))?;
+    Ok(buf.trim().to_owned())
+}
+
+fn is_stdin_tty() -> bool {
+    // Best-effort TTY check without pulling in another crate. `read` on
+    // closed stdin would block; we instead look at whether /dev/tty exists
+    // and is readable from the controlling process. This is conservative —
+    // when in doubt, treat stdin as non-TTY.
+    let mut probe = [0u8; 0];
+    std::fs::File::open("/dev/tty").is_ok_and(|mut f| f.read(&mut probe).is_ok())
+}
+
+fn emit_cleanup_report<W: Write>(
+    stdout: &mut W,
+    settings: &WatchdogSettings,
+    stale: &[StaleQueuedRun],
+    cancelled: &[u64],
+    failed: &[(u64, String)],
+    apply: bool,
+    json: bool,
+) -> Result<(), CliFailure> {
+    if json {
+        let mut data = BTreeMap::new();
+        data.insert("repo".to_owned(), Value::from(settings.repo_slug.clone()));
+        data.insert(
+            "stale_hours".to_owned(),
+            Value::from(settings.thresholds.max_queue_age_hours),
+        );
+        data.insert("apply".to_owned(), Value::Bool(apply));
+        data.insert(
+            "stale_queued_runs".to_owned(),
+            serde_json::to_value(stale).expect("stale serialization"),
+        );
+        data.insert(
+            "cancelled_run_ids".to_owned(),
+            serde_json::to_value(cancelled).expect("cancelled serialization"),
+        );
+        data.insert(
+            "failed".to_owned(),
+            Value::Array(
+                failed
+                    .iter()
+                    .map(|(id, msg)| {
+                        Value::Object(
+                            [
+                                ("run_id".to_owned(), Value::from(*id)),
+                                ("error".to_owned(), Value::from(msg.clone())),
+                            ]
+                            .into_iter()
+                            .collect(),
+                        )
+                    })
+                    .collect(),
+            ),
+        );
+        return write_json_envelope(stdout, "runner.cleanup", data)
+            .map_err(|error| CliFailure::new(1, error.to_string()));
+    }
+
+    let result: std::io::Result<()> = (|| {
+        if stale.is_empty() {
+            writeln!(
+                stdout,
+                "No queued runs older than {}h on {}.",
+                settings.thresholds.max_queue_age_hours, settings.repo_slug
+            )?;
+            return Ok(());
+        }
+        writeln!(
+            stdout,
+            "Found {} stale queued run(s) on {} (>= {}h old):",
+            stale.len(),
+            settings.repo_slug,
+            settings.thresholds.max_queue_age_hours,
+        )?;
+        for run in stale {
+            writeln!(
+                stdout,
+                "  - run {} ({}, branch={}) queued for {}s",
+                run.run_id, run.workflow, run.branch, run.queued_for_secs,
+            )?;
+        }
+        if apply {
+            if cancelled.is_empty() && failed.is_empty() {
+                writeln!(stdout, "No runs cancelled.")?;
+            } else {
+                writeln!(stdout, "Cancelled run ids: {cancelled:?}")?;
+            }
+            if !failed.is_empty() {
+                writeln!(stdout, "Cancel failures:")?;
+                for (id, msg) in failed {
+                    writeln!(stdout, "  - run {id}: {msg}")?;
+                }
+            }
+        } else {
+            writeln!(stdout, "Re-run with --fix to cancel these.")?;
+        }
+        Ok(())
+    })();
+    result.map_err(|error| CliFailure::new(1, error.to_string()))
+}
+
+// ---------- watch ----------
+
+#[allow(clippy::too_many_arguments)]
+fn watch_command<W: Write>(
+    config: &LoadedConfig,
+    cwd: &Path,
+    actions: &GitHubActions,
+    runner_id_override: Option<u64>,
+    repo_override: Option<String>,
+    runner_dir_override: Option<PathBuf>,
+    interval_override: Option<u64>,
+    fix: bool,
+    max_iterations: Option<u32>,
+    json: bool,
+    stdout: &mut W,
+) -> Result<ExitCode, CliFailure> {
+    let settings = resolve_watchdog_settings(
+        config,
+        cwd,
+        runner_id_override,
+        repo_override,
+        runner_dir_override,
+        None,
+        None,
+        interval_override,
+    )?;
+    let interval = Duration::from_secs(settings.thresholds.watch_interval_seconds.max(1));
+    if max_iterations == Some(0) {
+        return Ok(ExitCode::SUCCESS);
+    }
+    let mut iterations = 0u32;
+    let last_health = loop {
+        let snapshot_result = fetch_runner_snapshot(actions, &settings);
+        let queued_runs_result = fetch_queued_runs(actions, &settings.repo_slug);
+
+        let health = match (snapshot_result, queued_runs_result) {
+            (Ok(snapshot), Ok(queued_runs)) => {
+                let report =
+                    assess_runner(&snapshot, &queued_runs, settings.thresholds, Utc::now());
+                emit_watch_tick(stdout, &settings, &report, json)?;
+                if fix && report.health == RunnerHealth::Stuck {
+                    cancel_stale_inline(actions, &settings, &report, stdout, json)?;
+                }
+                report.health
+            }
+            (Err(err), _) | (_, Err(err)) => {
+                emit_watch_error(stdout, &settings, &err, json)?;
+                RunnerHealth::Offline
+            }
+        };
+
+        iterations = iterations.saturating_add(1);
+        if let Some(limit) = max_iterations
+            && iterations >= limit
+        {
+            break health;
+        }
+        sleep(interval);
+    };
+    Ok(ExitCode::from(last_health.exit_code()))
+}
+
+fn emit_watch_tick<W: Write>(
+    stdout: &mut W,
+    settings: &WatchdogSettings,
+    report: &RunnerReport,
+    json: bool,
+) -> Result<(), CliFailure> {
+    if json {
+        let mut data = report_to_json(report);
+        data.insert("event".to_owned(), Value::from("tick"));
+        data.insert("repo".to_owned(), Value::from(settings.repo_slug.clone()));
+        return write_json_envelope(stdout, "runner.watch", data)
+            .map_err(|error| CliFailure::new(1, error.to_string()));
+    }
+    let ts = Utc::now().format("%H:%M:%S");
+    let line = match report.health {
+        RunnerHealth::Healthy => format!(
+            "[{ts}] OK: runner healthy (busy={}, workers={}, stale=0)",
+            report.busy, report.worker_count,
+        ),
+        RunnerHealth::Stuck => format!(
+            "[{ts}] WARN: stuck runner — {} symptom(s); {} stale queued",
+            report.symptoms.len(),
+            report.stale_queued_runs.len(),
+        ),
+        RunnerHealth::Offline => format!("[{ts}] ERR: runner status={}", report.status),
+    };
+    writeln!(stdout, "{line}").map_err(|error| CliFailure::new(1, error.to_string()))
+}
+
+fn emit_watch_error<W: Write>(
+    stdout: &mut W,
+    settings: &WatchdogSettings,
+    err: &CliFailure,
+    json: bool,
+) -> Result<(), CliFailure> {
+    if json {
+        let mut data = BTreeMap::new();
+        data.insert("event".to_owned(), Value::from("error"));
+        data.insert("repo".to_owned(), Value::from(settings.repo_slug.clone()));
+        data.insert("error".to_owned(), Value::from(err.message.clone()));
+        return write_json_envelope(stdout, "runner.watch", data)
+            .map_err(|error| CliFailure::new(1, error.to_string()));
+    }
+    let ts = Utc::now().format("%H:%M:%S");
+    writeln!(stdout, "[{ts}] ERR: {}", err.message)
+        .map_err(|error| CliFailure::new(1, error.to_string()))
+}
+
+fn cancel_stale_inline<W: Write>(
+    actions: &GitHubActions,
+    settings: &WatchdogSettings,
+    report: &RunnerReport,
+    stdout: &mut W,
+    json: bool,
+) -> Result<(), CliFailure> {
+    let mut cancelled = Vec::new();
+    let mut failed = Vec::new();
+    for run in &report.stale_queued_runs {
+        match actions.cancel_workflow_run(&settings.repo_slug, run.run_id) {
+            Ok(()) => cancelled.push(run.run_id),
+            Err(err) => failed.push((run.run_id, err.to_string())),
+        }
+    }
+    if json {
+        let mut data = BTreeMap::new();
+        data.insert("event".to_owned(), Value::from("auto_fix"));
+        data.insert("repo".to_owned(), Value::from(settings.repo_slug.clone()));
+        data.insert(
+            "cancelled_run_ids".to_owned(),
+            serde_json::to_value(&cancelled).expect("cancelled serialization"),
+        );
+        data.insert(
+            "failed".to_owned(),
+            serde_json::to_value(
+                failed
+                    .iter()
+                    .map(|(id, msg)| {
+                        BTreeMap::from([
+                            ("run_id".to_owned(), Value::from(*id)),
+                            ("error".to_owned(), Value::from(msg.clone())),
+                        ])
+                    })
+                    .collect::<Vec<_>>(),
+            )
+            .expect("failed serialization"),
+        );
+        return write_json_envelope(stdout, "runner.watch", data)
+            .map_err(|error| CliFailure::new(1, error.to_string()));
+    }
+    if !cancelled.is_empty() {
+        writeln!(stdout, "  auto-fix: cancelled {cancelled:?}")
+            .map_err(|error| CliFailure::new(1, error.to_string()))?;
+    }
+    if !failed.is_empty() {
+        for (id, msg) in failed {
+            writeln!(stdout, "  auto-fix FAILED for run {id}: {msg}")
+                .map_err(|error| CliFailure::new(1, error.to_string()))?;
+        }
+    }
+    Ok(())
+}
+
+// ---------- settings / config wiring ----------
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct WatchdogSettings {
+    repo_slug: String,
+    runner_id: Option<u64>,
+    runner_dir: PathBuf,
+    thresholds: WatchdogThresholds,
+}
+
+#[allow(clippy::too_many_arguments)]
+fn resolve_watchdog_settings(
+    config: &LoadedConfig,
+    cwd: &Path,
+    runner_id_override: Option<u64>,
+    repo_override: Option<String>,
+    runner_dir_override: Option<PathBuf>,
+    max_job_min_override: Option<i64>,
+    max_queue_age_hours_override: Option<i64>,
+    interval_override: Option<u64>,
+) -> Result<WatchdogSettings, CliFailure> {
+    let repo_slug = resolve_repo_slug(repo_override, cwd)?;
+    let runner_id = runner_id_override.or_else(|| {
+        config
+            .get("runner.watchdog.runner_id")
+            .and_then(toml::Value::as_integer)
+            .and_then(|value| u64::try_from(value).ok())
+    });
+    let runner_dir = runner_dir_override
+        .or_else(|| {
+            config
+                .get_str("runner.watchdog.runner_dir")
+                .map(PathBuf::from)
+        })
+        .unwrap_or_else(default_runner_dir);
+
+    let max_job_min = max_job_min_override
+        .or_else(|| {
+            config
+                .get("runner.watchdog.max_job_min")
+                .and_then(toml::Value::as_integer)
+        })
+        .unwrap_or(DEFAULT_MAX_JOB_MIN);
+    let max_queue_age_hours = max_queue_age_hours_override
+        .or_else(|| {
+            config
+                .get("runner.watchdog.max_queue_age_hours")
+                .and_then(toml::Value::as_integer)
+        })
+        .unwrap_or(DEFAULT_MAX_QUEUE_AGE_HOURS);
+    let watch_interval_seconds = interval_override
+        .or_else(|| {
+            config
+                .get("runner.watchdog.watch_interval_seconds")
+                .and_then(toml::Value::as_integer)
+                .and_then(|value| u64::try_from(value).ok())
+        })
+        .unwrap_or(DEFAULT_WATCH_INTERVAL_SECONDS);
+    let auto_fix = config
+        .get("runner.watchdog.auto_fix")
+        .and_then(toml::Value::as_bool)
+        .unwrap_or(false);
+
+    Ok(WatchdogSettings {
+        repo_slug,
+        runner_id,
+        runner_dir,
+        thresholds: WatchdogThresholds {
+            max_job_min,
+            max_queue_age_hours,
+            watch_interval_seconds,
+            auto_fix,
+        },
+    })
+}
+
+fn default_runner_dir() -> PathBuf {
+    if let Ok(home) = std::env::var("HOME") {
+        PathBuf::from(home).join("actions-runner")
+    } else {
+        PathBuf::from("actions-runner")
+    }
+}
+
+fn resolve_repo_slug(repo: Option<String>, cwd: &Path) -> Result<String, CliFailure> {
+    if let Some(repo) = repo.filter(|value| !value.trim().is_empty()) {
+        return Ok(repo);
+    }
+    let output = Command::new("git")
+        .args(["remote", "get-url", "origin"])
+        .current_dir(cwd)
+        .output()
+        .map_err(|error| CliFailure::new(1, format!("failed to inspect git remote: {error}")))?;
+    if output.status.success() {
+        let remote = String::from_utf8_lossy(&output.stdout);
+        if let Some(slug) = parse_github_repo_slug(remote.trim()) {
+            return Ok(slug);
+        }
+    }
+    Err(CliFailure::new(
+        1,
+        "No repo detected. Pass --repo OWNER/REPO or run inside a git clone with a tracked remote.",
+    ))
+}
+
+fn parse_github_repo_slug(remote: &str) -> Option<String> {
+    // Mirrors crate::app::wait_cmd::parse_github_repo_slug but kept local so
+    // this module has no cross-module visibility creep.
+    let trimmed = remote.trim().trim_end_matches('/').trim_end_matches(".git");
+    if let Some(rest) = trimmed.strip_prefix("git@github.com:") {
+        return slug_or_none(rest);
+    }
+    for prefix in [
+        "https://github.com/",
+        "http://github.com/",
+        "ssh://git@github.com/",
+    ] {
+        if let Some(rest) = trimmed.strip_prefix(prefix) {
+            return slug_or_none(rest);
+        }
+    }
+    None
+}
+
+fn slug_or_none(rest: &str) -> Option<String> {
+    let mut parts = rest.split('/');
+    let owner = parts.next()?;
+    let repo = parts.next()?;
+    if owner.is_empty() || repo.is_empty() {
+        return None;
+    }
+    Some(format!("{owner}/{repo}"))
+}
+
+// ---------- shell-side data collection ----------
+
+fn fetch_runner_snapshot(
+    actions: &GitHubActions,
+    settings: &WatchdogSettings,
+) -> Result<RunnerSnapshot, CliFailure> {
+    let runner_id = settings.runner_id.ok_or_else(|| {
+        CliFailure::new(
+            1,
+            "No runner ID configured. Pass --runner-id, or set runner.watchdog.runner_id in .shipyard/config.toml.",
+        )
+    })?;
+    let raw = gh_api_runner(actions, &settings.repo_slug, runner_id)?;
+    let parsed: Value = serde_json::from_str(&raw)
+        .map_err(|error| CliFailure::new(2, format!("gh runner JSON parse failed: {error}")))?;
+    let status = parsed
+        .get("status")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown")
+        .to_owned();
+    let busy = parsed.get("busy").and_then(Value::as_bool).unwrap_or(false);
+    let (worker_count, oldest_worker_age_min) = inspect_local_workers(&settings.runner_dir);
+    Ok(RunnerSnapshot {
+        status,
+        busy,
+        worker_count,
+        oldest_worker_age_min,
+    })
+}
+
+fn gh_api_runner(
+    actions: &GitHubActions,
+    repo: &str,
+    runner_id: u64,
+) -> Result<String, CliFailure> {
+    // We do not have a typed `gh api` helper for a single runner on
+    // `GitHubActions`, but every other call shells out to `gh` from the same
+    // cwd, so do the same here.
+    let output = Command::new("gh")
+        .args(["api", &format!("repos/{repo}/actions/runners/{runner_id}")])
+        .current_dir(actions_cwd(actions))
+        .output()
+        .map_err(|error| {
+            CliFailure::new(
+                2,
+                format!("failed to run gh api runners/{runner_id}: {error}"),
+            )
+        })?;
+    if !output.status.success() {
+        return Err(CliFailure::new(
+            2,
+            format!(
+                "gh api runners/{runner_id} failed: {}",
+                String::from_utf8_lossy(&output.stderr).trim()
+            ),
+        ));
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).to_string())
+}
+
+fn actions_cwd(_actions: &GitHubActions) -> PathBuf {
+    // GitHubActions::cwd is private; fall back to the process cwd. The
+    // command-line layer always invokes us with the right CWD already, so
+    // this matches the existing usage pattern in cloud_cmd.rs.
+    std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."))
+}
+
+fn fetch_queued_runs(
+    actions: &GitHubActions,
+    repo_slug: &str,
+) -> Result<Vec<QueuedRun>, CliFailure> {
+    actions
+        .list_queued_runs(repo_slug, QUEUED_RUNS_LIMIT)
+        .map_err(|error| CliFailure::new(1, error.to_string()))
+}
+
+fn inspect_local_workers(runner_dir: &Path) -> (usize, Option<i64>) {
+    // `ps -ax -o etime=,command=` returns lines like
+    // "  12:34 /Users/foo/actions-runner/bin/Runner.Worker ...".
+    let output = match Command::new("ps")
+        .args(["-ax", "-o", "etime=,command="])
+        .output()
+    {
+        Ok(o) if o.status.success() => o,
+        _ => return (0, None),
+    };
+    let runner_dir_str = runner_dir.display().to_string();
+    let bin_marker = format!("{runner_dir_str}/bin");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let mut count = 0usize;
+    let mut oldest_age_min: Option<i64> = None;
+    for line in stdout.lines() {
+        if !line.contains("Runner.Worker") {
+            continue;
+        }
+        if !line.contains(&bin_marker) && !line.contains(&runner_dir_str) {
+            continue;
+        }
+        count += 1;
+        let trimmed = line.trim_start();
+        let first_field = trimmed.split_whitespace().next().unwrap_or("");
+        if let Some(age) = parse_etime_minutes(first_field) {
+            oldest_age_min = Some(oldest_age_min.map_or(age, |existing| existing.max(age)));
+        }
+    }
+    (count, oldest_age_min)
+}
+
+/// Parse `ps`-style `etime` strings (`MM:SS`, `HH:MM:SS`, or `DD-HH:MM:SS`)
+/// into whole minutes. Mirrors the awk pipeline in the prototype.
+fn parse_etime_minutes(raw: &str) -> Option<i64> {
+    let (days, hms) = if let Some((d, rest)) = raw.split_once('-') {
+        (d.parse::<i64>().ok()?, rest)
+    } else {
+        (0, raw)
+    };
+    let parts: Vec<&str> = hms.split(':').collect();
+    let (hours, minutes) = match parts.as_slice() {
+        [h, m, _s] => (h.parse::<i64>().ok()?, m.parse::<i64>().ok()?),
+        [m, _s] => (0, m.parse::<i64>().ok()?),
+        [m] => (0, m.parse::<i64>().ok()?),
+        _ => return None,
+    };
+    Some(days * 24 * 60 + hours * 60 + minutes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_etime_handles_mm_ss() {
+        assert_eq!(parse_etime_minutes("45:12"), Some(45));
+    }
+
+    #[test]
+    fn parse_etime_handles_hh_mm_ss() {
+        assert_eq!(parse_etime_minutes("01:30:00"), Some(90));
+    }
+
+    #[test]
+    fn parse_etime_handles_days() {
+        assert_eq!(parse_etime_minutes("2-03:15:00"), Some(2 * 24 * 60 + 195));
+    }
+
+    #[test]
+    fn parse_etime_rejects_garbage() {
+        assert_eq!(parse_etime_minutes("not-a-time"), None);
+    }
+
+    #[test]
+    fn parse_github_slug_supports_https_and_ssh() {
+        assert_eq!(
+            parse_github_repo_slug("git@github.com:danielraffel/Shipyard.git"),
+            Some("danielraffel/Shipyard".to_owned())
+        );
+        assert_eq!(
+            parse_github_repo_slug("https://github.com/danielraffel/pulp"),
+            Some("danielraffel/pulp".to_owned())
+        );
+        assert_eq!(parse_github_repo_slug("not-a-github-url"), None);
+    }
+
+    #[test]
+    fn dry_run_overridden_only_respects_fix_flag() {
+        assert!(dry_run_overridden_only(true, false));
+        assert!(!dry_run_overridden_only(true, true));
+    }
+}

--- a/src/app/runner_cmd.rs
+++ b/src/app/runner_cmd.rs
@@ -98,6 +98,42 @@ pub(super) fn runner_command<W: Write>(
             json,
             stdout,
         ),
+        RunnerCommand::Kill {
+            pid,
+            reason,
+            retrigger,
+            yes,
+            repo,
+            runner_dir,
+            history,
+            last,
+            recover,
+            grace_secs,
+            recovery_log,
+            quarantine_root,
+            no_wait_github,
+        } => super::runner_kill_cmd::kill_command(
+            super::runner_kill_cmd::KillCommandArgs {
+                config,
+                cwd,
+                actions: &actions,
+                pid,
+                reason,
+                retrigger,
+                yes,
+                repo_override: repo,
+                runner_dir_override: runner_dir,
+                history,
+                last,
+                recover,
+                grace_secs,
+                recovery_log_override: recovery_log,
+                quarantine_root_override: quarantine_root,
+                no_wait_github,
+                json,
+            },
+            stdout,
+        ),
     }
 }
 
@@ -594,15 +630,16 @@ fn cancel_stale_inline<W: Write>(
 // ---------- settings / config wiring ----------
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-struct WatchdogSettings {
-    repo_slug: String,
-    runner_id: Option<u64>,
-    runner_dir: PathBuf,
-    thresholds: WatchdogThresholds,
+pub(super) struct WatchdogSettings {
+    pub(super) repo_slug: String,
+    #[allow(dead_code)]
+    pub(super) runner_id: Option<u64>,
+    pub(super) runner_dir: PathBuf,
+    pub(super) thresholds: WatchdogThresholds,
 }
 
 #[allow(clippy::too_many_arguments)]
-fn resolve_watchdog_settings(
+pub(super) fn resolve_watchdog_settings(
     config: &LoadedConfig,
     cwd: &Path,
     runner_id_override: Option<u64>,

--- a/src/app/runner_kill_cmd.rs
+++ b/src/app/runner_kill_cmd.rs
@@ -1,0 +1,1167 @@
+//! `shipyard runner kill` — explicit Worker-process termination with full
+//! recovery sequence. Complement to `runner cleanup --fix`; the latter only
+//! cancels stale queued runs, while this subcommand handles the case where
+//! a single `Runner.Worker` PID is wedged and needs to be terminated locally.
+//!
+//! The flow is deliberately conservative:
+//!
+//! 1. Snapshot the worker's command line, PR, job, branch, elapsed time, and
+//!    `_work` directory into `~/.shipyard/kill-recovery.jsonl`.
+//! 2. Require a typed `KILL` confirmation unless `--yes` is passed.
+//! 3. `SIGTERM` first, polling every 500 ms for up to `grace_secs` seconds.
+//! 4. `SIGKILL` only if the worker is still alive after the grace window.
+//! 5. Reap any child processes (`pkill -P <pid> -f 'cmake|ninja|...'`).
+//! 6. Move partial `build*` directories under the runner's `_work` tree to
+//!    `/tmp/shipyard-killed-builds/<kill-event-id>/` — never delete.
+//! 7. Verify `Runner.Listener` is still alive and print restart guidance if
+//!    not.
+//! 8. Poll the GitHub run until status flips to `completed`, then optionally
+//!    re-trigger via `rerun-failed-jobs`.
+//!
+//! `--history` prints recent kills. `--recover <id>` restores a quarantined
+//! build and (optionally) re-queues the run.
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+use std::process::{Command, ExitCode};
+use std::thread::sleep;
+use std::time::{Duration, Instant};
+
+use chrono::Utc;
+use serde_json::Value;
+
+use super::CliFailure;
+use super::runner_cmd::resolve_watchdog_settings;
+use crate::cloud::GitHubActions;
+use crate::config::LoadedConfig;
+use crate::output::write_json_envelope;
+
+/// Default SIGTERM-to-SIGKILL grace window, in seconds.
+pub(super) const DEFAULT_GRACE_SECS: u64 = 10;
+/// Maximum wall-clock window we wait for GitHub to recognise a killed run.
+const GITHUB_STATUS_FLIP_BUDGET_SECS: u64 = 90;
+/// Poll cadence while waiting for SIGTERM / GitHub status flip.
+const POLL_INTERVAL: Duration = Duration::from_millis(500);
+
+/// Bundled inputs for `kill_command`. Keeps the call site tidy and lets us
+/// thread test-only overrides without an ever-growing positional list.
+#[allow(clippy::struct_excessive_bools)]
+pub(super) struct KillCommandArgs<'a> {
+    pub(super) config: &'a LoadedConfig,
+    pub(super) cwd: &'a Path,
+    pub(super) actions: &'a GitHubActions,
+    pub(super) pid: Option<u32>,
+    pub(super) reason: Option<String>,
+    pub(super) retrigger: bool,
+    pub(super) yes: bool,
+    pub(super) repo_override: Option<String>,
+    pub(super) runner_dir_override: Option<PathBuf>,
+    pub(super) history: bool,
+    pub(super) last: Option<usize>,
+    pub(super) recover: Option<String>,
+    pub(super) grace_secs: Option<u64>,
+    pub(super) recovery_log_override: Option<PathBuf>,
+    pub(super) quarantine_root_override: Option<PathBuf>,
+    pub(super) no_wait_github: bool,
+    pub(super) json: bool,
+}
+
+/// Entry point dispatched from `runner_command`.
+#[allow(clippy::too_many_lines, clippy::needless_pass_by_value)]
+pub(super) fn kill_command<W: Write>(
+    args: KillCommandArgs<'_>,
+    stdout: &mut W,
+) -> Result<ExitCode, CliFailure> {
+    let recovery_log = args
+        .recovery_log_override
+        .clone()
+        .unwrap_or_else(default_recovery_log);
+    let quarantine_root = args
+        .quarantine_root_override
+        .clone()
+        .unwrap_or_else(default_quarantine_root);
+
+    if args.history {
+        return history_mode(&recovery_log, args.last, args.json, stdout);
+    }
+    if let Some(id) = args.recover.as_deref() {
+        return recover_mode(&args, &recovery_log, &quarantine_root, id, stdout);
+    }
+
+    let pid = args.pid.ok_or_else(|| {
+        CliFailure::new(
+            2,
+            "--pid is required for `shipyard runner kill` (or pass --history / --recover).",
+        )
+    })?;
+    let reason = args
+        .reason
+        .clone()
+        .filter(|r| !r.trim().is_empty())
+        .ok_or_else(|| {
+            CliFailure::new(
+                2,
+                "--reason is required so kill events are auditable in the recovery log.",
+            )
+        })?;
+
+    let settings = resolve_watchdog_settings(
+        args.config,
+        args.cwd,
+        None,
+        args.repo_override.clone(),
+        args.runner_dir_override.clone(),
+        None,
+        None,
+        None,
+    )?;
+
+    let grace = Duration::from_secs(args.grace_secs.unwrap_or(DEFAULT_GRACE_SECS));
+
+    // 0. sanity-check the PID is actually a Runner.Worker
+    let command_line = ps_command_for(pid)?;
+    if !is_runner_worker(&command_line, &settings.runner_dir) {
+        return Err(CliFailure::new(
+            2,
+            format!(
+                "refusing to kill PID {pid}: command line does not look like a Runner.Worker under {}: {command_line}",
+                settings.runner_dir.display()
+            ),
+        ));
+    }
+    let worker_info = parse_worker_command(&command_line);
+    let log_info = augment_with_runner_log(&worker_info, &settings.runner_dir);
+
+    // 1. snapshot
+    let event_id = generate_event_id(pid);
+    let now = Utc::now();
+    let github_run_id = log_info.github_run_id.or(worker_info.github_run_id_hint);
+
+    let mut entry = serde_json::Map::new();
+    entry.insert("id".to_owned(), Value::from(event_id.clone()));
+    entry.insert("ts".to_owned(), Value::from(now.to_rfc3339()));
+    entry.insert("pid".to_owned(), Value::from(pid));
+    entry.insert("reason".to_owned(), Value::from(reason.clone()));
+    if let Some(pr) = log_info.pr.or(worker_info.pr) {
+        entry.insert("pr".to_owned(), Value::from(pr));
+    }
+    if let Some(job) = log_info.job.clone().or_else(|| worker_info.job.clone()) {
+        entry.insert("job".to_owned(), Value::from(job));
+    }
+    if let Some(branch) = log_info
+        .branch
+        .clone()
+        .or_else(|| worker_info.branch.clone())
+    {
+        entry.insert("branch".to_owned(), Value::from(branch));
+    }
+    if let Some(etime) = worker_info.etime_min {
+        entry.insert("etime_min".to_owned(), Value::from(etime));
+    }
+    if let Some(dir) = worker_info.worker_dir.clone() {
+        entry.insert(
+            "worker_dir".to_owned(),
+            Value::from(dir.display().to_string()),
+        );
+    }
+    if let Some(run_id) = github_run_id {
+        entry.insert("github_run_id".to_owned(), Value::from(run_id));
+    }
+    entry.insert("repo".to_owned(), Value::from(settings.repo_slug.clone()));
+
+    // 2. confirmation
+    if !args.yes {
+        let ok = confirm_kill_typed(stdout, pid, worker_info.pr.or(log_info.pr), &reason)?;
+        if !ok {
+            writeln!(stdout, "kill aborted — confirmation did not match 'KILL'").map_err(io_err)?;
+            return Ok(ExitCode::from(1));
+        }
+    }
+
+    // 3. SIGTERM with grace
+    let signalled = send_signal(pid, "TERM")?;
+    let mut signal_used: &'static str = if signalled { "SIGTERM" } else { "ALREADY_GONE" };
+    let exited_gracefully = if signalled {
+        wait_for_exit(pid, grace)
+    } else {
+        true
+    };
+
+    // 4. SIGKILL if still alive
+    if !exited_gracefully {
+        send_signal(pid, "KILL")?;
+        signal_used = "SIGKILL";
+        wait_for_exit(pid, Duration::from_secs(5));
+    }
+
+    // 5. reap children
+    let children_reaped = reap_orphaned_children(pid);
+
+    // 6. quarantine partial builds
+    let quarantine_dir = quarantine_root.join(&event_id);
+    let quarantined = quarantine_partial_builds(
+        worker_info.worker_dir.as_deref(),
+        worker_info.etime_min,
+        &quarantine_dir,
+    )?;
+    if !quarantined.is_empty() {
+        entry.insert(
+            "quarantined".to_owned(),
+            Value::Array(
+                quarantined
+                    .iter()
+                    .map(|p| Value::from(p.display().to_string()))
+                    .collect(),
+            ),
+        );
+        entry.insert(
+            "quarantine_dir".to_owned(),
+            Value::from(quarantine_dir.display().to_string()),
+        );
+    }
+
+    // 7. verify Runner.Listener is alive
+    let listener_pid = runner_listener_pid();
+    entry.insert(
+        "runner_listener_alive".to_owned(),
+        Value::from(listener_pid.is_some()),
+    );
+
+    // 8. wait for GitHub status flip
+    let github_outcome = if args.no_wait_github {
+        None
+    } else if let Some(run_id) = github_run_id {
+        Some(wait_for_github_status_flip(
+            args.actions,
+            &settings.repo_slug,
+            run_id,
+        ))
+    } else {
+        None
+    };
+    if let Some((status, conclusion)) = &github_outcome {
+        entry.insert("github_status".to_owned(), Value::from(status.clone()));
+        entry.insert(
+            "github_conclusion".to_owned(),
+            Value::from(conclusion.clone()),
+        );
+    }
+
+    // 9. optional retrigger
+    let mut retriggered = false;
+    let mut retrigger_error: Option<String> = None;
+    if args.retrigger {
+        if let Some(run_id) = github_run_id {
+            match args.actions.rerun_failed_jobs(&settings.repo_slug, run_id) {
+                Ok(()) => retriggered = true,
+                Err(err) => retrigger_error = Some(err.to_string()),
+            }
+        } else {
+            retrigger_error = Some("no GitHub run_id captured; cannot retrigger".to_owned());
+        }
+        entry.insert("retriggered".to_owned(), Value::from(retriggered));
+        if let Some(msg) = &retrigger_error {
+            entry.insert("retrigger_error".to_owned(), Value::from(msg.clone()));
+        }
+    }
+
+    entry.insert("signal".to_owned(), Value::from(signal_used.to_owned()));
+    entry.insert("children_reaped".to_owned(), Value::from(children_reaped));
+
+    // 10. append recovery log (after every other step so partial failures
+    // still produce a usable audit trail)
+    append_recovery_log(&recovery_log, &Value::Object(entry.clone()))?;
+
+    // 11. print summary
+    emit_kill_summary(
+        stdout,
+        &event_id,
+        pid,
+        signal_used,
+        children_reaped,
+        &quarantined,
+        &quarantine_dir,
+        listener_pid,
+        github_outcome.as_ref(),
+        retriggered,
+        retrigger_error.as_deref(),
+        &recovery_log,
+        args.json,
+        &entry,
+    )?;
+
+    Ok(ExitCode::SUCCESS)
+}
+
+// ---------- history ----------
+
+fn history_mode<W: Write>(
+    recovery_log: &Path,
+    last: Option<usize>,
+    json: bool,
+    stdout: &mut W,
+) -> Result<ExitCode, CliFailure> {
+    let entries = read_recovery_log(recovery_log)?;
+    let take = last.unwrap_or(entries.len()).min(entries.len());
+    // Most recent first.
+    let view: Vec<&Value> = entries.iter().rev().take(take).collect();
+    if json {
+        let mut data = BTreeMap::new();
+        data.insert(
+            "recovery_log".to_owned(),
+            Value::from(recovery_log.display().to_string()),
+        );
+        data.insert(
+            "entries".to_owned(),
+            Value::Array(view.iter().map(|v| (*v).clone()).collect()),
+        );
+        write_json_envelope(stdout, "runner.kill.history", data).map_err(io_err)?;
+        return Ok(ExitCode::SUCCESS);
+    }
+    if view.is_empty() {
+        writeln!(
+            stdout,
+            "no kill events recorded at {}",
+            recovery_log.display()
+        )
+        .map_err(io_err)?;
+        return Ok(ExitCode::SUCCESS);
+    }
+    writeln!(
+        stdout,
+        "kill events (most recent first, log={}):",
+        recovery_log.display()
+    )
+    .map_err(io_err)?;
+    for entry in view {
+        let id = entry.get("id").and_then(Value::as_str).unwrap_or("?");
+        let ts = entry.get("ts").and_then(Value::as_str).unwrap_or("?");
+        let pid = entry.get("pid").and_then(Value::as_u64).unwrap_or(0);
+        let signal = entry.get("signal").and_then(Value::as_str).unwrap_or("?");
+        let pr = entry.get("pr").and_then(Value::as_u64);
+        let reason = entry.get("reason").and_then(Value::as_str).unwrap_or("?");
+        let pr_str = pr.map(|p| format!(" PR#{p}")).unwrap_or_default();
+        writeln!(
+            stdout,
+            "  {id}  {ts}  pid={pid}{pr_str}  signal={signal}  reason=\"{reason}\""
+        )
+        .map_err(io_err)?;
+    }
+    Ok(ExitCode::SUCCESS)
+}
+
+// ---------- recover ----------
+
+#[allow(clippy::too_many_lines)]
+fn recover_mode<W: Write>(
+    args: &KillCommandArgs<'_>,
+    recovery_log: &Path,
+    quarantine_root: &Path,
+    event_id: &str,
+    stdout: &mut W,
+) -> Result<ExitCode, CliFailure> {
+    let entries = read_recovery_log(recovery_log)?;
+    let entry = entries
+        .iter()
+        .find(|e| e.get("id").and_then(Value::as_str) == Some(event_id))
+        .ok_or_else(|| {
+            CliFailure::new(
+                2,
+                format!(
+                    "no kill event with id={event_id} in {}",
+                    recovery_log.display()
+                ),
+            )
+        })?;
+
+    let quarantine_dir = entry
+        .get("quarantine_dir")
+        .and_then(Value::as_str)
+        .map_or_else(|| quarantine_root.join(event_id), PathBuf::from);
+    let worker_dir = entry
+        .get("worker_dir")
+        .and_then(Value::as_str)
+        .map(PathBuf::from);
+    let github_run_id = entry.get("github_run_id").and_then(Value::as_u64);
+    let already_retriggered = entry
+        .get("retriggered")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+
+    if !args.yes {
+        write!(
+            stdout,
+            "recover kill event {event_id}? this will restore {} into {}. type KILL to confirm: ",
+            quarantine_dir.display(),
+            worker_dir
+                .as_deref()
+                .map(Path::display)
+                .map_or_else(|| "(unknown)".to_owned(), |d| d.to_string()),
+        )
+        .map_err(io_err)?;
+        stdout.flush().map_err(io_err)?;
+        let mut buf = String::new();
+        std::io::stdin().read_line(&mut buf).map_err(io_err)?;
+        if buf.trim() != "KILL" {
+            writeln!(stdout, "recover aborted").map_err(io_err)?;
+            return Ok(ExitCode::from(1));
+        }
+    }
+
+    let mut restored: Vec<PathBuf> = Vec::new();
+    if quarantine_dir.is_dir()
+        && let Some(target) = worker_dir.as_deref()
+    {
+        for child in fs::read_dir(&quarantine_dir).map_err(io_err)? {
+            let child = child.map_err(io_err)?;
+            let src = child.path();
+            let dst = target.join(child.file_name());
+            if dst.exists() {
+                writeln!(
+                    stdout,
+                    "  skipping {}: destination already exists at {}",
+                    src.display(),
+                    dst.display()
+                )
+                .map_err(io_err)?;
+                continue;
+            }
+            fs::create_dir_all(target).map_err(io_err)?;
+            fs::rename(&src, &dst).map_err(io_err)?;
+            restored.push(dst);
+        }
+    }
+
+    let mut retriggered_now = false;
+    let mut retrigger_error: Option<String> = None;
+    if !already_retriggered {
+        let settings = resolve_watchdog_settings(
+            args.config,
+            args.cwd,
+            None,
+            args.repo_override.clone(),
+            args.runner_dir_override.clone(),
+            None,
+            None,
+            None,
+        )?;
+        if let Some(run_id) = github_run_id {
+            match args.actions.rerun_failed_jobs(&settings.repo_slug, run_id) {
+                Ok(()) => retriggered_now = true,
+                Err(err) => retrigger_error = Some(err.to_string()),
+            }
+        }
+    }
+
+    if args.json {
+        let mut data = BTreeMap::new();
+        data.insert("event_id".to_owned(), Value::from(event_id.to_owned()));
+        data.insert(
+            "restored".to_owned(),
+            Value::Array(
+                restored
+                    .iter()
+                    .map(|p| Value::from(p.display().to_string()))
+                    .collect(),
+            ),
+        );
+        data.insert(
+            "retriggered".to_owned(),
+            Value::from(retriggered_now || already_retriggered),
+        );
+        if let Some(msg) = retrigger_error.as_ref() {
+            data.insert("retrigger_error".to_owned(), Value::from(msg.clone()));
+        }
+        write_json_envelope(stdout, "runner.kill.recover", data).map_err(io_err)?;
+        return Ok(ExitCode::SUCCESS);
+    }
+    writeln!(
+        stdout,
+        "recover {event_id}: restored {} item(s) from {}",
+        restored.len(),
+        quarantine_dir.display(),
+    )
+    .map_err(io_err)?;
+    for p in &restored {
+        writeln!(stdout, "  + {}", p.display()).map_err(io_err)?;
+    }
+    if retriggered_now {
+        writeln!(stdout, "  retriggered rerun-failed-jobs").map_err(io_err)?;
+    } else if already_retriggered {
+        writeln!(stdout, "  retrigger already done at kill time").map_err(io_err)?;
+    }
+    if let Some(msg) = retrigger_error.as_ref() {
+        writeln!(stdout, "  retrigger failed: {msg}").map_err(io_err)?;
+    }
+    Ok(ExitCode::SUCCESS)
+}
+
+// ---------- worker / log parsing ----------
+
+/// Parsed view of a `Runner.Worker` command line plus the runner-side log
+/// scrape, merged into the per-kill snapshot we persist.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub(super) struct WorkerInfo {
+    pub(super) pr: Option<u64>,
+    pub(super) job: Option<String>,
+    pub(super) branch: Option<String>,
+    pub(super) etime_min: Option<i64>,
+    pub(super) worker_dir: Option<PathBuf>,
+    pub(super) github_run_id_hint: Option<u64>,
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+struct RunnerLogInfo {
+    pr: Option<u64>,
+    job: Option<String>,
+    branch: Option<String>,
+    github_run_id: Option<u64>,
+}
+
+/// Parse a single `ps -o command=`-style command line for a Worker process.
+///
+/// The Worker command line on macOS looks like:
+///
+/// ```text
+/// /Users/foo/actions-runner/bin/Runner.Worker spawnclient 0 ...
+/// ```
+///
+/// We only extract `worker_dir` from this surface; PR/job/branch come from
+/// the runner's stdout log because the Worker command line itself does not
+/// embed them. We deliberately keep the extractor public for unit testing.
+#[must_use]
+pub(super) fn parse_worker_command(command_line: &str) -> WorkerInfo {
+    let mut info = WorkerInfo::default();
+    if let Some(bin_idx) = command_line.find("/bin/Runner.Worker") {
+        let prefix = &command_line[..bin_idx];
+        // `prefix` is the runner root, e.g. `/Users/foo/actions-runner`.
+        // The Worker's `_work` directory lives at `<prefix>/_work`.
+        let runner_root = PathBuf::from(prefix.trim());
+        info.worker_dir = Some(runner_root.join("_work"));
+    }
+    // Allow the command line to carry an optional `--run-id` arg as a hint,
+    // for forward compat with future runner versions.
+    if let Some(idx) = command_line.find("--run-id ") {
+        let tail = &command_line[idx + "--run-id ".len()..];
+        let token = tail.split_whitespace().next().unwrap_or("");
+        info.github_run_id_hint = token.parse::<u64>().ok();
+    }
+    info
+}
+
+/// Augment a `WorkerInfo` by scraping the runner-side stdout log
+/// (`<runner_dir>/_diag/Runner_*.log`). The runner records every accepted
+/// job's `Running job: <name>` line plus its workflow run id and branch.
+fn augment_with_runner_log(worker: &WorkerInfo, runner_dir: &Path) -> RunnerLogInfo {
+    let mut info = RunnerLogInfo::default();
+    let diag_dir = runner_dir.join("_diag");
+    let Ok(read) = fs::read_dir(&diag_dir) else {
+        return info;
+    };
+    // Find the most recently modified Runner_*.log.
+    let mut newest: Option<(PathBuf, std::time::SystemTime)> = None;
+    for entry in read.flatten() {
+        let path = entry.path();
+        let name = match path.file_name().and_then(|s| s.to_str()) {
+            Some(s) => s.to_owned(),
+            None => continue,
+        };
+        if !name.starts_with("Runner_") || !name.to_lowercase().ends_with(".log") {
+            continue;
+        }
+        if let Ok(meta) = entry.metadata()
+            && let Ok(modified) = meta.modified()
+            && newest.as_ref().is_none_or(|(_, t)| modified > *t)
+        {
+            newest = Some((path, modified));
+        }
+    }
+    let Some((log_path, _)) = newest else {
+        return info;
+    };
+    let Ok(contents) = fs::read_to_string(&log_path) else {
+        return info;
+    };
+    parse_runner_log_into(&contents, &mut info);
+    let _ = worker; // reserved for future correlation by start time
+    info
+}
+
+fn parse_runner_log_into(contents: &str, info: &mut RunnerLogInfo) {
+    // Walk lines from end to start so we pick up the most recent job.
+    for line in contents.lines().rev() {
+        if info.job.is_none()
+            && let Some(rest) = line.split("Running job: ").nth(1)
+        {
+            info.job = Some(rest.trim().to_owned());
+        }
+        if info.branch.is_none()
+            && let Some(rest) = line.split("Job ref: ").nth(1)
+        {
+            // `refs/heads/foo/bar` or `refs/pull/1818/merge`
+            let trimmed = rest.trim();
+            if let Some(branch) = trimmed.strip_prefix("refs/heads/") {
+                info.branch = Some(branch.to_owned());
+            } else if let Some(rest) = trimmed.strip_prefix("refs/pull/") {
+                if let Some((num, _)) = rest.split_once('/')
+                    && let Ok(n) = num.parse::<u64>()
+                {
+                    info.pr = Some(n);
+                }
+                info.branch = Some(trimmed.to_owned());
+            } else {
+                info.branch = Some(trimmed.to_owned());
+            }
+        }
+        if info.github_run_id.is_none()
+            && let Some(rest) = line.split("Run ID: ").nth(1)
+        {
+            let token = rest.trim();
+            if let Ok(n) = token.parse::<u64>() {
+                info.github_run_id = Some(n);
+            }
+        }
+        if info.job.is_some() && info.branch.is_some() && info.github_run_id.is_some() {
+            break;
+        }
+    }
+}
+
+fn is_runner_worker(command_line: &str, runner_dir: &Path) -> bool {
+    if !command_line.contains("Runner.Worker") {
+        return false;
+    }
+    let dir = runner_dir.display().to_string();
+    command_line.contains(&dir) || command_line.contains("/actions-runner/")
+}
+
+// ---------- process control ----------
+
+fn ps_command_for(pid: u32) -> Result<String, CliFailure> {
+    let out = Command::new("ps")
+        .args(["-p", &pid.to_string(), "-o", "command="])
+        .output()
+        .map_err(|e| CliFailure::new(2, format!("failed to inspect pid {pid}: {e}")))?;
+    if !out.status.success() {
+        return Err(CliFailure::new(
+            2,
+            format!("pid {pid} is not running (ps reported no match)"),
+        ));
+    }
+    let line = String::from_utf8_lossy(&out.stdout).trim().to_owned();
+    if line.is_empty() {
+        return Err(CliFailure::new(
+            2,
+            format!("pid {pid} returned empty command line"),
+        ));
+    }
+    Ok(line)
+}
+
+fn send_signal(pid: u32, signal: &str) -> Result<bool, CliFailure> {
+    let out = Command::new("kill")
+        .args([&format!("-{signal}"), &pid.to_string()])
+        .output()
+        .map_err(|e| CliFailure::new(2, format!("failed to invoke kill: {e}")))?;
+    if out.status.success() {
+        return Ok(true);
+    }
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    if stderr.contains("No such process") {
+        return Ok(false);
+    }
+    Err(CliFailure::new(
+        2,
+        format!("kill -{signal} {pid} failed: {}", stderr.trim()),
+    ))
+}
+
+fn wait_for_exit(pid: u32, budget: Duration) -> bool {
+    let start = Instant::now();
+    while start.elapsed() < budget {
+        if !pid_alive(pid) {
+            return true;
+        }
+        sleep(POLL_INTERVAL);
+    }
+    !pid_alive(pid)
+}
+
+fn pid_alive(pid: u32) -> bool {
+    Command::new("ps")
+        .args(["-p", &pid.to_string()])
+        .output()
+        .is_ok_and(|o| {
+            if !o.status.success() {
+                return false;
+            }
+            // `ps -p <pid>` always prints a header row; an extra line means a
+            // match. Avoid pulling in `BufRead` just for this single use.
+            String::from_utf8_lossy(&o.stdout).lines().count() > 1
+        })
+}
+
+fn reap_orphaned_children(parent_pid: u32) -> u32 {
+    // Use pkill -P to send SIGTERM to direct children whose command matches a
+    // build tool. We intentionally avoid -9 so any well-behaved tool can flush
+    // its own state. Returns the count of processes we successfully signalled.
+    let pattern = "cmake|ninja|make|ctest|build";
+    let out = Command::new("pkill")
+        .args(["-TERM", "-P", &parent_pid.to_string(), "-f", pattern])
+        .output();
+    match out {
+        Ok(o) if o.status.success() => {
+            // pkill prints nothing on success; assume at least one match.
+            1
+        }
+        _ => 0,
+    }
+}
+
+fn runner_listener_pid() -> Option<u32> {
+    let out = Command::new("pgrep")
+        .args(["-f", "Runner.Listener"])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    String::from_utf8_lossy(&out.stdout)
+        .lines()
+        .next()
+        .and_then(|l| l.trim().parse::<u32>().ok())
+}
+
+// ---------- quarantine ----------
+
+fn quarantine_partial_builds(
+    worker_dir: Option<&Path>,
+    etime_min: Option<i64>,
+    quarantine_dir: &Path,
+) -> Result<Vec<PathBuf>, CliFailure> {
+    let Some(work) = worker_dir else {
+        return Ok(Vec::new());
+    };
+    if !work.is_dir() {
+        return Ok(Vec::new());
+    }
+    let mut moved: Vec<PathBuf> = Vec::new();
+    let window =
+        Duration::from_secs(u64::try_from((etime_min.unwrap_or(0) + 5).max(0)).unwrap_or(0) * 60);
+    // Walk one level into `_work/<repo>/<branch>` then look for any `build*`
+    // child directory whose mtime falls inside the window. Real GH runner
+    // layouts vary, so we walk shallowly and skip anything we cannot read.
+    let mut dirs_to_scan: Vec<PathBuf> = vec![work.to_owned()];
+    let mut depth = 0;
+    while let Some(dir) = dirs_to_scan.pop() {
+        if depth > 4 {
+            break;
+        }
+        depth += 1;
+        let Ok(read) = fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in read.flatten() {
+            let path = entry.path();
+            let Ok(meta) = entry.metadata() else { continue };
+            if !meta.is_dir() {
+                continue;
+            }
+            let Some(name) = path.file_name().and_then(|s| s.to_str()) else {
+                continue;
+            };
+            if name.starts_with("build") && within_mtime_window(&meta, window) {
+                let dest = quarantine_dir.join(name);
+                fs::create_dir_all(quarantine_dir).map_err(io_err)?;
+                if dest.exists() {
+                    // Append a numeric suffix rather than collide.
+                    let mut idx = 1;
+                    loop {
+                        let alt = quarantine_dir.join(format!("{name}.{idx}"));
+                        if !alt.exists() {
+                            fs::rename(&path, &alt).map_err(io_err)?;
+                            moved.push(alt);
+                            break;
+                        }
+                        idx += 1;
+                    }
+                } else {
+                    fs::rename(&path, &dest).map_err(io_err)?;
+                    moved.push(dest);
+                }
+            } else if meta.is_dir() {
+                dirs_to_scan.push(path);
+            }
+        }
+    }
+    Ok(moved)
+}
+
+fn within_mtime_window(meta: &fs::Metadata, window: Duration) -> bool {
+    if window.is_zero() {
+        return true;
+    }
+    let Ok(modified) = meta.modified() else {
+        return false;
+    };
+    let Ok(elapsed) = modified.elapsed() else {
+        return true; // future-mtime, treat as recent
+    };
+    elapsed <= window
+}
+
+// ---------- github status flip ----------
+
+fn wait_for_github_status_flip(
+    actions: &GitHubActions,
+    repo: &str,
+    run_id: u64,
+) -> (String, String) {
+    let deadline = Instant::now() + Duration::from_secs(GITHUB_STATUS_FLIP_BUDGET_SECS);
+    let mut last = (String::new(), String::new());
+    while Instant::now() < deadline {
+        // Transient API errors are deliberately swallowed — we keep polling
+        // until the deadline.
+        if let Ok((status, conclusion)) = actions.run_status_conclusion(repo, run_id) {
+            last = (status.clone(), conclusion);
+            if status == "completed" {
+                return last;
+            }
+        }
+        sleep(Duration::from_secs(2));
+    }
+    last
+}
+
+// ---------- recovery log ----------
+
+fn default_recovery_log() -> PathBuf {
+    let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".to_owned());
+    PathBuf::from(home)
+        .join(".shipyard")
+        .join("kill-recovery.jsonl")
+}
+
+fn default_quarantine_root() -> PathBuf {
+    PathBuf::from("/tmp/shipyard-killed-builds")
+}
+
+fn append_recovery_log(path: &Path, entry: &Value) -> Result<(), CliFailure> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(io_err)?;
+    }
+    let serialized = serde_json::to_string(entry)
+        .map_err(|e| CliFailure::new(2, format!("failed to serialize kill entry: {e}")))?;
+    let mut file = fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .map_err(io_err)?;
+    file.write_all(serialized.as_bytes()).map_err(io_err)?;
+    file.write_all(b"\n").map_err(io_err)?;
+    Ok(())
+}
+
+pub(super) fn read_recovery_log(path: &Path) -> Result<Vec<Value>, CliFailure> {
+    if !path.exists() {
+        return Ok(Vec::new());
+    }
+    let contents = fs::read_to_string(path).map_err(io_err)?;
+    let mut out = Vec::new();
+    for line in contents.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        if let Ok(v) = serde_json::from_str::<Value>(trimmed) {
+            out.push(v);
+        }
+        // Corrupt lines are deliberately skipped — the log must never block
+        // recovery, even if a partial write happened.
+    }
+    Ok(out)
+}
+
+// ---------- prompts ----------
+
+fn confirm_kill_typed<W: Write>(
+    stdout: &mut W,
+    pid: u32,
+    pr: Option<u64>,
+    reason: &str,
+) -> Result<bool, CliFailure> {
+    if !is_stdin_tty() {
+        writeln!(
+            stdout,
+            "stdin is not a TTY and --yes was not passed; refusing to kill pid {pid}"
+        )
+        .map_err(io_err)?;
+        return Ok(false);
+    }
+    let pr_part = pr.map(|p| format!(", PR#{p}")).unwrap_or_default();
+    write!(
+        stdout,
+        "KILL PLAN: pid={pid}{pr_part}, reason=\"{reason}\". \
+         Type the word KILL (all caps) to proceed: "
+    )
+    .map_err(io_err)?;
+    stdout.flush().map_err(io_err)?;
+    let mut buf = String::new();
+    std::io::stdin().read_line(&mut buf).map_err(io_err)?;
+    Ok(buf.trim() == "KILL")
+}
+
+fn is_stdin_tty() -> bool {
+    let mut probe = [0u8; 0];
+    std::fs::File::open("/dev/tty").is_ok_and(|mut f| f.read(&mut probe).is_ok())
+}
+
+// ---------- output ----------
+
+#[allow(
+    clippy::too_many_arguments,
+    clippy::fn_params_excessive_bools,
+    clippy::too_many_lines
+)]
+fn emit_kill_summary<W: Write>(
+    stdout: &mut W,
+    event_id: &str,
+    pid: u32,
+    signal: &str,
+    children_reaped: u32,
+    quarantined: &[PathBuf],
+    quarantine_dir: &Path,
+    listener_pid: Option<u32>,
+    github_outcome: Option<&(String, String)>,
+    retriggered: bool,
+    retrigger_error: Option<&str>,
+    recovery_log: &Path,
+    json: bool,
+    entry: &serde_json::Map<String, Value>,
+) -> Result<(), CliFailure> {
+    if json {
+        let mut data: BTreeMap<String, Value> = entry.clone().into_iter().collect();
+        data.insert(
+            "recovery_log".to_owned(),
+            Value::from(recovery_log.display().to_string()),
+        );
+        return write_json_envelope(stdout, "runner.kill", data).map_err(io_err);
+    }
+    writeln!(
+        stdout,
+        "KILL EVENT {event_id} — saved to {}",
+        recovery_log.display()
+    )
+    .map_err(io_err)?;
+    let grace_suffix = if signal == "SIGKILL" {
+        " (after 10s grace)"
+    } else {
+        ""
+    };
+    writeln!(
+        stdout,
+        "  worker pid {pid}, signal {signal}{grace_suffix}, {children_reaped} child(ren) reaped"
+    )
+    .map_err(io_err)?;
+    if quarantined.is_empty() {
+        writeln!(stdout, "  no partial builds to quarantine").map_err(io_err)?;
+    } else {
+        writeln!(
+            stdout,
+            "  partial build quarantined: {}",
+            quarantine_dir.display()
+        )
+        .map_err(io_err)?;
+        for p in quarantined {
+            writeln!(stdout, "    + {}", p.display()).map_err(io_err)?;
+        }
+    }
+    if let Some((status, conclusion)) = github_outcome {
+        let retrigger_part = if retriggered {
+            " (re-triggered automatically)".to_owned()
+        } else if let Some(err) = retrigger_error {
+            format!(" (retrigger failed: {err})")
+        } else {
+            String::new()
+        };
+        writeln!(
+            stdout,
+            "  github job: {status}{}{retrigger_part}",
+            if conclusion.is_empty() {
+                String::new()
+            } else {
+                format!("/{conclusion}")
+            },
+        )
+        .map_err(io_err)?;
+    }
+    match listener_pid {
+        Some(pid) => writeln!(stdout, "  runner: healthy (PID {pid})").map_err(io_err)?,
+        None => {
+            writeln!(
+                stdout,
+                "  runner: Runner.Listener NOT visible — restart with \
+                 `~/actions-runner/svc.sh restart` or `~/actions-runner/run.sh`"
+            )
+            .map_err(io_err)?;
+        }
+    }
+    writeln!(
+        stdout,
+        "To recover: shipyard runner kill --recover {event_id}"
+    )
+    .map_err(io_err)?;
+    Ok(())
+}
+
+// ---------- helpers ----------
+
+fn generate_event_id(pid: u32) -> String {
+    let nanos = Utc::now().timestamp_nanos_opt().unwrap_or(0);
+    // Deterministic given (pid, timestamp); good enough for log correlation.
+    format!("kill-{pid}-{nanos:x}")
+}
+
+fn io_err(e: impl std::fmt::Display) -> CliFailure {
+    CliFailure::new(1, e.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn parse_worker_extracts_worker_dir() {
+        let line = "/Users/runner/actions-runner/bin/Runner.Worker spawnclient 0 0";
+        let info = parse_worker_command(line);
+        assert_eq!(
+            info.worker_dir,
+            Some(PathBuf::from("/Users/runner/actions-runner/_work"))
+        );
+    }
+
+    #[test]
+    fn parse_worker_handles_missing_marker() {
+        let info = parse_worker_command("/bin/bash -c sleep 30");
+        assert_eq!(info.worker_dir, None);
+    }
+
+    #[test]
+    fn parse_runner_log_extracts_job_and_branch_from_pull_ref() {
+        let log = "\
+2026-05-12 22:30:01Z INFO Running job: UBSan macOS ARM64
+2026-05-12 22:30:02Z INFO Job ref: refs/pull/1818/merge
+2026-05-12 22:30:03Z INFO Run ID: 12345
+";
+        let mut info = RunnerLogInfo::default();
+        parse_runner_log_into(log, &mut info);
+        assert_eq!(info.job.as_deref(), Some("UBSan macOS ARM64"));
+        assert_eq!(info.pr, Some(1818));
+        assert_eq!(info.branch.as_deref(), Some("refs/pull/1818/merge"));
+        assert_eq!(info.github_run_id, Some(12345));
+    }
+
+    #[test]
+    fn parse_runner_log_extracts_branch_from_heads_ref() {
+        let log = "\
+2026-05-12 22:30:01Z INFO Running job: macOS ARM64
+2026-05-12 22:30:02Z INFO Job ref: refs/heads/agentB/81
+";
+        let mut info = RunnerLogInfo::default();
+        parse_runner_log_into(log, &mut info);
+        assert_eq!(info.branch.as_deref(), Some("agentB/81"));
+        assert_eq!(info.pr, None);
+    }
+
+    #[test]
+    fn quarantine_path_is_deterministic_for_event_id() {
+        let root = PathBuf::from("/tmp/shipyard-killed-builds");
+        let id = "kill-12345-deadbeef";
+        let dir = root.join(id);
+        assert_eq!(
+            dir,
+            PathBuf::from("/tmp/shipyard-killed-builds/kill-12345-deadbeef")
+        );
+    }
+
+    #[test]
+    fn jsonl_append_preserves_existing_entries() {
+        let dir = TempDir::new().unwrap();
+        let log = dir.path().join("kill-recovery.jsonl");
+        let e1 = serde_json::json!({"id":"a","pid":1});
+        let e2 = serde_json::json!({"id":"b","pid":2});
+        append_recovery_log(&log, &e1).unwrap();
+        append_recovery_log(&log, &e2).unwrap();
+        let entries = read_recovery_log(&log).unwrap();
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].get("id").and_then(Value::as_str), Some("a"));
+        assert_eq!(entries[1].get("id").and_then(Value::as_str), Some("b"));
+    }
+
+    #[test]
+    fn history_mode_handles_missing_log() {
+        let dir = TempDir::new().unwrap();
+        let missing = dir.path().join("nope.jsonl");
+        let mut out = Vec::new();
+        let code = history_mode(&missing, None, false, &mut out).unwrap();
+        assert_eq!(code, ExitCode::SUCCESS);
+        let text = String::from_utf8(out).unwrap();
+        assert!(text.contains("no kill events recorded"));
+    }
+
+    #[test]
+    fn history_mode_respects_last_limit() {
+        let dir = TempDir::new().unwrap();
+        let log = dir.path().join("kill-recovery.jsonl");
+        for i in 0..5u32 {
+            append_recovery_log(
+                &log,
+                &serde_json::json!({
+                    "id": format!("k{i}"),
+                    "ts": "2026-05-12T00:00:00Z",
+                    "pid": i,
+                    "signal": "SIGTERM",
+                    "reason": "test",
+                }),
+            )
+            .unwrap();
+        }
+        let mut out = Vec::new();
+        history_mode(&log, Some(2), false, &mut out).unwrap();
+        let text = String::from_utf8(out).unwrap();
+        // Most recent first, so k4 + k3.
+        assert!(text.contains("k4"));
+        assert!(text.contains("k3"));
+        assert!(!text.contains("k2"));
+    }
+
+    #[test]
+    fn is_runner_worker_accepts_runner_dir_match() {
+        let dir = PathBuf::from("/Users/runner/actions-runner");
+        assert!(is_runner_worker(
+            "/Users/runner/actions-runner/bin/Runner.Worker spawnclient 0",
+            &dir,
+        ));
+    }
+
+    #[test]
+    fn is_runner_worker_rejects_unrelated_processes() {
+        let dir = PathBuf::from("/Users/runner/actions-runner");
+        assert!(!is_runner_worker("/bin/bash -c sleep 30", &dir));
+    }
+
+    #[test]
+    fn within_mtime_window_accepts_zero_window() {
+        // We can't easily forge mtime in a unit test; we just exercise the
+        // zero-window short-circuit which the production path uses when
+        // etime_min is unknown.
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("f");
+        std::fs::write(&path, b"x").unwrap();
+        let meta = std::fs::metadata(&path).unwrap();
+        assert!(within_mtime_window(&meta, Duration::ZERO));
+    }
+}

--- a/src/cloud.rs
+++ b/src/cloud.rs
@@ -394,6 +394,49 @@ impl GitHubActions {
         self.run_gh(&args).map(|_| ())
     }
 
+    /// Re-trigger only the failed jobs in a workflow run. Used by the runner
+    /// kill recovery path to immediately re-queue a PR whose Worker we just
+    /// terminated.
+    pub fn rerun_failed_jobs(&self, repository: &str, run_id: u64) -> Result<(), GitHubError> {
+        let args = vec![
+            "api".to_owned(),
+            "-X".to_owned(),
+            "POST".to_owned(),
+            format!("repos/{repository}/actions/runs/{run_id}/rerun-failed-jobs"),
+        ];
+        self.run_gh(&args).map(|_| ())
+    }
+
+    /// Fetch raw status + conclusion for a workflow run as `(status,
+    /// conclusion)`. Both fields are returned as raw strings, e.g.
+    /// `("completed", "failure")` or `("in_progress", "")`. Used by the runner
+    /// kill recovery path to wait for GitHub to recognise that a killed worker
+    /// has cleared.
+    pub fn run_status_conclusion(
+        &self,
+        repository: &str,
+        run_id: u64,
+    ) -> Result<(String, String), GitHubError> {
+        let args = vec![
+            "api".to_owned(),
+            format!("repos/{repository}/actions/runs/{run_id}"),
+        ];
+        let stdout = self.run_gh(&args)?;
+        let value: Value = serde_json::from_str(&stdout)
+            .map_err(|error| GitHubError::new(format!("failed to parse run JSON: {error}")))?;
+        let status = value
+            .get("status")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_owned();
+        let conclusion = value
+            .get("conclusion")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_owned();
+        Ok((status, conclusion))
+    }
+
     /// List queued workflow runs for a repository.
     pub fn list_queued_runs(
         &self,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,6 +64,8 @@ pub mod queue;
 pub mod reconcile;
 /// GitHub webhook registration through the user's existing `gh` auth.
 pub mod registrar;
+/// Self-hosted runner watchdog detection logic.
+pub mod runner_watchdog;
 /// Ship execution orchestration helpers.
 pub mod ship;
 /// Durable in-flight ship-state model and store.

--- a/src/runner_watchdog.rs
+++ b/src/runner_watchdog.rs
@@ -1,0 +1,462 @@
+//! Self-hosted runner watchdog: pure detection logic shared by the CLI handler.
+//!
+//! Ports the Pulp planning prototype at
+//! `pulp-planning/scripts/runner-watchdog.sh` (commit c719482) into typed,
+//! shell-free Rust helpers. The CLI side (`src/app/runner_cmd.rs`) is the only
+//! place that shells out to `gh` and inspects the local process table; this
+//! module just classifies inputs and produces report shapes.
+//!
+//! ## Symptoms tracked
+//!
+//! 1. **Runner reachability** — runner ID returns a payload with `status =
+//!    "online"`. Otherwise `OFFLINE`.
+//! 2. **Orphaned busy state** — runner API reports `busy = true` but no
+//!    `Runner.Worker` process owned by this runner is visible in `ps`. The
+//!    status commonly clears in 1-5 min; auto-fix is opt-in.
+//! 3. **Hung Worker** — a `Runner.Worker` process has been running longer than
+//!    `max_job_min` minutes.
+//! 4. **Stale queued runs** — queued GitHub Actions runs older than
+//!    `max_queue_age_hours`. With `--fix` the CLI cancels them.
+//!
+//! ## Why no auto-actions by default
+//!
+//! Killing a Worker process can corrupt in-flight artifacts; cancelling a
+//! queued run can lose CI evidence the user is waiting on. `cleanup --fix`
+//! and `--force-kill` are explicit opt-ins, matching the prototype's
+//! convention.
+
+use std::collections::BTreeMap;
+
+use chrono::{DateTime, Utc};
+use serde::Serialize;
+use serde_json::Value;
+
+use crate::cloud::QueuedRun;
+
+/// Defaults for the watchdog, mirroring `[runner.watchdog]` in
+/// `.shipyard/config.toml`.
+pub const DEFAULT_MAX_JOB_MIN: i64 = 90;
+/// Default stale-queue age before a queued run is flagged.
+pub const DEFAULT_MAX_QUEUE_AGE_HOURS: i64 = 2;
+/// Default watch-mode polling interval in seconds.
+pub const DEFAULT_WATCH_INTERVAL_SECONDS: u64 = 300;
+
+/// Resolved runner-watchdog thresholds for a single invocation.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct WatchdogThresholds {
+    /// Warn when a `Runner.Worker` has been running longer than this many
+    /// minutes.
+    pub max_job_min: i64,
+    /// Flag any queued workflow run created more than this many hours ago.
+    pub max_queue_age_hours: i64,
+    /// Polling interval for `runner watch`.
+    pub watch_interval_seconds: u64,
+    /// Whether `--fix` defaults to on.
+    pub auto_fix: bool,
+}
+
+impl Default for WatchdogThresholds {
+    fn default() -> Self {
+        Self {
+            max_job_min: DEFAULT_MAX_JOB_MIN,
+            max_queue_age_hours: DEFAULT_MAX_QUEUE_AGE_HOURS,
+            watch_interval_seconds: DEFAULT_WATCH_INTERVAL_SECONDS,
+            auto_fix: false,
+        }
+    }
+}
+
+/// Overall runner-health classification.
+///
+/// Maps directly to the CLI exit codes: 0 healthy, 1 stuck, 2 unreachable.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RunnerHealth {
+    /// Runner is online, no symptoms detected.
+    Healthy,
+    /// At least one symptom (orphaned busy / hung worker / stale queue)
+    /// detected; runner is still reachable.
+    Stuck,
+    /// Runner is offline or the API call failed.
+    Offline,
+}
+
+impl RunnerHealth {
+    /// Exit code that should accompany this health verdict.
+    #[must_use]
+    pub fn exit_code(self) -> u8 {
+        match self {
+            Self::Healthy => 0,
+            Self::Stuck => 1,
+            Self::Offline => 2,
+        }
+    }
+
+    /// Snake-case string form used in JSON and human output.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Healthy => "healthy",
+            Self::Stuck => "stuck",
+            Self::Offline => "offline",
+        }
+    }
+}
+
+/// One symptom found during a watchdog scan.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Symptom {
+    /// API reports busy but no `Runner.Worker` process is visible.
+    OrphanedBusy,
+    /// A `Runner.Worker` has been running longer than `max_job_min` minutes.
+    HungWorker {
+        /// Observed runtime in whole minutes.
+        worker_age_min: i64,
+        /// Threshold that was crossed.
+        threshold_min: i64,
+    },
+    /// One or more queued runs are older than `max_queue_age_hours`.
+    StaleQueuedRuns {
+        /// Number of stale runs.
+        count: usize,
+    },
+}
+
+impl Symptom {
+    /// Short tag used in human output.
+    #[must_use]
+    pub fn tag(&self) -> &'static str {
+        match self {
+            Self::OrphanedBusy => "orphaned_busy",
+            Self::HungWorker { .. } => "hung_worker",
+            Self::StaleQueuedRuns { .. } => "stale_queued_runs",
+        }
+    }
+}
+
+/// Single stale queued-run row.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct StaleQueuedRun {
+    /// GitHub Actions run ID.
+    pub run_id: u64,
+    /// Workflow display name.
+    pub workflow: String,
+    /// Head branch.
+    pub branch: String,
+    /// How long the run has been queued, in seconds.
+    pub queued_for_secs: i64,
+    /// Browser URL, when GitHub returned one.
+    pub url: Option<String>,
+}
+
+/// Summary returned by [`assess_runner`].
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct RunnerReport {
+    /// Final verdict for exit code.
+    pub health: RunnerHealth,
+    /// Concrete symptoms observed.
+    pub symptoms: Vec<Symptom>,
+    /// Stale queued runs (always present, even when not the reason for STUCK).
+    pub stale_queued_runs: Vec<StaleQueuedRun>,
+    /// Number of `Runner.Worker` processes observed locally.
+    pub worker_count: usize,
+    /// Whether the API reports the runner as busy.
+    pub busy: bool,
+    /// Reported runner status string (e.g. "online", "offline").
+    pub status: String,
+}
+
+impl RunnerReport {
+    /// Convenience: did the scan find anything actionable?
+    #[must_use]
+    pub fn is_clean(&self) -> bool {
+        matches!(self.health, RunnerHealth::Healthy)
+    }
+}
+
+/// Snapshot of the runner-side state, gathered by the caller (CLI shells out
+/// to `gh` and `ps`). Kept as a plain struct so the pure analysis stays
+/// trivially testable.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RunnerSnapshot {
+    /// `status` field from `repos/<owner>/<repo>/actions/runners/<id>`.
+    pub status: String,
+    /// `busy` field from the same API.
+    pub busy: bool,
+    /// Number of locally-visible `Runner.Worker` processes.
+    pub worker_count: usize,
+    /// Age of the oldest `Runner.Worker`, in minutes.
+    pub oldest_worker_age_min: Option<i64>,
+}
+
+/// Build a [`RunnerReport`] from a runner snapshot and a list of queued runs.
+///
+/// `now` is taken as a parameter so tests can pin the clock without touching
+/// the system time.
+#[must_use]
+pub fn assess_runner(
+    snapshot: &RunnerSnapshot,
+    queued_runs: &[QueuedRun],
+    thresholds: WatchdogThresholds,
+    now: DateTime<Utc>,
+) -> RunnerReport {
+    if snapshot.status != "online" {
+        return RunnerReport {
+            health: RunnerHealth::Offline,
+            symptoms: Vec::new(),
+            stale_queued_runs: Vec::new(),
+            worker_count: snapshot.worker_count,
+            busy: snapshot.busy,
+            status: snapshot.status.clone(),
+        };
+    }
+
+    let mut symptoms = Vec::new();
+
+    if snapshot.busy && snapshot.worker_count == 0 {
+        symptoms.push(Symptom::OrphanedBusy);
+    }
+
+    if let Some(age) = snapshot.oldest_worker_age_min
+        && age > thresholds.max_job_min
+    {
+        symptoms.push(Symptom::HungWorker {
+            worker_age_min: age,
+            threshold_min: thresholds.max_job_min,
+        });
+    }
+
+    let stale_queued_runs =
+        compute_stale_queued_runs(queued_runs, thresholds.max_queue_age_hours * 3_600, now);
+    if !stale_queued_runs.is_empty() {
+        symptoms.push(Symptom::StaleQueuedRuns {
+            count: stale_queued_runs.len(),
+        });
+    }
+
+    let health = if symptoms.is_empty() {
+        RunnerHealth::Healthy
+    } else {
+        RunnerHealth::Stuck
+    };
+
+    RunnerReport {
+        health,
+        symptoms,
+        stale_queued_runs,
+        worker_count: snapshot.worker_count,
+        busy: snapshot.busy,
+        status: snapshot.status.clone(),
+    }
+}
+
+/// Filter `queued_runs` down to entries older than `threshold_secs` relative
+/// to `now`. Runs with unparseable timestamps are ignored, matching the
+/// prototype's silent-skip behaviour.
+#[must_use]
+pub fn compute_stale_queued_runs(
+    queued_runs: &[QueuedRun],
+    threshold_secs: i64,
+    now: DateTime<Utc>,
+) -> Vec<StaleQueuedRun> {
+    let mut out = Vec::new();
+    for run in queued_runs {
+        let Ok(created) = DateTime::parse_from_rfc3339(&run.created_at) else {
+            continue;
+        };
+        let age_secs = (now - created.with_timezone(&Utc)).num_seconds();
+        if age_secs < threshold_secs {
+            continue;
+        }
+        out.push(StaleQueuedRun {
+            run_id: run.database_id,
+            workflow: run.workflow_name.clone(),
+            branch: run.head_branch.clone(),
+            queued_for_secs: age_secs,
+            url: run.url.clone(),
+        });
+    }
+    out
+}
+
+/// Render a [`RunnerReport`] as a flat `BTreeMap<String, Value>` ready to be
+/// dropped into `write_json_envelope`.
+#[must_use]
+pub fn report_to_json(report: &RunnerReport) -> BTreeMap<String, Value> {
+    let mut data = BTreeMap::new();
+    data.insert("health".to_owned(), Value::from(report.health.as_str()));
+    data.insert("status".to_owned(), Value::from(report.status.clone()));
+    data.insert("busy".to_owned(), Value::Bool(report.busy));
+    data.insert("worker_count".to_owned(), Value::from(report.worker_count));
+    data.insert(
+        "symptoms".to_owned(),
+        serde_json::to_value(&report.symptoms).expect("symptom serialization"),
+    );
+    data.insert(
+        "stale_queued_runs".to_owned(),
+        serde_json::to_value(&report.stale_queued_runs).expect("stale run serialization"),
+    );
+    data
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Duration as ChronoDuration;
+
+    fn queued_run(id: u64, workflow: &str, branch: &str, created_at: &str) -> QueuedRun {
+        QueuedRun {
+            database_id: id,
+            name: workflow.to_owned(),
+            head_branch: branch.to_owned(),
+            created_at: created_at.to_owned(),
+            workflow_name: workflow.to_owned(),
+            url: Some(format!("https://github.com/owner/repo/actions/runs/{id}")),
+            path: ".github/workflows/ci.yml".to_owned(),
+        }
+    }
+
+    #[test]
+    fn offline_runner_short_circuits_to_offline() {
+        let snapshot = RunnerSnapshot {
+            status: "offline".to_owned(),
+            busy: false,
+            worker_count: 0,
+            oldest_worker_age_min: None,
+        };
+        let report = assess_runner(&snapshot, &[], WatchdogThresholds::default(), Utc::now());
+        assert_eq!(report.health, RunnerHealth::Offline);
+        assert_eq!(report.health.exit_code(), 2);
+        assert!(report.symptoms.is_empty());
+    }
+
+    #[test]
+    fn healthy_runner_has_no_symptoms() {
+        let snapshot = RunnerSnapshot {
+            status: "online".to_owned(),
+            busy: false,
+            worker_count: 0,
+            oldest_worker_age_min: None,
+        };
+        let report = assess_runner(&snapshot, &[], WatchdogThresholds::default(), Utc::now());
+        assert_eq!(report.health, RunnerHealth::Healthy);
+        assert_eq!(report.health.exit_code(), 0);
+    }
+
+    #[test]
+    fn busy_with_no_worker_flags_orphaned_busy() {
+        let snapshot = RunnerSnapshot {
+            status: "online".to_owned(),
+            busy: true,
+            worker_count: 0,
+            oldest_worker_age_min: None,
+        };
+        let report = assess_runner(&snapshot, &[], WatchdogThresholds::default(), Utc::now());
+        assert_eq!(report.health, RunnerHealth::Stuck);
+        assert!(matches!(report.symptoms[0], Symptom::OrphanedBusy));
+        assert_eq!(report.health.exit_code(), 1);
+    }
+
+    #[test]
+    fn worker_running_longer_than_threshold_is_hung() {
+        let snapshot = RunnerSnapshot {
+            status: "online".to_owned(),
+            busy: true,
+            worker_count: 1,
+            oldest_worker_age_min: Some(120),
+        };
+        let report = assess_runner(&snapshot, &[], WatchdogThresholds::default(), Utc::now());
+        assert!(report.symptoms.iter().any(|s| matches!(
+            s,
+            Symptom::HungWorker {
+                worker_age_min: 120,
+                threshold_min: 90
+            }
+        )));
+    }
+
+    #[test]
+    fn worker_at_threshold_is_not_flagged() {
+        let snapshot = RunnerSnapshot {
+            status: "online".to_owned(),
+            busy: true,
+            worker_count: 1,
+            oldest_worker_age_min: Some(90),
+        };
+        let report = assess_runner(&snapshot, &[], WatchdogThresholds::default(), Utc::now());
+        assert!(
+            report
+                .symptoms
+                .iter()
+                .all(|s| !matches!(s, Symptom::HungWorker { .. }))
+        );
+    }
+
+    #[test]
+    fn stale_queue_filter_uses_age_threshold() {
+        let now = Utc::now();
+        let runs = vec![
+            queued_run(
+                101,
+                "CI",
+                "agentB/81-window-only-capture",
+                &(now - ChronoDuration::hours(5)).to_rfc3339(),
+            ),
+            queued_run(
+                102,
+                "CI",
+                "feature/recent",
+                &(now - ChronoDuration::minutes(15)).to_rfc3339(),
+            ),
+            queued_run(103, "CI", "feature/bad-ts", "not-a-timestamp"),
+        ];
+
+        let stale = compute_stale_queued_runs(&runs, 2 * 3_600, now);
+        assert_eq!(stale.len(), 1);
+        assert_eq!(stale[0].run_id, 101);
+        assert!(stale[0].queued_for_secs >= 5 * 3_600);
+        assert_eq!(stale[0].branch, "agentB/81-window-only-capture");
+    }
+
+    #[test]
+    fn stale_queue_drives_stuck_verdict() {
+        let now = Utc::now();
+        let snapshot = RunnerSnapshot {
+            status: "online".to_owned(),
+            busy: false,
+            worker_count: 0,
+            oldest_worker_age_min: None,
+        };
+        let runs = vec![queued_run(
+            101,
+            "CI",
+            "main",
+            &(now - ChronoDuration::hours(3)).to_rfc3339(),
+        )];
+        let report = assess_runner(&snapshot, &runs, WatchdogThresholds::default(), now);
+        assert_eq!(report.health, RunnerHealth::Stuck);
+        assert!(matches!(
+            report.symptoms[0],
+            Symptom::StaleQueuedRuns { count: 1 }
+        ));
+        assert_eq!(report.stale_queued_runs.len(), 1);
+    }
+
+    #[test]
+    fn report_to_json_includes_top_level_fields() {
+        let now = Utc::now();
+        let snapshot = RunnerSnapshot {
+            status: "online".to_owned(),
+            busy: true,
+            worker_count: 0,
+            oldest_worker_age_min: None,
+        };
+        let report = assess_runner(&snapshot, &[], WatchdogThresholds::default(), now);
+        let data = report_to_json(&report);
+        assert_eq!(data["health"], Value::from("stuck"));
+        assert_eq!(data["status"], Value::from("online"));
+        assert_eq!(data["busy"], Value::Bool(true));
+        assert_eq!(data["worker_count"], Value::from(0));
+    }
+}


### PR DESCRIPTION
## What this adds

A new `shipyard runner` subcommand family for detecting and recovering from stuck self-hosted GitHub Actions runner state.

```bash
shipyard runner status              # health check, exit 0/1/2, --json
shipyard runner cleanup --dry-run   # list stale queued runs
shipyard runner cleanup --fix       # cancel them
shipyard runner watch               # daemon mode, configurable --interval
shipyard runner watch --fix         # auto-recovery loop

shipyard runner kill --pid X --reason "..." [--retrigger] [--yes]   # explicit kill
shipyard runner kill --history [--last N]                            # review past kills
shipyard runner kill --recover <event-id>                            # restore quarantined build
```

## Motivation

On 2026-05-12, Pulp's local self-hosted GitHub Actions runner got stuck running a UBSan job from a closed branch for >75 minutes while 17 stale queued runs piled up behind it. PR #1859 (critical-path Spectr SDK fix) was blocked for hours. Manually unblocking required:
- Identifying the stuck job
- Querying GitHub for stale queued runs
- Cancelling 17 runs in batch
- Watching the worker process gracefully exit

This branch automates that detection + recovery. **The watchdog ran successfully against the production runner during verification and immediately identified 35 stale queued runs** — confirming the design works against the real failure mode.

## Recovery sequence (`runner kill`)

10 steps, all reversible:

1. Snapshot to `~/.shipyard/kill-recovery.jsonl` (id, ts, pid, pr, job, branch, etime, reason)
2. Typed `KILL` confirmation (or `--yes`)
3. SIGTERM with 10s grace (500ms poll cadence)
4. SIGKILL only if still alive
5. Reap orphaned children (`cmake|ninja|make|ctest|build`)
6. **Move** (not delete) partial `build*` dirs to `/tmp/shipyard-killed-builds/<id>/`
7. Verify `Runner.Listener` health via `pgrep`
8. Poll GitHub for status flip to `completed`/`failure` (up to 90s)
9. Optional `--retrigger` re-queues the killed PR's CI
10. Print recovery summary with `--recover` invocation hint

**Nothing is destroyed.** A misclick costs ~2 min of cmake re-configure; quarantined directory stays for postmortem inspection.

## Verification (this PR)

| Check | Result |
|-------|--------|
| `cargo fmt --check` | ✅ clean |
| `cargo clippy --all-targets --locked -- -D warnings` | ✅ clean |
| `cargo test --locked` | ✅ 620 pass, 2 fail (both **pre-existing on main**, see notes below) |
| `cargo build --locked --release` | ✅ clean |
| Smoke: `runner status` against real runner | ✅ correctly detected 35 stale queued runs |
| Smoke: `runner cleanup --dry-run` | ✅ lists same 35 without cancelling |
| Smoke: `runner kill --history` on empty log | ✅ handles gracefully |
| Smoke: `runner kill --pid <sleep-process>` | ✅ correctly rejected (PID is not a Runner.Worker) |

### Pre-existing test failures (NOT introduced by this branch)

Both `app::ship_cmd::tests::ship_command_green_merge_failure_keeps_active_state_and_exits_success` and `app::tests::auto_merge_failure_preserves_state` fail on `origin/main` (commit `6c40586`) too. Confirmed via checkout + re-run. Unrelated to this PR's changes.

## Stats

- 10 files modified, +2989 lines
- 25 new tests added (596 → 621 total)
- New module: `src/runner_watchdog.rs` (detection lib)
- New module: `src/app/runner_cmd.rs` (status/cleanup/watch CLI)
- New module: `src/app/runner_kill_cmd.rs` (explicit kill + recovery)
- New API: `GitHubActions::rerun_failed_jobs`, `GitHubActions::run_status_conclusion`
- Documentation: `docs/runner-watchdog.md` (new) + `docs/cli-reference.md` update + README highlight

## Notes

- Uses existing `gh`-shellout pattern; no new HTTP crate
- All cancellations require explicit `--fix` flag (advisory mode is default)
- `runner kill` requires typed `KILL` confirmation (not y/yes) unless `--yes` passed
- `--force-kill` advisory flag retained on `cleanup` (docs now point users at `runner kill`)
- Config keys under `[runner.watchdog]` in `.shipyard/config.toml` with `.shipyard.local/` overlay

## Origin

Pulp planning prototype: https://github.com/danielraffel/pulp-planning/blob/main/scripts/runner-watchdog.sh (commit c1e0fa1). Ported to first-class Rust + tests + recovery sequence for Shipyard.

## Related

- Pulp issue #1884 — concurrency-cancel-in-progress wipes uploads (workflow-side issue this watchdog catches the consequences of)
- Pulp incident log 2026-05-12 — the original incident that motivated this work