### PR TITLE
feat(runner): add register/list/remove/tag provisioning suite

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "shipyard",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "Cross-platform CI coordination",
   "min_shipyard_version": "0.22.8",
   "commands": "./commands",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to Shipyard are documented here. Each entry links
 to its [GitHub Release](https://github.com/danielraffel/Shipyard/releases).
 
 <a id="v0601"></a>
+## [0.61.0]
+
 ## [0.60.1] - 2026-05-27
 
 - fix: route app-auth PR fallbacks through REST ([#315](https://github.com/danielraffel/Shipyard/pull/315))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -614,7 +614,7 @@ dependencies = [
 
 [[package]]
 name = "shipyard"
-version = "0.60.1"
+version = "0.61.0"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shipyard"
-version = "0.60.1"
+version = "0.61.0"
 edition = "2024"
 description = "Cross-platform CI coordination for local, SSH, and cloud runners."
 rust-version = "1.92"

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -64,6 +64,15 @@ shipyard runner cleanup --stale-hours 4   # override threshold for this call
 shipyard runner watch                     # poll loop (default 5 min)
 shipyard runner watch --fix               # auto-cancel stale runs each tick
 
+# Self-hosted runner provisioning (register / list / remove on this machine)
+shipyard runner tag --set studio          # set this box's machine tag (m1, m5, …)
+shipyard runner tag                       # print the stored machine tag
+shipyard runner register --repo OWNER/REPO --count 3 --ci-root /path/ci/repo
+shipyard runner register --repo OWNER/REPO --count 3 --dry-run   # plan only
+shipyard runner list --repo OWNER/REPO    # live pool, grouped by machine
+shipyard runner list                      # discover repos from local runner dirs
+shipyard runner remove --name repo-studio-03 --yes   # add --purge-dir to delete the dir
+
 # Explicit Worker termination (snapshot + SIGTERM grace + SIGKILL + quarantine)
 shipyard runner kill --pid 59996 --reason "wedged on agentB/81"
 shipyard runner kill --pid 59996 --reason "..." --retrigger     # re-queue CI

--- a/docs/runner-provisioning.md
+++ b/docs/runner-provisioning.md
@@ -1,0 +1,117 @@
+# Self-Hosted Runner Provisioning
+
+`shipyard runner register | list | remove | tag` brings a Mac into a repo's
+GitHub Actions CI fleet and lets you see/manage that fleet across machines. It
+is the provisioning complement to the [runner watchdog](./runner-watchdog.md),
+which recovers stuck runners. Pure naming/index/label/table logic lives in
+`src/runner_provision.rs`; the shell side (talks to `gh`, the runner's
+`config.sh`/`svc.sh`, and local `~/actions-runner-*` dirs) is
+`src/app/runner_provision_cmd.rs`.
+
+## Mental model
+
+- **GitHub is the cross-machine registry.** Every runner on every Mac reports
+  to GitHub, so "X jobs on the Studio, Y on the laptop" is just "register X
+  runner services on the Studio and Y on the laptop" — GitHub schedules each
+  queued job onto any idle runner whose labels match. No controller, no
+  inbound networking between your Macs.
+- **Two phases.** Provisioning the *host* (Xcode, Homebrew deps, caches, Skia)
+  is once per machine and is the repo's own concern (e.g. pulp's
+  `tools/ci/bootstrap-macos-host.sh`). Registering *runners* is once per repo
+  per machine and is what this command does. It assumes a buildable host.
+
+## Machine tag
+
+Runners are named `<repo>-<machine-tag>-NN`, e.g. `pulp-studio-01`. The tag is
+an explicit per-box value stored at `<state_dir>/machine-tag`, **never derived
+from the hostname** — two MacBook Pros can share a hostname, so a
+hostname-derived tag would collide and clobber runner names.
+
+```bash
+shipyard runner tag --set studio   # one-time, per machine (studio | m1 | m5 | …)
+shipyard runner tag                # print the stored tag
+```
+
+Tags must be lowercase letters, digits, and dashes (no leading/trailing/doubled
+dash).
+
+## Register
+
+```bash
+shipyard runner register --repo danielraffel/pulp --count 3 \
+  --ci-root /Volumes/Workshop/ci/pulp [--machine-tag studio] [--labels a,b,c] [--dry-run]
+```
+
+What it does per runner:
+
+1. Computes the next free index by listing the repo's existing runners (any
+   machine) and continuing past the highest `<repo>-<tag>-NN`. Re-running
+   appends capacity (`-04`, `-05`) without collisions.
+2. Downloads the `osx-arm64` runner tarball once into
+   `<ci-root>/cache/actions-runner-pkg/` and extracts it into
+   `~/actions-runner-<name>`.
+3. Writes a per-runner `.env` pointing ccache + FetchContent at the shared
+   caches and isolating each runner's `_work` for cross-worktree cache hits
+   (`CCACHE_BASEDIR` + `CCACHE_NOHASHDIR`). Cache **size** is owned by the
+   host's `ccache.conf`, not this command.
+4. Fetches a registration token, runs `config.sh --unattended --replace`, then
+   `svc.sh install && svc.sh start` (a user LaunchAgent — no sudo).
+
+### Labels
+
+Default: `self-hosted,macos,arm64,<repo>-build,<repo>-build-<tag>`.
+
+- `<repo>-build` — the shared routing label a repo's workflow selects (e.g.
+  pulp's `PULP_LOCAL_MACOS_RUNS_ON_JSON=["self-hosted","pulp-build"]`). Carry it
+  so the new runners immediately join the pool.
+- `<repo>-build-<tag>` — host pin label, to force work onto one machine.
+
+Override the whole set with `--labels` when a repo's workflow selects something
+else (e.g. Shipyard's own CI currently selects `local-mac`).
+
+### Paths
+
+| Path | What |
+|------|------|
+| `~/actions-runner-<name>` | the runner install + its `.env` |
+| `<ci-root>/work/<name>` | that runner's `_work` (isolated per runner) |
+| `<ci-root>/cache/ccache` | shared ccache (size set by host `ccache.conf`) |
+| `<ci-root>/cache/fetchcontent-src` | shared CMake FetchContent sources |
+
+`--dry-run` prints the full plan (names, work dirs, labels, parallelism)
+without downloading, configuring, or starting anything.
+
+## List
+
+```bash
+shipyard runner list                       # repos discovered from local dirs + cwd
+shipyard runner list --repo danielraffel/pulp [--repo …] [--all-repos]
+```
+
+Renders the live pool grouped by machine tag, pulled straight from GitHub (so a
+laptop's runners show up even when you run it on the Studio). It also scans this
+machine's `~/actions-runner-*` dirs and flags **orphans** — local runner dirs
+whose configured name is no longer registered on GitHub (e.g. a deregistered
+runner whose directory lingers).
+
+## Remove
+
+```bash
+shipyard runner remove --name pulp-studio-03 --yes [--purge-dir]
+```
+
+Stops the LaunchAgent, fetches a removal token, and runs `config.sh remove`.
+`--purge-dir` also deletes `~/actions-runner-<name>`. Requires `--yes`.
+
+## Adding a brand-new machine (e.g. an M5 laptop)
+
+1. Provision the host for the repo (its own bootstrap: Xcode, Homebrew deps,
+   Skia, ccache). For a fresh python.org Python, run its bundled
+   `Install Certificates.command` first or asset downloads fail with
+   `SSL: CERTIFICATE_VERIFY_FAILED`.
+2. `shipyard runner tag --set m5`
+3. `shipyard runner register --repo <owner/repo> --count <N> --ci-root <dir>`
+4. `shipyard runner list --repo <owner/repo>` to confirm `<repo>-m5-NN` online.
+
+The index continues from any existing runners on other machines, so the M5's
+runners never collide with the Studio's or the laptop's.

--- a/skills/ci/SKILL.md
+++ b/skills/ci/SKILL.md
@@ -43,6 +43,11 @@ Shipyard coordinates validation across local, SSH, and cloud targets.
 | **Runner watchdog: cancel stale queued runs** | `shipyard runner cleanup --fix` |
 | **Runner watchdog: daemon mode** | `shipyard runner watch --fix` |
 | **Runner watchdog: auto-kill hung workers (full recovery)** | `shipyard runner watch --kill-hung-workers` (implies `--fix`) |
+| **Runner provisioning: set this box's machine tag** | `shipyard runner tag --set <studio\|m1\|m5>` (stored per-box; never hostname-derived) |
+| **Runner provisioning: register N runners for a repo** | `shipyard runner register --repo <owner/repo> --count <N> [--ci-root <dir>]` (names `<repo>-<tag>-NN`, continues the index) |
+| **Runner provisioning: dry-run the registration plan** | `shipyard runner register --repo <owner/repo> --count <N> --dry-run` |
+| **Runner provisioning: live cross-repo pool view** | `shipyard runner list [--repo <owner/repo>]` (groups by machine; flags orphaned local dirs) |
+| **Runner provisioning: deregister a runner** | `shipyard runner remove --name <repo>-<tag>-NN --yes [--purge-dir]` |
 | **Self-update: check if a new release is available** | `shipyard update --check --json` |
 | **Self-update: apply latest stable** | `shipyard update` (delegates to `install.sh`) |
 | **Self-update: pin / rollback to a specific tag** | `shipyard update --to v0.53.0` |

--- a/skills/shipyard/SKILL.md
+++ b/skills/shipyard/SKILL.md
@@ -159,6 +159,66 @@ watch_interval_seconds = 300
 auto_fix = false
 ```
 
+## Runner Provisioning (register / list / remove / tag)
+
+The `runner` family also *provisions* self-hosted GitHub Actions runners, not
+just recovers them. This is the generic, repo-agnostic path for bringing a Mac
+into a repo's CI fleet — used to stand up the Mac Studio's pulp runners. Pure
+naming/index/label/table logic lives in `src/runner_provision.rs`; the shell
+side (gh, `config.sh`, `svc.sh`, local `~/actions-runner-*` dirs) is
+`src/app/runner_provision_cmd.rs`. See `docs/runner-provisioning.md`.
+
+### Machine tag (load-bearing for multi-Mac fleets)
+
+Runners are named `<repo>-<machine-tag>-NN` (e.g. `pulp-studio-01`). The tag is
+an explicit per-box value stored at `<state_dir>/machine-tag`, **never derived
+from the hostname** — two MacBook Pros can share a hostname, so a
+hostname-derived tag would collide. Set it once per machine:
+
+```bash
+shipyard runner tag --set studio   # or m1, m5, …
+shipyard runner tag                # prints the stored tag
+```
+
+### Register
+
+```bash
+# Host must already have the toolchain/caches (repo-specific bootstrap).
+# This step only registers runners and points their .env at the shared caches.
+shipyard runner register --repo danielraffel/pulp --count 3 \
+  --ci-root /Volumes/Workshop/ci/pulp [--dry-run]
+```
+
+- Names continue from the highest existing `<repo>-<tag>-NN` (any machine), so
+  re-running appends capacity without collisions.
+- Default labels: `self-hosted,macos,arm64,<repo>-build,<repo>-build-<tag>`.
+  `<repo>-build` is what a repo's workflow selects for normal routing;
+  `<repo>-build-<tag>` pins work to one machine. Override with `--labels`.
+- Per-runner `_work` is `<ci-root>/work/<name>`; the `.env` points ccache and
+  FetchContent at `<ci-root>/cache/*`. Cache *size* is owned by the host's
+  `ccache.conf`, not this command.
+
+### List and remove
+
+```bash
+shipyard runner list --repo danielraffel/pulp   # live pool, grouped by machine
+shipyard runner remove --name pulp-studio-03 --yes [--purge-dir]
+```
+
+`list` aggregates across machines straight from GitHub (no controller needed)
+and reconciles local `~/actions-runner-*` dirs against GitHub to flag orphans.
+
+### Gotchas
+
+- These four subcommands are newer than the watchdog set; an older installed
+  binary will not have them. Verify with `shipyard runner register --help`.
+- `register` does **not** provision the host toolchain (Xcode, Homebrew deps,
+  Skia, ccache sizing). Run the repo's own host bootstrap first; this command
+  assumes a buildable host and only wires up runners + caches.
+- A fresh python.org Python with no CA certs breaks asset downloads in repo
+  bootstraps (`SSL: CERTIFICATE_VERIFY_FAILED`) — run the bundled
+  `Install Certificates.command`.
+
 ## Supervised Subprocess Marker (issue #266)
 
 Every `git` / `gh` child process spawned by the supervised

--- a/skills/shipyard/SKILL.md
+++ b/skills/shipyard/SKILL.md
@@ -297,7 +297,25 @@ pre-fix SHA).
 
 ## Validation Gates
 
-Prefer non-mutating checks first:
+**Before `shipyard pr` / `shipyard ship`, run the *exact* chain the `mac`
+target enforces** (`.shipyard/config.toml` `[targets.mac]`). `--lib`-scoped
+checks are NOT enough — `--all-targets -- -D warnings` and `cargo fmt` catch
+things the lib build won't, and a miss costs a full ship round-trip (the
+2026-06-01 runner-provisioning PR failed mac validation twice this way):
+
+```sh
+cargo fmt --all --check \
+  && cargo clippy --all-targets --locked -- -D warnings \
+  && cargo test --all-targets --locked
+```
+
+**`Cargo.lock` gotcha after a version bump:** `shipyard pr` rewrites
+`Cargo.toml` / `.claude-plugin/plugin.json` but does NOT touch `Cargo.lock`,
+so the `--locked` steps then fail with a lock-vs-manifest mismatch. After any
+bump, refresh the lock (`cargo build`/`cargo check`) and commit `Cargo.lock`
+in the same PR. (`cargo fmt --all` on new modules is the other easy miss.)
+
+Other non-mutating checks:
 
 ```sh
 cargo test --all-targets --locked

--- a/src/app.rs
+++ b/src/app.rs
@@ -34,6 +34,7 @@ mod rescue_cmd;
 mod run_cmd;
 mod runner_cmd;
 mod runner_kill_cmd;
+mod runner_provision_cmd;
 mod ship_cmd;
 mod ship_state_cmd;
 mod targets_cmd;
@@ -462,7 +463,7 @@ fn handle_runner_command<W: Write>(
 ) -> Result<ExitCode, CliFailure> {
     let config = crate::config::LoadedConfig::load_from_cwd(mode, cwd)
         .map_err(|error| CliFailure::new(1, error.to_string()))?;
-    runner_command(command, &config, cwd, json, stdout)
+    runner_command(command, mode, &config, cwd, json, stdout)
 }
 
 struct AutoMergeInvocation {

--- a/src/app/cli.rs
+++ b/src/app/cli.rs
@@ -447,6 +447,66 @@ pub(super) enum RunnerCommand {
         #[arg(long = "no-wait-github", hide = true)]
         no_wait_github: bool,
     },
+    /// Show or set this machine's runner tag (e.g. `studio`, `m1`, `m5`).
+    /// The tag names runners `<repo>-<tag>-NN`; it is stored per-box in
+    /// Shipyard state and is never derived from the hostname (two laptops
+    /// can share a hostname, which would collide).
+    Tag {
+        /// New tag to store. Omit to print the current tag.
+        #[arg(long)]
+        set: Option<String>,
+    },
+    /// Register N self-hosted GitHub Actions runners on this machine for a
+    /// repo. Names continue from the highest existing `<repo>-<tag>-NN` so
+    /// re-running appends capacity without collisions.
+    Register {
+        /// Owner/repo slug. Defaults to the current git repo.
+        #[arg(long)]
+        repo: Option<String>,
+        /// Number of runners to register.
+        #[arg(long, default_value_t = 1)]
+        count: u32,
+        /// Machine tag override. Defaults to the stored per-box tag.
+        #[arg(long = "machine-tag")]
+        machine_tag: Option<String>,
+        /// Comma-separated labels override. Defaults to
+        /// `self-hosted,macos,arm64,<repo>-build,<repo>-build-<tag>`.
+        #[arg(long, value_delimiter = ',')]
+        labels: Vec<String>,
+        /// CI root holding per-runner `_work` and shared caches. Defaults to
+        /// `runner.provision.ci_root` or `$HOME/actions-ci`.
+        #[arg(long = "ci-root")]
+        ci_root: Option<PathBuf>,
+        /// Print the plan without downloading, configuring, or starting.
+        #[arg(long = "dry-run")]
+        dry_run: bool,
+    },
+    /// List self-hosted runners across repos, grouped by machine, reconciling
+    /// local runner directories against GitHub to flag orphans.
+    List {
+        /// Owner/repo slug. Repeatable. Defaults to repos discovered from
+        /// local `actions-runner-*` dirs plus the current repo.
+        #[arg(long)]
+        repo: Vec<String>,
+        /// Query every repo with a local runner dir on this machine.
+        #[arg(long = "all-repos")]
+        all_repos: bool,
+    },
+    /// Deregister a runner: stop its launchd service and remove it from GitHub.
+    Remove {
+        /// Runner name, e.g. `pulp-studio-03`.
+        #[arg(long)]
+        name: String,
+        /// Owner/repo slug. Defaults to the current git repo.
+        #[arg(long)]
+        repo: Option<String>,
+        /// Also delete the local `actions-runner-<name>` directory.
+        #[arg(long = "purge-dir")]
+        purge_dir: bool,
+        /// Skip the confirmation prompt.
+        #[arg(long)]
+        yes: bool,
+    },
 }
 
 #[derive(Clone, Copy, Debug, Subcommand)]

--- a/src/app/runner_cmd.rs
+++ b/src/app/runner_cmd.rs
@@ -145,28 +145,16 @@ pub(super) fn runner_command<W: Write>(
             },
             stdout,
         ),
-        RunnerCommand::List { repo, all_repos } => super::runner_provision_cmd::list_command(
-            cwd,
-            &actions,
-            &repo,
-            all_repos,
-            json,
-            stdout,
-        ),
+        RunnerCommand::List { repo, all_repos } => {
+            super::runner_provision_cmd::list_command(cwd, &actions, &repo, all_repos, json, stdout)
+        }
         RunnerCommand::Remove {
             name,
             repo,
             purge_dir,
             yes,
         } => super::runner_provision_cmd::remove_command(
-            cwd,
-            &actions,
-            name,
-            repo,
-            purge_dir,
-            yes,
-            json,
-            stdout,
+            cwd, &actions, name, repo, purge_dir, yes, json, stdout,
         ),
     }
 }

--- a/src/app/runner_cmd.rs
+++ b/src/app/runner_cmd.rs
@@ -21,6 +21,7 @@ use super::CliFailure;
 use super::cli::RunnerCommand;
 use crate::cloud::{GitHubActions, QueuedRun};
 use crate::config::LoadedConfig;
+use crate::identity::RuntimeMode;
 use crate::output::write_json_envelope;
 use crate::runner_watchdog::{
     DEFAULT_MAX_JOB_MIN, DEFAULT_MAX_QUEUE_AGE_HOURS, DEFAULT_WATCH_INTERVAL_SECONDS, RunnerHealth,
@@ -31,8 +32,10 @@ use crate::runner_watchdog::{
 const QUEUED_RUNS_LIMIT: u32 = 100;
 
 /// Entry point dispatched from `src/app.rs`.
+#[allow(clippy::too_many_lines)]
 pub(super) fn runner_command<W: Write>(
     command: RunnerCommand,
+    mode: RuntimeMode,
     config: &LoadedConfig,
     cwd: &Path,
     json: bool,
@@ -115,6 +118,54 @@ pub(super) fn runner_command<W: Write>(
                 no_wait_github,
                 json,
             },
+            stdout,
+        ),
+        RunnerCommand::Tag { set } => {
+            super::runner_provision_cmd::tag_command(mode, set, json, stdout)
+        }
+        RunnerCommand::Register {
+            repo,
+            count,
+            machine_tag,
+            labels,
+            ci_root,
+            dry_run,
+        } => super::runner_provision_cmd::register_command(
+            super::runner_provision_cmd::RegisterArgs {
+                mode,
+                cwd,
+                actions: &actions,
+                repo,
+                count,
+                machine_tag,
+                labels,
+                ci_root,
+                dry_run,
+                json,
+            },
+            stdout,
+        ),
+        RunnerCommand::List { repo, all_repos } => super::runner_provision_cmd::list_command(
+            cwd,
+            &actions,
+            &repo,
+            all_repos,
+            json,
+            stdout,
+        ),
+        RunnerCommand::Remove {
+            name,
+            repo,
+            purge_dir,
+            yes,
+        } => super::runner_provision_cmd::remove_command(
+            cwd,
+            &actions,
+            name,
+            repo,
+            purge_dir,
+            yes,
+            json,
             stdout,
         ),
     }
@@ -876,7 +927,7 @@ fn default_runner_dir() -> PathBuf {
     }
 }
 
-fn resolve_repo_slug(repo: Option<String>, cwd: &Path) -> Result<String, CliFailure> {
+pub(super) fn resolve_repo_slug(repo: Option<String>, cwd: &Path) -> Result<String, CliFailure> {
     if let Some(repo) = repo.filter(|value| !value.trim().is_empty()) {
         return Ok(repo);
     }
@@ -897,7 +948,7 @@ fn resolve_repo_slug(repo: Option<String>, cwd: &Path) -> Result<String, CliFail
     ))
 }
 
-fn parse_github_repo_slug(remote: &str) -> Option<String> {
+pub(super) fn parse_github_repo_slug(remote: &str) -> Option<String> {
     // Mirrors crate::app::wait_cmd::parse_github_repo_slug but kept local so
     // this module has no cross-module visibility creep.
     let trimmed = remote.trim().trim_end_matches('/').trim_end_matches(".git");

--- a/src/app/runner_provision_cmd.rs
+++ b/src/app/runner_provision_cmd.rs
@@ -1,0 +1,649 @@
+//! CLI handlers for `shipyard runner register|list|remove|tag`.
+//!
+//! This is the shell-out side of runner provisioning: it talks to `gh`
+//! (registration/removal tokens, the runners API, the runner release asset),
+//! the GitHub Actions runner's own `config.sh`/`svc.sh`, and the local
+//! `~/actions-runner-*` directories. All naming/index/label/table logic is the
+//! pure code in [`crate::runner_provision`]; this module only does I/O.
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::{Command, ExitCode};
+
+use serde_json::Value;
+
+use super::CliFailure;
+use super::runner_cmd::{parse_github_repo_slug, resolve_repo_slug};
+use crate::cloud::GitHubActions;
+use crate::identity::RuntimeMode;
+use crate::output::write_json_envelope;
+use crate::paths::RuntimePaths;
+use crate::runner_provision::{
+    PoolRow, default_labels, format_pool_table, next_index, orphan_local_runners,
+    parse_runners_response, pool_rows, runner_name, short_repo, validate_machine_tag,
+};
+
+/// jq filter selecting the Apple-silicon macOS runner tarball download URL.
+const RUNNER_ASSET_JQ: &str =
+    r#".assets[] | select(.name | test("osx-arm64.*tar.gz$")) | .browser_download_url"#;
+
+// ---------- tag ----------
+
+fn machine_tag_path(mode: RuntimeMode) -> PathBuf {
+    RuntimePaths::current(mode).state_dir.join("machine-tag")
+}
+
+/// Read this box's stored machine tag, if any.
+fn read_stored_tag(mode: RuntimeMode) -> Option<String> {
+    let raw = fs::read_to_string(machine_tag_path(mode)).ok()?;
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_owned())
+    }
+}
+
+/// `shipyard runner tag [--set <tag>]`.
+pub(super) fn tag_command<W: Write>(
+    mode: RuntimeMode,
+    set: Option<String>,
+    json: bool,
+    stdout: &mut W,
+) -> Result<ExitCode, CliFailure> {
+    if let Some(tag) = set {
+        let tag = tag.trim().to_owned();
+        validate_machine_tag(&tag).map_err(|reason| CliFailure::new(2, reason))?;
+        let path = machine_tag_path(mode);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)
+                .map_err(|e| CliFailure::new(1, format!("failed to create state dir: {e}")))?;
+        }
+        fs::write(&path, format!("{tag}\n"))
+            .map_err(|e| CliFailure::new(1, format!("failed to write machine tag: {e}")))?;
+        if json {
+            let mut data = BTreeMap::new();
+            data.insert("machine_tag".to_owned(), Value::from(tag.clone()));
+            data.insert("path".to_owned(), Value::from(path.display().to_string()));
+            envelope(stdout, "runner.tag", data)?;
+        } else {
+            writeln!(stdout, "machine tag set to `{tag}` ({})", path.display()).ok();
+        }
+        return Ok(ExitCode::SUCCESS);
+    }
+
+    match read_stored_tag(mode) {
+        Some(tag) => {
+            if json {
+                let mut data = BTreeMap::new();
+                data.insert("machine_tag".to_owned(), Value::from(tag.clone()));
+                envelope(stdout, "runner.tag", data)?;
+            } else {
+                writeln!(stdout, "{tag}").ok();
+            }
+            Ok(ExitCode::SUCCESS)
+        }
+        None => Err(CliFailure::new(
+            1,
+            "No machine tag set. Set one with `shipyard runner tag --set <studio|m1|m5>`.",
+        )),
+    }
+}
+
+// ---------- register ----------
+
+/// Inputs for [`register_command`].
+pub(super) struct RegisterArgs<'a> {
+    pub mode: RuntimeMode,
+    pub cwd: &'a Path,
+    pub actions: &'a GitHubActions,
+    pub repo: Option<String>,
+    pub count: u32,
+    pub machine_tag: Option<String>,
+    pub labels: Vec<String>,
+    pub ci_root: Option<PathBuf>,
+    pub dry_run: bool,
+    pub json: bool,
+}
+
+fn default_ci_root() -> PathBuf {
+    home_dir().join("actions-ci")
+}
+
+fn home_dir() -> PathBuf {
+    std::env::var("HOME").map_or_else(|_| PathBuf::from("."), PathBuf::from)
+}
+
+fn cpu_count() -> usize {
+    Command::new("sysctl")
+        .args(["-n", "hw.ncpu"])
+        .output()
+        .ok()
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .and_then(|s| s.trim().parse::<usize>().ok())
+        .filter(|n| *n > 0)
+        .unwrap_or(4)
+}
+
+/// The per-runner `.env` the GitHub Actions service loads: points jobs at the
+/// shared caches and isolates each runner's ccache base path so cross-worktree
+/// hits work (`CCACHE_BASEDIR` + `CCACHE_NOHASHDIR`). Cache *size* is owned by
+/// the host's `ccache.conf`, not set here.
+fn runner_env_file(ci_root: &Path, work: &Path, parallel: usize) -> String {
+    let cache = ci_root.join("cache");
+    format!(
+        "CCACHE_DIR={ccache}\n\
+         CCACHE_BASEDIR={work}\n\
+         CCACHE_NOHASHDIR=true\n\
+         CCACHE_DEPEND=true\n\
+         CCACHE_SLOPPINESS=time_macros,pch_defines\n\
+         CMAKE_BUILD_PARALLEL_LEVEL={parallel}\n\
+         CTEST_PARALLEL_LEVEL={parallel}\n\
+         FETCHCONTENT_BASE_DIR={fetchcontent}\n",
+        ccache = cache.join("ccache").display(),
+        work = work.display(),
+        fetchcontent = cache.join("fetchcontent-src").display(),
+    )
+}
+
+/// Existing runner names registered on a repo (any machine), for index
+/// continuation.
+fn existing_runner_names(actions: &GitHubActions, slug: &str) -> Result<Vec<String>, CliFailure> {
+    let raw = actions
+        .run_gh(&[
+            "api".to_owned(),
+            format!("repos/{slug}/actions/runners?per_page=100"),
+        ])
+        .map_err(|e| CliFailure::new(2, format!("failed to list existing runners: {e}")))?;
+    let parsed = parse_runners_response(&raw).map_err(|e| CliFailure::new(2, e))?;
+    Ok(parsed.runners.into_iter().map(|r| r.name).collect())
+}
+
+/// `shipyard runner register`.
+#[allow(clippy::needless_pass_by_value, clippy::too_many_lines)]
+pub(super) fn register_command<W: Write>(
+    args: RegisterArgs,
+    stdout: &mut W,
+) -> Result<ExitCode, CliFailure> {
+    if args.count == 0 {
+        return Err(CliFailure::new(2, "--count must be at least 1"));
+    }
+    let slug = resolve_repo_slug(args.repo.clone(), args.cwd)?;
+    let repo_short = short_repo(&slug).to_owned();
+
+    let tag = match args.machine_tag.clone() {
+        Some(tag) => {
+            let tag = tag.trim().to_owned();
+            validate_machine_tag(&tag).map_err(|reason| CliFailure::new(2, reason))?;
+            tag
+        }
+        None => read_stored_tag(args.mode).ok_or_else(|| {
+            CliFailure::new(
+                1,
+                "No machine tag set. Pass --machine-tag or run `shipyard runner tag --set <tag>`.",
+            )
+        })?,
+    };
+    validate_machine_tag(&tag).map_err(|reason| CliFailure::new(2, reason))?;
+
+    let labels = if args.labels.is_empty() {
+        default_labels(&repo_short, &tag)
+    } else {
+        args.labels.clone()
+    };
+    let labels_csv = labels.join(",");
+    let ci_root = args.ci_root.clone().unwrap_or_else(default_ci_root);
+
+    let existing = existing_runner_names(args.actions, &slug)?;
+    let start = next_index(&existing, &repo_short, &tag);
+    let parallel = (cpu_count() / args.count as usize).max(1);
+
+    // Build the plan first so dry-run and real runs agree.
+    let plan: Vec<RunnerPlan> = (0..args.count)
+        .map(|k| {
+            let name = runner_name(&repo_short, &tag, start + k);
+            RunnerPlan {
+                work: ci_root.join("work").join(&name),
+                dir: home_dir().join(format!("actions-runner-{name}")),
+                name,
+            }
+        })
+        .collect();
+
+    if args.dry_run {
+        return report_register(
+            stdout, args.json, &slug, &tag, &labels_csv, &ci_root, parallel, &plan, true,
+        );
+    }
+
+    // Resolve + cache the runner tarball once, then provision each runner.
+    let pkg_url = args
+        .actions
+        .run_gh(&[
+            "api".to_owned(),
+            "repos/actions/runner/releases/latest".to_owned(),
+            "--jq".to_owned(),
+            RUNNER_ASSET_JQ.to_owned(),
+        ])
+        .map_err(|e| CliFailure::new(2, format!("failed to resolve runner package URL: {e}")))?
+        .trim()
+        .to_owned();
+    if pkg_url.is_empty() {
+        return Err(CliFailure::new(
+            2,
+            "could not resolve the osx-arm64 actions-runner package URL",
+        ));
+    }
+    let pkg_name = pkg_url.rsplit('/').next().unwrap_or("actions-runner.tar.gz");
+    let pkg_cache = ci_root.join("cache").join("actions-runner-pkg");
+    fs::create_dir_all(&pkg_cache)
+        .map_err(|e| CliFailure::new(1, format!("failed to create package cache: {e}")))?;
+    let pkg_path = pkg_cache.join(pkg_name);
+    if !pkg_path.exists() {
+        run("curl", &["-fsSL", "-o", &pkg_path.to_string_lossy(), &pkg_url], "download runner")?;
+    }
+
+    for entry in &plan {
+        fs::create_dir_all(&entry.dir)
+            .map_err(|e| CliFailure::new(1, format!("failed to create runner dir: {e}")))?;
+        fs::create_dir_all(&entry.work)
+            .map_err(|e| CliFailure::new(1, format!("failed to create work dir: {e}")))?;
+        if !entry.dir.join("config.sh").exists() {
+            run(
+                "tar",
+                &["xzf", &pkg_path.to_string_lossy(), "-C", &entry.dir.to_string_lossy()],
+                "extract runner",
+            )?;
+        }
+        fs::write(
+            entry.dir.join(".env"),
+            runner_env_file(&ci_root, &entry.work, parallel),
+        )
+        .map_err(|e| CliFailure::new(1, format!("failed to write .env: {e}")))?;
+
+        let token = args
+            .actions
+            .run_gh(&[
+                "api".to_owned(),
+                "-X".to_owned(),
+                "POST".to_owned(),
+                format!("repos/{slug}/actions/runners/registration-token"),
+                "--jq".to_owned(),
+                ".token".to_owned(),
+            ])
+            .map_err(|e| CliFailure::new(2, format!("failed to get registration token: {e}")))?
+            .trim()
+            .to_owned();
+
+        run_in(
+            &entry.dir,
+            "./config.sh",
+            &[
+                "--unattended",
+                "--replace",
+                "--url",
+                &format!("https://github.com/{slug}"),
+                "--token",
+                &token,
+                "--name",
+                &entry.name,
+                "--labels",
+                &labels_csv,
+                "--work",
+                &entry.work.to_string_lossy(),
+            ],
+            "configure runner",
+        )?;
+        run_in(&entry.dir, "./svc.sh", &["install"], "install runner service")?;
+        run_in(&entry.dir, "./svc.sh", &["start"], "start runner service")?;
+    }
+
+    report_register(
+        stdout, args.json, &slug, &tag, &labels_csv, &ci_root, parallel, &plan, false,
+    )
+}
+
+struct RunnerPlan {
+    name: String,
+    dir: PathBuf,
+    work: PathBuf,
+}
+
+#[allow(clippy::too_many_arguments)]
+fn report_register<W: Write>(
+    stdout: &mut W,
+    json: bool,
+    slug: &str,
+    tag: &str,
+    labels_csv: &str,
+    ci_root: &Path,
+    parallel: usize,
+    plan: &[RunnerPlan],
+    dry_run: bool,
+) -> Result<ExitCode, CliFailure> {
+    if json {
+        let mut data = BTreeMap::new();
+        data.insert("repo".to_owned(), Value::from(slug.to_owned()));
+        data.insert("machine_tag".to_owned(), Value::from(tag.to_owned()));
+        data.insert("labels".to_owned(), Value::from(labels_csv.to_owned()));
+        data.insert("dry_run".to_owned(), Value::from(dry_run));
+        data.insert(
+            "parallel_per_runner".to_owned(),
+            Value::from(parallel as u64),
+        );
+        let runners: Vec<Value> = plan
+            .iter()
+            .map(|p| {
+                let mut m = serde_json::Map::new();
+                m.insert("name".to_owned(), Value::from(p.name.clone()));
+                m.insert("dir".to_owned(), Value::from(p.dir.display().to_string()));
+                m.insert("work".to_owned(), Value::from(p.work.display().to_string()));
+                Value::Object(m)
+            })
+            .collect();
+        data.insert("runners".to_owned(), Value::from(runners));
+        envelope(stdout, "runner.register", data)?;
+        return Ok(ExitCode::SUCCESS);
+    }
+
+    let verb = if dry_run { "Would register" } else { "Registered" };
+    writeln!(
+        stdout,
+        "{verb} {} runner(s) for {slug} [tag={tag}, ~{parallel} cores each]",
+        plan.len()
+    )
+    .ok();
+    writeln!(stdout, "  labels:  {labels_csv}").ok();
+    writeln!(stdout, "  ci-root: {}", ci_root.display()).ok();
+    for p in plan {
+        writeln!(stdout, "  - {}  (work={})", p.name, p.work.display()).ok();
+    }
+    if dry_run {
+        writeln!(stdout, "\nRe-run without --dry-run to apply.").ok();
+    }
+    Ok(ExitCode::SUCCESS)
+}
+
+// ---------- list ----------
+
+struct LocalRunner {
+    name: String,
+    repo_slug: String,
+}
+
+/// Parse a runner `.runner` config file, returning `(agent_name, repo_slug)`.
+fn parse_dot_runner(raw: &str) -> Option<(String, String)> {
+    // `.runner` files are written with a UTF-8 BOM; strip it before parsing.
+    let cleaned = raw.trim_start_matches('\u{feff}').trim_start();
+    let value: Value = serde_json::from_str(cleaned).ok()?;
+    let name = value.get("agentName")?.as_str()?.to_owned();
+    let url = value.get("gitHubUrl")?.as_str()?;
+    let slug = parse_github_repo_slug(url)?;
+    Some((name, slug))
+}
+
+/// Discover configured runners from this machine's `~/actions-runner*` dirs.
+fn scan_local_runners() -> Vec<LocalRunner> {
+    let mut found = Vec::new();
+    let Ok(entries) = fs::read_dir(home_dir()) else {
+        return found;
+    };
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let Some(name) = name.to_str() else { continue };
+        if !name.starts_with("actions-runner") {
+            continue;
+        }
+        let dot = entry.path().join(".runner");
+        let Ok(raw) = fs::read_to_string(&dot) else {
+            continue;
+        };
+        if let Some((agent, slug)) = parse_dot_runner(&raw) {
+            found.push(LocalRunner {
+                name: agent,
+                repo_slug: slug,
+            });
+        }
+    }
+    found
+}
+
+/// `shipyard runner list`.
+pub(super) fn list_command<W: Write>(
+    cwd: &Path,
+    actions: &GitHubActions,
+    repo: &[String],
+    all_repos: bool,
+    json: bool,
+    stdout: &mut W,
+) -> Result<ExitCode, CliFailure> {
+    let locals = scan_local_runners();
+
+    let mut slugs: Vec<String> = Vec::new();
+    let push = |slug: String, slugs: &mut Vec<String>| {
+        if !slug.is_empty() && !slugs.iter().any(|s| s.eq_ignore_ascii_case(&slug)) {
+            slugs.push(slug);
+        }
+    };
+    for r in repo {
+        push(r.clone(), &mut slugs);
+    }
+    if repo.is_empty() || all_repos {
+        for local in &locals {
+            push(local.repo_slug.clone(), &mut slugs);
+        }
+    }
+    if let Ok(current) = resolve_repo_slug(None, cwd) {
+        push(current, &mut slugs);
+    }
+    if slugs.is_empty() {
+        return Err(CliFailure::new(
+            1,
+            "No repos to query. Pass --repo OWNER/REPO, or run where local runner dirs exist.",
+        ));
+    }
+
+    let mut rows: Vec<PoolRow> = Vec::new();
+    let mut github_names: Vec<String> = Vec::new();
+    for slug in &slugs {
+        let raw = actions
+            .run_gh(&[
+                "api".to_owned(),
+                format!("repos/{slug}/actions/runners?per_page=100"),
+            ])
+            .map_err(|e| CliFailure::new(2, format!("failed to list runners for {slug}: {e}")))?;
+        let parsed = parse_runners_response(&raw).map_err(|e| CliFailure::new(2, e))?;
+        for r in &parsed.runners {
+            github_names.push(r.name.clone());
+        }
+        rows.extend(pool_rows(short_repo(slug), &parsed.runners));
+    }
+
+    let local_names: Vec<String> = locals.iter().map(|l| l.name.clone()).collect();
+    let orphans = orphan_local_runners(&local_names, &github_names);
+
+    if json {
+        let mut data = BTreeMap::new();
+        data.insert("repos".to_owned(), Value::from(slugs.clone()));
+        let row_values: Vec<Value> = rows
+            .iter()
+            .map(|r| {
+                let mut m = serde_json::Map::new();
+                m.insert("name".to_owned(), Value::from(r.name.clone()));
+                m.insert("repo".to_owned(), Value::from(r.repo.clone()));
+                m.insert("machine".to_owned(), Value::from(r.machine.clone()));
+                m.insert("status".to_owned(), Value::from(r.status.clone()));
+                m.insert("busy".to_owned(), Value::from(r.busy));
+                m.insert("labels".to_owned(), Value::from(r.labels.clone()));
+                Value::Object(m)
+            })
+            .collect();
+        data.insert("runners".to_owned(), Value::from(row_values));
+        data.insert("orphans".to_owned(), Value::from(orphans.clone()));
+        envelope(stdout, "runner.list", data)?;
+        return Ok(ExitCode::SUCCESS);
+    }
+
+    writeln!(stdout, "{}", format_pool_table(&rows)).ok();
+    if !orphans.is_empty() {
+        writeln!(
+            stdout,
+            "\n⚠︎ {} local runner dir(s) not registered on GitHub (orphaned — remove with `shipyard runner remove`):",
+            orphans.len()
+        )
+        .ok();
+        for name in &orphans {
+            writeln!(stdout, "  - {name}  (~/actions-runner-{name} or ~/actions-runner)").ok();
+        }
+    }
+    Ok(ExitCode::SUCCESS)
+}
+
+// ---------- remove ----------
+
+/// `shipyard runner remove`.
+#[allow(clippy::too_many_arguments)]
+pub(super) fn remove_command<W: Write>(
+    cwd: &Path,
+    actions: &GitHubActions,
+    name: String,
+    repo: Option<String>,
+    purge_dir: bool,
+    yes: bool,
+    json: bool,
+    stdout: &mut W,
+) -> Result<ExitCode, CliFailure> {
+    if !yes {
+        return Err(CliFailure::new(
+            2,
+            format!("Refusing to remove `{name}` without confirmation. Re-run with --yes."),
+        ));
+    }
+    let slug = resolve_repo_slug(repo, cwd)?;
+    let dir = home_dir().join(format!("actions-runner-{name}"));
+    if !dir.join("config.sh").exists() {
+        return Err(CliFailure::new(
+            1,
+            format!("no configured runner dir at {}", dir.display()),
+        ));
+    }
+
+    let token = actions
+        .run_gh(&[
+            "api".to_owned(),
+            "-X".to_owned(),
+            "POST".to_owned(),
+            format!("repos/{slug}/actions/runners/remove-token"),
+            "--jq".to_owned(),
+            ".token".to_owned(),
+        ])
+        .map_err(|e| CliFailure::new(2, format!("failed to get removal token: {e}")))?
+        .trim()
+        .to_owned();
+
+    // Stop the service first; ignore failure (it may already be stopped).
+    let _ = Command::new("./svc.sh").current_dir(&dir).arg("stop").status();
+    run_in(
+        &dir,
+        "./config.sh",
+        &["remove", "--token", &token],
+        "deregister runner",
+    )?;
+
+    if purge_dir {
+        fs::remove_dir_all(&dir)
+            .map_err(|e| CliFailure::new(1, format!("failed to purge runner dir: {e}")))?;
+    }
+
+    if json {
+        let mut data = BTreeMap::new();
+        data.insert("removed".to_owned(), Value::from(name));
+        data.insert("repo".to_owned(), Value::from(slug));
+        data.insert("purged_dir".to_owned(), Value::from(purge_dir));
+        envelope(stdout, "runner.remove", data)?;
+    } else {
+        writeln!(stdout, "Removed runner `{name}` from {slug}").ok();
+        if purge_dir {
+            writeln!(stdout, "  purged {}", dir.display()).ok();
+        }
+    }
+    Ok(ExitCode::SUCCESS)
+}
+
+// ---------- shared shell helpers ----------
+
+fn run(program: &str, args: &[&str], what: &str) -> Result<(), CliFailure> {
+    let status = Command::new(program)
+        .args(args)
+        .status()
+        .map_err(|e| CliFailure::new(1, format!("failed to {what}: {e}")))?;
+    if status.success() {
+        Ok(())
+    } else {
+        Err(CliFailure::new(
+            1,
+            format!("{what} failed (exit {:?})", status.code()),
+        ))
+    }
+}
+
+fn run_in(dir: &Path, program: &str, args: &[&str], what: &str) -> Result<(), CliFailure> {
+    let status = Command::new(program)
+        .current_dir(dir)
+        .args(args)
+        .status()
+        .map_err(|e| CliFailure::new(1, format!("failed to {what}: {e}")))?;
+    if status.success() {
+        Ok(())
+    } else {
+        Err(CliFailure::new(
+            1,
+            format!("{what} failed (exit {:?})", status.code()),
+        ))
+    }
+}
+
+fn envelope<W: Write>(
+    stdout: &mut W,
+    command: &str,
+    data: BTreeMap<String, Value>,
+) -> Result<(), CliFailure> {
+    write_json_envelope(stdout, command, data)
+        .map_err(|e| CliFailure::new(1, format!("failed to write JSON: {e}")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_dot_runner_handles_bom_and_extracts_slug() {
+        let raw = "\u{feff}{\"agentName\":\"pulp-m1-01\",\"gitHubUrl\":\"https://github.com/danielraffel/pulp\"}";
+        let (name, slug) = parse_dot_runner(raw).expect("parse");
+        assert_eq!(name, "pulp-m1-01");
+        assert_eq!(slug, "danielraffel/pulp");
+    }
+
+    #[test]
+    fn parse_dot_runner_rejects_missing_fields() {
+        assert!(parse_dot_runner("{}").is_none());
+        assert!(parse_dot_runner("not json").is_none());
+    }
+
+    #[test]
+    fn runner_env_file_points_at_shared_caches() {
+        let env = runner_env_file(
+            Path::new("/Volumes/Workshop/ci/pulp"),
+            Path::new("/Volumes/Workshop/ci/pulp/work/pulp-studio-01"),
+            9,
+        );
+        assert!(env.contains("CCACHE_DIR=/Volumes/Workshop/ci/pulp/cache/ccache"));
+        assert!(env.contains("CCACHE_BASEDIR=/Volumes/Workshop/ci/pulp/work/pulp-studio-01"));
+        assert!(env.contains("FETCHCONTENT_BASE_DIR=/Volumes/Workshop/ci/pulp/cache/fetchcontent-src"));
+        assert!(env.contains("CMAKE_BUILD_PARALLEL_LEVEL=9"));
+        assert!(env.contains("CTEST_PARALLEL_LEVEL=9"));
+        assert!(env.contains("CCACHE_NOHASHDIR=true"));
+    }
+}

--- a/src/app/runner_provision_cmd.rs
+++ b/src/app/runner_provision_cmd.rs
@@ -214,7 +214,15 @@ pub(super) fn register_command<W: Write>(
 
     if args.dry_run {
         return report_register(
-            stdout, args.json, &slug, &tag, &labels_csv, &ci_root, parallel, &plan, true,
+            stdout,
+            args.json,
+            &slug,
+            &tag,
+            &labels_csv,
+            &ci_root,
+            parallel,
+            &plan,
+            true,
         );
     }
 
@@ -236,13 +244,20 @@ pub(super) fn register_command<W: Write>(
             "could not resolve the osx-arm64 actions-runner package URL",
         ));
     }
-    let pkg_name = pkg_url.rsplit('/').next().unwrap_or("actions-runner.tar.gz");
+    let pkg_name = pkg_url
+        .rsplit('/')
+        .next()
+        .unwrap_or("actions-runner.tar.gz");
     let pkg_cache = ci_root.join("cache").join("actions-runner-pkg");
     fs::create_dir_all(&pkg_cache)
         .map_err(|e| CliFailure::new(1, format!("failed to create package cache: {e}")))?;
     let pkg_path = pkg_cache.join(pkg_name);
     if !pkg_path.exists() {
-        run("curl", &["-fsSL", "-o", &pkg_path.to_string_lossy(), &pkg_url], "download runner")?;
+        run(
+            "curl",
+            &["-fsSL", "-o", &pkg_path.to_string_lossy(), &pkg_url],
+            "download runner",
+        )?;
     }
 
     for entry in &plan {
@@ -253,7 +268,12 @@ pub(super) fn register_command<W: Write>(
         if !entry.dir.join("config.sh").exists() {
             run(
                 "tar",
-                &["xzf", &pkg_path.to_string_lossy(), "-C", &entry.dir.to_string_lossy()],
+                &[
+                    "xzf",
+                    &pkg_path.to_string_lossy(),
+                    "-C",
+                    &entry.dir.to_string_lossy(),
+                ],
                 "extract runner",
             )?;
         }
@@ -296,12 +316,25 @@ pub(super) fn register_command<W: Write>(
             ],
             "configure runner",
         )?;
-        run_in(&entry.dir, "./svc.sh", &["install"], "install runner service")?;
+        run_in(
+            &entry.dir,
+            "./svc.sh",
+            &["install"],
+            "install runner service",
+        )?;
         run_in(&entry.dir, "./svc.sh", &["start"], "start runner service")?;
     }
 
     report_register(
-        stdout, args.json, &slug, &tag, &labels_csv, &ci_root, parallel, &plan, false,
+        stdout,
+        args.json,
+        &slug,
+        &tag,
+        &labels_csv,
+        &ci_root,
+        parallel,
+        &plan,
+        false,
     )
 }
 
@@ -348,7 +381,11 @@ fn report_register<W: Write>(
         return Ok(ExitCode::SUCCESS);
     }
 
-    let verb = if dry_run { "Would register" } else { "Registered" };
+    let verb = if dry_run {
+        "Would register"
+    } else {
+        "Registered"
+    };
     writeln!(
         stdout,
         "{verb} {} runner(s) for {slug} [tag={tag}, ~{parallel} cores each]",
@@ -495,7 +532,11 @@ pub(super) fn list_command<W: Write>(
         )
         .ok();
         for name in &orphans {
-            writeln!(stdout, "  - {name}  (~/actions-runner-{name} or ~/actions-runner)").ok();
+            writeln!(
+                stdout,
+                "  - {name}  (~/actions-runner-{name} or ~/actions-runner)"
+            )
+            .ok();
         }
     }
     Ok(ExitCode::SUCCESS)
@@ -544,7 +585,10 @@ pub(super) fn remove_command<W: Write>(
         .to_owned();
 
     // Stop the service first; ignore failure (it may already be stopped).
-    let _ = Command::new("./svc.sh").current_dir(&dir).arg("stop").status();
+    let _ = Command::new("./svc.sh")
+        .current_dir(&dir)
+        .arg("stop")
+        .status();
     run_in(
         &dir,
         "./config.sh",
@@ -641,7 +685,9 @@ mod tests {
         );
         assert!(env.contains("CCACHE_DIR=/Volumes/Workshop/ci/pulp/cache/ccache"));
         assert!(env.contains("CCACHE_BASEDIR=/Volumes/Workshop/ci/pulp/work/pulp-studio-01"));
-        assert!(env.contains("FETCHCONTENT_BASE_DIR=/Volumes/Workshop/ci/pulp/cache/fetchcontent-src"));
+        assert!(
+            env.contains("FETCHCONTENT_BASE_DIR=/Volumes/Workshop/ci/pulp/cache/fetchcontent-src")
+        );
         assert!(env.contains("CMAKE_BUILD_PARALLEL_LEVEL=9"));
         assert!(env.contains("CTEST_PARALLEL_LEVEL=9"));
         assert!(env.contains("CCACHE_NOHASHDIR=true"));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,6 +76,8 @@ pub mod queue_scheduler;
 pub mod reconcile;
 /// GitHub webhook registration through the user's existing `gh` auth.
 pub mod registrar;
+/// Self-hosted runner provisioning (register/list/remove) pure logic.
+pub mod runner_provision;
 /// Self-hosted runner watchdog detection logic.
 pub mod runner_watchdog;
 /// Ship execution orchestration helpers.

--- a/src/runner_provision.rs
+++ b/src/runner_provision.rs
@@ -1,0 +1,477 @@
+//! Self-hosted runner provisioning: pure logic shared by the CLI handler.
+//!
+//! `shipyard runner register|list|remove` need to name runners consistently
+//! across a multi-Mac fleet, pick the next free index, derive labels that a
+//! repo's workflow will actually select, parse the GitHub Actions runners API,
+//! render the cross-repo pool view, and reconcile local runner directories
+//! against what GitHub thinks is registered. All of that is shell-free and
+//! lives here; the CLI side (`src/app/runner_provision_cmd.rs`) is the only
+//! place that shells out to `gh`, `config.sh`, and `svc.sh`.
+//!
+//! ## Naming model
+//!
+//! Runners are named `<repo>-<machine-tag>-<NN>`, e.g. `pulp-studio-01`. The
+//! machine tag is an explicit per-box label (`studio`, `m1`, `m5`) read from
+//! Shipyard state, never derived from the hostname — two MacBook Pros can share
+//! a hostname, so hostname-derived tags would collide. The shared label
+//! `<repo>-build` is what a repo's workflow selects for normal routing; the
+//! host label `<repo>-build-<machine-tag>` lets you pin work to one machine.
+
+use std::fmt::Write as _;
+
+use serde::Deserialize;
+
+/// Default labels GitHub injects automatically for an Apple-silicon macOS
+/// runner. We still pass them to `config.sh --labels` so the registered set is
+/// explicit and matches the existing fleet convention; GitHub de-duplicates the
+/// auto-added ones.
+const BASE_LABELS: [&str; 3] = ["self-hosted", "macos", "arm64"];
+
+/// One label entry from the GitHub Actions runners API.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ApiLabel {
+    /// Label text, e.g. `pulp-build`.
+    pub name: String,
+}
+
+/// A self-hosted runner as reported by `GET /repos/{slug}/actions/runners`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ApiRunner {
+    /// Registered runner name, e.g. `pulp-studio-01`.
+    pub name: String,
+    /// `"online"` or `"offline"`.
+    #[serde(default)]
+    pub status: String,
+    /// Whether the runner is currently executing a job.
+    #[serde(default)]
+    pub busy: bool,
+    /// Labels attached to the runner.
+    #[serde(default)]
+    pub labels: Vec<ApiLabel>,
+}
+
+impl ApiRunner {
+    /// Label names as plain strings, lowercased for stable comparison.
+    #[must_use]
+    pub fn label_names(&self) -> Vec<String> {
+        self.labels
+            .iter()
+            .map(|label| label.name.to_lowercase())
+            .collect()
+    }
+}
+
+/// The envelope returned by the runners list endpoint.
+#[derive(Debug, Clone, Deserialize)]
+pub struct RunnersResponse {
+    /// Total runners registered on the repo.
+    #[serde(default)]
+    pub total_count: u32,
+    /// The runner records.
+    #[serde(default)]
+    pub runners: Vec<ApiRunner>,
+}
+
+/// Parse the runners list JSON returned by `gh api`.
+///
+/// # Errors
+/// Returns the serde error message when the payload is not the expected shape.
+pub fn parse_runners_response(raw: &str) -> Result<RunnersResponse, String> {
+    serde_json::from_str(raw).map_err(|error| format!("runner list JSON parse failed: {error}"))
+}
+
+/// The short repo name (segment after `/`) for an `owner/repo` slug.
+///
+/// Falls back to the whole string when there is no slash.
+#[must_use]
+pub fn short_repo(slug: &str) -> &str {
+    slug.rsplit('/').next().unwrap_or(slug)
+}
+
+/// Validate a machine tag: lowercase ASCII alphanumerics and dashes, non-empty,
+/// not leading/trailing/doubled dashes.
+///
+/// # Errors
+/// Returns a human-readable reason when the tag is unusable in a runner name.
+pub fn validate_machine_tag(tag: &str) -> Result<(), String> {
+    if tag.is_empty() {
+        return Err("machine tag is empty".to_owned());
+    }
+    if tag.starts_with('-') || tag.ends_with('-') || tag.contains("--") {
+        return Err(format!(
+            "machine tag `{tag}` must not start, end, or repeat a dash"
+        ));
+    }
+    if !tag
+        .chars()
+        .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
+    {
+        return Err(format!(
+            "machine tag `{tag}` must be lowercase letters, digits, and dashes only"
+        ));
+    }
+    Ok(())
+}
+
+/// The runner name for a repo + machine tag + 1-based index, e.g.
+/// `pulp-studio-01`.
+#[must_use]
+pub fn runner_name(repo_short: &str, machine_tag: &str, index: u32) -> String {
+    format!("{repo_short}-{machine_tag}-{index:02}")
+}
+
+/// The default label set for a repo + machine tag: the three auto-added base
+/// labels plus the shared `<repo>-build` routing label and the per-host
+/// `<repo>-build-<tag>` pin label.
+#[must_use]
+pub fn default_labels(repo_short: &str, machine_tag: &str) -> Vec<String> {
+    let mut labels: Vec<String> = BASE_LABELS.iter().map(|s| (*s).to_owned()).collect();
+    labels.push(format!("{repo_short}-build"));
+    labels.push(format!("{repo_short}-build-{machine_tag}"));
+    labels
+}
+
+/// The next free 1-based index for `<repo>-<tag>-NN`, given existing runner
+/// names (from any machine). Returns `max + 1`, or `1` when none match.
+///
+/// This lets `register` be re-run to append capacity (`-03`, `-04`) without
+/// colliding with names already taken on this or another box.
+#[must_use]
+pub fn next_index(existing_names: &[String], repo_short: &str, machine_tag: &str) -> u32 {
+    let prefix = format!("{repo_short}-{machine_tag}-");
+    let highest = existing_names
+        .iter()
+        .filter_map(|name| name.strip_prefix(&prefix))
+        .filter(|suffix| !suffix.is_empty() && suffix.chars().all(|c| c.is_ascii_digit()))
+        .filter_map(|suffix| suffix.parse::<u32>().ok())
+        .max();
+    highest.map_or(1, |n| n + 1)
+}
+
+/// Infer the machine tag for a runner from its labels first (a
+/// `<repo>-build-<tag>` label is authoritative), then from the middle segment
+/// of a `<repo>-<tag>-NN` name. Returns `None` when neither yields a tag.
+#[must_use]
+pub fn infer_machine_tag(name: &str, label_names: &[String]) -> Option<String> {
+    for label in label_names {
+        if let Some(idx) = label.find("-build-") {
+            let tag = &label[idx + "-build-".len()..];
+            if !tag.is_empty() {
+                return Some(tag.to_owned());
+            }
+        }
+    }
+    // Fall back to the name's middle segment(s): repo-<tag>-NN where the last
+    // segment is the numeric index. Anything between the first and last segment
+    // is treated as the tag (tags themselves never contain the index).
+    let segments: Vec<&str> = name.split('-').collect();
+    if segments.len() >= 3 {
+        let last = segments[segments.len() - 1];
+        if last.chars().all(|c| c.is_ascii_digit()) {
+            let tag = segments[1..segments.len() - 1].join("-");
+            if !tag.is_empty() {
+                return Some(tag);
+            }
+        }
+    }
+    None
+}
+
+/// A single row in the `shipyard runner list` pool view.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PoolRow {
+    /// Runner name.
+    pub name: String,
+    /// Short repo name the runner is registered to.
+    pub repo: String,
+    /// `"online"` / `"offline"`.
+    pub status: String,
+    /// `true` when executing a job.
+    pub busy: bool,
+    /// Inferred machine tag, or `"?"` when unknown.
+    pub machine: String,
+    /// Comma-joined label names.
+    pub labels: String,
+}
+
+/// Build pool rows for one repo's runners.
+#[must_use]
+pub fn pool_rows(repo_short: &str, runners: &[ApiRunner]) -> Vec<PoolRow> {
+    runners
+        .iter()
+        .map(|runner| {
+            let label_names = runner.label_names();
+            PoolRow {
+                name: runner.name.clone(),
+                repo: repo_short.to_owned(),
+                status: if runner.status.is_empty() {
+                    "unknown".to_owned()
+                } else {
+                    runner.status.clone()
+                },
+                busy: runner.busy,
+                machine: infer_machine_tag(&runner.name, &label_names)
+                    .unwrap_or_else(|| "?".to_owned()),
+                labels: label_names.join(","),
+            }
+        })
+        .collect()
+}
+
+/// Render the pool rows as an aligned text table, grouped by machine tag.
+/// Rows are sorted by machine, then repo, then name for stable output.
+#[must_use]
+pub fn format_pool_table(rows: &[PoolRow]) -> String {
+    if rows.is_empty() {
+        return "No self-hosted runners found.".to_owned();
+    }
+    let mut sorted = rows.to_vec();
+    sorted.sort_by(|a, b| {
+        a.machine
+            .cmp(&b.machine)
+            .then(a.repo.cmp(&b.repo))
+            .then(a.name.cmp(&b.name))
+    });
+
+    let name_w = sorted
+        .iter()
+        .map(|r| r.name.len())
+        .chain(std::iter::once("RUNNER".len()))
+        .max()
+        .unwrap_or(6);
+    let repo_w = sorted
+        .iter()
+        .map(|r| r.repo.len())
+        .chain(std::iter::once("REPO".len()))
+        .max()
+        .unwrap_or(4);
+    let machine_w = sorted
+        .iter()
+        .map(|r| r.machine.len())
+        .chain(std::iter::once("MACHINE".len()))
+        .max()
+        .unwrap_or(7);
+
+    let mut out = String::new();
+    let _ = writeln!(
+        out,
+        "{:<name_w$}  {:<machine_w$}  {:<repo_w$}  {:<8}  LABELS",
+        "RUNNER", "MACHINE", "REPO", "STATE"
+    );
+    for r in &sorted {
+        let state = format!("{}/{}", r.status, if r.busy { "busy" } else { "idle" });
+        let _ = writeln!(
+            out,
+            "{:<name_w$}  {:<machine_w$}  {:<repo_w$}  {:<8}  {}",
+            r.name, r.machine, r.repo, state, r.labels
+        );
+    }
+    out.trim_end().to_owned()
+}
+
+/// Local runner directories on this machine that GitHub no longer knows about —
+/// i.e. orphaned `~/actions-runner-*` checkouts whose configured name is absent
+/// from the live runner set. `local_names` are the configured agent names read
+/// from each local `.runner` file; `github_names` is every runner GitHub
+/// reports for the relevant repos.
+#[must_use]
+pub fn orphan_local_runners(local_names: &[String], github_names: &[String]) -> Vec<String> {
+    local_names
+        .iter()
+        .filter(|name| !github_names.iter().any(|g| g.eq_ignore_ascii_case(name)))
+        .cloned()
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn short_repo_extracts_segment() {
+        assert_eq!(short_repo("danielraffel/pulp"), "pulp");
+        assert_eq!(short_repo("pulp"), "pulp");
+    }
+
+    #[test]
+    fn runner_name_zero_pads_index() {
+        assert_eq!(runner_name("pulp", "studio", 1), "pulp-studio-01");
+        assert_eq!(runner_name("pulp", "studio", 12), "pulp-studio-12");
+    }
+
+    #[test]
+    fn default_labels_include_routing_and_host_labels() {
+        let labels = default_labels("pulp", "studio");
+        assert_eq!(
+            labels,
+            vec![
+                "self-hosted",
+                "macos",
+                "arm64",
+                "pulp-build",
+                "pulp-build-studio"
+            ]
+        );
+    }
+
+    #[test]
+    fn next_index_starts_at_one_when_none_match() {
+        assert_eq!(next_index(&[], "pulp", "studio"), 1);
+        assert_eq!(
+            next_index(&["pulp-m1-01".to_owned()], "pulp", "studio"),
+            1,
+            "other-machine runners must not advance the studio index"
+        );
+    }
+
+    #[test]
+    fn next_index_continues_after_highest() {
+        let existing = vec![
+            "pulp-studio-01".to_owned(),
+            "pulp-studio-03".to_owned(),
+            "pulp-studio-02".to_owned(),
+            "pulp-m1-09".to_owned(),
+        ];
+        assert_eq!(next_index(&existing, "pulp", "studio"), 4);
+    }
+
+    #[test]
+    fn next_index_ignores_non_numeric_suffix() {
+        let existing = vec!["pulp-studio-build".to_owned(), "pulp-studio-2x".to_owned()];
+        assert_eq!(next_index(&existing, "pulp", "studio"), 1);
+    }
+
+    #[test]
+    fn infer_machine_tag_prefers_host_label() {
+        let labels = vec!["pulp-build".to_owned(), "pulp-build-studio".to_owned()];
+        assert_eq!(
+            infer_machine_tag("anything", &labels),
+            Some("studio".to_owned())
+        );
+    }
+
+    #[test]
+    fn infer_machine_tag_falls_back_to_name() {
+        assert_eq!(
+            infer_machine_tag("pulp-m1-02", &[]),
+            Some("m1".to_owned())
+        );
+    }
+
+    #[test]
+    fn infer_machine_tag_handles_multi_segment_tag() {
+        assert_eq!(
+            infer_machine_tag("pulp-mac-studio-02", &[]),
+            Some("mac-studio".to_owned())
+        );
+    }
+
+    #[test]
+    fn infer_machine_tag_none_when_no_index_or_label() {
+        assert_eq!(infer_machine_tag("daniels-macbook-shipyard", &[]), None);
+    }
+
+    #[test]
+    fn validate_machine_tag_accepts_clean_tags() {
+        assert!(validate_machine_tag("studio").is_ok());
+        assert!(validate_machine_tag("m5").is_ok());
+        assert!(validate_machine_tag("mac-studio").is_ok());
+    }
+
+    #[test]
+    fn validate_machine_tag_rejects_bad_tags() {
+        assert!(validate_machine_tag("").is_err());
+        assert!(validate_machine_tag("Studio").is_err());
+        assert!(validate_machine_tag("-m1").is_err());
+        assert!(validate_machine_tag("m1-").is_err());
+        assert!(validate_machine_tag("mac--studio").is_err());
+        assert!(validate_machine_tag("m 1").is_err());
+    }
+
+    #[test]
+    fn parse_runners_response_reads_github_shape() {
+        let raw = r#"{
+            "total_count": 2,
+            "runners": [
+                {"id": 1, "name": "pulp-studio-01", "status": "online", "busy": true,
+                 "labels": [{"name": "self-hosted"}, {"name": "pulp-build"}]},
+                {"id": 2, "name": "pulp-studio-02", "status": "offline", "busy": false,
+                 "labels": [{"name": "pulp-build-studio"}]}
+            ]
+        }"#;
+        let parsed = parse_runners_response(raw).expect("parse");
+        assert_eq!(parsed.total_count, 2);
+        assert_eq!(parsed.runners.len(), 2);
+        assert_eq!(parsed.runners[0].name, "pulp-studio-01");
+        assert!(parsed.runners[0].busy);
+        assert_eq!(
+            parsed.runners[0].label_names(),
+            vec!["self-hosted", "pulp-build"]
+        );
+    }
+
+    #[test]
+    fn pool_rows_infer_machine_and_state() {
+        let runners = vec![ApiRunner {
+            name: "pulp-studio-01".to_owned(),
+            status: "online".to_owned(),
+            busy: true,
+            labels: vec![ApiLabel {
+                name: "pulp-build-studio".to_owned(),
+            }],
+        }];
+        let rows = pool_rows("pulp", &runners);
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].machine, "studio");
+        assert_eq!(rows[0].repo, "pulp");
+        assert!(rows[0].busy);
+    }
+
+    #[test]
+    fn format_pool_table_groups_and_aligns() {
+        let rows = vec![
+            PoolRow {
+                name: "pulp-studio-01".to_owned(),
+                repo: "pulp".to_owned(),
+                status: "online".to_owned(),
+                busy: false,
+                machine: "studio".to_owned(),
+                labels: "pulp-build".to_owned(),
+            },
+            PoolRow {
+                name: "pulp-m1-01".to_owned(),
+                repo: "pulp".to_owned(),
+                status: "online".to_owned(),
+                busy: true,
+                machine: "m1".to_owned(),
+                labels: "pulp-build".to_owned(),
+            },
+        ];
+        let table = format_pool_table(&rows);
+        // m1 sorts before studio.
+        let m1_pos = table.find("pulp-m1-01").expect("m1 row");
+        let studio_pos = table.find("pulp-studio-01").expect("studio row");
+        assert!(m1_pos < studio_pos);
+        assert!(table.contains("online/busy"));
+        assert!(table.contains("online/idle"));
+    }
+
+    #[test]
+    fn format_pool_table_empty_is_friendly() {
+        assert_eq!(format_pool_table(&[]), "No self-hosted runners found.");
+    }
+
+    #[test]
+    fn orphan_local_runners_flags_dirs_missing_from_github() {
+        let local = vec![
+            "pulp-studio-01".to_owned(),
+            "pulp-studio-02".to_owned(),
+            "Daniels-MacBook-Pro".to_owned(),
+        ];
+        let github = vec!["pulp-studio-01".to_owned(), "pulp-studio-02".to_owned()];
+        assert_eq!(
+            orphan_local_runners(&local, &github),
+            vec!["Daniels-MacBook-Pro".to_owned()]
+        );
+    }
+}

--- a/src/runner_provision.rs
+++ b/src/runner_provision.rs
@@ -352,10 +352,7 @@ mod tests {
 
     #[test]
     fn infer_machine_tag_falls_back_to_name() {
-        assert_eq!(
-            infer_machine_tag("pulp-m1-02", &[]),
-            Some("m1".to_owned())
-        );
+        assert_eq!(infer_machine_tag("pulp-m1-02", &[]), Some("m1".to_owned()));
     }
 
     #[test]


### PR DESCRIPTION
Adds shipyard runner register|list|remove|tag for self-hosted GitHub Actions
runner provisioning across a multi-Mac fleet. Pure naming/index/label/table
logic in src/runner_provision.rs; shell side (gh, config.sh, svc.sh, local
runner dirs) in src/app/runner_provision_cmd.rs.

- register: <repo>-<machine-tag>-NN names continuing the index; downloads +
  caches the runner tarball; writes per-runner .env pointing ccache and
  FetchContent at shared caches; config.sh + svc.sh install/start.
- list: live cross-repo pool view grouped by machine, reconciling local
  runner dirs against GitHub to flag orphans.
- remove: stop service + deregister; optional dir purge.
- tag: explicit per-box machine tag in state dir (never hostname-derived, so
  two laptops can't collide).

Docs: docs/runner-provisioning.md, cli-reference + ci/shipyard SKILL updates.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>