### PR TITLE
fix(windows): gate WEBHOOK_REGISTRATION_RETRY_INTERVAL on cfg(unix)

### DIFF
--- a/src/daemon_runtime.rs
+++ b/src/daemon_runtime.rs
@@ -47,6 +47,7 @@ use crate::webhook::{decode_webhook_event, is_valid_signature};
 
 #[cfg(unix)]
 const SHIP_STATE_SCAN_INTERVAL: Duration = Duration::from_secs(1);
+#[cfg(unix)]
 const WEBHOOK_REGISTRATION_RETRY_INTERVAL: Duration = Duration::from_mins(5);
 
 /// Foreground daemon runtime configuration.


### PR DESCRIPTION
## Problem

After v0.58.0 landed on `origin/main`, the Windows CI lane has been red:

```
error: constant `WEBHOOK_REGISTRATION_RETRY_INTERVAL` is never used
 --> src/daemon_runtime.rs:50:1
error: could not compile `shipyard` (lib) due to 1 previous error
```

`-D warnings` is in effect for the Windows compile.

## Cause

The constant is consumed only by `RegistrationSyncState::record_failure` at `src/daemon_runtime.rs:435` and by a `#[cfg(unix)]` test at `:1589`. Both are gated to Unix because `RegistrationSyncState` itself is `#[cfg(unix)]`. The constant was left unguarded, so on Windows it compiles in with zero references → `dead_code` lint fires.

## Fix

One line: add `#[cfg(unix)]` above the constant declaration, mirroring the existing `#[cfg(unix)]` above `SHIP_STATE_SCAN_INTERVAL` directly above it (which sits in the same const block for the same reason).

```diff
 #[cfg(unix)]
 const SHIP_STATE_SCAN_INTERVAL: Duration = Duration::from_secs(1);
+#[cfg(unix)]
 const WEBHOOK_REGISTRATION_RETRY_INTERVAL: Duration = Duration::from_mins(5);
```

## Verification

- `cargo check --tests` clean on macOS (no regression).
- Windows CI lane on Shipyard `origin/main` was failing on this exact line; this PR addresses it directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)