### PR TITLE
fix(ship): pin auto-merge failure-path probe to a snapshot (closes #296)

### DIFF
--- a/.shipyard/config.toml
+++ b/.shipyard/config.toml
@@ -11,10 +11,7 @@ platforms = ["macos", "linux", "windows"]
 # is broken on some hosts after partial rustup updates), then exec the
 # pipeline through that.
 [validation.default]
-command = "_sy_find_cargo_bin() { for c in cargo \"$HOME/.cargo/bin/cargo\"; do command -v \"$c\" >/dev/null 2>&1 && \"$c\" fmt --version >/dev/null 2>&1 && { dirname \"$(command -v \"$c\")\"; return 0; }; done; for c in \"$HOME\"/.rustup/toolchains/*/bin/cargo; do [ -x \"$c\" ] && \"$c\" --version >/dev/null 2>&1 && { dirname \"$c\"; return 0; }; done; return 1; }; CARGO_BIN=$(_sy_find_cargo_bin) || { echo 'shipyard validation: could not locate a working cargo (with rustfmt + clippy) binary' >&2; exit 1; }; export PATH=\"$CARGO_BIN:$PATH\"; cargo fmt --all --check && cargo clippy --all-targets --locked -- -D warnings && cargo test --all-targets --locked -- --skip auto_merge_failure_preserves_state --skip ship_command_green_merge_failure_keeps_active_state_and_exits_success"
-# `--skip` flags above are a workaround for two pre-existing flaky tests
-# tracked in https://github.com/danielraffel/Shipyard/issues/296. Drop the
-# skip clauses once that issue is fixed.
+command = "_sy_find_cargo_bin() { for c in cargo \"$HOME/.cargo/bin/cargo\"; do command -v \"$c\" >/dev/null 2>&1 && \"$c\" fmt --version >/dev/null 2>&1 && { dirname \"$(command -v \"$c\")\"; return 0; }; done; for c in \"$HOME\"/.rustup/toolchains/*/bin/cargo; do [ -x \"$c\" ] && \"$c\" --version >/dev/null 2>&1 && { dirname \"$c\"; return 0; }; done; return 1; }; CARGO_BIN=$(_sy_find_cargo_bin) || { echo 'shipyard validation: could not locate a working cargo (with rustfmt + clippy) binary' >&2; exit 1; }; export PATH=\"$CARGO_BIN:$PATH\"; cargo fmt --all --check && cargo clippy --all-targets --locked -- -D warnings && cargo test --all-targets --locked"
 
 [targets.mac]
 backend = "local"

--- a/src/app.rs
+++ b/src/app.rs
@@ -495,6 +495,7 @@ fn handle_ship_variant<W: Write>(
             merge_command: None,
             merge_result: None,
             gh_command: None,
+            pr_snapshot_file: None,
             allow_unreachable_targets,
             skip_targets,
         },
@@ -2258,12 +2259,15 @@ mod tests {
         assert_eq!(store.list_archived().len(), 1);
     }
 
-    // FIXME(danielraffel/Shipyard#296): pre-existing deterministic-on-some-hosts
-    // failure on origin/main — same `merge_result: Failure` path issue as
-    // `ship_command_green_merge_failure_keeps_active_state_and_exits_success`
-    // in ship_cmd.rs. Both ignored so unrelated PRs can land. Real fix needs
-    // a separate investigation of execute_auto_merge state-store sequencing.
-    #[ignore = "pre-existing flake — Shipyard issue #296"]
+    // Regression coverage for Shipyard issue #296: without an isolated
+    // `--pr-snapshot-file`, `execute_auto_merge`'s failure path falls
+    // through to `pr_is_merged`, which shells out to `gh pr view <pr>`
+    // against the process CWD's `origin` remote. When that remote happens
+    // to host a real merged PR with the same number (PR #14 in
+    // danielraffel/Shipyard *is* merged), the test would observe
+    // `AutoMergeOutcome::Merged` instead of the synthetic `MergeFailed`.
+    // The snapshot file pins `pr_is_merged` to `state=OPEN` so the
+    // failure-path archive escape hatch stays closed in the test.
     #[test]
     fn auto_merge_failure_preserves_state() {
         let temp = tempfile::tempdir().expect("tempdir");
@@ -2271,6 +2275,8 @@ mod tests {
         store
             .save(&auto_merge_state(14, &[("macos", "pass")]))
             .expect("save");
+        let snapshot = temp.path().join("pr.json");
+        std::fs::write(&snapshot, r#"{"state":"OPEN"}"#).expect("write snapshot");
         let cli = Cli::parse_from([
             "shipyard",
             "--json",
@@ -2280,6 +2286,8 @@ mod tests {
             "14",
             "--merge-result",
             "failure",
+            "--pr-snapshot-file",
+            snapshot.to_str().expect("snapshot path"),
         ]);
         let mut stdout = Vec::new();
         let mut stderr = Vec::new();

--- a/src/app/pr_cmd.rs
+++ b/src/app/pr_cmd.rs
@@ -114,6 +114,7 @@ pub(super) fn pr_command<W: Write>(
             merge_command: None,
             merge_result: None,
             gh_command: None,
+            pr_snapshot_file: None,
             allow_unreachable_targets: args.allow_unreachable_targets,
             skip_targets: args.skip_targets,
         },

--- a/src/app/ship_cmd.rs
+++ b/src/app/ship_cmd.rs
@@ -44,6 +44,10 @@ pub(super) struct ShipCommandArgs {
     pub(super) merge_command: Option<PathBuf>,
     pub(super) merge_result: Option<MergeResult>,
     pub(super) gh_command: Option<PathBuf>,
+    /// Test hook: bypass `gh pr view` for archived-PR checks in the
+    /// auto-merge handoff. Mirrors `auto-merge --pr-snapshot-file`. See
+    /// Shipyard issue #296 for the failure mode this guards against.
+    pub(super) pr_snapshot_file: Option<PathBuf>,
     pub(super) allow_unreachable_targets: bool,
     pub(super) skip_targets: Vec<String>,
 }
@@ -133,6 +137,7 @@ pub(super) fn ship_command<W: Write>(
         outcome.job.passed(),
         args.merge_command,
         args.merge_result,
+        args.pr_snapshot_file,
     )?;
     // Issue #303: when validation failed, resolve failing-job + log diagnostics
     // before we render so the human / JSON output points the user at the
@@ -461,6 +466,7 @@ fn post_run_merge_state(
     validation_passed: bool,
     merge_command: Option<PathBuf>,
     merge_result: Option<MergeResult>,
+    pr_snapshot_file: Option<PathBuf>,
 ) -> Result<ShipRenderState, CliFailure> {
     if !validation_passed {
         return Ok(ShipRenderState::ValidationFailed);
@@ -470,7 +476,7 @@ fn post_run_merge_state(
         merge_method: MergeMethod::Squash,
         delete_branch: true,
         admin: false,
-        pr_snapshot_file: None,
+        pr_snapshot_file,
         merge_command,
         merge_result,
     };
@@ -912,6 +918,7 @@ mod tests {
                 merge_command: None,
                 merge_result: Some(MergeResult::Success),
                 gh_command: None,
+                pr_snapshot_file: None,
                 allow_unreachable_targets: false,
                 skip_targets: Vec::new(),
             },
@@ -940,13 +947,19 @@ mod tests {
         );
     }
 
-    // FIXME(danielraffel/Shipyard#296): pre-existing deterministic-on-some-hosts
-    // failure on origin/main — `merged: Bool(true)` is observed when the test
-    // expects `false`, suggesting a state-store race where the synthetic
-    // `merge_result: Failure` path doesn't always reach `MergeFailed`. Ignored
-    // here so unrelated PRs can land; the real fix needs a separate
-    // investigation of the ship_command/execute_auto_merge interaction.
-    #[ignore = "pre-existing flake — Shipyard issue #296"]
+    // Regression coverage for Shipyard issue #296. The synthetic
+    // `MergeResult::Failure` injects `Err("simulated merge failure")` in
+    // `merge_pr`. `execute_auto_merge` then evaluates
+    // `merge_error_confirms_merged(error) || pr_is_merged(...)` as a
+    // "did the merge actually succeed despite the error?" escape hatch.
+    // `pr_is_merged` shells out to `gh pr view <pr> --json state` against
+    // the temp repo's `origin` remote (https://github.com/danielraffel/pulp).
+    // PR #43 *is* merged in that upstream repo, so on hosts with a fresh
+    // GraphQL budget `pr_is_merged` returns true and the failure path
+    // archives the state and returns `Merged` — producing the observed
+    // `merged: true`. Pinning `--pr-snapshot-file` (via the new
+    // `pr_snapshot_file` field on `ShipCommandArgs`) keeps `pr_is_merged`
+    // offline and deterministic.
     #[test]
     fn ship_command_green_merge_failure_keeps_active_state_and_exits_success() {
         let temp = tempfile::tempdir().expect("tempdir");
@@ -957,6 +970,8 @@ mod tests {
             Some(temp.path().join("global")),
             Some(temp.path().join("state")),
         );
+        let snapshot = temp.path().join("pr.json");
+        std::fs::write(&snapshot, r#"{"state":"OPEN"}"#).expect("write snapshot");
         let mut stdout = Vec::new();
 
         let code = ship_command(
@@ -969,6 +984,7 @@ mod tests {
                 merge_command: None,
                 merge_result: Some(MergeResult::Failure),
                 gh_command: None,
+                pr_snapshot_file: Some(snapshot),
                 allow_unreachable_targets: false,
                 skip_targets: Vec::new(),
             },
@@ -1015,6 +1031,7 @@ mod tests {
                 merge_command: None,
                 merge_result: Some(MergeResult::Success),
                 gh_command: None,
+                pr_snapshot_file: None,
                 allow_unreachable_targets: false,
                 skip_targets: Vec::new(),
             },
@@ -1060,6 +1077,7 @@ mod tests {
                 merge_command: None,
                 merge_result: Some(MergeResult::Success),
                 gh_command: None,
+                pr_snapshot_file: None,
                 allow_unreachable_targets: false,
                 skip_targets: vec!["linux".to_owned()],
             },
@@ -1121,6 +1139,7 @@ exit 2
                 merge_command: None,
                 merge_result: Some(MergeResult::Success),
                 gh_command: Some(gh),
+                pr_snapshot_file: None,
                 allow_unreachable_targets: false,
                 skip_targets: Vec::new(),
             },
@@ -1220,6 +1239,7 @@ exit 2
                 merge_command: None,
                 merge_result: Some(MergeResult::Success),
                 gh_command: Some(gh),
+                pr_snapshot_file: None,
                 allow_unreachable_targets: false,
                 skip_targets: Vec::new(),
             },


### PR DESCRIPTION
## Summary

Closes #296.

Two tests were marked `#[ignore]` in PR #307 as a pre-existing flake:

- `app::tests::auto_merge_failure_preserves_state`
- `app::ship_cmd::tests::ship_command_green_merge_failure_keeps_active_state_and_exits_success`

Both inject the synthetic `--merge-result failure` path, expecting `AutoMergeOutcome::MergeFailed` (exit 1, `event: merge-failed`, `merged: false`).

## Root cause (H2 variant — `gh` consulted live)

`execute_auto_merge` (src/app/auto_merge_cmd.rs:99-110) treats a merge error as "actually merged" when either `merge_error_confirms_merged(error)` is true *or* `pr_is_merged()` returns true. `pr_is_merged()` shells out to `gh pr view <pr> --json state` against the test process's CWD `origin` remote and returns true when GitHub reports `state == "merged"`.

- `auto_merge_failure_preserves_state` runs without `--cwd`, so the CWD is the Shipyard checkout. **PR #14 is a real merged PR in `danielraffel/Shipyard`**, so `gh pr view 14` returns `MERGED` and the failure path archives the state and returns `Merged` → exit 0 / `event: merged`. Observed as `left: ExitCode(0), right: ExitCode(1)`.
- `ship_command_green_merge_failure_..` uses `seed_repo` which sets `origin = https://github.com/danielraffel/pulp.git`. **PR #43 is merged in `danielraffel/pulp`**, triggering the same escape hatch and producing `merged: true`. Observed as `left: Bool(true), right: false`.

The "intermittent" symptom is GraphQL-budget-coupled: `gh pr view` uses GraphQL, and when GitHub returns "API rate limit exceeded" `pr_is_merged()` falls back to `false` and the test happens to pass. With fresh budget on a clean mac local lane, both tests fail deterministically.

Codex's H1/H3 (state-store sequencing) and H4 (test parallelism) are not the cause. The proof: pointing the new `pr_snapshot_file` at `{"state":"MERGED"}` (rather than `OPEN`) reproduces the original `ExitCode(0) vs ExitCode(1)` failure deterministically on this commit, with `--test-threads 1`.

## Fix

Route both tests through an isolated `pr_snapshot_file`.

- The `auto-merge` CLI already exposes `--pr-snapshot-file` as a hidden test hook (used by `auto_merge_missing_state_already_merged_is_success` for the symmetric `state: MERGED` case). The failing test just needs to pass an `OPEN`-state snapshot.
- For the `ship_command` path, this PR adds a `pr_snapshot_file: Option<PathBuf>` field on `ShipCommandArgs` that mirrors the existing `merge_command` / `merge_result` / `gh_command` hidden test hooks. It threads through `post_run_merge_state` to the same `AutoMergeRequest.pr_snapshot_file` slot. Production callers (`handle_ship_variant`, `pr_cmd`) pass `None` and continue to consult the live `gh pr view`.

Also removes the `--skip auto_merge_failure_preserves_state --skip ship_command_green_merge_failure_..` workaround from `.shipyard/config.toml` (per the issue's acceptance criterion).

## Before vs after

Before (this branch, with the snapshot temporarily pointing at `{"state":"MERGED"}` to simulate the live-`gh` path):

```
test app::tests::auto_merge_failure_preserves_state ... FAILED
left: ExitCode(unix_exit_status(0))
right: ExitCode(unix_exit_status(1))
```

After (this branch, with the snapshot pointing at `{"state":"OPEN"}`), 3 consecutive runs:

```
=== Run 1 ===
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 686 filtered out
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 686 filtered out
=== Run 2 ===
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 686 filtered out
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 686 filtered out
=== Run 3 ===
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 686 filtered out
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 686 filtered out
```

Full suite `cargo test --all-targets --locked`: **687 passed; 0 failed; 0 ignored**. `cargo fmt --all --check` and `cargo clippy --all-targets --locked -- -D warnings` both clean.

The `#[ignore]` attributes added in #307 are removed by this PR.

## Test plan

- [x] `cargo test --all-targets --locked` (687 / 0 / 0)
- [x] `cargo clippy --all-targets --locked -- -D warnings`
- [x] `cargo fmt --all --check`
- [x] Targeted tests pass 3x in a row
- [x] Reproduced original failure mode with `{"state":"MERGED"}` snapshot
- [x] `.shipyard/config.toml` `--skip` clauses removed