### PR TITLE
feat(wait): REST fallback for wait pr + README audit + bundle #131 (#299)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to Shipyard are documented here. Each entry links
 to its [GitHub Release](https://github.com/danielraffel/Shipyard/releases).
 
+<a id="v0562"></a>
+## [0.56.2]
+
 <a id="v0561"></a>
 ## [0.56.1] - 2026-05-13
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -614,7 +614,7 @@ dependencies = [
 
 [[package]]
 name = "shipyard"
-version = "0.56.1"
+version = "0.56.2"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shipyard"
-version = "0.56.1"
+version = "0.56.2"
 edition = "2024"
 description = "Cross-platform CI coordination for local, SSH, and cloud runners."
 rust-version = "1.92"


### PR DESCRIPTION
* feat(wait): REST fallback for wait pr + README audit + bundle #131

Three coordinated docs-and-code fixes:

1. **#298 — wait pr REST fallback** (src/wait_transport.rs)

   Sibling to #289's auto-merge REST fallback. `fetch_pr_snapshot` now
   classifies `gh pr view --json` failures: if stderr matches the
   GraphQL rate-limit pattern (via the `is_graphql_rate_limited`
   helper promoted to `pub(crate)` in #295), the function falls back to
   synthesising the same GraphQL shape from
   `gh api repos/:r/pulls/:n` + `gh api repos/:r/commits/:sha/check-runs`.

   Pure transform extracted as `synthesize_pr_snapshot_from_rest` and
   covered by 3 unit tests (green PR happy path, missing check-runs
   array, state/mergeable_state case normalisation). The shape carries
   `_rest_fallback: true` so debug output / tests can distinguish the
   source. REST check-runs has no per-check `isRequired`, so the
   evaluator's "every check is required" default keeps the green
   verdict safe.

2. **#131 — simpler plugin install docs**

   Adopts the two-command flow:
       claude plugin marketplace add danielraffel/Shipyard
       claude plugin install shipyard
   ...replacing the manual `~/.claude/settings.json` editing step.
   Verbatim adoption of the patch from #131 (which has been clean +
   open since 2026-04-21 with no activity).

3. **README audit**

   - Top cheat-sheet adds `rescue`, `runner watch --kill-hung-workers`,
     `update`, `doctor --rate-limit` (all shipped in v0.53.0–v0.56.1).
   - Highlights gain a "One-shot PR rescue", "In-tool self-update",
     and "Graceful GraphQL rate-limit degradation" bullet alongside
     the existing watchdog highlight.
   - Fixed the broken uninstall instructions (the manual install path
     said `rm -rf ~/.pulp`, the install.sh-installed path is actually
     `~/.local/bin/shipyard` — also removed the obsolete
     `pip uninstall shipyard` line since the CLI has been Rust since
     v0.51.x).

4. **CI skill** clarifies that `wait pr` (not just `auto-merge`) now
   degrades to REST on GraphQL exhaustion.

Closes #298, closes #131.

Skill-Update: skip skill=shipyard reason="wait-pr REST fallback (#298) + bundled README/plugin-install doc improvements. No impact on Python parity, install state semantics, drift baselines, or GUI cutover."

* chore: bump versions