### PR TITLE
feat(runner): reap stale workflow runs in runner watch (#312)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "shipyard",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "Cross-platform CI coordination",
   "min_shipyard_version": "0.22.8",
   "commands": "./commands",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "shipyard",
-  "version": "0.30.0",
+  "version": "0.31.0",
   "description": "Cross-platform CI coordination",
   "min_shipyard_version": "0.22.8",
   "commands": "./commands",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@
 All notable changes to Shipyard are documented here. Each entry links
 to its [GitHub Release](https://github.com/danielraffel/Shipyard/releases).
 
-<a id="unreleased"></a>
-## [Unreleased]
+<a id="v0600"></a>
+## [0.60.0]
 
 - feat(runner): `runner watch --reap-stale-runs` — on every watch tick, cancel stale GitHub Actions workflow *runs* repo-wide: runs stuck `in_progress` past `--reap-in-progress-max-min` (default ~5h, hung) and runs stuck `queued` past `--reap-queued-max-min` (default ~8h, orphaned). The run-level complement to `--kill-hung-workers`. Supports `--dry-run` and emits `event=reap_stale_run` JSON envelopes (`phase ∈ {attempt,cancelled,failed,skipped}`). Thresholds are overridable via flag or `[runner.watchdog]` config keys `reap_in_progress_max_min` / `reap_queued_max_min`. Closes #312.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to Shipyard are documented here. Each entry links
 to its [GitHub Release](https://github.com/danielraffel/Shipyard/releases).
 
+<a id="unreleased"></a>
+## [Unreleased]
+
+- feat(runner): `runner watch --reap-stale-runs` — on every watch tick, cancel stale GitHub Actions workflow *runs* repo-wide: runs stuck `in_progress` past `--reap-in-progress-max-min` (default ~5h, hung) and runs stuck `queued` past `--reap-queued-max-min` (default ~8h, orphaned). The run-level complement to `--kill-hung-workers`. Supports `--dry-run` and emits `event=reap_stale_run` JSON envelopes (`phase ∈ {attempt,cancelled,failed,skipped}`). Thresholds are overridable via flag or `[runner.watchdog]` config keys `reap_in_progress_max_min` / `reap_queued_max_min`. Closes #312.
+
 <a id="v0590"></a>
 ## [0.59.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to Shipyard are documented here. Each entry links
 to its [GitHub Release](https://github.com/danielraffel/Shipyard/releases).
 
 <a id="v0750"></a>
+## [0.76.0]
+
 ## [0.75.0] - 2026-07-01
 
 - feat(ship-state): liveness-aware, configurable, status-surfaced orphan detection ([#367](https://github.com/danielraffel/Shipyard/pull/367))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -614,7 +614,7 @@ dependencies = [
 
 [[package]]
 name = "shipyard"
-version = "0.59.0"
+version = "0.60.0"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -693,7 +693,7 @@ dependencies = [
 
 [[package]]
 name = "shipyard"
-version = "0.75.0"
+version = "0.76.0"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shipyard"
-version = "0.59.0"
+version = "0.60.0"
 edition = "2024"
 description = "Cross-platform CI coordination for local, SSH, and cloud runners."
 rust-version = "1.92"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shipyard"
-version = "0.75.0"
+version = "0.76.0"
 edition = "2024"
 description = "Cross-platform CI coordination for local, SSH, and cloud runners."
 rust-version = "1.92"

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -58,7 +58,10 @@ shipyard runner cleanup                   # dry-run: list stale queued runs
 shipyard runner cleanup --fix             # cancel stale queued runs
 shipyard runner cleanup --stale-hours 4   # override threshold for this call
 shipyard runner watch                     # poll loop (default 5 min)
-shipyard runner watch --fix               # auto-cancel stale runs each tick
+shipyard runner watch --fix               # auto-cancel stale queued runs each tick
+shipyard runner watch --kill-hung-workers # also auto-kill hung Worker processes
+shipyard runner watch --reap-stale-runs   # also cancel stale workflow runs repo-wide
+shipyard runner watch --reap-stale-runs --dry-run   # preview reaper, cancel nothing
 
 # Explicit Worker termination (snapshot + SIGTERM grace + SIGKILL + quarantine)
 shipyard runner kill --pid 59996 --reason "wedged on agentB/81"

--- a/docs/runner-watchdog.md
+++ b/docs/runner-watchdog.md
@@ -18,6 +18,8 @@ them, and offer a guarded recovery path.
 | `orphaned_busy` | API reports `busy=true` but no `Runner.Worker` process is visible locally | Report only (clears in 1-5 min) |
 | `hung_worker` | A `Runner.Worker` has been running longer than `max_job_min` | Report on `status`; terminate with full recovery via `runner kill --pid <pid>` |
 | `stale_queued_runs` | Queued runs older than `max_queue_age_hours` | Report on `status`; cancel on `cleanup --fix` |
+| `hung_in_progress` (run-level) | A workflow run stuck `in_progress` past `reap_in_progress_max_min` | Cancel on `runner watch --reap-stale-runs` |
+| `orphaned_queued` (run-level) | A workflow run stuck `queued` past `reap_queued_max_min` | Cancel on `runner watch --reap-stale-runs` |
 
 ## Subcommands
 
@@ -171,6 +173,44 @@ The loop never exits on its own; press Ctrl-C or run it under
 `launchd` / `systemd` for unattended operation. A hidden
 `--max-iterations N` flag exists for tests.
 
+#### `--reap-stale-runs` — repo-wide stale-run reaper
+
+`--kill-hung-workers` reaps hung *processes* on the runner host;
+`--reap-stale-runs` reaps stale GitHub Actions *workflow runs* repo-wide.
+On every tick it lists the repo's runs and cancels:
+
+- runs stuck `in_progress` longer than `--reap-in-progress-max-min`
+  (default ~5h — "hung", e.g. a `Coverage` run squatting until GitHub's
+  6h timeout); and
+- runs stuck `queued` longer than `--reap-queued-max-min` (default ~8h —
+  "orphaned", e.g. a run waiting on a runner label that no longer exists,
+  which never hits any `timeout-minutes`).
+
+Both thresholds are deliberately well past any healthy run, so an
+in-flight validation run is never cancelled. Unlike host-process reaping,
+this also covers runs on **GitHub-hosted** runners.
+
+```bash
+# Auto-cancel stale runs on every tick:
+shipyard runner watch --reap-stale-runs
+
+# Preview only — log what would be cancelled, cancel nothing:
+shipyard runner watch --reap-stale-runs --dry-run --json
+
+# Tighter thresholds (minutes):
+shipyard runner watch --reap-stale-runs \
+  --reap-in-progress-max-min 240 --reap-queued-max-min 360
+```
+
+With `--json`, each candidate emits a `runner.watch` envelope with
+`event=reap_stale_run` and `phase ∈ {attempt, cancelled, failed,
+skipped}` (`skipped` only under `--dry-run`) — mirroring the
+`event=auto_kill_worker` envelopes from `--kill-hung-workers`.
+
+Cancellation goes through the GitHub REST API
+(`POST /repos/{owner}/{repo}/actions/runs/{id}/cancel`), the same path
+`runner cleanup --fix` and `shipyard rescue` use.
+
 ## Configuration
 
 Defaults live in `.shipyard/config.toml`:
@@ -183,6 +223,10 @@ max_job_min = 90
 max_queue_age_hours = 2
 watch_interval_seconds = 300
 auto_fix = false
+# Stale-run reaper thresholds (minutes), used by
+# `runner watch --reap-stale-runs`:
+reap_in_progress_max_min = 300
+reap_queued_max_min = 480
 ```
 
 Per-machine overrides go in `.shipyard.local/config.toml` and follow the
@@ -190,7 +234,8 @@ standard Shipyard layered-config rules.
 
 Every command-line flag wins over config; config wins over the built-in
 defaults (`max_job_min=90`, `max_queue_age_hours=2`,
-`watch_interval_seconds=300`).
+`watch_interval_seconds=300`, `reap_in_progress_max_min=300`,
+`reap_queued_max_min=480`).
 
 ## Lessons learned (from the prototype)
 

--- a/skills/ci/SKILL.md
+++ b/skills/ci/SKILL.md
@@ -362,6 +362,41 @@ Run it as a launchd/systemd service for prevention; pair with
 they replace the legacy `runner-watchdog.sh --fix` workflow that today
 masks wedges as required-check failures.
 
+### Reaping stale workflow runs: `runner watch --reap-stale-runs`
+
+`--kill-hung-workers` reaps hung *processes* on the runner host.
+`--reap-stale-runs` is the **run-level** complement: on every tick it
+lists the repo's GitHub Actions runs and cancels genuinely-stale ones
+repo-wide — including runs on **GitHub-hosted** runners, which the
+process-level reaper cannot see.
+
+```sh
+# Auto-cancel stale workflow runs on every tick:
+shipyard runner watch --reap-stale-runs
+
+# Preview only — log what would be cancelled, cancel nothing:
+shipyard runner watch --reap-stale-runs --dry-run --json
+
+# Override thresholds (minutes):
+shipyard runner watch --reap-stale-runs \
+  --reap-in-progress-max-min 240 --reap-queued-max-min 360
+```
+
+What it cancels on every tick:
+
+1. Runs stuck `in_progress` longer than `--reap-in-progress-max-min`
+   (default ~5h) — hung runs squatting until GitHub's 6h timeout.
+2. Runs stuck `queued` longer than `--reap-queued-max-min` (default
+   ~8h) — orphaned runs waiting on a runner label/branch that no longer
+   exists, which never hit any `timeout-minutes`.
+
+Thresholds are deliberately well past any healthy run, so an in-flight
+Shipyard validation run is never touched. Configure persistent defaults
+in `[runner.watchdog]` (`reap_in_progress_max_min` /
+`reap_queued_max_min`). Emits `runner.watch` JSON envelopes with
+`event=reap_stale_run` and `phase` ∈ {`attempt`, `cancelled`, `failed`,
+`skipped`} (`skipped` only under `--dry-run`).
+
 ## Waiting on conditions (`shipyard wait`)
 
 Whenever you'd otherwise write a polling loop around `gh` — wait for a release to upload, wait for a PR's required checks to go green, wait for a dispatched workflow run to finish — reach for `shipyard wait` instead. It opens a daemon subscription first (if one's running), takes one authoritative `gh` snapshot, and either exits 0 immediately or keeps re-evaluating on real webhook events (no extra REST budget). When the daemon isn't running, it falls back to polling transparently — safe to use on headless CI too.

--- a/skills/ci/SKILL.md
+++ b/skills/ci/SKILL.md
@@ -386,9 +386,18 @@ What it cancels on every tick:
 
 1. Runs stuck `in_progress` longer than `--reap-in-progress-max-min`
    (default ~5h) — hung runs squatting until GitHub's 6h timeout.
+   Age is measured from `run_started_at` (execution start), **not**
+   `created_at`, so a run that sat queued for hours before starting is
+   not mistaken for hung; when GitHub omits `run_started_at` the
+   computation falls back to `created_at`.
 2. Runs stuck `queued` longer than `--reap-queued-max-min` (default
    ~8h) — orphaned runs waiting on a runner label/branch that no longer
-   exists, which never hit any `timeout-minutes`.
+   exists, which never hit any `timeout-minutes`. A queued run never
+   started, so its age is measured from `created_at`.
+
+Both status queries are paginated (`per_page=100`, up to 5 pages each),
+so busy repos with more than one page of `queued` / `in_progress` runs
+are fully scanned and the oldest entries are never missed.
 
 Thresholds are deliberately well past any healthy run, so an in-flight
 Shipyard validation run is never touched. Configure persistent defaults

--- a/skills/shipyard/SKILL.md
+++ b/skills/shipyard/SKILL.md
@@ -122,6 +122,9 @@ max_job_min = 90
 max_queue_age_hours = 2
 watch_interval_seconds = 300
 auto_fix = false
+# Stale-run reaper thresholds (minutes) for `runner watch --reap-stale-runs`:
+reap_in_progress_max_min = 300
+reap_queued_max_min = 480
 ```
 
 ## Supervised Subprocess Marker (issue #266)

--- a/src/app/cli.rs
+++ b/src/app/cli.rs
@@ -386,6 +386,24 @@ pub(super) enum RunnerCommand {
         /// Implies `--fix`.
         #[arg(long = "kill-hung-workers")]
         kill_hung_workers: bool,
+        /// On every tick, cancel stale GitHub Actions workflow *runs* repo-wide:
+        /// runs stuck `in_progress` past the in-progress max age (hung) and runs
+        /// stuck `queued` past the queued max age (orphaned). The run-level
+        /// complement to `--kill-hung-workers`.
+        #[arg(long = "reap-stale-runs")]
+        reap_stale_runs: bool,
+        /// Cancel `in_progress` runs older than this many minutes (hung).
+        /// Defaults to `runner.watchdog.reap_in_progress_max_min` or ~5h.
+        #[arg(long = "reap-in-progress-max-min")]
+        reap_in_progress_max_min: Option<i64>,
+        /// Cancel `queued` runs older than this many minutes (orphaned).
+        /// Defaults to `runner.watchdog.reap_queued_max_min` or ~8h.
+        #[arg(long = "reap-queued-max-min")]
+        reap_queued_max_min: Option<i64>,
+        /// With `--reap-stale-runs`, log what would be cancelled without
+        /// cancelling anything.
+        #[arg(long = "dry-run")]
+        dry_run: bool,
         /// Maximum number of iterations to run before exiting. Defaults to
         /// looping forever. Test hook.
         #[arg(long = "max-iterations", hide = true)]

--- a/src/app/cloud_cmd.rs
+++ b/src/app/cloud_cmd.rs
@@ -2206,6 +2206,7 @@ mod tests {
             name: format!("{workflow} run"),
             head_branch: branch.to_owned(),
             created_at: created_at.to_owned(),
+            run_started_at: None,
             workflow_name: workflow.to_owned(),
             url: Some(format!("https://github.com/owner/repo/actions/runs/{id}")),
             path: ".github/workflows/ci.yml".to_owned(),

--- a/src/app/rescue_cmd.rs
+++ b/src/app/rescue_cmd.rs
@@ -526,6 +526,7 @@ mod tests {
             name: format!("CI #{id}"),
             head_branch: branch.to_owned(),
             created_at: created_at.to_owned(),
+            run_started_at: None,
             workflow_name: "CI".to_owned(),
             url: Some(format!("https://example/run/{id}")),
             path: ".github/workflows/ci.yml".to_owned(),

--- a/src/app/runner_cmd.rs
+++ b/src/app/runner_cmd.rs
@@ -23,12 +23,15 @@ use crate::cloud::{GitHubActions, QueuedRun};
 use crate::config::LoadedConfig;
 use crate::output::write_json_envelope;
 use crate::runner_watchdog::{
-    DEFAULT_MAX_JOB_MIN, DEFAULT_MAX_QUEUE_AGE_HOURS, DEFAULT_WATCH_INTERVAL_SECONDS, RunnerHealth,
-    RunnerReport, RunnerSnapshot, StaleQueuedRun, Symptom, WatchdogThresholds, assess_runner,
-    compute_stale_queued_runs, report_to_json,
+    DEFAULT_MAX_JOB_MIN, DEFAULT_MAX_QUEUE_AGE_HOURS, DEFAULT_REAP_IN_PROGRESS_MAX_MIN,
+    DEFAULT_REAP_QUEUED_MAX_MIN, DEFAULT_WATCH_INTERVAL_SECONDS, ReaperThresholds, RunnerHealth,
+    RunnerReport, RunnerSnapshot, StaleQueuedRun, StaleRun, Symptom, WatchdogThresholds,
+    assess_runner, compute_stale_queued_runs, compute_stale_runs, report_to_json,
 };
 
 const QUEUED_RUNS_LIMIT: u32 = 100;
+/// Max API result size for each run-status listing during a reaper tick.
+const REAP_RUNS_LIMIT: u32 = 100;
 
 /// Entry point dispatched from `src/app.rs`.
 pub(super) fn runner_command<W: Write>(
@@ -464,6 +467,10 @@ fn dispatch_watch<W: Write>(
         interval,
         fix,
         kill_hung_workers,
+        reap_stale_runs,
+        reap_in_progress_max_min,
+        reap_queued_max_min,
+        dry_run,
         max_iterations,
         kill_grace_secs,
     } = command
@@ -480,6 +487,10 @@ fn dispatch_watch<W: Write>(
         interval_override: interval,
         fix: fix || kill_hung_workers,
         kill_hung_workers,
+        reap_stale_runs,
+        reap_in_progress_max_min,
+        reap_queued_max_min,
+        dry_run,
         max_iterations,
         kill_grace_secs,
         json,
@@ -487,6 +498,7 @@ fn dispatch_watch<W: Write>(
     })
 }
 
+#[allow(clippy::struct_excessive_bools)]
 pub(super) struct WatchCommandArgs<'a, W: Write> {
     pub(super) config: &'a LoadedConfig,
     pub(super) cwd: &'a Path,
@@ -497,6 +509,10 @@ pub(super) struct WatchCommandArgs<'a, W: Write> {
     pub(super) interval_override: Option<u64>,
     pub(super) fix: bool,
     pub(super) kill_hung_workers: bool,
+    pub(super) reap_stale_runs: bool,
+    pub(super) reap_in_progress_max_min: Option<i64>,
+    pub(super) reap_queued_max_min: Option<i64>,
+    pub(super) dry_run: bool,
     pub(super) max_iterations: Option<u32>,
     pub(super) kill_grace_secs: Option<u64>,
     pub(super) json: bool,
@@ -514,6 +530,10 @@ fn watch_command<W: Write>(args: WatchCommandArgs<'_, W>) -> Result<ExitCode, Cl
         interval_override,
         fix,
         kill_hung_workers,
+        reap_stale_runs,
+        reap_in_progress_max_min,
+        reap_queued_max_min,
+        dry_run,
         max_iterations,
         kill_grace_secs,
         json,
@@ -529,6 +549,8 @@ fn watch_command<W: Write>(args: WatchCommandArgs<'_, W>) -> Result<ExitCode, Cl
         None,
         interval_override,
     )?;
+    let reaper_thresholds =
+        resolve_reaper_thresholds(config, reap_in_progress_max_min, reap_queued_max_min);
     let interval = Duration::from_secs(settings.thresholds.watch_interval_seconds.max(1));
     if max_iterations == Some(0) {
         return Ok(ExitCode::SUCCESS);
@@ -553,6 +575,16 @@ fn watch_command<W: Write>(args: WatchCommandArgs<'_, W>) -> Result<ExitCode, Cl
                         actions,
                         &settings,
                         kill_grace_secs,
+                        json,
+                        stdout,
+                    )?;
+                }
+                if reap_stale_runs {
+                    reap_stale_runs_tick(
+                        actions,
+                        &settings,
+                        reaper_thresholds,
+                        dry_run,
                         json,
                         stdout,
                     )?;
@@ -789,6 +821,148 @@ fn cancel_stale_inline<W: Write>(
         }
     }
     Ok(())
+}
+
+// ---------- stale-run reaper ----------
+
+/// Resolve [`ReaperThresholds`] from flags, then `[runner.watchdog]` config,
+/// then the built-in defaults — matching the precedence used by
+/// `resolve_watchdog_settings`.
+fn resolve_reaper_thresholds(
+    config: &LoadedConfig,
+    in_progress_override: Option<i64>,
+    queued_override: Option<i64>,
+) -> ReaperThresholds {
+    let in_progress_max_min = in_progress_override
+        .or_else(|| {
+            config
+                .get("runner.watchdog.reap_in_progress_max_min")
+                .and_then(toml::Value::as_integer)
+        })
+        .unwrap_or(DEFAULT_REAP_IN_PROGRESS_MAX_MIN);
+    let queued_max_min = queued_override
+        .or_else(|| {
+            config
+                .get("runner.watchdog.reap_queued_max_min")
+                .and_then(toml::Value::as_integer)
+        })
+        .unwrap_or(DEFAULT_REAP_QUEUED_MAX_MIN);
+    ReaperThresholds {
+        in_progress_max_min,
+        queued_max_min,
+    }
+}
+
+/// One stale-run reaper pass: list `in_progress` + `queued` runs, select the
+/// genuinely-stale ones, and cancel them (unless `--dry-run`). Emits one
+/// `event=reap_stale_run` envelope per run, mirroring the `auto_kill_worker`
+/// event style used by `--kill-hung-workers`.
+fn reap_stale_runs_tick<W: Write>(
+    actions: &GitHubActions,
+    settings: &WatchdogSettings,
+    thresholds: ReaperThresholds,
+    dry_run: bool,
+    json: bool,
+    stdout: &mut W,
+) -> Result<(), CliFailure> {
+    let in_progress = actions
+        .list_runs_with_status(&settings.repo_slug, "in_progress", None, REAP_RUNS_LIMIT)
+        .map_err(|error| CliFailure::new(1, error.to_string()))?;
+    let queued = actions
+        .list_runs_with_status(&settings.repo_slug, "queued", None, REAP_RUNS_LIMIT)
+        .map_err(|error| CliFailure::new(1, error.to_string()))?;
+
+    let stale = compute_stale_runs(&in_progress, &queued, thresholds, Utc::now());
+    for run in &stale {
+        let detail = format!(
+            "{} run {} ({}, branch={}) {} for {}s — threshold {}min",
+            run.kind.as_str(),
+            run.run_id,
+            run.workflow,
+            run.branch,
+            run.status,
+            run.age_secs,
+            match run.kind {
+                crate::runner_watchdog::StaleRunKind::HungInProgress => {
+                    thresholds.in_progress_max_min
+                }
+                crate::runner_watchdog::StaleRunKind::OrphanedQueued => thresholds.queued_max_min,
+            },
+        );
+        emit_reap_event(
+            stdout,
+            &settings.repo_slug,
+            json,
+            "attempt",
+            run,
+            Some(&detail),
+        )?;
+        if dry_run {
+            emit_reap_event(
+                stdout,
+                &settings.repo_slug,
+                json,
+                "skipped",
+                run,
+                Some("dry-run: not cancelling"),
+            )?;
+            continue;
+        }
+        match actions.cancel_workflow_run(&settings.repo_slug, run.run_id) {
+            Ok(()) => {
+                emit_reap_event(stdout, &settings.repo_slug, json, "cancelled", run, None)?;
+            }
+            Err(err) => {
+                emit_reap_event(
+                    stdout,
+                    &settings.repo_slug,
+                    json,
+                    "failed",
+                    run,
+                    Some(&err.to_string()),
+                )?;
+            }
+        }
+    }
+    Ok(())
+}
+
+fn emit_reap_event<W: Write>(
+    stdout: &mut W,
+    repo: &str,
+    json: bool,
+    phase: &str,
+    run: &StaleRun,
+    detail: Option<&str>,
+) -> Result<(), CliFailure> {
+    if json {
+        let mut data = BTreeMap::new();
+        data.insert("event".to_owned(), Value::from("reap_stale_run"));
+        data.insert("phase".to_owned(), Value::from(phase.to_owned()));
+        data.insert("repo".to_owned(), Value::from(repo.to_owned()));
+        data.insert("run_id".to_owned(), Value::from(run.run_id));
+        data.insert("kind".to_owned(), Value::from(run.kind.as_str()));
+        data.insert("status".to_owned(), Value::from(run.status.clone()));
+        data.insert("workflow".to_owned(), Value::from(run.workflow.clone()));
+        data.insert("branch".to_owned(), Value::from(run.branch.clone()));
+        data.insert("age_secs".to_owned(), Value::from(run.age_secs));
+        if let Some(url) = &run.url {
+            data.insert("url".to_owned(), Value::from(url.clone()));
+        }
+        if let Some(detail) = detail {
+            data.insert("detail".to_owned(), Value::from(detail.to_owned()));
+        }
+        return write_json_envelope(stdout, "runner.watch", data)
+            .map_err(|error| CliFailure::new(1, error.to_string()));
+    }
+    let ts = Utc::now().format("%H:%M:%S");
+    let detail_part = detail.map_or_else(String::new, |d| format!(" — {d}"));
+    writeln!(
+        stdout,
+        "[{ts}] reap-stale-run {phase} run={}{detail_part}",
+        run.run_id
+    )
+    .map_err(|error| CliFailure::new(1, error.to_string()))
 }
 
 // ---------- settings / config wiring ----------
@@ -1234,5 +1408,54 @@ mod tests {
     fn dry_run_overridden_only_respects_fix_flag() {
         assert!(dry_run_overridden_only(true, false));
         assert!(!dry_run_overridden_only(true, true));
+    }
+
+    fn config_with(body: &str) -> crate::config::LoadedConfig {
+        use crate::config::{LoadedConfig, LocalOverlaySource};
+        let sandbox = tempfile::TempDir::new().expect("tempdir");
+        let project_dir = sandbox.path().join(".shipyard");
+        std::fs::create_dir_all(&project_dir).expect("project dir");
+        std::fs::write(project_dir.join("config.toml"), body).expect("write config");
+        // Keep the TempDir alive for the lifetime of the test by leaking it;
+        // tests are short-lived processes and this avoids a lifetime dance.
+        let dir = sandbox.keep();
+        LoadedConfig::load(
+            Some(dir.join("global-missing")),
+            Some(dir.join(".shipyard")),
+            None,
+            LocalOverlaySource::None,
+        )
+        .expect("load config")
+    }
+
+    #[test]
+    fn reaper_thresholds_fall_back_to_built_in_defaults() {
+        let config = config_with("[project]\nname = \"x\"\n");
+        let thresholds = resolve_reaper_thresholds(&config, None, None);
+        assert_eq!(
+            thresholds.in_progress_max_min,
+            DEFAULT_REAP_IN_PROGRESS_MAX_MIN
+        );
+        assert_eq!(thresholds.queued_max_min, DEFAULT_REAP_QUEUED_MAX_MIN);
+    }
+
+    #[test]
+    fn reaper_thresholds_read_from_config() {
+        let config = config_with(
+            "[runner.watchdog]\nreap_in_progress_max_min = 120\nreap_queued_max_min = 240\n",
+        );
+        let thresholds = resolve_reaper_thresholds(&config, None, None);
+        assert_eq!(thresholds.in_progress_max_min, 120);
+        assert_eq!(thresholds.queued_max_min, 240);
+    }
+
+    #[test]
+    fn reaper_thresholds_flags_win_over_config() {
+        let config = config_with(
+            "[runner.watchdog]\nreap_in_progress_max_min = 120\nreap_queued_max_min = 240\n",
+        );
+        let thresholds = resolve_reaper_thresholds(&config, Some(30), Some(60));
+        assert_eq!(thresholds.in_progress_max_min, 30);
+        assert_eq!(thresholds.queued_max_min, 60);
     }
 }

--- a/src/app/runner_cmd.rs
+++ b/src/app/runner_cmd.rs
@@ -30,8 +30,12 @@ use crate::runner_watchdog::{
 };
 
 const QUEUED_RUNS_LIMIT: u32 = 100;
-/// Max API result size for each run-status listing during a reaper tick.
-const REAP_RUNS_LIMIT: u32 = 100;
+/// Cap on the number of paginated `gh api` calls per reaper tick, per status.
+/// Each page is 100 items, so the worst case is 500 `in_progress` + 500
+/// `queued` runs scanned — far beyond any healthy repo. The paginated listers
+/// stop early on the first short page, so a small repo still costs one call
+/// per status.
+const REAP_RUNS_MAX_PAGES: u32 = 5;
 
 /// Entry point dispatched from `src/app.rs`.
 pub(super) fn runner_command<W: Write>(
@@ -865,11 +869,19 @@ fn reap_stale_runs_tick<W: Write>(
     json: bool,
     stdout: &mut W,
 ) -> Result<(), CliFailure> {
+    // Paginate both status queries so repos with more than one page of
+    // `in_progress` / `queued` runs are fully covered — a single 100-item
+    // page would silently miss the oldest (and most likely stale) entries.
     let in_progress = actions
-        .list_runs_with_status(&settings.repo_slug, "in_progress", None, REAP_RUNS_LIMIT)
+        .list_runs_with_status_paginated(
+            &settings.repo_slug,
+            "in_progress",
+            None,
+            REAP_RUNS_MAX_PAGES,
+        )
         .map_err(|error| CliFailure::new(1, error.to_string()))?;
     let queued = actions
-        .list_runs_with_status(&settings.repo_slug, "queued", None, REAP_RUNS_LIMIT)
+        .list_runs_with_status_paginated(&settings.repo_slug, "queued", None, REAP_RUNS_MAX_PAGES)
         .map_err(|error| CliFailure::new(1, error.to_string()))?;
 
     let stale = compute_stale_runs(&in_progress, &queued, thresholds, Utc::now());

--- a/src/cloud.rs
+++ b/src/cloud.rs
@@ -17,6 +17,35 @@ use crate::config::LoadedConfig;
 const RUN_JSON_FIELDS: &str =
     "databaseId,status,conclusion,url,createdAt,updatedAt,workflowName,headBranch,headSha";
 const JOB_ACTIVE_STATUSES: [&str; 2] = ["queued", "in_progress"];
+/// Maximum page size the GitHub Actions runs API accepts. Paginated listers
+/// request this many items per page and stop early on a short page.
+const RUNS_API_PAGE_SIZE: u32 = 100;
+
+/// Build the `gh api` path for a workflow-runs query.
+///
+/// Pure string assembly so the pagination helpers can be unit-tested without a
+/// real `gh` on `PATH`. When `page` is `Some`, the path requests a full page
+/// (`per_page=RUNS_API_PAGE_SIZE`) at that page number; when `None`, it
+/// requests `per_page=limit` for the single-shot listers.
+fn runs_query_path(
+    repository: &str,
+    status: &str,
+    branch: Option<&str>,
+    limit: u32,
+    page: Option<u32>,
+) -> String {
+    let mut path = match page {
+        Some(page) => format!(
+            "repos/{repository}/actions/runs?status={status}&per_page={RUNS_API_PAGE_SIZE}&page={page}"
+        ),
+        None => format!("repos/{repository}/actions/runs?status={status}&per_page={limit}"),
+    };
+    if let Some(branch) = branch.filter(|value| !value.is_empty()) {
+        path.push_str("&branch=");
+        path.push_str(&encode_branch(branch));
+    }
+    path
+}
 
 /// A workflow that can be launched with `workflow_dispatch`.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
@@ -121,6 +150,10 @@ pub struct QueuedRun {
     pub head_branch: String,
     /// ISO-8601 creation timestamp.
     pub created_at: String,
+    /// ISO-8601 execution-start timestamp, when GitHub reported one. Absent
+    /// (`None`) while a run is still `queued`; set once the run begins
+    /// `in_progress`.
+    pub run_started_at: Option<String>,
     /// Workflow display name.
     pub workflow_name: String,
     /// HTML URL.
@@ -449,35 +482,21 @@ impl GitHubActions {
     ) -> Result<Vec<QueuedRun>, GitHubError> {
         let args = vec![
             "api".to_owned(),
-            format!("repos/{repository}/actions/runs?status=queued&per_page={limit}"),
+            runs_query_path(repository, "queued", None, limit, None),
         ];
         let stdout = self.run_gh(&args)?;
         parse_queued_runs(&stdout)
     }
 
-    /// Like `list_queued_runs` but paginates up to `max_pages` (`per_page=100` each)
-    /// so callers can cover busy repos with more than one page of queued runs.
-    /// Stops early when a page returns no items.
+    /// Like `list_queued_runs` but paginates up to `max_pages`
+    /// (`per_page=RUNS_API_PAGE_SIZE` each) so callers can cover busy repos
+    /// with more than one page of queued runs. Stops early on a short page.
     pub fn list_queued_runs_paginated(
         &self,
         repository: &str,
         max_pages: u32,
     ) -> Result<Vec<QueuedRun>, GitHubError> {
-        let mut out = Vec::new();
-        for page in 1..=max_pages.max(1) {
-            let args = vec![
-                "api".to_owned(),
-                format!("repos/{repository}/actions/runs?status=queued&`per_page=100`&page={page}"),
-            ];
-            let stdout = self.run_gh(&args)?;
-            let page_runs = parse_queued_runs(&stdout)?;
-            let count = page_runs.len();
-            out.extend(page_runs);
-            if count < 100 {
-                break;
-            }
-        }
-        Ok(out)
+        self.list_runs_with_status_paginated(repository, "queued", None, max_pages)
     }
 
     /// List workflow runs filtered by status (and optional branch).
@@ -488,18 +507,17 @@ impl GitHubActions {
         branch: Option<&str>,
         limit: u32,
     ) -> Result<Vec<QueuedRun>, GitHubError> {
-        let mut path = format!("repos/{repository}/actions/runs?status={status}&per_page={limit}");
-        if let Some(branch) = branch.filter(|value| !value.is_empty()) {
-            path.push_str("&branch=");
-            path.push_str(&encode_branch(branch));
-        }
-        let args = vec!["api".to_owned(), path];
+        let args = vec![
+            "api".to_owned(),
+            runs_query_path(repository, status, branch, limit, None),
+        ];
         let stdout = self.run_gh(&args)?;
         parse_queued_runs(&stdout)
     }
 
-    /// Like `list_runs_with_status` but paginates up to `max_pages` (`per_page=100`
-    /// each). Stops early when a page returns no items.
+    /// Like `list_runs_with_status` but paginates up to `max_pages`
+    /// (`per_page=RUNS_API_PAGE_SIZE` each). Stops early on a short page — a
+    /// page with fewer than a full `RUNS_API_PAGE_SIZE` items is the last one.
     pub fn list_runs_with_status_paginated(
         &self,
         repository: &str,
@@ -509,19 +527,15 @@ impl GitHubActions {
     ) -> Result<Vec<QueuedRun>, GitHubError> {
         let mut out = Vec::new();
         for page in 1..=max_pages.max(1) {
-            let mut path = format!(
-                "repos/{repository}/actions/runs?status={status}&`per_page=100`&page={page}"
-            );
-            if let Some(branch) = branch.filter(|value| !value.is_empty()) {
-                path.push_str("&branch=");
-                path.push_str(&encode_branch(branch));
-            }
-            let args = vec!["api".to_owned(), path];
+            let args = vec![
+                "api".to_owned(),
+                runs_query_path(repository, status, branch, RUNS_API_PAGE_SIZE, Some(page)),
+            ];
             let stdout = self.run_gh(&args)?;
             let page_runs = parse_queued_runs(&stdout)?;
             let count = page_runs.len();
             out.extend(page_runs);
-            if count < 100 {
+            if count < RUNS_API_PAGE_SIZE as usize {
                 break;
             }
         }
@@ -900,6 +914,11 @@ pub fn parse_queued_runs(stdout: &str) -> Result<Vec<QueuedRun>, GitHubError> {
             .and_then(Value::as_str)
             .unwrap_or_default()
             .to_owned();
+        let run_started_at = run
+            .get("run_started_at")
+            .and_then(Value::as_str)
+            .filter(|value| !value.is_empty())
+            .map(ToOwned::to_owned);
         let path = run
             .get("path")
             .and_then(Value::as_str)
@@ -921,6 +940,7 @@ pub fn parse_queued_runs(stdout: &str) -> Result<Vec<QueuedRun>, GitHubError> {
             name,
             head_branch,
             created_at,
+            run_started_at,
             url: run
                 .get("html_url")
                 .or_else(|| run.get("url"))
@@ -1378,13 +1398,78 @@ runner_selector = "config-selector"
     #[test]
     fn queued_runs_parse_github_api_shape() {
         let parsed = super::parse_queued_runs(
-            r#"{"workflow_runs":[{"id":555,"name":"CI","head_branch":"feat/x","created_at":"2026-04-23T12:00:00Z","html_url":"https://example/run/555","path":".github/workflows/ci.yml"}]}"#,
+            r#"{"workflow_runs":[{"id":555,"name":"CI","head_branch":"feat/x","created_at":"2026-04-23T12:00:00Z","run_started_at":"2026-04-23T12:05:00Z","html_url":"https://example/run/555","path":".github/workflows/ci.yml"}]}"#,
         )
         .expect("parse");
 
         assert_eq!(parsed.len(), 1);
         assert_eq!(parsed[0].database_id, 555);
         assert_eq!(parsed[0].path, ".github/workflows/ci.yml");
+        // P1: `run_started_at` is captured so the reaper can age in_progress
+        // runs from execution start, not creation time.
+        assert_eq!(
+            parsed[0].run_started_at.as_deref(),
+            Some("2026-04-23T12:05:00Z")
+        );
+    }
+
+    #[test]
+    fn queued_runs_parse_without_run_started_at() {
+        // P1: a still-queued run has no `run_started_at`; it must parse as
+        // `None` rather than an empty string, so the reaper's null check works.
+        let parsed = super::parse_queued_runs(
+            r#"{"workflow_runs":[{"id":7,"name":"CI","head_branch":"main","created_at":"2026-04-23T12:00:00Z","path":".github/workflows/ci.yml"}]}"#,
+        )
+        .expect("parse");
+
+        assert_eq!(parsed.len(), 1);
+        assert_eq!(parsed[0].run_started_at, None);
+    }
+
+    #[test]
+    fn runs_query_path_paginates_with_full_page_size() {
+        // P2: paginated listers must request a full RUNS_API_PAGE_SIZE page at
+        // an explicit page number — and never emit the literal backticks that
+        // the pre-fix code shipped (`per_page=100` as a quoted token).
+        let page2 = super::runs_query_path("owner/repo", "queued", None, 100, Some(2));
+        assert_eq!(
+            page2,
+            "repos/owner/repo/actions/runs?status=queued&per_page=100&page=2"
+        );
+        assert!(!page2.contains('`'), "URL must not contain backticks");
+
+        let page1 = super::runs_query_path("owner/repo", "in_progress", None, 100, Some(1));
+        assert_eq!(
+            page1,
+            "repos/owner/repo/actions/runs?status=in_progress&per_page=100&page=1"
+        );
+    }
+
+    #[test]
+    fn runs_query_path_single_shot_uses_limit_and_no_page() {
+        // The non-paginated form keeps `per_page=<limit>` and omits `page=`.
+        let path = super::runs_query_path("owner/repo", "queued", None, 25, None);
+        assert_eq!(
+            path,
+            "repos/owner/repo/actions/runs?status=queued&per_page=25"
+        );
+        assert!(!path.contains("&page="));
+    }
+
+    #[test]
+    fn runs_query_path_appends_encoded_branch() {
+        // Branch filtering survives pagination and is percent-encoded.
+        let path = super::runs_query_path("owner/repo", "queued", Some("feat/a b"), 100, Some(3));
+        assert!(
+            path.starts_with(
+                "repos/owner/repo/actions/runs?status=queued&per_page=100&page=3&branch="
+            ),
+            "got {path}"
+        );
+        assert!(
+            path.contains("feat/a%20b"),
+            "branch must be encoded: {path}"
+        );
     }
 
     #[test]

--- a/src/runner_watchdog.rs
+++ b/src/runner_watchdog.rs
@@ -348,11 +348,19 @@ impl Default for ReaperThresholds {
 /// Select workflow runs that are genuinely stale and should be cancelled.
 ///
 /// `in_progress_runs` and `queued_runs` are the raw run lists from the GitHub
-/// Actions API. A run is flagged only when its age (computed from
-/// `created_at`) strictly exceeds the matching threshold — a healthy in-flight
-/// run, or one just under the threshold, is always kept. Runs with an
-/// unparseable timestamp are silently skipped, matching
-/// [`compute_stale_queued_runs`].
+/// Actions API. A run is flagged only when its age strictly exceeds the
+/// matching threshold — a healthy in-flight run, or one just under the
+/// threshold, is always kept. Runs with an unparseable timestamp are silently
+/// skipped, matching [`compute_stale_queued_runs`].
+///
+/// Age basis differs by kind:
+///
+/// * **`in_progress`** runs are aged from `run_started_at` (execution start),
+///   so a run that sat in queue for hours and only just began executing is
+///   *not* treated as hung. When GitHub did not report `run_started_at`, the
+///   computation falls back to `created_at`.
+/// * **`queued`** runs are aged from `created_at` — a queued run has not
+///   started, so time-since-creation *is* its meaningful age.
 ///
 /// `now` is a parameter so tests can pin the clock.
 #[must_use]
@@ -380,6 +388,24 @@ pub fn compute_stale_runs(
     out
 }
 
+/// Pick the timestamp a run's age should be measured from.
+///
+/// For a [`StaleRunKind::HungInProgress`] run, "age" means how long it has
+/// been *executing* — so prefer `run_started_at`, falling back to
+/// `created_at` only when GitHub did not report a start time. For a
+/// [`StaleRunKind::OrphanedQueued`] run, the run never started, so
+/// `created_at` is the meaningful basis.
+fn age_basis(run: &QueuedRun, kind: StaleRunKind) -> &str {
+    match kind {
+        StaleRunKind::HungInProgress => run
+            .run_started_at
+            .as_deref()
+            .filter(|value| !value.is_empty())
+            .unwrap_or(&run.created_at),
+        StaleRunKind::OrphanedQueued => &run.created_at,
+    }
+}
+
 fn collect_stale(
     out: &mut Vec<StaleRun>,
     runs: &[QueuedRun],
@@ -388,10 +414,10 @@ fn collect_stale(
     now: DateTime<Utc>,
 ) {
     for run in runs {
-        let Ok(created) = DateTime::parse_from_rfc3339(&run.created_at) else {
+        let Ok(started) = DateTime::parse_from_rfc3339(age_basis(run, kind)) else {
             continue;
         };
-        let age_secs = (now - created.with_timezone(&Utc)).num_seconds();
+        let age_secs = (now - started.with_timezone(&Utc)).num_seconds();
         if age_secs <= threshold_secs {
             continue;
         }
@@ -438,6 +464,7 @@ mod tests {
             name: workflow.to_owned(),
             head_branch: branch.to_owned(),
             created_at: created_at.to_owned(),
+            run_started_at: None,
             workflow_name: workflow.to_owned(),
             url: Some(format!("https://github.com/owner/repo/actions/runs/{id}")),
             path: ".github/workflows/ci.yml".to_owned(),
@@ -584,11 +611,27 @@ mod tests {
             name: workflow.to_owned(),
             head_branch: branch.to_owned(),
             created_at: created_at.to_owned(),
+            run_started_at: None,
             workflow_name: workflow.to_owned(),
             url: Some(format!("https://github.com/owner/repo/actions/runs/{id}")),
             path: ".github/workflows/ci.yml".to_owned(),
             status: status.to_owned(),
             conclusion: None,
+        }
+    }
+
+    /// Like [`run_with_status`] but also pins `run_started_at`. Used by the
+    /// P1 hung-detection tests, where an `in_progress` run's age must be
+    /// measured from execution start, not creation time.
+    fn in_progress_run(
+        id: u64,
+        branch: &str,
+        created_at: &str,
+        run_started_at: Option<&str>,
+    ) -> QueuedRun {
+        QueuedRun {
+            run_started_at: run_started_at.map(ToOwned::to_owned),
+            ..run_with_status(id, "Coverage", branch, "in_progress", created_at)
         }
     }
 
@@ -710,6 +753,85 @@ mod tests {
         let stale = compute_stale_runs(&in_progress, &[], thresholds, now);
         assert_eq!(stale.len(), 1);
         assert_eq!(stale[0].kind, StaleRunKind::HungInProgress);
+    }
+
+    #[test]
+    fn reaper_keeps_recently_started_in_progress_run_with_old_created_at() {
+        // P1: a run that sat queued for ~9h then started executing 10 min ago
+        // is healthy. Aging it from `created_at` would (wrongly) cancel it;
+        // aging it from `run_started_at` keeps it.
+        let now = Utc::now();
+        let in_progress = vec![in_progress_run(
+            1,
+            "main",
+            &(now - ChronoDuration::hours(9)).to_rfc3339(),
+            Some(&(now - ChronoDuration::minutes(10)).to_rfc3339()),
+        )];
+        let stale = compute_stale_runs(&in_progress, &[], ReaperThresholds::default(), now);
+        assert!(
+            stale.is_empty(),
+            "an in_progress run started 10 min ago is healthy regardless of queue wait"
+        );
+    }
+
+    #[test]
+    fn reaper_reaps_in_progress_run_with_old_run_started_at() {
+        // P1: a genuinely hung run — started executing 6h ago, past the
+        // 300-min default — is still reaped when aged from `run_started_at`.
+        let now = Utc::now();
+        let in_progress = vec![in_progress_run(
+            2,
+            "main",
+            &(now - ChronoDuration::hours(7)).to_rfc3339(),
+            Some(&(now - ChronoDuration::hours(6)).to_rfc3339()),
+        )];
+        let stale = compute_stale_runs(&in_progress, &[], ReaperThresholds::default(), now);
+        assert_eq!(stale.len(), 1);
+        assert_eq!(stale[0].run_id, 2);
+        assert_eq!(stale[0].kind, StaleRunKind::HungInProgress);
+    }
+
+    #[test]
+    fn reaper_falls_back_to_created_at_when_run_started_at_missing() {
+        // P1: GitHub can omit `run_started_at`; the reaper must not crash and
+        // should fall back to `created_at` for in_progress runs.
+        let now = Utc::now();
+        let in_progress = vec![in_progress_run(
+            3,
+            "main",
+            &(now - ChronoDuration::minutes(301)).to_rfc3339(),
+            None,
+        )];
+        let stale = compute_stale_runs(&in_progress, &[], ReaperThresholds::default(), now);
+        assert_eq!(
+            stale.len(),
+            1,
+            "missing run_started_at falls back to created_at"
+        );
+        assert_eq!(stale[0].kind, StaleRunKind::HungInProgress);
+    }
+
+    #[test]
+    fn reaper_queued_run_age_still_uses_created_at() {
+        // P1: queued runs never started, so a (spurious) `run_started_at` must
+        // be ignored — age is measured from `created_at`. Here `created_at` is
+        // 5 days old (well past the 480-min queued threshold) so the run is
+        // reaped even though a stray recent `run_started_at` is present.
+        let now = Utc::now();
+        let queued = vec![QueuedRun {
+            run_started_at: Some((now - ChronoDuration::minutes(1)).to_rfc3339()),
+            ..run_with_status(
+                4,
+                "CI",
+                "feature/orphan",
+                "queued",
+                &(now - ChronoDuration::days(5)).to_rfc3339(),
+            )
+        }];
+        let stale = compute_stale_runs(&[], &queued, ReaperThresholds::default(), now);
+        assert_eq!(stale.len(), 1, "queued run age ignores run_started_at");
+        assert_eq!(stale[0].run_id, 4);
+        assert_eq!(stale[0].kind, StaleRunKind::OrphanedQueued);
     }
 
     #[test]

--- a/src/runner_watchdog.rs
+++ b/src/runner_watchdog.rs
@@ -40,6 +40,13 @@ pub const DEFAULT_MAX_JOB_MIN: i64 = 90;
 pub const DEFAULT_MAX_QUEUE_AGE_HOURS: i64 = 2;
 /// Default watch-mode polling interval in seconds.
 pub const DEFAULT_WATCH_INTERVAL_SECONDS: u64 = 300;
+/// Default max age (minutes) for an `in_progress` run before the stale-run
+/// reaper treats it as hung. ~5h — well past any healthy run, so an in-flight
+/// validation is never touched.
+pub const DEFAULT_REAP_IN_PROGRESS_MAX_MIN: i64 = 300;
+/// Default max age (minutes) for a `queued` run before the stale-run reaper
+/// treats it as orphaned (~8h).
+pub const DEFAULT_REAP_QUEUED_MAX_MIN: i64 = 480;
 
 /// Resolved runner-watchdog thresholds for a single invocation.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -280,6 +287,126 @@ pub fn compute_stale_queued_runs(
     out
 }
 
+/// Why a workflow run was selected for reaping.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum StaleRunKind {
+    /// Run stuck `in_progress` past the in-progress max age (hung).
+    HungInProgress,
+    /// Run stuck `queued` past the queued max age (orphaned).
+    OrphanedQueued,
+}
+
+impl StaleRunKind {
+    /// Snake-case string form used in JSON and human output.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::HungInProgress => "hung_in_progress",
+            Self::OrphanedQueued => "orphaned_queued",
+        }
+    }
+}
+
+/// A single workflow run the stale-run reaper would cancel.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct StaleRun {
+    /// GitHub Actions run ID.
+    pub run_id: u64,
+    /// Workflow display name.
+    pub workflow: String,
+    /// Head branch.
+    pub branch: String,
+    /// Raw GitHub status (`queued` / `in_progress`).
+    pub status: String,
+    /// Why this run was flagged.
+    pub kind: StaleRunKind,
+    /// How long the run has existed, in seconds.
+    pub age_secs: i64,
+    /// Browser URL, when GitHub returned one.
+    pub url: Option<String>,
+}
+
+/// Thresholds for the stale-run reaper, in minutes.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ReaperThresholds {
+    /// Cancel `in_progress` runs older than this many minutes (hung).
+    pub in_progress_max_min: i64,
+    /// Cancel `queued` runs older than this many minutes (orphaned).
+    pub queued_max_min: i64,
+}
+
+impl Default for ReaperThresholds {
+    fn default() -> Self {
+        Self {
+            in_progress_max_min: DEFAULT_REAP_IN_PROGRESS_MAX_MIN,
+            queued_max_min: DEFAULT_REAP_QUEUED_MAX_MIN,
+        }
+    }
+}
+
+/// Select workflow runs that are genuinely stale and should be cancelled.
+///
+/// `in_progress_runs` and `queued_runs` are the raw run lists from the GitHub
+/// Actions API. A run is flagged only when its age (computed from
+/// `created_at`) strictly exceeds the matching threshold — a healthy in-flight
+/// run, or one just under the threshold, is always kept. Runs with an
+/// unparseable timestamp are silently skipped, matching
+/// [`compute_stale_queued_runs`].
+///
+/// `now` is a parameter so tests can pin the clock.
+#[must_use]
+pub fn compute_stale_runs(
+    in_progress_runs: &[QueuedRun],
+    queued_runs: &[QueuedRun],
+    thresholds: ReaperThresholds,
+    now: DateTime<Utc>,
+) -> Vec<StaleRun> {
+    let mut out = Vec::new();
+    collect_stale(
+        &mut out,
+        in_progress_runs,
+        thresholds.in_progress_max_min.max(0) * 60,
+        StaleRunKind::HungInProgress,
+        now,
+    );
+    collect_stale(
+        &mut out,
+        queued_runs,
+        thresholds.queued_max_min.max(0) * 60,
+        StaleRunKind::OrphanedQueued,
+        now,
+    );
+    out
+}
+
+fn collect_stale(
+    out: &mut Vec<StaleRun>,
+    runs: &[QueuedRun],
+    threshold_secs: i64,
+    kind: StaleRunKind,
+    now: DateTime<Utc>,
+) {
+    for run in runs {
+        let Ok(created) = DateTime::parse_from_rfc3339(&run.created_at) else {
+            continue;
+        };
+        let age_secs = (now - created.with_timezone(&Utc)).num_seconds();
+        if age_secs <= threshold_secs {
+            continue;
+        }
+        out.push(StaleRun {
+            run_id: run.database_id,
+            workflow: run.workflow_name.clone(),
+            branch: run.head_branch.clone(),
+            status: run.status.clone(),
+            kind,
+            age_secs,
+            url: run.url.clone(),
+        });
+    }
+}
+
 /// Render a [`RunnerReport`] as a flat `BTreeMap<String, Value>` ready to be
 /// dropped into `write_json_envelope`.
 #[must_use]
@@ -443,6 +570,146 @@ mod tests {
             Symptom::StaleQueuedRuns { count: 1 }
         ));
         assert_eq!(report.stale_queued_runs.len(), 1);
+    }
+
+    fn run_with_status(
+        id: u64,
+        workflow: &str,
+        branch: &str,
+        status: &str,
+        created_at: &str,
+    ) -> QueuedRun {
+        QueuedRun {
+            database_id: id,
+            name: workflow.to_owned(),
+            head_branch: branch.to_owned(),
+            created_at: created_at.to_owned(),
+            workflow_name: workflow.to_owned(),
+            url: Some(format!("https://github.com/owner/repo/actions/runs/{id}")),
+            path: ".github/workflows/ci.yml".to_owned(),
+            status: status.to_owned(),
+            conclusion: None,
+        }
+    }
+
+    #[test]
+    fn reaper_keeps_run_just_under_threshold() {
+        let now = Utc::now();
+        // in_progress threshold is 300 min by default; 299 min must be kept.
+        let in_progress = vec![run_with_status(
+            1,
+            "Coverage",
+            "main",
+            "in_progress",
+            &(now - ChronoDuration::minutes(299)).to_rfc3339(),
+        )];
+        let stale = compute_stale_runs(&in_progress, &[], ReaperThresholds::default(), now);
+        assert!(stale.is_empty(), "a 299-min run is healthy, must be kept");
+    }
+
+    #[test]
+    fn reaper_reaps_hung_in_progress_run_over_threshold() {
+        let now = Utc::now();
+        let in_progress = vec![run_with_status(
+            42,
+            "Coverage",
+            "main",
+            "in_progress",
+            &(now - ChronoDuration::minutes(301)).to_rfc3339(),
+        )];
+        let stale = compute_stale_runs(&in_progress, &[], ReaperThresholds::default(), now);
+        assert_eq!(stale.len(), 1);
+        assert_eq!(stale[0].run_id, 42);
+        assert_eq!(stale[0].kind, StaleRunKind::HungInProgress);
+        assert!(stale[0].age_secs > 300 * 60);
+    }
+
+    #[test]
+    fn reaper_reaps_orphaned_queued_run_over_threshold() {
+        let now = Utc::now();
+        // queued threshold is 480 min by default; 5 days is way past it.
+        let queued = vec![run_with_status(
+            7,
+            "CI",
+            "feature/orphan",
+            "queued",
+            &(now - ChronoDuration::days(5)).to_rfc3339(),
+        )];
+        let stale = compute_stale_runs(&[], &queued, ReaperThresholds::default(), now);
+        assert_eq!(stale.len(), 1);
+        assert_eq!(stale[0].run_id, 7);
+        assert_eq!(stale[0].kind, StaleRunKind::OrphanedQueued);
+    }
+
+    #[test]
+    fn reaper_keeps_queued_run_just_under_threshold() {
+        let now = Utc::now();
+        let queued = vec![run_with_status(
+            8,
+            "CI",
+            "feature/recent",
+            "queued",
+            &(now - ChronoDuration::minutes(479)).to_rfc3339(),
+        )];
+        let stale = compute_stale_runs(&[], &queued, ReaperThresholds::default(), now);
+        assert!(stale.is_empty());
+    }
+
+    #[test]
+    fn reaper_skips_unparseable_timestamps() {
+        let now = Utc::now();
+        let in_progress = vec![run_with_status(
+            9,
+            "CI",
+            "main",
+            "in_progress",
+            "not-a-timestamp",
+        )];
+        let stale = compute_stale_runs(&in_progress, &[], ReaperThresholds::default(), now);
+        assert!(stale.is_empty());
+    }
+
+    #[test]
+    fn reaper_classifies_both_kinds_in_one_pass() {
+        let now = Utc::now();
+        let in_progress = vec![run_with_status(
+            100,
+            "Coverage",
+            "main",
+            "in_progress",
+            &(now - ChronoDuration::hours(7)).to_rfc3339(),
+        )];
+        let queued = vec![run_with_status(
+            200,
+            "CI",
+            "feature/x",
+            "queued",
+            &(now - ChronoDuration::days(3)).to_rfc3339(),
+        )];
+        let stale = compute_stale_runs(&in_progress, &queued, ReaperThresholds::default(), now);
+        assert_eq!(stale.len(), 2);
+        assert_eq!(stale[0].kind, StaleRunKind::HungInProgress);
+        assert_eq!(stale[1].kind, StaleRunKind::OrphanedQueued);
+    }
+
+    #[test]
+    fn reaper_respects_custom_thresholds() {
+        let now = Utc::now();
+        let in_progress = vec![run_with_status(
+            1,
+            "CI",
+            "main",
+            "in_progress",
+            &(now - ChronoDuration::minutes(45)).to_rfc3339(),
+        )];
+        // A tight 30-min in_progress threshold flags the 45-min run.
+        let thresholds = ReaperThresholds {
+            in_progress_max_min: 30,
+            queued_max_min: 60,
+        };
+        let stale = compute_stale_runs(&in_progress, &[], thresholds, now);
+        assert_eq!(stale.len(), 1);
+        assert_eq!(stale[0].kind, StaleRunKind::HungInProgress);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Implements #312 — extends the `shipyard runner watch` daemon with a **run-level stale-run reaper**, the GitHub-side complement to the existing process-level `--kill-hung-workers`.

`--kill-hung-workers` reaps hung `Runner.Worker` *processes* on the runner host. It cannot see runs on GitHub-hosted runners and never touches GitHub-side run state. `--reap-stale-runs` closes that gap: on every watch tick it lists the repo's Actions runs and cancels:

- runs stuck `in_progress` past `--reap-in-progress-max-min` (default **300 min / ~5h**) — hung runs squatting until GitHub's 6h timeout, and
- runs stuck `queued` past `--reap-queued-max-min` (default **480 min / ~8h**) — orphaned runs waiting on a runner label/branch that no longer exists, which never hit any `timeout-minutes`.

Thresholds are deliberately well past any healthy run, so a Shipyard-dispatched in-flight validation run is never cancelled.

## Flag / config shape

- `runner watch --reap-stale-runs` — enable the reaper (opt-in, off by default).
- `--reap-in-progress-max-min <MIN>` / `--reap-queued-max-min <MIN>` — threshold overrides.
- `--dry-run` — log what would be cancelled, cancel nothing.
- Config keys `runner.watchdog.reap_in_progress_max_min` / `reap_queued_max_min`. Precedence: flag > config > built-in default — matching `resolve_watchdog_settings`.

## Behavior

- Cancels via the existing `GitHubActions::cancel_workflow_run` (`POST /repos/{owner}/{repo}/actions/runs/{id}/cancel`) — reuses Shipyard's `gh`-backed API client; no new HTTP path.
- Run enumeration reuses the existing `list_runs_with_status` (`status=in_progress` / `status=queued`).
- Each candidate emits a `runner.watch` JSON envelope with `event=reap_stale_run` and `phase ∈ {attempt, cancelled, failed, skipped}` — mirrors the `event=auto_kill_worker` envelopes from `--kill-hung-workers` (`skipped` is the `--dry-run` phase).

## Files changed

- `src/runner_watchdog.rs` — pure logic: `ReaperThresholds`, `StaleRun`, `StaleRunKind`, `compute_stale_runs`, new default constants. Fully unit-tested.
- `src/app/runner_cmd.rs` — `runner watch` wiring: `reap_stale_runs_tick`, `emit_reap_event`, `resolve_reaper_thresholds`. CLI-side threshold-precedence tests.
- `src/app/cli.rs` — new `runner watch` flags.
- `CHANGELOG.md`, `docs/runner-watchdog.md`, `docs/cli-reference.md`, `skills/ci/SKILL.md`, `skills/shipyard/SKILL.md` — docs for the new flag + behavior.
- `Cargo.toml` / `Cargo.lock` / `.claude-plugin/plugin.json` — version bump (0.59.0 → 0.60.0) applied by the repo's `version_bump_check.py --mode=apply`.

## Tests

`cargo build`, `cargo test` (708 pass), `cargo clippy --all-targets --locked -- -D warnings`, and `cargo fmt --check` all pass locally.

New unit tests cover the threshold boundary (a run just under the threshold is kept, just over is reaped), both run kinds in one pass, unparseable-timestamp skip, custom thresholds, dry-run cancels nothing (via `phase=skipped`), and flag > config > default precedence.

## Test plan

- [ ] `cargo test` green in CI
- [ ] Manual smoke: `shipyard runner watch --reap-stale-runs --dry-run --json --max-iterations 1` against a repo with a known-old run logs `event=reap_stale_run phase=attempt` then `phase=skipped`, cancels nothing.

Closes #312.