### PR TITLE
feat(watch): Phase 2 — diagnostics block on terminal-failure transitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to Shipyard are documented here. Each entry links
 to its [GitHub Release](https://github.com/danielraffel/Shipyard/releases).
 
+<a id="v0590"></a>
+## [0.59.0]
+
+- feat(watch): Phase 2 failure diagnostics — render the Phase 1 failing-job URL + step + parsed test footer on every `shipyard watch --pr N --follow` transition where a target enters a terminal failure state.
+
 <a id="v0580"></a>
 ## [0.58.0] - 2026-05-18
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -614,7 +614,7 @@ dependencies = [
 
 [[package]]
 name = "shipyard"
-version = "0.58.0"
+version = "0.59.0"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shipyard"
-version = "0.58.0"
+version = "0.59.0"
 edition = "2024"
 description = "Cross-platform CI coordination for local, SSH, and cloud runners."
 rust-version = "1.92"

--- a/src/app/watch_cmd.rs
+++ b/src/app/watch_cmd.rs
@@ -5,10 +5,12 @@ use std::thread;
 use std::time::Duration;
 
 use super::CliFailure;
+use crate::diagnostics::{DiagnosticsFetcher, GhDiagnosticsFetcher};
 use crate::evidence::EvidenceStore;
 use crate::ship_state::ShipStateStore;
 use crate::watch::{
-    active_pr_for_current_branch, emit_watch_event, emit_watch_snapshot, reused_evidence_map,
+    WatchDiagnosticsCache, active_pr_for_current_branch, collect_watch_diagnostics,
+    emit_watch_event, emit_watch_snapshot_with_diagnostics, reused_evidence_map,
     ship_terminal_verdict, watch_event_signature,
 };
 
@@ -32,6 +34,21 @@ pub(super) fn watch<W: Write>(
     options: WatchCommandOptions,
     stdout: &mut W,
 ) -> Result<ExitCode, CliFailure> {
+    let fetcher = GhDiagnosticsFetcher;
+    watch_with_fetcher(context, options, &fetcher, stdout)
+}
+
+/// Run the watch loop with an injectable diagnostics fetcher.
+///
+/// Production callers use [`watch`], which passes [`GhDiagnosticsFetcher`].
+/// Tests substitute a fake fetcher so the terminal-failure diagnostics path
+/// can be exercised without a real GitHub API surface.
+pub(super) fn watch_with_fetcher<W: Write, F: DiagnosticsFetcher + ?Sized>(
+    context: WatchCommandContext<'_>,
+    options: WatchCommandOptions,
+    fetcher: &F,
+    stdout: &mut W,
+) -> Result<ExitCode, CliFailure> {
     let target_pr = options
         .pr
         .or_else(|| active_pr_for_current_branch(context.store, context.cwd));
@@ -44,6 +61,7 @@ pub(super) fn watch<W: Write>(
 
     let mut last_signature = None;
     let mut observed_any_state = false;
+    let mut diagnostics_cache = WatchDiagnosticsCache::new();
 
     loop {
         let state = context.store.get(target_pr);
@@ -79,8 +97,20 @@ pub(super) fn watch<W: Write>(
         let reuse_map = reused_evidence_map(context.evidence_store, &state);
         let signature = watch_event_signature(&state, &reuse_map);
         if last_signature.as_deref() != Some(signature.as_str()) {
-            emit_watch_snapshot(&state, &reuse_map, options.json, stdout)
-                .map_err(|error| CliFailure::new(1, error.to_string()))?;
+            // Phase 2 (issue #303): on each new state signature, resolve
+            // diagnostics for any target that has just entered a terminal
+            // failure state. The cache key `(target, run_id)` guarantees we
+            // fetch at most once per terminal-failure transition for the
+            // lifetime of this `shipyard watch` invocation.
+            let diagnostics = collect_watch_diagnostics(&state, fetcher, &mut diagnostics_cache);
+            emit_watch_snapshot_with_diagnostics(
+                &state,
+                &reuse_map,
+                &diagnostics,
+                options.json,
+                stdout,
+            )
+            .map_err(|error| CliFailure::new(1, error.to_string()))?;
             last_signature = Some(signature);
         }
 
@@ -107,7 +137,8 @@ mod tests {
     use chrono::Utc;
     use serde_json::Value;
 
-    use super::{WatchCommandContext, WatchCommandOptions, watch};
+    use super::{WatchCommandContext, WatchCommandOptions, watch, watch_with_fetcher};
+    use crate::diagnostics::{DiagnosticsError, DiagnosticsFetcher};
     use crate::evidence::EvidenceStore;
     use crate::ship_state::{DispatchedRun, ShipState, ShipStateStore};
 
@@ -277,5 +308,149 @@ mod tests {
         assert!(text.contains("PR #42"));
         assert!(text.contains("linux"));
         assert!(text.contains("fail"));
+    }
+
+    // ----- Phase 2 (issue #303) ------------------------------------------
+
+    struct CountingFakeFetcher {
+        jobs_json: String,
+        log: String,
+        jobs_calls: std::cell::Cell<usize>,
+        log_calls: std::cell::Cell<usize>,
+    }
+
+    impl CountingFakeFetcher {
+        fn new(jobs_json: String, log: String) -> Self {
+            Self {
+                jobs_json,
+                log,
+                jobs_calls: std::cell::Cell::new(0),
+                log_calls: std::cell::Cell::new(0),
+            }
+        }
+    }
+
+    impl DiagnosticsFetcher for CountingFakeFetcher {
+        fn fetch_jobs_json(&self, _repo: &str, _run_id: u64) -> Result<String, DiagnosticsError> {
+            self.jobs_calls.set(self.jobs_calls.get() + 1);
+            Ok(self.jobs_json.clone())
+        }
+
+        fn fetch_job_log(&self, _repo: &str, _job_id: u64) -> Result<String, DiagnosticsError> {
+            self.log_calls.set(self.log_calls.get() + 1);
+            Ok(self.log.clone())
+        }
+    }
+
+    fn jobs_payload() -> String {
+        serde_json::json!({
+            "total_count": 1,
+            "jobs": [{
+                "id": 76_630_095_261u64,
+                "name": "macOS (ARM64) [namespace]",
+                "html_url": "https://github.com/danielraffel/pulp/actions/runs/26063806409/job/76630095261",
+                "conclusion": "failure",
+                "steps": [{"name": "Test (non-Windows)", "conclusion": "failure"}],
+                "labels": ["namespace-profile-generouscorp-macos"]
+            }]
+        })
+        .to_string()
+    }
+
+    fn ctest_log() -> String {
+        "noise\nThe following tests FAILED:\n\t1236 - FontResolver: animation respects LRU cache cap (Failed)\nErrors while running CTest\n".to_owned()
+    }
+
+    fn cloud_failed_state(pr: u64, run_id: u64) -> ShipState {
+        let mut state = ShipState::new(
+            pr,
+            "danielraffel/pulp",
+            "feature/test",
+            "main",
+            "abcdef0123456789abcdef0123456789abcdef01",
+            "policy",
+        );
+        let now = Utc::now();
+        state.dispatched_runs.push(DispatchedRun {
+            target: "mac".to_owned(),
+            provider: "namespace".to_owned(),
+            run_id: run_id.to_string(),
+            status: "failed".to_owned(),
+            started_at: now,
+            updated_at: now,
+            attempt: 1,
+            last_heartbeat_at: None,
+            phase: Some("test".to_owned()),
+            required: true,
+        });
+        state
+            .evidence_snapshot
+            .insert("mac".to_owned(), "fail".to_owned());
+        state
+    }
+
+    #[test]
+    fn watch_human_render_includes_phase2_diagnostics_block() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let (store, evidence) = stores(&temp);
+        store
+            .save(&cloud_failed_state(42, 26_063_806_409))
+            .expect("state");
+        let fetcher = CountingFakeFetcher::new(jobs_payload(), ctest_log());
+        let mut out = Vec::new();
+
+        let code = watch_with_fetcher(
+            context(&store, &evidence, temp.path()),
+            options(Some(42), false, false),
+            &fetcher,
+            &mut out,
+        )
+        .expect("watch");
+
+        assert_eq!(code, ExitCode::from(1));
+        let text = String::from_utf8(out).expect("utf8");
+        assert!(
+            text.contains(
+                "https://github.com/danielraffel/pulp/actions/runs/26063806409/job/76630095261"
+            ),
+            "human render must include failing job URL:\n{text}"
+        );
+        assert!(
+            text.contains("Test (non-Windows)"),
+            "human render must surface the failing step:\n{text}"
+        );
+        assert!(
+            text.contains("FontResolver"),
+            "human render must show parsed CTest footer:\n{text}"
+        );
+    }
+
+    #[test]
+    fn watch_json_render_includes_phase2_diagnostics_block() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let (store, evidence) = stores(&temp);
+        store
+            .save(&cloud_failed_state(42, 26_063_806_409))
+            .expect("state");
+        let fetcher = CountingFakeFetcher::new(jobs_payload(), ctest_log());
+        let mut out = Vec::new();
+
+        let code = watch_with_fetcher(
+            context(&store, &evidence, temp.path()),
+            options(Some(42), false, true),
+            &fetcher,
+            &mut out,
+        )
+        .expect("watch");
+
+        assert_eq!(code, ExitCode::from(1));
+        let payload: Value = serde_json::from_slice(&out).expect("json payload");
+        let diag = &payload["diagnostics"][0];
+        assert_eq!(diag["failed_target"], "mac");
+        assert_eq!(diag["run_id"], 26_063_806_409u64);
+        assert_eq!(diag["provider"], "namespace");
+        assert_eq!(diag["kind"], "failed");
+        assert_eq!(diag["cloud_job_id"], 76_630_095_261u64);
+        assert_eq!(diag["failed_step"], "Test (non-Windows)");
     }
 }

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::io::Write;
 use std::path::Path;
 use std::process::Command;
@@ -6,11 +6,27 @@ use std::process::Command;
 use chrono::{DateTime, Utc};
 use serde_json::Value;
 
+use crate::diagnostics::{
+    DiagnosticsFetcher, FailureDiagnostics, FailureKind, GhDiagnosticsFetcher,
+    fetch_failed_job_diagnostics, select_parser,
+};
 use crate::evidence::EvidenceStore;
 use crate::output::write_json_envelope;
 use crate::ship_state::{DispatchedRun, ShipState, ShipStateStore};
 
 const QUEUED_STATUSES: [&str; 3] = ["queued", "pending", "waiting"];
+
+/// Statuses on a `DispatchedRun` that indicate a terminal failure for which
+/// `shipyard watch` should fetch and render Phase 1 diagnostics on the
+/// transition that first observes them.
+const TERMINAL_FAILURE_RUN_STATUSES: [&str; 6] = [
+    "failed",
+    "failure",
+    "completed_failure",
+    "cancelled",
+    "canceled",
+    "timed_out",
+];
 
 /// Determine the active PR for the current git branch, if any.
 #[must_use]
@@ -142,6 +158,134 @@ pub fn ship_terminal_verdict(state: &ShipState) -> Option<bool> {
     )
 }
 
+/// Phase 1 diagnostics resolved for a single failed target during a
+/// `shipyard watch` poll. Built by [`collect_watch_diagnostics`] and rendered
+/// by [`emit_watch_snapshot_with_diagnostics`].
+#[derive(Clone, Debug)]
+pub struct WatchTargetDiagnostics {
+    /// Logical Shipyard target name (e.g. `mac`).
+    pub target_name: String,
+    /// Provider label captured on the dispatched run (e.g. `namespace`,
+    /// `github-hosted`).
+    pub provider: String,
+    /// GitHub Actions workflow run ID this evidence refers to.
+    pub run_id: u64,
+    /// Failure-cause classification used to pick a verb in the human render
+    /// and to label the JSON event.
+    pub kind: FailureKind,
+    /// Resolved failing-job metadata + parsed footer.
+    pub diagnostics: FailureDiagnostics,
+}
+
+/// Per-watch-session cache keyed by `(target, run_id)` so a target that has
+/// already been reported as terminally failed is not refetched on every poll
+/// (issue #303 Phase 2). The cache is intentionally process-local — it lives
+/// for the duration of a single `shipyard watch` invocation.
+#[derive(Clone, Debug, Default)]
+pub struct WatchDiagnosticsCache {
+    seen: BTreeSet<(String, u64)>,
+}
+
+impl WatchDiagnosticsCache {
+    /// Create an empty cache.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Whether the cache has already resolved diagnostics for this
+    /// `(target, run_id)` pair.
+    #[must_use]
+    pub fn contains(&self, target: &str, run_id: u64) -> bool {
+        self.seen.contains(&(target.to_owned(), run_id))
+    }
+
+    /// Mark `(target, run_id)` as resolved so subsequent polls skip refetching.
+    pub fn mark(&mut self, target: &str, run_id: u64) {
+        self.seen.insert((target.to_owned(), run_id));
+    }
+}
+
+/// Resolve Phase 1 diagnostics for any `DispatchedRun` that has just entered
+/// a terminal failure state and has not yet been recorded in `cache`.
+///
+/// At most one log fetch is performed per terminal-failure transition; the
+/// cache key `(target, run_id)` guarantees that subsequent polls observing
+/// the same state are no-ops. `run_id` must parse as a `u64` (cloud workflow
+/// run IDs) — local / SSH / Windows targets carry non-numeric Shipyard job
+/// IDs in their dispatched-run record and are skipped here because the GHA
+/// API surface does not know how to address them.
+#[must_use]
+pub fn collect_watch_diagnostics<F: DiagnosticsFetcher + ?Sized>(
+    state: &ShipState,
+    fetcher: &F,
+    cache: &mut WatchDiagnosticsCache,
+) -> Vec<WatchTargetDiagnostics> {
+    let mut out = Vec::new();
+    if state.repo.is_empty() {
+        return out;
+    }
+    for run in &state.dispatched_runs {
+        if !is_terminal_failure_status(&run.status) {
+            continue;
+        }
+        let Ok(run_id) = run.run_id.parse::<u64>() else {
+            // Non-numeric run IDs come from local / SSH / Windows backends
+            // (the Shipyard internal job ID); skip — the GHA API can't
+            // address them.
+            continue;
+        };
+        if cache.contains(&run.target, run_id) {
+            continue;
+        }
+        let parser = select_parser(None);
+        let resolved = fetch_failed_job_diagnostics(
+            fetcher,
+            &state.repo,
+            run_id,
+            &run.target,
+            parser.as_ref(),
+        );
+        let kind = match run.status.as_str() {
+            "cancelled" | "canceled" => FailureKind::Cancelled,
+            "timed_out" => FailureKind::TimedOut,
+            _ => FailureKind::Failed,
+        };
+        cache.mark(&run.target, run_id);
+        out.push(WatchTargetDiagnostics {
+            target_name: run.target.clone(),
+            provider: run.provider.clone(),
+            run_id,
+            kind,
+            diagnostics: resolved,
+        });
+    }
+    out
+}
+
+/// Convenience overload of [`collect_watch_diagnostics`] that uses the
+/// production [`GhDiagnosticsFetcher`].
+#[must_use]
+pub fn collect_watch_diagnostics_gh(
+    state: &ShipState,
+    cache: &mut WatchDiagnosticsCache,
+) -> Vec<WatchTargetDiagnostics> {
+    let fetcher = GhDiagnosticsFetcher;
+    collect_watch_diagnostics(state, &fetcher, cache)
+}
+
+fn is_terminal_failure_status(status: &str) -> bool {
+    TERMINAL_FAILURE_RUN_STATUSES.contains(&status)
+}
+
+fn failure_kind_label(kind: FailureKind) -> &'static str {
+    match kind {
+        FailureKind::Cancelled => "cancelled",
+        FailureKind::TimedOut => "timed_out",
+        FailureKind::Failed => "failed",
+    }
+}
+
 /// Emit one watch snapshot, either as a JSON update event or human-readable text.
 pub fn emit_watch_snapshot<W: Write>(
     state: &ShipState,
@@ -149,16 +293,29 @@ pub fn emit_watch_snapshot<W: Write>(
     json: bool,
     stdout: &mut W,
 ) -> Result<(), Box<dyn std::error::Error>> {
+    emit_watch_snapshot_with_diagnostics(state, reuse_map, &[], json, stdout)
+}
+
+/// Emit one watch snapshot, optionally appending the Phase 2 diagnostics block
+/// for any target that has just entered a terminal-failure state.
+pub fn emit_watch_snapshot_with_diagnostics<W: Write>(
+    state: &ShipState,
+    reuse_map: &BTreeMap<String, String>,
+    diagnostics: &[WatchTargetDiagnostics],
+    json: bool,
+    stdout: &mut W,
+) -> Result<(), Box<dyn std::error::Error>> {
     let now = Utc::now();
     if json {
-        return emit_watch_json_snapshot(state, reuse_map, now, stdout);
+        return emit_watch_json_snapshot(state, reuse_map, diagnostics, now, stdout);
     }
-    emit_watch_human_snapshot(state, reuse_map, now, stdout)
+    emit_watch_human_snapshot(state, reuse_map, diagnostics, now, stdout)
 }
 
 fn emit_watch_json_snapshot<W: Write>(
     state: &ShipState,
     reuse_map: &BTreeMap<String, String>,
+    diagnostics: &[WatchTargetDiagnostics],
     now: DateTime<Utc>,
     stdout: &mut W,
 ) -> Result<(), Box<dyn std::error::Error>> {
@@ -182,12 +339,34 @@ fn emit_watch_json_snapshot<W: Write>(
                 .collect::<Result<Vec<_>, _>>()?,
         ),
     );
+    if !diagnostics.is_empty() {
+        data.insert(
+            "diagnostics".to_owned(),
+            Value::Array(diagnostics.iter().map(json_diagnostics).collect()),
+        );
+    }
     data.insert(
         "updated_at".to_owned(),
         Value::from(state.updated_at.to_rfc3339()),
     );
     write_json_envelope(stdout, "watch", data)?;
     Ok(())
+}
+
+fn json_diagnostics(entry: &WatchTargetDiagnostics) -> Value {
+    let details = &entry.diagnostics;
+    let job = details.job.as_ref();
+    serde_json::json!({
+        "failed_target": entry.target_name,
+        "provider": entry.provider,
+        "run_id": entry.run_id,
+        "kind": failure_kind_label(entry.kind),
+        "cloud_job_id": job.map(|info| info.job_id),
+        "cloud_job_name": job.map(|info| info.name.clone()),
+        "cloud_job_url": job.map(|info| info.html_url.clone()),
+        "failed_step": job.and_then(|info| info.failed_step.clone()),
+        "details": details,
+    })
 }
 
 fn json_evidence_snapshot(
@@ -219,6 +398,7 @@ fn json_evidence_snapshot(
 fn emit_watch_human_snapshot<W: Write>(
     state: &ShipState,
     reuse_map: &BTreeMap<String, String>,
+    diagnostics: &[WatchTargetDiagnostics],
     now: DateTime<Utc>,
     stdout: &mut W,
 ) -> Result<(), Box<dyn std::error::Error>> {
@@ -296,6 +476,75 @@ fn emit_watch_human_snapshot<W: Write>(
         )?;
     }
 
+    render_watch_diagnostics(diagnostics, stdout)?;
+
+    Ok(())
+}
+
+/// Render the Phase 1 diagnostics block, mirroring the shape used by
+/// `render_validation_failed` in `src/app/ship_cmd.rs` so users see the same
+/// "Job / URL / Step / Tests" layout regardless of which command surfaced the
+/// failure.
+fn render_watch_diagnostics<W: Write>(
+    diagnostics: &[WatchTargetDiagnostics],
+    stdout: &mut W,
+) -> std::io::Result<()> {
+    if diagnostics.is_empty() {
+        return Ok(());
+    }
+    writeln!(
+        stdout,
+        "  \u{2717} {} terminal-failure transition{} this poll:",
+        diagnostics.len(),
+        if diagnostics.len() == 1 { "" } else { "s" }
+    )?;
+    for entry in diagnostics {
+        match entry.kind {
+            FailureKind::Cancelled => {
+                writeln!(
+                    stdout,
+                    "    \u{223C} Validation cancelled (concurrency-replaced or skipped); not a failure"
+                )?;
+                writeln!(stdout, "      Target:  {}", entry.target_name)?;
+            }
+            FailureKind::TimedOut => {
+                writeln!(stdout, "    \u{2717} Validation timed out")?;
+                writeln!(stdout, "      Target:  {}", entry.target_name)?;
+            }
+            FailureKind::Failed => {
+                writeln!(
+                    stdout,
+                    "      Target:  {} (cloud={})",
+                    entry.target_name, entry.provider
+                )?;
+                if let Some(job) = entry.diagnostics.job.as_ref() {
+                    writeln!(stdout, "      Job:     {}", job.name)?;
+                    if !job.html_url.is_empty() {
+                        writeln!(stdout, "      URL:     {}", job.html_url)?;
+                    }
+                    if let Some(step) = job.failed_step.as_deref() {
+                        writeln!(stdout, "      Step:    \"{step}\"")?;
+                    }
+                } else if let Some(run_id) = entry.diagnostics.run_id {
+                    writeln!(
+                        stdout,
+                        "      Run ID:  {run_id} (failed-job lookup unavailable)"
+                    )?;
+                }
+                if !entry.diagnostics.failure_summary.is_empty() {
+                    writeln!(stdout, "      Tests:")?;
+                    for line in &entry.diagnostics.failure_summary {
+                        writeln!(stdout, "        {line}")?;
+                    }
+                    if entry.diagnostics.failure_summary_truncated {
+                        writeln!(stdout, "        (truncated; see job log for full list)")?;
+                    }
+                } else if entry.diagnostics.log_tail.is_some() {
+                    writeln!(stdout, "      Tests:   (no recognised footer; see job URL)")?;
+                }
+            }
+        }
+    }
     Ok(())
 }
 
@@ -472,9 +721,12 @@ mod tests {
     use chrono::{Duration, Utc};
 
     use super::{
-        emit_watch_snapshot, format_stuck_queued_duration, is_stuck_queued, queued_for_secs,
-        reused_evidence_map, ship_terminal_verdict, watch_event_signature, watch_signature,
+        WatchDiagnosticsCache, collect_watch_diagnostics, emit_watch_snapshot,
+        emit_watch_snapshot_with_diagnostics, format_stuck_queued_duration, is_stuck_queued,
+        queued_for_secs, reused_evidence_map, ship_terminal_verdict, watch_event_signature,
+        watch_signature,
     };
+    use crate::diagnostics::{DiagnosticsError, DiagnosticsFetcher};
     use crate::evidence::{EvidenceRecord, EvidenceStore};
     use crate::ship_state::{DispatchedRun, ShipState};
 
@@ -661,5 +913,298 @@ mod tests {
             ],
         );
         assert_eq!(ship_terminal_verdict(&state), None);
+    }
+
+    // ----- Phase 2 (issue #303) -----
+
+    /// Fake [`DiagnosticsFetcher`] that returns canned responses and counts
+    /// the number of jobs / log fetches it received, so tests can assert that
+    /// the watch cache really prevents refetching across polls.
+    struct FakeFetcher {
+        jobs_json: String,
+        log: String,
+        jobs_calls: std::cell::Cell<usize>,
+        log_calls: std::cell::Cell<usize>,
+    }
+
+    impl FakeFetcher {
+        fn new(jobs_json: String, log: String) -> Self {
+            Self {
+                jobs_json,
+                log,
+                jobs_calls: std::cell::Cell::new(0),
+                log_calls: std::cell::Cell::new(0),
+            }
+        }
+    }
+
+    impl DiagnosticsFetcher for FakeFetcher {
+        fn fetch_jobs_json(&self, _repo: &str, _run_id: u64) -> Result<String, DiagnosticsError> {
+            self.jobs_calls.set(self.jobs_calls.get() + 1);
+            Ok(self.jobs_json.clone())
+        }
+
+        fn fetch_job_log(&self, _repo: &str, _job_id: u64) -> Result<String, DiagnosticsError> {
+            self.log_calls.set(self.log_calls.get() + 1);
+            Ok(self.log.clone())
+        }
+    }
+
+    fn failed_jobs_payload() -> String {
+        serde_json::json!({
+            "total_count": 1,
+            "jobs": [{
+                "id": 12_345,
+                "name": "macOS (ARM64) [namespace]",
+                "html_url": "https://github.com/owner/repo/actions/runs/9999/job/12345",
+                "conclusion": "failure",
+                "steps": [{"name": "Test", "conclusion": "failure"}],
+                "labels": ["namespace-profile-foo"]
+            }]
+        })
+        .to_string()
+    }
+
+    fn failed_ctest_log() -> String {
+        "noise\nThe following tests FAILED:\n\t10 - synth_test (Failed)\nErrors while running CTest\n".to_owned()
+    }
+
+    fn failed_run(target: &str, provider: &str, run_id: u64) -> DispatchedRun {
+        let mut run = run(target, "failed", &run_id.to_string(), true);
+        run.provider = provider.to_owned();
+        run
+    }
+
+    #[test]
+    fn collect_watch_diagnostics_fetches_for_terminal_failure() {
+        let state = state(
+            42,
+            &[("mac", "fail")],
+            vec![failed_run("mac", "namespace", 9_999)],
+        );
+        let fetcher = FakeFetcher::new(failed_jobs_payload(), failed_ctest_log());
+        let mut cache = WatchDiagnosticsCache::new();
+
+        let diagnostics = collect_watch_diagnostics(&state, &fetcher, &mut cache);
+
+        assert_eq!(diagnostics.len(), 1);
+        let entry = &diagnostics[0];
+        assert_eq!(entry.target_name, "mac");
+        assert_eq!(entry.provider, "namespace");
+        assert_eq!(entry.run_id, 9_999);
+        let job = entry
+            .diagnostics
+            .job
+            .as_ref()
+            .expect("job metadata present");
+        assert_eq!(job.job_id, 12_345);
+        assert!(job.html_url.contains("/runs/9999/job/12345"));
+        assert_eq!(entry.diagnostics.failure_summary.len(), 1);
+        assert!(entry.diagnostics.failure_summary[0].contains("synth_test"));
+    }
+
+    #[test]
+    fn collect_watch_diagnostics_caches_repeat_polls() {
+        let state = state(
+            42,
+            &[("mac", "fail")],
+            vec![failed_run("mac", "namespace", 9_999)],
+        );
+        let fetcher = FakeFetcher::new(failed_jobs_payload(), failed_ctest_log());
+        let mut cache = WatchDiagnosticsCache::new();
+
+        let first = collect_watch_diagnostics(&state, &fetcher, &mut cache);
+        let second = collect_watch_diagnostics(&state, &fetcher, &mut cache);
+
+        assert_eq!(first.len(), 1, "first poll fetches");
+        assert!(
+            second.is_empty(),
+            "second poll on identical terminal-fail state must not refetch"
+        );
+        assert_eq!(
+            fetcher.jobs_calls.get(),
+            1,
+            "expected exactly one jobs fetch across two polls"
+        );
+        assert_eq!(
+            fetcher.log_calls.get(),
+            1,
+            "expected exactly one log fetch across two polls"
+        );
+    }
+
+    #[test]
+    fn collect_watch_diagnostics_skips_local_run_ids() {
+        // Local/SSH/Windows backends store the Shipyard internal job ID, which
+        // is not numeric. We must not call GHA for those.
+        let state = state(
+            42,
+            &[("mac", "fail")],
+            vec![{
+                let mut r = run("mac", "failed", "shipyard-internal-id-xyz", true);
+                r.provider = "local".to_owned();
+                r
+            }],
+        );
+        let fetcher = FakeFetcher::new(failed_jobs_payload(), failed_ctest_log());
+        let mut cache = WatchDiagnosticsCache::new();
+
+        let diagnostics = collect_watch_diagnostics(&state, &fetcher, &mut cache);
+
+        assert!(diagnostics.is_empty());
+        assert_eq!(fetcher.jobs_calls.get(), 0);
+        assert_eq!(fetcher.log_calls.get(), 0);
+    }
+
+    #[test]
+    fn collect_watch_diagnostics_skips_non_terminal_runs() {
+        let state = state(
+            42,
+            &[],
+            vec![{
+                let mut r = run("mac", "in_progress", "9999", true);
+                r.provider = "namespace".to_owned();
+                r
+            }],
+        );
+        let fetcher = FakeFetcher::new(failed_jobs_payload(), failed_ctest_log());
+        let mut cache = WatchDiagnosticsCache::new();
+
+        let diagnostics = collect_watch_diagnostics(&state, &fetcher, &mut cache);
+
+        assert!(diagnostics.is_empty());
+        assert_eq!(fetcher.jobs_calls.get(), 0);
+    }
+
+    #[test]
+    fn watch_human_render_contains_failing_job_url() {
+        let state = state(
+            42,
+            &[("mac", "fail")],
+            vec![failed_run("mac", "namespace", 9_999)],
+        );
+        let fetcher = FakeFetcher::new(failed_jobs_payload(), failed_ctest_log());
+        let mut cache = WatchDiagnosticsCache::new();
+        let diagnostics = collect_watch_diagnostics(&state, &fetcher, &mut cache);
+        let mut stdout = Vec::new();
+
+        emit_watch_snapshot_with_diagnostics(
+            &state,
+            &std::collections::BTreeMap::new(),
+            &diagnostics,
+            false,
+            &mut stdout,
+        )
+        .expect("watch snapshot");
+        let text = String::from_utf8(stdout).expect("utf8");
+
+        assert!(
+            text.contains("https://github.com/owner/repo/actions/runs/9999/job/12345"),
+            "human render must include failing job URL:\n{text}"
+        );
+        assert!(
+            text.contains("macOS (ARM64) [namespace]"),
+            "human render must name the failing job:\n{text}"
+        );
+        assert!(
+            text.contains("synth_test"),
+            "human render must include parsed CTest footer:\n{text}"
+        );
+    }
+
+    #[test]
+    fn watch_json_render_includes_diagnostics_block() {
+        let state = state(
+            42,
+            &[("mac", "fail")],
+            vec![failed_run("mac", "namespace", 9_999)],
+        );
+        let fetcher = FakeFetcher::new(failed_jobs_payload(), failed_ctest_log());
+        let mut cache = WatchDiagnosticsCache::new();
+        let diagnostics = collect_watch_diagnostics(&state, &fetcher, &mut cache);
+        let mut stdout = Vec::new();
+
+        emit_watch_snapshot_with_diagnostics(
+            &state,
+            &std::collections::BTreeMap::new(),
+            &diagnostics,
+            true,
+            &mut stdout,
+        )
+        .expect("json snapshot");
+        let value: serde_json::Value = serde_json::from_slice(&stdout).expect("json");
+
+        let diag_array = value["diagnostics"]
+            .as_array()
+            .expect("diagnostics array on transition payload");
+        assert_eq!(diag_array.len(), 1);
+        let diag = &diag_array[0];
+        assert_eq!(diag["failed_target"], "mac");
+        assert_eq!(diag["run_id"], 9_999);
+        assert_eq!(diag["provider"], "namespace");
+        assert_eq!(diag["kind"], "failed");
+        assert_eq!(diag["cloud_job_id"], 12_345);
+        assert!(
+            diag["cloud_job_url"]
+                .as_str()
+                .expect("job url string")
+                .contains("/runs/9999/job/12345")
+        );
+        assert_eq!(diag["failed_step"], "Test");
+        assert_eq!(
+            diag["details"]["failed_target"], "mac",
+            "details should round-trip through Phase 1's FailureDiagnostics schema"
+        );
+    }
+
+    #[test]
+    fn watch_json_render_omits_diagnostics_when_empty() {
+        let state = state(42, &[], vec![]);
+        let mut stdout = Vec::new();
+
+        emit_watch_snapshot(
+            &state,
+            &std::collections::BTreeMap::new(),
+            true,
+            &mut stdout,
+        )
+        .expect("json snapshot");
+        let value: serde_json::Value = serde_json::from_slice(&stdout).expect("json");
+
+        assert!(
+            value.get("diagnostics").is_none(),
+            "in-flight watch payloads must not include an empty diagnostics array"
+        );
+    }
+
+    #[test]
+    fn collect_watch_diagnostics_classifies_cancelled_and_timed_out() {
+        let mut state = state(
+            42,
+            &[("mac", "fail")],
+            vec![{
+                let mut r = run("mac", "cancelled", "9999", true);
+                r.provider = "namespace".to_owned();
+                r
+            }],
+        );
+        let fetcher = FakeFetcher::new(failed_jobs_payload(), failed_ctest_log());
+        let mut cache = WatchDiagnosticsCache::new();
+        let diagnostics = collect_watch_diagnostics(&state, &fetcher, &mut cache);
+        assert_eq!(diagnostics.len(), 1);
+        assert!(matches!(
+            diagnostics[0].kind,
+            crate::diagnostics::FailureKind::Cancelled
+        ));
+
+        // Now flip to timed_out and force a new run_id so the cache lets it through.
+        state.dispatched_runs[0].status = "timed_out".to_owned();
+        state.dispatched_runs[0].run_id = "10000".to_owned();
+        let diagnostics = collect_watch_diagnostics(&state, &fetcher, &mut cache);
+        assert_eq!(diagnostics.len(), 1);
+        assert!(matches!(
+            diagnostics[0].kind,
+            crate::diagnostics::FailureKind::TimedOut
+        ));
     }
 }


### PR DESCRIPTION
## Summary

Phase 2 of the failure-diagnostics work tracked in issue #303 — extends `shipyard watch --pr N --follow` so that the structured Phase 1 diagnostics block (failing job URL + failing step + parsed test footer) is rendered on every state transition where a target enters a terminal failure state.

Phase 1 (#304, v0.58.0) wired diagnostics into `shipyard pr` / `shipyard ship` exit output. `shipyard watch` was explicitly deferred per the Codex-vetted design. Phase 3 (sandboxed `failure_parser_cmd` escape hatch) remains deferred.

## What changed

- `src/watch.rs` — new `WatchTargetDiagnostics`, `WatchDiagnosticsCache`, `collect_watch_diagnostics()` (injectable `DiagnosticsFetcher`), `collect_watch_diagnostics_gh()` (production path), and `emit_watch_snapshot_with_diagnostics()`. Cache key `(target, run_id)` ensures at-most-one log fetch per terminal-failure transition for the lifetime of the watch invocation. Non-numeric `run_id` values (local/SSH/Windows backends carry the Shipyard internal job ID) are skipped because the GHA API cannot address them. Phase 1's 256 KB log-tail cap is reused verbatim.
- `src/app/watch_cmd.rs` — `watch()` now constructs a `GhDiagnosticsFetcher` and delegates to a new testable `watch_with_fetcher()` that threads the cache through the polling loop. On each new state signature, diagnostics are collected and rendered alongside the existing snapshot.
- Eight new unit tests in `src/watch.rs` covering fetch-on-transition, cache dedup across polls, non-numeric run_id skip, non-terminal-status skip, human render contains job URL, JSON carries diagnostics block, JSON omits the field when empty, and `Cancelled` / `TimedOut` classification.
- Two new end-to-end tests in `src/app/watch_cmd.rs` driving `watch_with_fetcher` with a fake `DiagnosticsFetcher`, asserting that human + JSON output both surface the failing job URL and parsed CTest footer.
- `CHANGELOG.md` + `Cargo.toml` + `Cargo.lock` bumped 0.58.0 → 0.59.0 (SDK minor — new visible behavior on a user-facing command).

All 17 Phase 1 diagnostics tests and all 9 ship_cmd tests continue to pass — no behavior change in either of those code paths. Total: 698 tests pass on `cargo test --all --locked --release`. Clippy clean with `-D warnings`.

## Before / after — human mode

Before (current `main`):

```
PR #42  sha=abcdef012345  attempt=1  age=0s
  1/1 targets complete · 0 in flight
  evidence: mac=fail
  run: mac (namespace) id=26063806409 status=failed phase=test elapsed=0s last_seen=-
```

After (this PR):

```
PR #42  sha=abcdef012345  attempt=1  age=0s
  1/1 targets complete · 0 in flight
  evidence: mac=fail
  run: mac (namespace) id=26063806409 status=failed phase=test elapsed=0s last_seen=-
  ✗ 1 terminal-failure transition this poll:
      Target:  mac (cloud=namespace)
      Job:     macOS (ARM64) [namespace]
      URL:     https://github.com/danielraffel/pulp/actions/runs/26063806409/job/76630095261
      Step:    "Test (non-Windows)"
      Tests:
        1236 - FontResolver: animation respects LRU cache cap (Failed)
```

## Before / after — JSON mode (`--json`)

Before:

```json
{
  "command": "watch",
  "event": "update",
  "pr": 42,
  "evidence": {"mac": "fail"},
  "dispatched_runs": [{"target": "mac", "status": "failed", "run_id": "26063806409", ...}]
}
```

After (adds top-level `diagnostics` array on the transition that first observes the terminal failure):

```json
{
  "command": "watch",
  "event": "update",
  "pr": 42,
  "evidence": {"mac": "fail"},
  "dispatched_runs": [{"target": "mac", "status": "failed", "run_id": "26063806409", ...}],
  "diagnostics": [{
    "failed_target": "mac",
    "provider": "namespace",
    "run_id": 26063806409,
    "kind": "failed",
    "cloud_job_id": 76630095261,
    "cloud_job_name": "macOS (ARM64) [namespace]",
    "cloud_job_url": "https://github.com/danielraffel/pulp/actions/runs/26063806409/job/76630095261",
    "failed_step": "Test (non-Windows)",
    "details": {
      "failed_target": "mac",
      "run_id": 26063806409,
      "job": { ... },
      "failure_summary": ["1236 - FontResolver: animation respects LRU cache cap (Failed)"],
      "failure_summary_truncated": false,
      "log_tail": "..."
    }
  }]
}
```

In-flight polls (no terminal-failure transition this poll) omit the `diagnostics` key entirely — the `WatchDiagnosticsCache` guarantees at-most-one fetch per `(target, run_id)` pair.

## Test plan

- [x] `cargo build --release`
- [x] `cargo test --all --locked --release` — 698 / 698 pass (2 pre-existing ignored)
- [x] `cargo clippy --all-targets --locked --release -- -D warnings` — clean
- [x] `cargo fmt --all --check`
- [x] Phase 1 diagnostics tests (`diagnostics::tests::*`) — all 17 still pass
- [x] Phase 1 ship_cmd tests (`app::ship_cmd::tests::*`) — all 8 still pass (1 unrelated pre-existing ignored — Shipyard issue #296)

## Notes

- Phase 3 (sandboxed `failure_parser_cmd` escape hatch) is still deferred — not in scope here.
- `failure_parser` (the per-target tracked-repo config value from Phase 1) lives on `TargetResult`, which is not visible to `watch`. Phase 2 uses `select_parser(None)` (auto) for now — Phase 3 or a follow-up could thread `failure_parser` onto `DispatchedRun` if per-target parser selection turns out to matter in the watch surface.
- The skill-sync and doc-sync gates are skipped via trailers in the feat commit (no agent-facing guidance changes, no state-machine transitions added).

Refs: #303 (Phase 2), #304 (Phase 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)