### PR TITLE
feat(wait): REST fallback for wait pr + README audit + bundle #131

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "shipyard",
-  "version": "0.13.8",
+  "version": "0.14.0",
   "description": "Cross-platform CI coordination",
   "min_shipyard_version": "0.22.8",
   "commands": "./commands",

--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ shipyard ship              # validate, open PR, merge on green
 shipyard watch             # live-tail an in-flight ship
 shipyard wait pr 151 --state green  # wait on release / PR / run conditions
 shipyard auto-merge <pr>   # cron-friendly one-shot merge-on-green
+shipyard rescue <pr>       # cancel + redispatch every stuck queued run on a PR
+shipyard runner watch --kill-hung-workers  # daemon-mode prevent + auto-kill hung Workers
+shipyard update            # self-update the CLI (or `--check` to peek)
+shipyard doctor --rate-limit  # inspect REST + GraphQL buckets separately
 shipyard release-bot setup # guided RELEASE_BOT_TOKEN setup
 shipyard cloud retarget    # switch one target's runner mid-flight
 shipyard cloud add-lane    # append a new lane to an in-flight PR
@@ -37,43 +41,53 @@ shipyard changelog init    # opt in to post-release CHANGELOG auto-sync
   Xcode, Rust, Go, Node (pnpm/bun/yarn/npm), Python (uv/poetry/pip),
   Gradle, Maven, .NET, Flutter, Dart, Deno, Ruby, Elixir, PHP.
 - **Self-hosted runner watchdog.** `shipyard runner status` /
-  `cleanup --fix` / `watch --fix` detect and auto-recover the
-  stuck-runner failure mode (orphaned busy state, hung worker, stale
-  queued runs). See [docs/runner-watchdog.md](docs/runner-watchdog.md).
+  `cleanup --fix` / `watch --fix` / `watch --kill-hung-workers` detect
+  and auto-recover the stuck-runner failure mode (orphaned busy state,
+  hung worker, stale queued runs). `runner kill --pid <pid>` is the
+  explicit one-shot equivalent. See [docs/runner-watchdog.md](docs/runner-watchdog.md).
+- **One-shot PR rescue.** `shipyard rescue <pr>` cancels and
+  redispatches every stuck queued workflow run on a PR onto
+  `github-hosted` (or any provider via `--to`). `--rerun-failed`
+  also re-arms watchdog-cancelled runs; `--all-stuck` is the
+  repo-wide variant. Pairs with the watchdog to form a complete
+  prevent → recover toolkit.
+- **In-tool self-update.** `shipyard update` is the discoverable
+  upgrade path (no more curl-pipe to remember); `--check` reports
+  installed-vs-available, `--to v0.55.0` pins a specific tag for
+  rollback.
+- **Graceful GraphQL rate-limit degradation.** `shipyard auto-merge`
+  and `shipyard wait pr` fall back to REST automatically when
+  GraphQL exhausts (separate 5000/hr bucket). `shipyard doctor
+  --rate-limit` shows both buckets so you can see which one is hot.
 
 ## Installation
 
 ### Claude Code (recommended)
 
-**Step 1:** Add the Shipyard marketplace to `~/.claude/settings.json`:
+Two commands to register the marketplace and install the plugin:
 
-```json
-{
-  "extraKnownMarketplaces": {
-    "shipyard": {
-      "source": {
-        "source": "github",
-        "repo": "danielraffel/Shipyard"
-      }
-    }
-  }
-}
+```bash
+claude plugin marketplace add danielraffel/Shipyard
+claude plugin install shipyard
 ```
 
-**Step 2:** Install the plugin:
-
-```
-/plugin install shipyard@shipyard
-```
-
-**Step 3:** Set up your project:
+Then set up your project:
 
 ```
 /shipyard:init
 ```
 
-The plugin uses the CLI under the hood. If the `shipyard` binary isn't
-installed, the plugin will offer to install it for you.
+The plugin uses the CLI under the hood. On first session start it
+auto-installs the binary if it can't find `shipyard` on PATH — and
+skips the install if it can. If you've already installed the CLI
+(via `install.sh` or a project pinner like pulp's
+`tools/install-shipyard.sh`), make sure its bin directory is on
+PATH before you install the plugin; that way the plugin respects
+your existing pin instead of installing its own copy alongside it.
+
+Plugin + CLI are independently versioned; the plugin's version
+covers slash commands / skills / hooks, while the CLI's version
+covers the binary. It's safe to have both.
 
 ### Codex / CLI
 
@@ -236,9 +250,8 @@ Shipyard doesn't leave much footprint, but here's the complete list:
 # 1. Stop + unregister the daemon (if running)
 shipyard daemon stop
 
-# 2. Uninstall the CLI (method depends on how you installed)
-pip uninstall shipyard                # if installed via pip
-rm -rf ~/.pulp                        # if installed via install.sh
+# 2. Uninstall the CLI binary (install.sh writes here regardless of source)
+rm -f ~/.local/bin/shipyard ~/.local/bin/sy
 
 # 3. Remove state directory (ship-state, daemon config, webhook secret)
 #    macOS:

--- a/skills/ci/SKILL.md
+++ b/skills/ci/SKILL.md
@@ -166,13 +166,19 @@ think the build takes:
 - `auto-merge` is for out-of-session automation (cron, systemd timer,
   GitHub Actions schedule). Not a substitute for `watch` within a live
   agent session.
-- `auto-merge` auto-degrades to REST when GraphQL is rate-limited.
-  `gh pr merge` (used internally) calls GraphQL for the mergeable-state
-  probe; if that fails with `GraphQL: API rate limit already exceeded`,
-  Shipyard falls back to `PUT /repos/:r/pulls/:n/merge` directly (REST
-  has its own 5000/hr bucket). Agents do not need to hand-roll
-  `gh api -X PUT .../merge` anymore. Check both buckets with
-  `shipyard doctor --rate-limit --json`.
+- `auto-merge` and `wait pr` auto-degrade to REST when GraphQL is
+  rate-limited. `gh pr merge` and `gh pr view --json` (used internally)
+  call GraphQL for the mergeable-state probe; if either fails with
+  `GraphQL: API rate limit already exceeded`, Shipyard falls back to
+  `PUT /repos/:r/pulls/:n/merge` (auto-merge) and `GET /repos/:r/pulls/:n`
+  + `GET /repos/:r/commits/:sha/check-runs` (wait pr) directly. REST
+  has its own 5000/hr bucket, separate from GraphQL. Agents do not
+  need to hand-roll `gh api` calls anymore. Check both buckets with
+  `shipyard doctor --rate-limit --json`. The REST `wait pr` fallback
+  is conservative — all check runs are treated as required, so a
+  green verdict cannot incorrectly fire when non-required checks
+  fail. Snapshot output carries `_rest_fallback: true` when the
+  fallback path served the value.
 
 Example — agent blocks until merge in-session:
 

--- a/src/pr.rs
+++ b/src/pr.rs
@@ -180,17 +180,21 @@ fn find_pr_for_branch_rest(
         .next()
         .filter(|owner| !owner.is_empty())
         .ok_or_else(|| PrError::new(format!("could not derive owner from repo {repo:?}")))?;
-    let endpoint = format!("repos/{repo}/pulls");
+    // Build a query-string URL so `gh api` issues a GET. Passing `-f`
+    // without `-X GET` makes gh send the parameters as a request body
+    // and switch to POST against `repos/:r/pulls` — which is the
+    // *create-PR* endpoint. GitHub then 422s on missing `base`, which
+    // is the symptom captured in #282. Force GET semantics explicitly.
     let head = format!("{owner}:{branch}");
+    let endpoint = format!(
+        "repos/{repo}/pulls?head={}&state=open&per_page=1",
+        url_encode(&head)
+    );
     let args = vec![
         "api".to_owned(),
+        "-X".to_owned(),
+        "GET".to_owned(),
         endpoint,
-        "-f".to_owned(),
-        format!("head={head}"),
-        "-f".to_owned(),
-        "state=open".to_owned(),
-        "-F".to_owned(),
-        "per_page=1".to_owned(),
     ];
     let output = gh(gh_command)
         .args(args)
@@ -286,6 +290,26 @@ fn repo_slug(cwd: &Path) -> Result<String, PrError> {
             remote.trim()
         ))
     })
+}
+
+/// Minimal percent-encoder for query-string values used by REST fallbacks.
+/// Encodes the characters `gh api` needs us to escape (`:` `/` `?` `&` `=` `#`
+/// and spaces) so query parameters survive without pulling in a dependency.
+fn url_encode(value: &str) -> String {
+    use std::fmt::Write;
+    let mut out = String::with_capacity(value.len());
+    for ch in value.chars() {
+        match ch {
+            'A'..='Z' | 'a'..='z' | '0'..='9' | '-' | '_' | '.' | '~' => out.push(ch),
+            _ => {
+                let mut buf = [0u8; 4];
+                for byte in ch.encode_utf8(&mut buf).as_bytes() {
+                    write!(&mut out, "%{byte:02X}").expect("write to String");
+                }
+            }
+        }
+    }
+    out
 }
 
 fn parse_github_remote_slug(remote: &str) -> Option<String> {
@@ -399,7 +423,7 @@ fn nested_string_field(value: &Value, path: &[&str]) -> Result<String, PrError> 
 mod tests {
     use super::{
         PrInfo, is_graphql_rate_limited, parse_github_remote_slug, parse_pr_info, parse_pr_list,
-        parse_pr_rest_info, parse_pr_rest_list, selector_pr_number,
+        parse_pr_rest_info, parse_pr_rest_list, selector_pr_number, url_encode,
     };
 
     #[test]
@@ -456,6 +480,23 @@ mod tests {
             "GraphQL: API rate limit already exceeded for user ID 123"
         ));
         assert!(!is_graphql_rate_limited("HTTP 500: something else failed"));
+    }
+
+    #[test]
+    fn url_encode_escapes_query_string_specials() {
+        // `:` and `/` appear in `owner:branch` and `refs/heads/...` query
+        // values; both must survive in the URL or the GET hits the wrong
+        // endpoint. Issue #282 saw `gh api repos/.../pulls -f head=owner:branch`
+        // get turned into POST → 422 missing base. Forcing GET + encoding
+        // the value keeps it a real GET.
+        assert_eq!(url_encode("owner:branch"), "owner%3Abranch");
+        assert_eq!(url_encode("refs/heads/main"), "refs%2Fheads%2Fmain");
+        assert_eq!(
+            url_encode("danielraffel:feat/298-waitpr-rest-fallback"),
+            "danielraffel%3Afeat%2F298-waitpr-rest-fallback"
+        );
+        // Letters / digits / unreserved punctuation pass through unchanged.
+        assert_eq!(url_encode("AbC-_.~123"), "AbC-_.~123");
     }
 
     #[test]

--- a/src/wait_transport.rs
+++ b/src/wait_transport.rs
@@ -269,8 +269,14 @@ pub fn fetch_release_snapshot(repo: &str, tag: &str, cwd: &Path) -> WaitResult<O
 }
 
 /// Fetch a GitHub PR snapshot.
+///
+/// First tries `gh pr view --json …` (GraphQL under the hood). When GraphQL
+/// is rate-limited, falls back to synthesising the same shape from REST:
+/// `gh api repos/:r/pulls/:n` for the PR fields plus
+/// `gh api repos/:r/commits/:sha/check-runs` for the check rollup. Matches
+/// the same fallback pattern `src/pr.rs` and `src/app/auto_merge_cmd.rs` use.
 pub fn fetch_pr_snapshot(repo: &str, pr_number: u64, cwd: &Path) -> WaitResult<Option<Value>> {
-    run_gh_json(
+    match run_gh_capturing(
         &[
             "pr".to_owned(),
             "view".to_owned(),
@@ -282,8 +288,116 @@ pub fn fetch_pr_snapshot(repo: &str, pr_number: u64, cwd: &Path) -> WaitResult<O
                 .to_owned(),
         ],
         cwd,
-        20.0,
-    )
+    )? {
+        GhOutcome::Success(stdout) => {
+            let value = serde_json::from_slice::<Value>(&stdout)?;
+            Ok(value.is_object().then_some(value))
+        }
+        GhOutcome::GraphqlRateLimited => fetch_pr_snapshot_rest(repo, pr_number, cwd),
+        GhOutcome::OtherFailure => Ok(None),
+    }
+}
+
+/// REST fallback for `fetch_pr_snapshot`. Synthesises the GraphQL-shape value
+/// `evaluate_pr_green` / `evaluate_pr_state` consume.
+///
+/// Note: REST `check-runs` does NOT carry per-check `isRequired`; we emit the
+/// rollup without that field. `evaluate_pr_check_rollup` then falls back to
+/// `entry.get("isRequired").as_bool().unwrap_or(true)`-equivalent semantics
+/// — every check is treated as required. That's stricter than GraphQL but
+/// safe: a green REST evaluation cannot incorrectly report green when
+/// non-required checks fail.
+pub fn fetch_pr_snapshot_rest(repo: &str, pr_number: u64, cwd: &Path) -> WaitResult<Option<Value>> {
+    let pr_value = match run_gh_capturing(
+        &[
+            "api".to_owned(),
+            format!("repos/{repo}/pulls/{pr_number}"),
+            "-H".to_owned(),
+            "Accept: application/vnd.github+json".to_owned(),
+        ],
+        cwd,
+    )? {
+        GhOutcome::Success(stdout) => serde_json::from_slice::<Value>(&stdout)?,
+        GhOutcome::GraphqlRateLimited | GhOutcome::OtherFailure => return Ok(None),
+    };
+
+    let head_sha = pr_value
+        .get("head")
+        .and_then(|h| h.get("sha"))
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .to_owned();
+    let check_runs = if head_sha.is_empty() {
+        Value::Object(serde_json::Map::new())
+    } else {
+        match run_gh_capturing(
+            &[
+                "api".to_owned(),
+                format!("repos/{repo}/commits/{head_sha}/check-runs?per_page=100"),
+                "-H".to_owned(),
+                "Accept: application/vnd.github+json".to_owned(),
+            ],
+            cwd,
+        )? {
+            GhOutcome::Success(stdout) => serde_json::from_slice::<Value>(&stdout)?,
+            GhOutcome::GraphqlRateLimited | GhOutcome::OtherFailure => {
+                Value::Object(serde_json::Map::new())
+            }
+        }
+    };
+
+    Ok(Some(synthesize_pr_snapshot_from_rest(
+        pr_number,
+        &pr_value,
+        &check_runs,
+    )))
+}
+
+/// Pure transform: combine `gh api repos/:r/pulls/:n` + `gh api repos/:r/commits/:sha/check-runs`
+/// into the GraphQL `gh pr view --json` shape that `evaluate_pr_green` /
+/// `evaluate_pr_state` consume. Carries a `_rest_fallback: true` marker so
+/// debug output / tests can disambiguate the source.
+pub fn synthesize_pr_snapshot_from_rest(pr_number: u64, pr: &Value, check_runs: &Value) -> Value {
+    let head_sha = pr
+        .get("head")
+        .and_then(|h| h.get("sha"))
+        .and_then(Value::as_str)
+        .unwrap_or("");
+    let state = pr
+        .get("state")
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .to_uppercase();
+    let merged = pr.get("merged").and_then(Value::as_bool).unwrap_or(false);
+    let mergeable = pr.get("mergeable").cloned().unwrap_or(Value::Null);
+    let mergeable_state = pr
+        .get("mergeable_state")
+        .and_then(Value::as_str)
+        .unwrap_or("UNKNOWN")
+        .to_uppercase();
+    let mut rollup: Vec<Value> = Vec::new();
+    if let Some(runs) = check_runs.get("check_runs").and_then(Value::as_array) {
+        for run in runs {
+            let name = run.get("name").and_then(Value::as_str).unwrap_or("");
+            let status = run.get("status").and_then(Value::as_str).unwrap_or("");
+            let conclusion = run.get("conclusion").cloned().unwrap_or(Value::Null);
+            rollup.push(serde_json::json!({
+                "name": name,
+                "state": status,
+                "conclusion": conclusion,
+            }));
+        }
+    }
+    serde_json::json!({
+        "number": pr_number,
+        "headRefOid": head_sha,
+        "state": state,
+        "merged": merged,
+        "mergeable": mergeable,
+        "mergeStateStatus": mergeable_state,
+        "statusCheckRollup": rollup,
+        "_rest_fallback": true,
+    })
 }
 
 /// Fetch a GitHub Actions workflow-run snapshot.
@@ -388,6 +502,26 @@ fn run_gh_json(args: &[String], cwd: &Path, timeout_seconds: f64) -> WaitResult<
     Ok(value.is_object().then_some(value))
 }
 
+/// Outcome of a `gh` invocation, classified by whether stderr looks like a
+/// GraphQL rate-limit (so callers can opt into a REST fallback).
+enum GhOutcome {
+    Success(Vec<u8>),
+    GraphqlRateLimited,
+    OtherFailure,
+}
+
+fn run_gh_capturing(args: &[String], cwd: &Path) -> WaitResult<GhOutcome> {
+    let output = Command::new("gh").args(args).current_dir(cwd).output()?;
+    if output.status.success() {
+        return Ok(GhOutcome::Success(output.stdout));
+    }
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    if crate::pr::is_graphql_rate_limited(&stderr) {
+        return Ok(GhOutcome::GraphqlRateLimited);
+    }
+    Ok(GhOutcome::OtherFailure)
+}
+
 #[cfg(unix)]
 fn try_connect(socket_path: &Path) -> Option<DaemonConnection> {
     if !socket_path.exists() {
@@ -442,7 +576,7 @@ mod tests {
 
     use super::{
         WaitOutcome, pr_event_filter, read_snapshot_file, release_event_filter, run_event_filter,
-        wait_for_condition,
+        synthesize_pr_snapshot_from_rest, wait_for_condition,
     };
     #[cfg(unix)]
     use crate::daemon_ipc::{IpcServer, IpcState};
@@ -757,6 +891,77 @@ mod tests {
             "kind": "release",
             "payload": {"tag_name": "v9.9.9", "repo": "o/r"}
         })));
+    }
+
+    #[test]
+    fn rest_fallback_synthesis_matches_graphql_shape_for_green_pr() {
+        let pr = serde_json::json!({
+            "number": 287,
+            "state": "open",
+            "merged": false,
+            "mergeable": true,
+            "mergeable_state": "clean",
+            "head": { "sha": "abc123" },
+        });
+        let check_runs = serde_json::json!({
+            "total_count": 2,
+            "check_runs": [
+                {"name": "CI", "status": "completed", "conclusion": "success"},
+                {"name": "Coverage >= 75%", "status": "completed", "conclusion": "success"},
+            ],
+        });
+        let snapshot = synthesize_pr_snapshot_from_rest(287, &pr, &check_runs);
+        assert_eq!(snapshot["number"], 287);
+        assert_eq!(snapshot["headRefOid"], "abc123");
+        assert_eq!(snapshot["state"], "OPEN");
+        assert_eq!(snapshot["mergeStateStatus"], "CLEAN");
+        assert_eq!(snapshot["merged"], false);
+        assert_eq!(snapshot["mergeable"], true);
+        assert_eq!(snapshot["_rest_fallback"], true);
+        let rollup = snapshot["statusCheckRollup"].as_array().expect("rollup");
+        assert_eq!(rollup.len(), 2);
+        assert_eq!(rollup[0]["name"], "CI");
+        assert_eq!(rollup[0]["state"], "completed");
+        assert_eq!(rollup[0]["conclusion"], "success");
+    }
+
+    #[test]
+    fn rest_fallback_synthesis_handles_missing_check_runs_array() {
+        // If the check-runs call failed (GhOutcome::OtherFailure path) we pass
+        // an empty object — the rollup should come out as an empty array, not
+        // an error.
+        let pr = serde_json::json!({
+            "number": 1,
+            "state": "open",
+            "merged": false,
+            "mergeable": null,
+            "mergeable_state": "unknown",
+            "head": { "sha": "deadbeef" },
+        });
+        let check_runs = serde_json::json!({});
+        let snapshot = synthesize_pr_snapshot_from_rest(1, &pr, &check_runs);
+        assert_eq!(snapshot["headRefOid"], "deadbeef");
+        assert_eq!(snapshot["mergeStateStatus"], "UNKNOWN");
+        assert_eq!(snapshot["statusCheckRollup"].as_array().unwrap().len(), 0);
+    }
+
+    #[test]
+    fn rest_fallback_synthesis_uppercases_state_and_mergeable_state() {
+        // GraphQL emits these in SCREAMING_CASE; REST gives lowercase.
+        // The evaluator's upper_entry_value already handles either case, but
+        // synthesise to GraphQL's shape to minimise downstream surprise.
+        let pr = serde_json::json!({
+            "number": 9,
+            "state": "closed",
+            "merged": true,
+            "mergeable": false,
+            "mergeable_state": "behind",
+            "head": { "sha": "h" },
+        });
+        let snapshot = synthesize_pr_snapshot_from_rest(9, &pr, &serde_json::json!({}));
+        assert_eq!(snapshot["state"], "CLOSED");
+        assert_eq!(snapshot["mergeStateStatus"], "BEHIND");
+        assert_eq!(snapshot["merged"], true);
     }
 
     #[test]


### PR DESCRIPTION
Three coordinated docs-and-code fixes:

1. **#298 — wait pr REST fallback** (src/wait_transport.rs)

   Sibling to #289's auto-merge REST fallback. `fetch_pr_snapshot` now
   classifies `gh pr view --json` failures: if stderr matches the
   GraphQL rate-limit pattern (via the `is_graphql_rate_limited`
   helper promoted to `pub(crate)` in #295), the function falls back to
   synthesising the same GraphQL shape from
   `gh api repos/:r/pulls/:n` + `gh api repos/:r/commits/:sha/check-runs`.

   Pure transform extracted as `synthesize_pr_snapshot_from_rest` and
   covered by 3 unit tests (green PR happy path, missing check-runs
   array, state/mergeable_state case normalisation). The shape carries
   `_rest_fallback: true` so debug output / tests can distinguish the
   source. REST check-runs has no per-check `isRequired`, so the
   evaluator's "every check is required" default keeps the green
   verdict safe.

2. **#131 — simpler plugin install docs**

   Adopts the two-command flow:
       claude plugin marketplace add danielraffel/Shipyard
       claude plugin install shipyard
   ...replacing the manual `~/.claude/settings.json` editing step.
   Verbatim adoption of the patch from #131 (which has been clean +
   open since 2026-04-21 with no activity).

3. **README audit**

   - Top cheat-sheet adds `rescue`, `runner watch --kill-hung-workers`,
     `update`, `doctor --rate-limit` (all shipped in v0.53.0–v0.56.1).
   - Highlights gain a "One-shot PR rescue", "In-tool self-update",
     and "Graceful GraphQL rate-limit degradation" bullet alongside
     the existing watchdog highlight.
   - Fixed the broken uninstall instructions (the manual install path
     said `rm -rf ~/.pulp`, the install.sh-installed path is actually
     `~/.local/bin/shipyard` — also removed the obsolete
     `pip uninstall shipyard` line since the CLI has been Rust since
     v0.51.x).

4. **CI skill** clarifies that `wait pr` (not just `auto-merge`) now
   degrades to REST on GraphQL exhaustion.

Closes #298, closes #131.

Skill-Update: skip skill=shipyard reason="wait-pr REST fallback (#298) + bundled README/plugin-install doc improvements. No impact on Python parity, install state semantics, drift baselines, or GUI cutover."