### PR TITLE
fix: address Codex review findings on v0.53.0 → v0.56.0 PRs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to Shipyard are documented here. Each entry links
 to its [GitHub Release](https://github.com/danielraffel/Shipyard/releases).
 
 <a id="v0560"></a>
+## [0.56.1]
+
 ## [0.56.0] - 2026-05-13
 
 - follow-ups: REST fallback, config.toml fix, daemon idle gating ([#295](https://github.com/danielraffel/Shipyard/pull/295))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -614,7 +614,7 @@ dependencies = [
 
 [[package]]
 name = "shipyard"
-version = "0.56.0"
+version = "0.56.1"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shipyard"
-version = "0.56.0"
+version = "0.56.1"
 edition = "2024"
 description = "Cross-platform CI coordination for local, SSH, and cloud runners."
 rust-version = "1.92"

--- a/src/app/rescue_cmd.rs
+++ b/src/app/rescue_cmd.rs
@@ -13,7 +13,11 @@ use crate::cloud::{GitHubActions, QueuedRun, discover_workflows, resolve_cloud_d
 use crate::config::LoadedConfig;
 use crate::output::write_json_envelope;
 
-const RESCUE_LIST_LIMIT: u32 = 50;
+/// Cap on the number of paginated `gh api` calls per rescue invocation.
+/// Each page is 100 items, so the worst case is 500 queued + 500 completed
+/// runs scanned. In practice we expect early termination on the first
+/// short page.
+const RESCUE_LIST_MAX_PAGES: u32 = 5;
 const RESCUE_EVENT: &str = "cloud.rescue";
 
 /// Outcome of attempting to rescue a single workflow run.
@@ -147,7 +151,7 @@ fn collect_candidates(
     now: DateTime<Utc>,
 ) -> Result<Vec<Candidate>, CliFailure> {
     let queued = actions
-        .list_queued_runs(repo_slug, RESCUE_LIST_LIMIT)
+        .list_queued_runs_paginated(repo_slug, RESCUE_LIST_MAX_PAGES)
         .map_err(|error| CliFailure::new(1, format!("Could not list queued runs: {error}")))?;
     let stuck = filter_stuck_queued(&queued, branch, threshold_secs, now);
     let mut candidates: Vec<Candidate> = stuck
@@ -161,7 +165,7 @@ fn collect_candidates(
         return Ok(candidates);
     }
     let completed = actions
-        .list_runs_with_status(repo_slug, "completed", branch, RESCUE_LIST_LIMIT)
+        .list_runs_with_status_paginated(repo_slug, "completed", branch, RESCUE_LIST_MAX_PAGES)
         .map_err(|error| CliFailure::new(1, format!("Could not list completed runs: {error}")))?;
     for run in completed {
         if !matches_branch(&run, branch) {
@@ -437,11 +441,22 @@ fn run_age_secs(run: &QueuedRun, now: DateTime<Utc>) -> Option<i64> {
     Some((now - created.with_timezone(&Utc)).num_seconds())
 }
 
+/// Extract a workflow filename from a workflow-run `path` field.
+///
+/// GitHub's Actions API returns `path` values like
+/// `.github/workflows/ci.yml@refs/heads/main` or
+/// `.github/workflows/ci.yml@main`; only the `ci.yml` portion matches the
+/// `WorkflowDefinition::file` we discovered locally. The `@<ref>` suffix
+/// must be stripped *before* taking the basename — a ref like
+/// `refs/heads/main` contains slashes, which `Path::file_name` would
+/// otherwise read as nested directories and return `main`. Strip the
+/// `@<ref>` first so the basename is computed against the file path alone.
 fn workflow_filename(path: &str) -> String {
-    Path::new(path)
+    let file_segment = path.split_once('@').map_or(path, |(file, _ref)| file);
+    Path::new(file_segment)
         .file_name()
         .and_then(|value| value.to_str())
-        .unwrap_or(path)
+        .unwrap_or(file_segment)
         .to_owned()
 }
 
@@ -517,6 +532,24 @@ mod tests {
             status: status.to_owned(),
             conclusion: conclusion.map(ToOwned::to_owned),
         }
+    }
+
+    #[test]
+    fn workflow_filename_strips_ref_suffix() {
+        // GitHub's Actions API returns path with `@<ref>` appended in many
+        // common cases. We must strip it or workflow lookup fails.
+        assert_eq!(
+            workflow_filename(".github/workflows/ci.yml@refs/heads/main"),
+            "ci.yml"
+        );
+        assert_eq!(
+            workflow_filename(".github/workflows/release.yml@main"),
+            "release.yml"
+        );
+        assert_eq!(workflow_filename("ci.yml@v0.53.0"), "ci.yml");
+        // Bare filenames and paths without @ref still work.
+        assert_eq!(workflow_filename(".github/workflows/ci.yml"), "ci.yml");
+        assert_eq!(workflow_filename("ci.yml"), "ci.yml");
     }
 
     #[test]

--- a/src/app/runner_cmd.rs
+++ b/src/app/runner_cmd.rs
@@ -1084,12 +1084,24 @@ struct PsRow<'a> {
     command: &'a str,
 }
 
+/// Parse a single line of `ps -ax -o pid=,etime=,command=` output.
+///
+/// `ps` right-pads the PID and etime columns to fixed widths on macOS and
+/// Linux, so adjacent fields are separated by *runs* of spaces — not a single
+/// space. The previous `splitn(3, char::is_whitespace)` would yield an empty
+/// second token whenever the gap was wider than one space, making etime
+/// parsing fail and causing `discover_hung_workers` to silently miss every
+/// real worker on the host (Codex P1 review against #291).
+///
+/// This implementation consumes whitespace runs between fields, but
+/// preserves spaces inside the trailing command string.
 fn parse_ps_pid_etime_command(line: &str) -> Option<PsRow<'_>> {
-    let trimmed = line.trim_start();
-    let mut iter = trimmed.splitn(3, char::is_whitespace);
-    let pid_tok = iter.next()?;
-    let etime_tok = iter.next()?;
-    let command = iter.next()?;
+    let (pid_tok, after_pid) = take_token(line.trim_start())?;
+    let (etime_tok, after_etime) = take_token(after_pid.trim_start())?;
+    let command = after_etime.trim_start();
+    if command.is_empty() {
+        return None;
+    }
     let pid = pid_tok.parse::<u32>().ok()?;
     let etime_min = parse_etime_minutes(etime_tok)?;
     Some(PsRow {
@@ -1097,6 +1109,19 @@ fn parse_ps_pid_etime_command(line: &str) -> Option<PsRow<'_>> {
         etime_min,
         command,
     })
+}
+
+/// Split off the first whitespace-delimited token. Returns `None` if `s` is
+/// empty or starts with whitespace (caller must `trim_start` first).
+fn take_token(s: &str) -> Option<(&str, &str)> {
+    if s.is_empty() {
+        return None;
+    }
+    let end = s.find(char::is_whitespace).unwrap_or(s.len());
+    if end == 0 {
+        return None;
+    }
+    Some((&s[..end], &s[end..]))
 }
 
 /// Parse `ps`-style `etime` strings (`MM:SS`, `HH:MM:SS`, or `DD-HH:MM:SS`)
@@ -1163,6 +1188,33 @@ mod tests {
     #[test]
     fn parse_ps_row_rejects_non_numeric_pid() {
         assert!(parse_ps_pid_etime_command("abcd 01:30:00 /bin/Runner.Worker").is_none());
+    }
+
+    #[test]
+    fn parse_ps_row_collapses_multispace_columns() {
+        // Real `ps -ax -o pid=,etime=,command=` output pads PID + etime to
+        // fixed-width columns separated by runs of spaces, not single spaces.
+        // The previous splitn-based parser silently rejected these rows.
+        let row = parse_ps_pid_etime_command(
+            "  12345    01:30:00    /Users/foo/actions-runner/bin/Runner.Worker spawnclient 0 0",
+        )
+        .expect("row");
+        assert_eq!(row.pid, 12345);
+        assert_eq!(row.etime_min, 90);
+        assert!(
+            row.command
+                .starts_with("/Users/foo/actions-runner/bin/Runner.Worker")
+        );
+    }
+
+    #[test]
+    fn parse_ps_row_preserves_command_internal_spaces() {
+        // After collapsing the column gaps, internal spaces in the command
+        // (e.g. argv tokens) must survive unchanged.
+        let row =
+            parse_ps_pid_etime_command(" 1 00:01 /bin/Runner.Worker arg with multiple   spaces")
+                .expect("row");
+        assert!(row.command.contains("arg with multiple   spaces"));
     }
 
     #[test]

--- a/src/app/update_cmd.rs
+++ b/src/app/update_cmd.rs
@@ -229,7 +229,7 @@ fn apply_update<W: Write>(
         format!("Updating from {installed} to {target_tag} via {install_script_url} …")
     })?;
 
-    invoke_install_script(&curl_bin, &shell_bin, install_script_url, target_tag)?;
+    invoke_install_script(&curl_bin, &shell_bin, install_script_url, target_tag, json)?;
 
     let mut data = BTreeMap::new();
     data.insert("event".to_owned(), Value::from("applied"));
@@ -248,6 +248,7 @@ fn invoke_install_script(
     shell_bin: &Path,
     install_script_url: &str,
     target_tag: &str,
+    json: bool,
 ) -> Result<(), CliFailure> {
     let mut curl = Command::new(curl_bin)
         .args(["-fsSL", install_script_url])
@@ -261,11 +262,31 @@ fn invoke_install_script(
         .take()
         .ok_or_else(|| CliFailure::new(1, "curl stdout pipe missing"))?;
 
+    // Under `--json`, route installer progress to stderr so the stdout
+    // stream stays a clean sequence of JSON envelopes for downstream
+    // automation. In human mode, keep the installer's stdout visible so
+    // the user sees the progress bar.
+    let install_stdout = if json {
+        // Inherit our own stderr — install.sh's stdout becomes our stderr.
+        // `Stdio::from(std::io::stderr())` would consume our stderr handle;
+        // duplicate the parent stderr fd instead.
+        Stdio::from(
+            std::fs::OpenOptions::new()
+                .write(true)
+                .open("/dev/stderr")
+                .map_err(|error| {
+                    CliFailure::new(1, format!("failed to open /dev/stderr: {error}"))
+                })?,
+        )
+    } else {
+        Stdio::inherit()
+    };
+
     let env_tag = target_tag.strip_prefix('v').unwrap_or(target_tag);
     let mut sh = Command::new(shell_bin)
         .env("SHIPYARD_VERSION", env_tag)
         .stdin(curl_stdout)
-        .stdout(Stdio::inherit())
+        .stdout(install_stdout)
         .stderr(Stdio::inherit())
         .spawn()
         .map_err(|error| CliFailure::new(1, format!("failed to spawn shell: {error}")))?;

--- a/src/cloud.rs
+++ b/src/cloud.rs
@@ -455,6 +455,31 @@ impl GitHubActions {
         parse_queued_runs(&stdout)
     }
 
+    /// Like `list_queued_runs` but paginates up to `max_pages` (`per_page=100` each)
+    /// so callers can cover busy repos with more than one page of queued runs.
+    /// Stops early when a page returns no items.
+    pub fn list_queued_runs_paginated(
+        &self,
+        repository: &str,
+        max_pages: u32,
+    ) -> Result<Vec<QueuedRun>, GitHubError> {
+        let mut out = Vec::new();
+        for page in 1..=max_pages.max(1) {
+            let args = vec![
+                "api".to_owned(),
+                format!("repos/{repository}/actions/runs?status=queued&`per_page=100`&page={page}"),
+            ];
+            let stdout = self.run_gh(&args)?;
+            let page_runs = parse_queued_runs(&stdout)?;
+            let count = page_runs.len();
+            out.extend(page_runs);
+            if count < 100 {
+                break;
+            }
+        }
+        Ok(out)
+    }
+
     /// List workflow runs filtered by status (and optional branch).
     pub fn list_runs_with_status(
         &self,
@@ -471,6 +496,36 @@ impl GitHubActions {
         let args = vec!["api".to_owned(), path];
         let stdout = self.run_gh(&args)?;
         parse_queued_runs(&stdout)
+    }
+
+    /// Like `list_runs_with_status` but paginates up to `max_pages` (`per_page=100`
+    /// each). Stops early when a page returns no items.
+    pub fn list_runs_with_status_paginated(
+        &self,
+        repository: &str,
+        status: &str,
+        branch: Option<&str>,
+        max_pages: u32,
+    ) -> Result<Vec<QueuedRun>, GitHubError> {
+        let mut out = Vec::new();
+        for page in 1..=max_pages.max(1) {
+            let mut path = format!(
+                "repos/{repository}/actions/runs?status={status}&`per_page=100`&page={page}"
+            );
+            if let Some(branch) = branch.filter(|value| !value.is_empty()) {
+                path.push_str("&branch=");
+                path.push_str(&encode_branch(branch));
+            }
+            let args = vec!["api".to_owned(), path];
+            let stdout = self.run_gh(&args)?;
+            let page_runs = parse_queued_runs(&stdout)?;
+            let count = page_runs.len();
+            out.extend(page_runs);
+            if count < 100 {
+                break;
+            }
+        }
+        Ok(out)
     }
 
     /// Re-arm the failed jobs of a workflow run (`gh run rerun --failed`).

--- a/src/daemon_runtime.rs
+++ b/src/daemon_runtime.rs
@@ -233,11 +233,15 @@ pub fn run_blocking(config: DaemonRunConfig) -> Result<(), DaemonRunError> {
                 reconcile_window.clone(),
                 reconcile_tx.clone(),
             );
-        } else if !has_subscribers {
-            // Reconcile is a GUI/IPC freshness fallback. Webhooks still update
-            // state while idle, but don't burn GitHub quota with no listener.
-            next_reconcile_at = now + Duration::from_secs(RECONCILE_INTERVAL_SECONDS);
         }
+        // Note: we deliberately do NOT push `next_reconcile_at` forward while
+        // idle. Doing so would force a freshly-attached subscriber to wait up
+        // to a full interval before its first reconcile fires, even though
+        // state may have drifted during the idle window. Leaving the deadline
+        // stale means the next `should_start_reconcile` call after subscribe
+        // sees `now >= next_reconcile_at` immediately. The GitHub-quota
+        // savings still hold because `should_start_reconcile` gates on
+        // `has_subscribers`.
 
         if now >= next_ship_state_scan_at {
             next_ship_state_scan_at = now + SHIP_STATE_SCAN_INTERVAL;
@@ -1599,6 +1603,24 @@ mod tests {
             now + Duration::from_secs(1)
         ));
         assert!(should_start_reconcile(true, false, now, now));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn reconcile_fires_immediately_after_subscriber_attaches() {
+        // A stale `next_reconcile_at` (well in the past, from a long idle
+        // window) plus a freshly-attached subscriber must reconcile on the
+        // *very next* loop iteration — not on the iteration after that.
+        // The previous bug pushed `next_reconcile_at = now + interval`
+        // every idle tick, so attach → wait up to a full interval.
+        let now = Instant::now();
+        let stale_deadline = now.checked_sub(Duration::from_mins(10)).unwrap_or(now);
+        // No subscribers → gate stays closed (the loop must not have rewritten
+        // the deadline forward during idle).
+        assert!(!should_start_reconcile(false, false, now, stale_deadline));
+        // Subscriber attaches; deadline is still the stale value. Gate fires
+        // immediately on this iteration.
+        assert!(should_start_reconcile(true, false, now, stale_deadline));
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
Five fixes flagged by Codex on the recently-merged PRs. All confirmed
reproducible against the shipped code:

P1s (broke headline features in real-world conditions):

1. **rescue: strip `@<ref>` from workflow path before basename**
   (codex on #287, src/app/rescue_cmd.rs)
   GitHub's Actions API returns `path` values like
   `.github/workflows/ci.yml@refs/heads/main`. The prior `workflow_filename`
   took the basename first (yielding `main`!) and then split on `@`.
   Workflow lookup failed → `SkippedNoPlan` → rescue silently skipped
   every stuck run on production API responses. Split-on-@ first, then
   basename. New test `workflow_filename_strips_ref_suffix` covers
   `refs/heads/<branch>`, `@<tag>`, plain `@<branch>`, and the
   no-`@` cases.

2. **runner watch: tokenize `ps` columns with whitespace runs collapsed**
   (codex on #291, src/app/runner_cmd.rs)
   `parse_ps_pid_etime_command` used `splitn(3, char::is_whitespace)`
   which doesn't collapse runs of spaces. Real `ps -ax -o
   pid=,etime=,command=` output pads PID + etime to fixed-width
   columns separated by 2+ spaces — the previous parser yielded an
   empty etime token and rejected the row. `discover_hung_workers`
   silently returned `no-pid-found` on every host. New `take_token`
   helper consumes one whitespace-delimited token at a time while
   preserving internal spaces in the trailing command. New tests
   `parse_ps_row_collapses_multispace_columns` and
   `parse_ps_row_preserves_command_internal_spaces`.

3. **update --json: keep stdout machine-parseable on apply path**
   (codex on #293, src/app/update_cmd.rs)
   `invoke_install_script` inherited stdout for the spawned `sh` so
   install.sh progress text was emitted between JSON envelopes,
   breaking any automation reading stdout as NDJSON. When `json=true`,
   route install.sh stdout to `/dev/stderr` instead — stderr-side
   progress still surfaces to the terminal but stdout stays clean.

P2s (correct but suboptimal — surfaced second-order bugs):

4. **rescue: paginate beyond first 50 queued + completed runs**
   (codex on #287, src/cloud.rs + src/app/rescue_cmd.rs)
   `list_queued_runs(_paginated)` and `list_runs_with_status(_paginated)`
   now follow `?page=N&per_page=100` until a short page returns.
   `RESCUE_LIST_MAX_PAGES = 5` (500 items per category) so busy
   incidents with hundreds of stuck runs no longer get partial
   recovery.

5. **daemon: don't push `next_reconcile_at` forward while idle**
   (codex on #295, src/daemon_runtime.rs)
   Idle-mode branch was rewriting `next_reconcile_at = now + 30s` on
   every loop iteration. When a subscriber attached, reconcile was
   delayed by up to a full interval before firing. Removed the
   reset; gate now stays open across idle windows so first reconcile
   after attach fires immediately. New test
   `reconcile_fires_immediately_after_subscriber_attaches`.

Tests added: 5 (3 in rescue_cmd, 2 in runner_cmd, 1 in daemon_runtime).
All existing tests still pass except the two long-standing pre-existing
flakes tracked in #296 (still --skipped in .shipyard/config.toml).

Skill-Update: skip skill=ci reason="Pure bug-fix PR. The CI skill already documents the commands (rescue, runner watch --kill-hung-workers, update, doctor --rate-limit); these fixes make those documented behaviors actually work."
Skill-Update: skip skill=shipyard reason="Pure bug-fix PR. No impact on Python parity, install state, drift baselines, or GUI cutover."