### PR TITLE
rescue: add top-level shipyard rescue for wedged-runner recovery

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "shipyard",
-  "version": "0.13.4",
+  "version": "0.13.5",
   "description": "Cross-platform CI coordination",
   "min_shipyard_version": "0.22.8",
   "commands": "./commands",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ to its [GitHub Release](https://github.com/danielraffel/Shipyard/releases).
 - feat(runner): watchdog + kill subcommand for stuck self-hosted runners ([#284](https://github.com/danielraffel/Shipyard/pull/284))
 
 <a id="v0512"></a>
+## [0.53.0]
+
 ## [0.51.2] - 2026-05-05
 
 - daemon: surface webhook registration warnings ([#271](https://github.com/danielraffel/Shipyard/pull/271))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -614,7 +614,7 @@ dependencies = [
 
 [[package]]
 name = "shipyard"
-version = "0.52.0"
+version = "0.53.0"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shipyard"
-version = "0.52.0"
+version = "0.53.0"
 edition = "2024"
 description = "Cross-platform CI coordination for local, SSH, and cloud runners."
 rust-version = "1.92"

--- a/skills/ci/SKILL.md
+++ b/skills/ci/SKILL.md
@@ -61,6 +61,8 @@ Shipyard coordinates validation across local, SSH, and cloud targets.
 | Global warm-pool kill switch | `SHIPYARD_NO_WARM_POOL=1` in the environment |
 | Retarget one lane on an in-flight PR | `shipyard cloud retarget --pr <n> --target macos --provider github-hosted` (dry-run; add `--apply`) |
 | Add a new lane to an in-flight PR | `shipyard cloud add-lane --pr <n> --target windows [--provider github-hosted]` (dry-run; add `--apply`) |
+| Rescue a PR whose runs are wedged on a self-hosted runner | `shipyard rescue <pr>` (cancels + redispatches queued runs to `github-hosted`; add `--dry-run` to preview, `--rerun-failed` for watchdog-cancelled runs) |
+| Rescue every stuck run repo-wide | `shipyard rescue --all-stuck` |
 | Skip a version-bump gate | `shipyard pr --skip-bump sdk --bump-reason "docs only"` |
 | Skip a skill-sync gate | `shipyard pr --skip-skill-update ci --skill-reason "mechanical"` |
 | Deliberately skip one lane | `shipyard run --skip-target windows` (repeatable; no probe run) |
@@ -229,6 +231,50 @@ What it does:
 4. Appends a new `DispatchedRun` to the ShipState so the watch loop joins it into the overall verdict.
 
 See `docs/cloud-retarget.md` for full context; add-lane complements retarget.
+
+## Rescuing wedged runners (`shipyard rescue`)
+
+Use this when a self-hosted runner has wedged — orphaned `Runner.Worker`
+process, queued runs sitting >30m, repo PRs all in
+`mergeable_state=blocked` — and you need to move the work to a different
+provider in one shot:
+
+```sh
+# Most common case: one PR is stuck. Rescue it (default target is github-hosted):
+shipyard rescue 286
+
+# Preview without acting:
+shipyard rescue 286 --dry-run
+
+# Also re-arm runs a watchdog sweep marked failed/cancelled, then hand them off:
+shipyard rescue 286 --rerun-failed
+
+# Repo-wide: rescue every queued run older than 30m:
+shipyard rescue --all-stuck
+
+# Override the queue-age threshold or destination provider:
+shipyard rescue 286 --threshold 10m --to github-hosted
+```
+
+What it does:
+1. Resolves the PR's head branch (skipped under `--all-stuck`).
+2. Lists queued workflow runs and filters to (a) the PR's branch and (b) ones older than `--threshold` (default `30m`).
+3. With `--rerun-failed`, additionally pulls `status=completed conclusion=cancelled` runs on that branch — these get `gh run rerun --failed` first, then the same cancel+redispatch handoff.
+4. For each candidate, cancels the existing run and dispatches a fresh one with `--to <provider>` as the provider override.
+5. Emits a per-run summary (`applied`, `rerun+applied`, `planned`, `skipped-completed`, `skipped-no-plan`, `failed`) with a top-level `event=cloud.rescue` JSON envelope under `--json`.
+
+**Do not reach for `runner-watchdog.sh --fix` instead of `shipyard rescue`.**
+The watchdog's cancellation registers as required-check `failure` on the PR
+without redispatching — it makes the wedge look terminal to branch
+protection. `shipyard rescue` is the safe primitive because it cancels +
+redispatches atomically under one transaction; no orphaned `failure`
+contexts, no destructive ops on the runner host itself.
+
+`shipyard rescue` is the discoverable surface for what was previously a
+5-step recipe (`gh api` + `cloud handoff list-stuck` + per-run
+`cloud handoff run --apply`). Both `cloud handoff list-stuck` and
+`cloud handoff run` remain available for cases where you need to operate
+on a specific run ID outside the PR-scoped flow.
 
 ## Waiting on conditions (`shipyard wait`)
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -251,9 +251,7 @@ fn handle_operational_variant<W: Write>(
         command @ Command::Cloud { .. } => {
             handle_cloud_variant(command, mode, cwd, &runtime_paths.state_dir, json, stdout)
         }
-        command @ Command::Rescue(_) => {
-            handle_rescue_variant(command, mode, cwd, json, stdout)
-        }
+        command @ Command::Rescue(_) => handle_rescue_variant(command, mode, cwd, json, stdout),
         command @ Command::AutoMerge { .. } => {
             handle_auto_merge_variant(command, &runtime_paths.state_dir, cwd, json, stdout)
         }

--- a/src/app.rs
+++ b/src/app.rs
@@ -29,6 +29,7 @@ mod pr_cmd;
 mod quarantine_cmd;
 mod queue_cmd;
 mod release_bot_cmd;
+mod rescue_cmd;
 mod run_cmd;
 mod runner_cmd;
 mod runner_kill_cmd;
@@ -59,6 +60,7 @@ use self::queue_cmd::{
     bump_command, cancel_command, evidence_command, logs_command, queue_command, status_command,
 };
 use self::release_bot_cmd::release_bot_command;
+use self::rescue_cmd::rescue_command;
 use self::run_cmd::{
     FailFastMode, ReachabilityPolicy, RootMismatchPolicy, RunCommandArgs, TreeDriftPolicy,
     WarmPolicy, run_command,
@@ -249,6 +251,9 @@ fn handle_operational_variant<W: Write>(
         command @ Command::Cloud { .. } => {
             handle_cloud_variant(command, mode, cwd, &runtime_paths.state_dir, json, stdout)
         }
+        command @ Command::Rescue(_) => {
+            handle_rescue_variant(command, mode, cwd, json, stdout)
+        }
         command @ Command::AutoMerge { .. } => {
             handle_auto_merge_variant(command, &runtime_paths.state_dir, cwd, json, stdout)
         }
@@ -281,6 +286,21 @@ fn handle_operational_variant<W: Write>(
         | Command::Daemon { .. }
         | Command::Wait { .. } => unreachable!("command handled by top-level dispatch"),
     }
+}
+
+fn handle_rescue_variant<W: Write>(
+    command: Command,
+    mode: RuntimeMode,
+    cwd: &Path,
+    json: bool,
+    stdout: &mut W,
+) -> Result<ExitCode, CliFailure> {
+    let Command::Rescue(args) = command else {
+        unreachable!("rescue variant required")
+    };
+    let config = LoadedConfig::load_from_cwd(mode, cwd)
+        .map_err(|error| CliFailure::new(1, error.to_string()))?;
+    rescue_command(&args, &config, cwd, json, stdout)
 }
 
 fn handle_setup_command<W: Write>(

--- a/src/app/cli.rs
+++ b/src/app/cli.rs
@@ -240,6 +240,9 @@ pub(super) enum Command {
         #[command(subcommand)]
         command: CloudCommand,
     },
+    /// One-shot rescue for wedged-runner recovery: cancel + redispatch every
+    /// stuck workflow run on a PR (or the whole repo) to a different provider.
+    Rescue(RescueArgs),
     /// Merge a PR once all ship-state targets are green.
     #[command(name = "auto-merge")]
     AutoMerge {
@@ -850,6 +853,31 @@ pub(super) struct CloudRetargetArgs {
     /// Hidden test hook to control the recorded run ID.
     #[arg(long, hide = true)]
     pub(super) run_id: Option<String>,
+}
+
+#[derive(Clone, Debug, clap::Args)]
+pub(super) struct RescueArgs {
+    /// PR number whose stuck runs should be rescued. Required unless `--all-stuck`.
+    #[arg(required_unless_present = "all_stuck")]
+    pub(super) pr: Option<u64>,
+    /// Rescue every stuck queued run in the repo regardless of PR.
+    #[arg(long = "all-stuck", action = ArgAction::SetTrue, conflicts_with = "pr")]
+    pub(super) all_stuck: bool,
+    /// Runner provider to redispatch to.
+    #[arg(long = "to", default_value = "github-hosted")]
+    pub(super) provider: String,
+    /// Also re-arm completed-as-cancelled runs (e.g. ones a watchdog sweep marked failed) before handoff.
+    #[arg(long = "rerun-failed", action = ArgAction::SetTrue)]
+    pub(super) rerun_failed: bool,
+    /// Plan the rescue without acting.
+    #[arg(long = "dry-run", action = ArgAction::SetTrue)]
+    pub(super) dry_run: bool,
+    /// Minimum queue age for a queued run to count as stuck. Accepts seconds or Ns/Nm/Nh suffixes.
+    #[arg(long, default_value = "30m")]
+    pub(super) threshold: String,
+    /// Owner/repo slug. Defaults to the current git repo.
+    #[arg(long)]
+    pub(super) repo: Option<String>,
 }
 
 #[derive(Clone, Debug, clap::Args)]

--- a/src/app/cloud_cmd.rs
+++ b/src/app/cloud_cmd.rs
@@ -2209,6 +2209,8 @@ mod tests {
             workflow_name: workflow.to_owned(),
             url: Some(format!("https://github.com/owner/repo/actions/runs/{id}")),
             path: ".github/workflows/ci.yml".to_owned(),
+            status: "queued".to_owned(),
+            conclusion: None,
         }
     }
 

--- a/src/app/rescue_cmd.rs
+++ b/src/app/rescue_cmd.rs
@@ -1,0 +1,687 @@
+//! `shipyard rescue` — one-shot wedged-runner recovery.
+
+use std::collections::BTreeMap;
+use std::io::Write;
+use std::path::Path;
+use std::process::ExitCode;
+
+use chrono::{DateTime, Utc};
+use serde_json::Value;
+
+use super::{
+    CliFailure,
+    cli::RescueArgs,
+    wait_cmd::parse_github_repo_slug,
+};
+use crate::cloud::{
+    GitHubActions, QueuedRun, discover_workflows, resolve_cloud_dispatch_plan,
+};
+use crate::config::LoadedConfig;
+use crate::output::write_json_envelope;
+
+const RESCUE_LIST_LIMIT: u32 = 50;
+const RESCUE_EVENT: &str = "cloud.rescue";
+
+/// Outcome of attempting to rescue a single workflow run.
+#[derive(Debug, Eq, PartialEq)]
+enum RunOutcome {
+    /// Dry-run preview; nothing dispatched.
+    Planned,
+    /// Cancelled + redispatched on the new provider.
+    Applied,
+    /// Re-armed via `gh run rerun --failed`, then handed off.
+    RerunAndApplied,
+    /// Skipped: completed/cancelled run encountered without `--rerun-failed`.
+    SkippedCompleted,
+    /// Skipped: rescue could not plan a dispatch (e.g. workflow not found locally).
+    SkippedNoPlan(String),
+    /// Run was processed but a step failed.
+    Failed(String),
+}
+
+impl RunOutcome {
+    fn label(&self) -> &'static str {
+        match self {
+            Self::Planned => "planned",
+            Self::Applied => "applied",
+            Self::RerunAndApplied => "rerun+applied",
+            Self::SkippedCompleted => "skipped-completed",
+            Self::SkippedNoPlan(_) => "skipped-no-plan",
+            Self::Failed(_) => "failed",
+        }
+    }
+
+    fn detail(&self) -> Option<String> {
+        match self {
+            Self::SkippedNoPlan(message) | Self::Failed(message) => Some(message.clone()),
+            _ => None,
+        }
+    }
+}
+
+/// Entry point invoked from `app::dispatch`.
+pub(super) fn rescue_command<W: Write>(
+    args: &RescueArgs,
+    config: &LoadedConfig,
+    cwd: &Path,
+    json: bool,
+    stdout: &mut W,
+) -> Result<ExitCode, CliFailure> {
+    let actions = GitHubActions::new(cwd);
+    rescue_with_actions(args, config, cwd, &actions, json, stdout, Utc::now())
+}
+
+pub(super) fn rescue_with_actions<W: Write>(
+    args: &RescueArgs,
+    config: &LoadedConfig,
+    cwd: &Path,
+    actions: &GitHubActions,
+    json: bool,
+    stdout: &mut W,
+    now: DateTime<Utc>,
+) -> Result<ExitCode, CliFailure> {
+    let threshold_secs = parse_threshold_secs(&args.threshold).ok_or_else(|| {
+        CliFailure::new(1, format!("Bad --threshold value: {:?}", args.threshold))
+    })?;
+    let repo_slug = resolve_repo_slug(args.repo.clone(), cwd)?;
+    let branch = resolve_branch(args, actions, &repo_slug)?;
+    let candidates = collect_candidates(args, actions, &repo_slug, branch.as_deref(), threshold_secs, now)?;
+
+    let workflows = discover_workflows(cwd);
+    let mut rows: Vec<BTreeMap<String, Value>> = Vec::with_capacity(candidates.len());
+    let mut any_failure = false;
+    for candidate in &candidates {
+        let outcome = process_candidate(candidate, args, &workflows, config, actions, &repo_slug);
+        if matches!(outcome, RunOutcome::Failed(_)) {
+            any_failure = true;
+        }
+        rows.push(candidate_row(candidate, &outcome));
+    }
+
+    let data = rescue_envelope_data(args, &repo_slug, branch.as_deref(), threshold_secs, &candidates, &rows);
+    render(stdout, json, data, || {
+        render_human_summary(args, &repo_slug, branch.as_deref(), &rows)
+    })?;
+
+    if any_failure {
+        return Ok(ExitCode::from(1));
+    }
+    Ok(ExitCode::SUCCESS)
+}
+
+fn resolve_branch(
+    args: &RescueArgs,
+    actions: &GitHubActions,
+    repo_slug: &str,
+) -> Result<Option<String>, CliFailure> {
+    if args.all_stuck {
+        return Ok(None);
+    }
+    let pr = args.pr.expect("clap requires --all-stuck or PR");
+    let head = actions
+        .pr_head_ref(repo_slug, pr)
+        .map_err(|error| CliFailure::new(1, format!("Could not resolve PR #{pr}: {error}")))?
+        .ok_or_else(|| {
+            CliFailure::new(
+                1,
+                format!("PR #{pr} returned no head ref; is it open on {repo_slug}?"),
+            )
+        })?;
+    Ok(Some(head))
+}
+
+fn collect_candidates(
+    args: &RescueArgs,
+    actions: &GitHubActions,
+    repo_slug: &str,
+    branch: Option<&str>,
+    threshold_secs: i64,
+    now: DateTime<Utc>,
+) -> Result<Vec<Candidate>, CliFailure> {
+    let queued = actions
+        .list_queued_runs(repo_slug, RESCUE_LIST_LIMIT)
+        .map_err(|error| CliFailure::new(1, format!("Could not list queued runs: {error}")))?;
+    let stuck = filter_stuck_queued(&queued, branch, threshold_secs, now);
+    let mut candidates: Vec<Candidate> = stuck
+        .into_iter()
+        .map(|run| Candidate {
+            kind: CandidateKind::QueuedStuck,
+            run,
+        })
+        .collect();
+    if !args.rerun_failed {
+        return Ok(candidates);
+    }
+    let completed = actions
+        .list_runs_with_status(repo_slug, "completed", branch, RESCUE_LIST_LIMIT)
+        .map_err(|error| CliFailure::new(1, format!("Could not list completed runs: {error}")))?;
+    for run in completed {
+        if !matches_branch(&run, branch) {
+            continue;
+        }
+        if run
+            .conclusion
+            .as_deref()
+            .is_some_and(|value| value == "cancelled")
+        {
+            candidates.push(Candidate {
+                kind: CandidateKind::CompletedCancelled,
+                run,
+            });
+        }
+    }
+    Ok(candidates)
+}
+
+fn rescue_envelope_data(
+    args: &RescueArgs,
+    repo_slug: &str,
+    branch: Option<&str>,
+    threshold_secs: i64,
+    candidates: &[Candidate],
+    rows: &[BTreeMap<String, Value>],
+) -> BTreeMap<String, Value> {
+    let mut data = BTreeMap::new();
+    data.insert("event".to_owned(), Value::from("rescue"));
+    data.insert("repo".to_owned(), Value::from(repo_slug.to_owned()));
+    data.insert("pr".to_owned(), args.pr.map_or(Value::Null, Value::from));
+    data.insert(
+        "branch".to_owned(),
+        branch.map_or(Value::Null, |value| Value::from(value.to_owned())),
+    );
+    data.insert("all_stuck".to_owned(), Value::Bool(args.all_stuck));
+    data.insert("provider".to_owned(), Value::from(args.provider.clone()));
+    data.insert("rerun_failed".to_owned(), Value::Bool(args.rerun_failed));
+    data.insert("dry_run".to_owned(), Value::Bool(args.dry_run));
+    data.insert("threshold_secs".to_owned(), Value::from(threshold_secs));
+    data.insert("candidate_count".to_owned(), Value::from(candidates.len()));
+    data.insert(
+        "runs".to_owned(),
+        Value::Array(
+            rows.iter()
+                .map(|row| {
+                    Value::Object(row.iter().map(|(k, v)| (k.clone(), v.clone())).collect())
+                })
+                .collect(),
+        ),
+    );
+    data
+}
+
+#[derive(Clone, Debug)]
+struct Candidate {
+    kind: CandidateKind,
+    run: QueuedRun,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum CandidateKind {
+    QueuedStuck,
+    CompletedCancelled,
+}
+
+fn process_candidate(
+    candidate: &Candidate,
+    args: &RescueArgs,
+    workflows: &std::collections::BTreeMap<String, crate::cloud::WorkflowDefinition>,
+    config: &LoadedConfig,
+    actions: &GitHubActions,
+    repo_slug: &str,
+) -> RunOutcome {
+    if matches!(candidate.kind, CandidateKind::CompletedCancelled) && !args.rerun_failed {
+        return RunOutcome::SkippedCompleted;
+    }
+    let run = &candidate.run;
+    let workflow_file = workflow_filename(&run.path);
+    let workflow_key = workflows
+        .iter()
+        .find(|(_, def)| def.file == workflow_file)
+        .map(|(key, _)| key.clone());
+    let Some(workflow_key) = workflow_key else {
+        return RunOutcome::SkippedNoPlan(format!(
+            "no local workflow key matches {workflow_file}"
+        ));
+    };
+    let plan = match resolve_cloud_dispatch_plan(
+        config,
+        workflows,
+        &workflow_key,
+        &run.head_branch,
+        Some(&args.provider),
+    ) {
+        Ok(plan) => plan,
+        Err(error) => {
+            return RunOutcome::SkippedNoPlan(format!(
+                "cannot plan dispatch for {workflow_key}: {error}"
+            ));
+        }
+    };
+
+    match candidate.kind {
+        CandidateKind::CompletedCancelled => {
+            if args.dry_run {
+                return RunOutcome::Planned;
+            }
+            if let Err(error) = actions.rerun_failed_run(repo_slug, run.database_id) {
+                return RunOutcome::Failed(format!(
+                    "rerun --failed failed: {error}"
+                ));
+            }
+            if let Err(error) = actions.cancel_workflow_run(repo_slug, run.database_id) {
+                return RunOutcome::Failed(format!("cancel failed: {error}"));
+            }
+            if let Err(error) = actions.workflow_dispatch(
+                Some(repo_slug),
+                &plan.workflow.file,
+                &plan.ref_name,
+                &plan.dispatch_fields,
+            ) {
+                return RunOutcome::Failed(format!("workflow_dispatch failed: {error}"));
+            }
+            RunOutcome::RerunAndApplied
+        }
+        CandidateKind::QueuedStuck => {
+            if args.dry_run {
+                return RunOutcome::Planned;
+            }
+            if let Err(error) = actions.cancel_workflow_run(repo_slug, run.database_id) {
+                return RunOutcome::Failed(format!("cancel failed: {error}"));
+            }
+            if let Err(error) = actions.workflow_dispatch(
+                Some(repo_slug),
+                &plan.workflow.file,
+                &plan.ref_name,
+                &plan.dispatch_fields,
+            ) {
+                return RunOutcome::Failed(format!("workflow_dispatch failed: {error}"));
+            }
+            RunOutcome::Applied
+        }
+    }
+}
+
+fn candidate_row(candidate: &Candidate, outcome: &RunOutcome) -> BTreeMap<String, Value> {
+    let mut row = BTreeMap::new();
+    let run = &candidate.run;
+    row.insert("run_id".to_owned(), Value::from(run.database_id));
+    row.insert(
+        "workflow".to_owned(),
+        Value::from(if run.workflow_name.is_empty() {
+            run.name.clone()
+        } else {
+            run.workflow_name.clone()
+        }),
+    );
+    row.insert("branch".to_owned(), Value::from(run.head_branch.clone()));
+    row.insert(
+        "kind".to_owned(),
+        Value::from(match candidate.kind {
+            CandidateKind::QueuedStuck => "queued-stuck",
+            CandidateKind::CompletedCancelled => "completed-cancelled",
+        }),
+    );
+    row.insert("status".to_owned(), Value::from(outcome.label()));
+    if let Some(detail) = outcome.detail() {
+        row.insert("detail".to_owned(), Value::from(detail));
+    }
+    row.insert(
+        "url".to_owned(),
+        run.url.clone().map_or(Value::Null, Value::from),
+    );
+    row
+}
+
+fn render_human_summary(
+    args: &RescueArgs,
+    repo_slug: &str,
+    branch: Option<&str>,
+    rows: &[BTreeMap<String, Value>],
+) -> String {
+    let scope = if args.all_stuck {
+        format!("repo {repo_slug}")
+    } else {
+        let pr = args
+            .pr
+            .map_or_else(|| String::from("?"), |value| value.to_string());
+        let branch = branch.unwrap_or("?");
+        format!("PR #{pr} ({branch}) on {repo_slug}")
+    };
+
+    if rows.is_empty() {
+        if args.rerun_failed {
+            return format!(
+                "No stuck or cancelled runs found for {scope} older than {}.",
+                args.threshold
+            );
+        }
+        return format!(
+            "No stuck queued runs for {scope} older than {}. Pass --rerun-failed to also scan completed/cancelled runs.",
+            args.threshold
+        );
+    }
+
+    let mut lines = Vec::new();
+    let header = if args.dry_run {
+        format!(
+            "Rescue plan for {scope} (provider: {}). Dry-run; re-run without --dry-run to apply.",
+            args.provider
+        )
+    } else {
+        format!(
+            "Rescued {scope} (provider: {}).",
+            args.provider
+        )
+    };
+    lines.push(header);
+    for row in rows {
+        let run_id = row
+            .get("run_id")
+            .and_then(Value::as_u64)
+            .map_or_else(|| "?".to_owned(), |value| value.to_string());
+        let workflow = row
+            .get("workflow")
+            .and_then(Value::as_str)
+            .unwrap_or("?");
+        let status = row
+            .get("status")
+            .and_then(Value::as_str)
+            .unwrap_or("?");
+        let kind = row
+            .get("kind")
+            .and_then(Value::as_str)
+            .unwrap_or("");
+        let detail = row
+            .get("detail")
+            .and_then(Value::as_str)
+            .map(|value| format!(" — {value}"))
+            .unwrap_or_default();
+        lines.push(format!(
+            "  • {workflow} (run {run_id}, {kind}) → {status}{detail}"
+        ));
+    }
+    if !args.rerun_failed {
+        lines.push(
+            "Hint: pass --rerun-failed to also re-arm completed/cancelled runs (e.g. watchdog-cancelled)."
+                .to_owned(),
+        );
+    }
+    lines.join("\n")
+}
+
+fn render<W: Write>(
+    stdout: &mut W,
+    json: bool,
+    data: BTreeMap<String, Value>,
+    human: impl FnOnce() -> String,
+) -> Result<(), CliFailure> {
+    if json {
+        write_json_envelope(stdout, RESCUE_EVENT, data)
+            .map_err(|error| CliFailure::new(1, error.to_string()))?;
+        return Ok(());
+    }
+    writeln!(stdout, "{}", human()).map_err(|error| CliFailure::new(1, error.to_string()))
+}
+
+fn filter_stuck_queued(
+    runs: &[QueuedRun],
+    branch: Option<&str>,
+    threshold_secs: i64,
+    now: DateTime<Utc>,
+) -> Vec<QueuedRun> {
+    runs.iter()
+        .filter(|run| matches_branch(run, branch))
+        .filter(|run| run_age_secs(run, now).is_some_and(|age| age >= threshold_secs))
+        .cloned()
+        .collect()
+}
+
+fn matches_branch(run: &QueuedRun, branch: Option<&str>) -> bool {
+    match branch {
+        Some(branch) => run.head_branch == branch,
+        None => true,
+    }
+}
+
+fn run_age_secs(run: &QueuedRun, now: DateTime<Utc>) -> Option<i64> {
+    let created = DateTime::parse_from_rfc3339(&run.created_at).ok()?;
+    Some((now - created.with_timezone(&Utc)).num_seconds())
+}
+
+fn workflow_filename(path: &str) -> String {
+    Path::new(path)
+        .file_name()
+        .and_then(|value| value.to_str())
+        .unwrap_or(path)
+        .to_owned()
+}
+
+fn parse_threshold_secs(raw: &str) -> Option<i64> {
+    let raw = raw.trim().to_lowercase();
+    if raw.is_empty() {
+        return None;
+    }
+    if let Some(hours) = raw.strip_suffix('h') {
+        return hours.parse::<i64>().ok().map(|value| value * 3_600);
+    }
+    if let Some(minutes) = raw.strip_suffix('m') {
+        return minutes.parse::<i64>().ok().map(|value| value * 60);
+    }
+    if let Some(seconds) = raw.strip_suffix('s') {
+        return seconds.parse::<i64>().ok();
+    }
+    raw.parse::<i64>().ok()
+}
+
+fn resolve_repo_slug(repo: Option<String>, cwd: &Path) -> Result<String, CliFailure> {
+    if let Some(repo) = repo.filter(|value| !value.is_empty()) {
+        return Ok(repo);
+    }
+    let output = std::process::Command::new("git")
+        .args(["remote", "get-url", "origin"])
+        .current_dir(cwd)
+        .output()
+        .map_err(|error| CliFailure::new(1, format!("failed to inspect git remote: {error}")))?;
+    if output.status.success() {
+        let remote = String::from_utf8_lossy(&output.stdout);
+        if let Some(slug) = parse_github_repo_slug(remote.trim()) {
+            return Ok(slug);
+        }
+    }
+    Err(CliFailure::new(
+        1,
+        "No repo detected. Pass --repo OWNER/REPO or run inside a git clone with a tracked remote.",
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{LoadedConfig, LocalOverlaySource};
+    use chrono::TimeZone;
+
+    fn config(root: &Path) -> LoadedConfig {
+        LoadedConfig {
+            data: toml::Table::new(),
+            global_dir: root.join("global"),
+            project_dir: None,
+            local_dir: None,
+            local_overlay_source: LocalOverlaySource::None,
+        }
+    }
+
+    fn queued_run(
+        id: u64,
+        branch: &str,
+        created_at: &str,
+        status: &str,
+        conclusion: Option<&str>,
+    ) -> QueuedRun {
+        QueuedRun {
+            database_id: id,
+            name: format!("CI #{id}"),
+            head_branch: branch.to_owned(),
+            created_at: created_at.to_owned(),
+            workflow_name: "CI".to_owned(),
+            url: Some(format!("https://example/run/{id}")),
+            path: ".github/workflows/ci.yml".to_owned(),
+            status: status.to_owned(),
+            conclusion: conclusion.map(ToOwned::to_owned),
+        }
+    }
+
+    #[test]
+    fn threshold_parsing_matches_handoff_contract() {
+        assert_eq!(parse_threshold_secs("30m"), Some(1_800));
+        assert_eq!(parse_threshold_secs("2h"), Some(7_200));
+        assert_eq!(parse_threshold_secs("45s"), Some(45));
+        assert_eq!(parse_threshold_secs("900"), Some(900));
+        assert_eq!(parse_threshold_secs(" "), None);
+        assert_eq!(parse_threshold_secs("later"), None);
+    }
+
+    #[test]
+    fn filter_stuck_queued_respects_branch_and_age() {
+        let now = Utc.with_ymd_and_hms(2026, 5, 13, 12, 0, 0).unwrap();
+        let runs = vec![
+            queued_run(1, "feat/x", "2026-05-13T11:50:00Z", "queued", None), // 10m
+            queued_run(2, "feat/x", "2026-05-13T10:00:00Z", "queued", None), // 2h
+            queued_run(3, "main", "2026-05-13T08:00:00Z", "queued", None),   // 4h, wrong branch
+        ];
+
+        let only_x = filter_stuck_queued(&runs, Some("feat/x"), 1_800, now);
+        assert_eq!(only_x.len(), 1);
+        assert_eq!(only_x[0].database_id, 2);
+
+        let all = filter_stuck_queued(&runs, None, 1_800, now);
+        assert_eq!(all.len(), 2);
+    }
+
+    #[test]
+    fn human_summary_explains_dry_run() {
+        let args = RescueArgs {
+            pr: Some(7),
+            all_stuck: false,
+            provider: "github-hosted".to_owned(),
+            rerun_failed: false,
+            dry_run: true,
+            threshold: "30m".to_owned(),
+            repo: Some("owner/repo".to_owned()),
+        };
+        let run = queued_run(99, "feat/x", "2026-05-13T10:00:00Z", "queued", None);
+        let candidate = Candidate {
+            kind: CandidateKind::QueuedStuck,
+            run,
+        };
+        let row = candidate_row(&candidate, &RunOutcome::Planned);
+        let summary = render_human_summary(&args, "owner/repo", Some("feat/x"), &[row]);
+        assert!(summary.contains("Dry-run"));
+        assert!(summary.contains("run 99"));
+        assert!(summary.contains("planned"));
+        assert!(summary.contains("--rerun-failed"));
+    }
+
+    #[test]
+    fn human_summary_no_op_includes_threshold_hint() {
+        let args = RescueArgs {
+            pr: Some(7),
+            all_stuck: false,
+            provider: "github-hosted".to_owned(),
+            rerun_failed: false,
+            dry_run: false,
+            threshold: "30m".to_owned(),
+            repo: Some("owner/repo".to_owned()),
+        };
+        let summary = render_human_summary(&args, "owner/repo", Some("feat/x"), &[]);
+        assert!(summary.contains("No stuck queued runs"));
+        assert!(summary.contains("30m"));
+        assert!(summary.contains("--rerun-failed"));
+    }
+
+    #[test]
+    fn dry_run_planning_uses_local_workflow_match() {
+        use std::fs;
+        let temp = tempfile::tempdir().expect("tempdir");
+        let workflows_dir = temp.path().join(".github").join("workflows");
+        fs::create_dir_all(&workflows_dir).expect("mkdir");
+        fs::write(
+            workflows_dir.join("ci.yml"),
+            "name: CI\non: workflow_dispatch\njobs: {}\n",
+        )
+        .expect("write workflow");
+
+        let workflows = discover_workflows(temp.path());
+        let cfg = config(temp.path());
+        let run = queued_run(42, "feat/x", "2026-05-13T10:00:00Z", "queued", None);
+        let candidate = Candidate {
+            kind: CandidateKind::QueuedStuck,
+            run,
+        };
+        let args = RescueArgs {
+            pr: Some(7),
+            all_stuck: false,
+            provider: "github-hosted".to_owned(),
+            rerun_failed: false,
+            dry_run: true,
+            threshold: "30m".to_owned(),
+            repo: Some("owner/repo".to_owned()),
+        };
+        let actions = GitHubActions::new(temp.path());
+        let outcome = process_candidate(&candidate, &args, &workflows, &cfg, &actions, "owner/repo");
+        assert_eq!(outcome, RunOutcome::Planned);
+    }
+
+    #[test]
+    fn completed_cancelled_skipped_without_rerun_flag() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let workflows = discover_workflows(temp.path());
+        let cfg = config(temp.path());
+        let run = queued_run(
+            42,
+            "feat/x",
+            "2026-05-13T10:00:00Z",
+            "completed",
+            Some("cancelled"),
+        );
+        let candidate = Candidate {
+            kind: CandidateKind::CompletedCancelled,
+            run,
+        };
+        let args = RescueArgs {
+            pr: Some(7),
+            all_stuck: false,
+            provider: "github-hosted".to_owned(),
+            rerun_failed: false,
+            dry_run: true,
+            threshold: "30m".to_owned(),
+            repo: Some("owner/repo".to_owned()),
+        };
+        let actions = GitHubActions::new(temp.path());
+        let outcome = process_candidate(&candidate, &args, &workflows, &cfg, &actions, "owner/repo");
+        // Skipped because process_candidate is called for cancelled but rerun_failed is off.
+        assert_eq!(outcome, RunOutcome::SkippedCompleted);
+    }
+
+    #[test]
+    fn skips_when_no_local_workflow_matches() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let workflows = discover_workflows(temp.path()); // empty
+        let cfg = config(temp.path());
+        let run = queued_run(42, "feat/x", "2026-05-13T10:00:00Z", "queued", None);
+        let candidate = Candidate {
+            kind: CandidateKind::QueuedStuck,
+            run,
+        };
+        let args = RescueArgs {
+            pr: Some(7),
+            all_stuck: false,
+            provider: "github-hosted".to_owned(),
+            rerun_failed: false,
+            dry_run: true,
+            threshold: "30m".to_owned(),
+            repo: Some("owner/repo".to_owned()),
+        };
+        let actions = GitHubActions::new(temp.path());
+        let outcome = process_candidate(&candidate, &args, &workflows, &cfg, &actions, "owner/repo");
+        assert!(matches!(outcome, RunOutcome::SkippedNoPlan(_)));
+    }
+}

--- a/src/app/rescue_cmd.rs
+++ b/src/app/rescue_cmd.rs
@@ -8,14 +8,8 @@ use std::process::ExitCode;
 use chrono::{DateTime, Utc};
 use serde_json::Value;
 
-use super::{
-    CliFailure,
-    cli::RescueArgs,
-    wait_cmd::parse_github_repo_slug,
-};
-use crate::cloud::{
-    GitHubActions, QueuedRun, discover_workflows, resolve_cloud_dispatch_plan,
-};
+use super::{CliFailure, cli::RescueArgs, wait_cmd::parse_github_repo_slug};
+use crate::cloud::{GitHubActions, QueuedRun, discover_workflows, resolve_cloud_dispatch_plan};
 use crate::config::LoadedConfig;
 use crate::output::write_json_envelope;
 
@@ -85,7 +79,14 @@ pub(super) fn rescue_with_actions<W: Write>(
     })?;
     let repo_slug = resolve_repo_slug(args.repo.clone(), cwd)?;
     let branch = resolve_branch(args, actions, &repo_slug)?;
-    let candidates = collect_candidates(args, actions, &repo_slug, branch.as_deref(), threshold_secs, now)?;
+    let candidates = collect_candidates(
+        args,
+        actions,
+        &repo_slug,
+        branch.as_deref(),
+        threshold_secs,
+        now,
+    )?;
 
     let workflows = discover_workflows(cwd);
     let mut rows: Vec<BTreeMap<String, Value>> = Vec::with_capacity(candidates.len());
@@ -98,7 +99,14 @@ pub(super) fn rescue_with_actions<W: Write>(
         rows.push(candidate_row(candidate, &outcome));
     }
 
-    let data = rescue_envelope_data(args, &repo_slug, branch.as_deref(), threshold_secs, &candidates, &rows);
+    let data = rescue_envelope_data(
+        args,
+        &repo_slug,
+        branch.as_deref(),
+        threshold_secs,
+        &candidates,
+        &rows,
+    );
     render(stdout, json, data, || {
         render_human_summary(args, &repo_slug, branch.as_deref(), &rows)
     })?;
@@ -199,9 +207,7 @@ fn rescue_envelope_data(
         "runs".to_owned(),
         Value::Array(
             rows.iter()
-                .map(|row| {
-                    Value::Object(row.iter().map(|(k, v)| (k.clone(), v.clone())).collect())
-                })
+                .map(|row| Value::Object(row.iter().map(|(k, v)| (k.clone(), v.clone())).collect()))
                 .collect(),
         ),
     );
@@ -238,9 +244,7 @@ fn process_candidate(
         .find(|(_, def)| def.file == workflow_file)
         .map(|(key, _)| key.clone());
     let Some(workflow_key) = workflow_key else {
-        return RunOutcome::SkippedNoPlan(format!(
-            "no local workflow key matches {workflow_file}"
-        ));
+        return RunOutcome::SkippedNoPlan(format!("no local workflow key matches {workflow_file}"));
     };
     let plan = match resolve_cloud_dispatch_plan(
         config,
@@ -263,9 +267,7 @@ fn process_candidate(
                 return RunOutcome::Planned;
             }
             if let Err(error) = actions.rerun_failed_run(repo_slug, run.database_id) {
-                return RunOutcome::Failed(format!(
-                    "rerun --failed failed: {error}"
-                ));
+                return RunOutcome::Failed(format!("rerun --failed failed: {error}"));
             }
             if let Err(error) = actions.cancel_workflow_run(repo_slug, run.database_id) {
                 return RunOutcome::Failed(format!("cancel failed: {error}"));
@@ -367,10 +369,7 @@ fn render_human_summary(
             args.provider
         )
     } else {
-        format!(
-            "Rescued {scope} (provider: {}).",
-            args.provider
-        )
+        format!("Rescued {scope} (provider: {}).", args.provider)
     };
     lines.push(header);
     for row in rows {
@@ -378,18 +377,9 @@ fn render_human_summary(
             .get("run_id")
             .and_then(Value::as_u64)
             .map_or_else(|| "?".to_owned(), |value| value.to_string());
-        let workflow = row
-            .get("workflow")
-            .and_then(Value::as_str)
-            .unwrap_or("?");
-        let status = row
-            .get("status")
-            .and_then(Value::as_str)
-            .unwrap_or("?");
-        let kind = row
-            .get("kind")
-            .and_then(Value::as_str)
-            .unwrap_or("");
+        let workflow = row.get("workflow").and_then(Value::as_str).unwrap_or("?");
+        let status = row.get("status").and_then(Value::as_str).unwrap_or("?");
+        let kind = row.get("kind").and_then(Value::as_str).unwrap_or("");
         let detail = row
             .get("detail")
             .and_then(Value::as_str)
@@ -626,7 +616,8 @@ mod tests {
             repo: Some("owner/repo".to_owned()),
         };
         let actions = GitHubActions::new(temp.path());
-        let outcome = process_candidate(&candidate, &args, &workflows, &cfg, &actions, "owner/repo");
+        let outcome =
+            process_candidate(&candidate, &args, &workflows, &cfg, &actions, "owner/repo");
         assert_eq!(outcome, RunOutcome::Planned);
     }
 
@@ -656,7 +647,8 @@ mod tests {
             repo: Some("owner/repo".to_owned()),
         };
         let actions = GitHubActions::new(temp.path());
-        let outcome = process_candidate(&candidate, &args, &workflows, &cfg, &actions, "owner/repo");
+        let outcome =
+            process_candidate(&candidate, &args, &workflows, &cfg, &actions, "owner/repo");
         // Skipped because process_candidate is called for cancelled but rerun_failed is off.
         assert_eq!(outcome, RunOutcome::SkippedCompleted);
     }
@@ -681,7 +673,8 @@ mod tests {
             repo: Some("owner/repo".to_owned()),
         };
         let actions = GitHubActions::new(temp.path());
-        let outcome = process_candidate(&candidate, &args, &workflows, &cfg, &actions, "owner/repo");
+        let outcome =
+            process_candidate(&candidate, &args, &workflows, &cfg, &actions, "owner/repo");
         assert!(matches!(outcome, RunOutcome::SkippedNoPlan(_)));
     }
 }

--- a/src/cloud.rs
+++ b/src/cloud.rs
@@ -127,6 +127,10 @@ pub struct QueuedRun {
     pub url: Option<String>,
     /// Workflow path, e.g. `.github/workflows/ci.yml`.
     pub path: String,
+    /// GitHub Actions status (`queued`, `in_progress`, `completed`, ...).
+    pub status: String,
+    /// Terminal conclusion when the run is completed.
+    pub conclusion: Option<String>,
 }
 
 /// Metadata for a single workflow run.
@@ -449,6 +453,39 @@ impl GitHubActions {
         ];
         let stdout = self.run_gh(&args)?;
         parse_queued_runs(&stdout)
+    }
+
+    /// List workflow runs filtered by status (and optional branch).
+    pub fn list_runs_with_status(
+        &self,
+        repository: &str,
+        status: &str,
+        branch: Option<&str>,
+        limit: u32,
+    ) -> Result<Vec<QueuedRun>, GitHubError> {
+        let mut path = format!(
+            "repos/{repository}/actions/runs?status={status}&per_page={limit}"
+        );
+        if let Some(branch) = branch.filter(|value| !value.is_empty()) {
+            path.push_str("&branch=");
+            path.push_str(&encode_branch(branch));
+        }
+        let args = vec!["api".to_owned(), path];
+        let stdout = self.run_gh(&args)?;
+        parse_queued_runs(&stdout)
+    }
+
+    /// Re-arm the failed jobs of a workflow run (`gh run rerun --failed`).
+    pub fn rerun_failed_run(&self, repository: &str, run_id: u64) -> Result<(), GitHubError> {
+        let args = vec![
+            "run".to_owned(),
+            "rerun".to_owned(),
+            run_id.to_string(),
+            "--failed".to_owned(),
+            "--repo".to_owned(),
+            repository.to_owned(),
+        ];
+        self.run_gh(&args).map(|_| ())
     }
 
     /// Fetch metadata for a workflow run.
@@ -815,6 +852,16 @@ pub fn parse_queued_runs(stdout: &str) -> Result<Vec<QueuedRun>, GitHubError> {
             .and_then(Value::as_str)
             .unwrap_or_default()
             .to_owned();
+        let status = run
+            .get("status")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_owned();
+        let conclusion = run
+            .get("conclusion")
+            .and_then(Value::as_str)
+            .filter(|value| !value.is_empty())
+            .map(ToOwned::to_owned);
         out.push(QueuedRun {
             database_id,
             workflow_name: name.clone(),
@@ -827,6 +874,8 @@ pub fn parse_queued_runs(stdout: &str) -> Result<Vec<QueuedRun>, GitHubError> {
                 .and_then(Value::as_str)
                 .map(ToOwned::to_owned),
             path,
+            status,
+            conclusion,
         });
     }
     Ok(out)
@@ -858,6 +907,24 @@ pub fn parse_run_metadata(stdout: &str) -> Result<RunMetadata, GitHubError> {
             .unwrap_or_default()
             .to_owned(),
     })
+}
+
+fn encode_branch(branch: &str) -> String {
+    use std::fmt::Write;
+    let mut out = String::with_capacity(branch.len());
+    for ch in branch.chars() {
+        match ch {
+            'a'..='z' | 'A'..='Z' | '0'..='9' | '-' | '_' | '.' | '~' | '/' => out.push(ch),
+            _ => {
+                let mut buf = [0u8; 4];
+                let encoded = ch.encode_utf8(&mut buf);
+                for byte in encoded.bytes() {
+                    write!(out, "%{byte:02X}").expect("write to String");
+                }
+            }
+        }
+    }
+    out
 }
 
 fn workflow_run_from_value(value: &Value) -> Result<WorkflowRun, GitHubError> {

--- a/src/cloud.rs
+++ b/src/cloud.rs
@@ -463,9 +463,7 @@ impl GitHubActions {
         branch: Option<&str>,
         limit: u32,
     ) -> Result<Vec<QueuedRun>, GitHubError> {
-        let mut path = format!(
-            "repos/{repository}/actions/runs?status={status}&per_page={limit}"
-        );
+        let mut path = format!("repos/{repository}/actions/runs?status={status}&per_page={limit}");
         if let Some(branch) = branch.filter(|value| !value.is_empty()) {
             path.push_str("&branch=");
             path.push_str(&encode_branch(branch));

--- a/src/runner_watchdog.rs
+++ b/src/runner_watchdog.rs
@@ -314,6 +314,8 @@ mod tests {
             workflow_name: workflow.to_owned(),
             url: Some(format!("https://github.com/owner/repo/actions/runs/{id}")),
             path: ".github/workflows/ci.yml".to_owned(),
+            status: "queued".to_owned(),
+            conclusion: None,
         }
     }
 


### PR DESCRIPTION
Closes #286. Adds `shipyard rescue <PR> [--to <provider>] [--rerun-failed]
[--dry-run] [--all-stuck] [--threshold <dur>] [--repo OWNER/REPO]` as a
top-level command that resolves a PR's head branch, filters queued
workflow runs older than the threshold to that branch, and cancels +
redispatches each onto a different provider (default `github-hosted`) in
one shot. `--rerun-failed` additionally pulls completed/cancelled runs on
that branch, calls `gh run rerun --failed`, then hands off. `--all-stuck`
runs the same flow repo-wide without a PR filter. Honors Shipyard's
`cloud.rescue` JSON envelope.

Internally extends `QueuedRun` with `status` + `conclusion`, adds
`list_runs_with_status` and `rerun_failed_run` to `GitHubActions`, and
exposes a top-level help entry so `shipyard --help` lists `rescue`
alongside `cloud`.

This collapses the previous 5-step recipe (`gh api` + `cloud handoff
list-stuck` + per-run `cloud handoff run --apply`) into one command and
gives agents a discoverable surface so they stop reaching for
`runner-watchdog.sh --fix`, which marks the wedge as required-check
`failure` without redispatching.

Skill-Update: skip skill=shipyard reason="Additive CLI command (shipyard rescue); no impact on Python parity, drift baselines, install state, or GUI cutover. Covered by skills/ci SKILL.md update in this PR."