### PR TITLE
feat(ci): add `local` runner provider to route macOS jobs to a self-hosted Mac

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "shipyard",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "Cross-platform CI coordination",
   "min_shipyard_version": "0.22.8",
   "commands": "./commands",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ on:
         options:
           - github-hosted
           - namespace
+          - local
       linux_runner_selector_json:
         description: Optional JSON string/array for Linux runs-on
         required: false

--- a/.github/workflows/cloud-live-smoke.yml
+++ b/.github/workflows/cloud-live-smoke.yml
@@ -15,6 +15,7 @@ on:
         options:
           - github-hosted
           - namespace
+          - local
       workflow_runner_selector_json:
         description: Optional JSON string/array for this smoke workflow runs-on
         required: false

--- a/.github/workflows/package-smoke.yml
+++ b/.github/workflows/package-smoke.yml
@@ -11,6 +11,7 @@ on:
         options:
           - github-hosted
           - namespace
+          - local
       linux_runner_selector_json:
         description: Optional JSON string/array for Linux runs-on
         required: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ on:
         options:
           - github-hosted
           - namespace
+          - local
       linux_runner_selector_json:
         description: Optional JSON string/array for Linux x64 runs-on
         required: false

--- a/.github/workflows/sandbox-e2e.yml
+++ b/.github/workflows/sandbox-e2e.yml
@@ -15,6 +15,7 @@ on:
         options:
           - github-hosted
           - namespace
+          - local
       linux_runner_selector_json:
         description: Optional JSON string/array for Linux runs-on
         required: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to Shipyard are documented here. Each entry links
 to its [GitHub Release](https://github.com/danielraffel/Shipyard/releases).
 
 <a id="v0610"></a>
+## [0.62.0]
+
 ## [0.61.0] - 2026-06-01
 
 - feat(runner): add register/list/remove/tag provisioning suite ([#323](https://github.com/danielraffel/Shipyard/pull/323))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -614,7 +614,7 @@ dependencies = [
 
 [[package]]
 name = "shipyard"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shipyard"
-version = "0.61.0"
+version = "0.62.0"
 edition = "2024"
 description = "Cross-platform CI coordination for local, SSH, and cloud runners."
 rust-version = "1.92"

--- a/scripts/ci_matrix.py
+++ b/scripts/ci_matrix.py
@@ -2,8 +2,11 @@
 """Resolve GitHub Actions runner matrices for Shipyard workflows.
 
 GitHub-hosted runners are the safe default. Namespace remains an explicit
-opt-in provider for repos/accounts that still have access, and workflow inputs
-or repository variables can override defaults without editing YAML.
+opt-in provider for repos/accounts that still have access. The `local`
+provider routes to the maintainer's self-hosted Mac (label set
+`["self-hosted","local-mac"]`) for the macOS release/build leg, falling back
+to github-hosted for targets with no local box. Workflow inputs or repository
+variables can override defaults without editing YAML.
 """
 
 from __future__ import annotations
@@ -17,7 +20,7 @@ from pathlib import Path
 from typing import Mapping
 
 
-VALID_PROVIDERS = ("namespace", "github-hosted")
+VALID_PROVIDERS = ("namespace", "github-hosted", "local")
 
 
 @dataclass(frozen=True)
@@ -27,6 +30,11 @@ class RunnerTarget:
     env_suffix: str
     github_hosted_label: str
     namespace_label: str | None
+    # Built-in runs-on selector for the `local` (self-hosted) provider. macOS
+    # is the only target with a local Mac to land on; every other target has no
+    # local box and falls back to github-hosted. May be a single label string
+    # or a list of labels (AND-matched by GitHub Actions). None = no local box.
+    local_label: str | list[str] | None = None
 
 
 TARGETS: dict[str, RunnerTarget] = {
@@ -50,6 +58,7 @@ TARGETS: dict[str, RunnerTarget] = {
         env_suffix="MACOS_ARM64",
         github_hosted_label="macos-15",
         namespace_label="namespace-profile-generouscorp-macos",
+        local_label=["self-hosted", "local-mac"],
     ),
     "windows": RunnerTarget(
         key="windows",
@@ -130,14 +139,14 @@ def resolve_runs_on(target_key: str, env: Mapping[str, str] = os.environ) -> dic
     target = TARGETS[target_key]
     provider = requested_provider(env)
     explicit_env = f"EXPLICIT_{target.env_suffix}_RUNNER_SELECTOR_JSON"
-    namespace_env = f"NAMESPACE_{target.env_suffix}_RUNS_ON_JSON"
 
     explicit = _env(env, explicit_env)
     if explicit:
         selector = _load_selector(explicit, target=target, source=explicit_env)
     elif provider == "github-hosted":
         selector = json.dumps(target.github_hosted_label)
-    else:
+    elif provider == "namespace":
+        namespace_env = f"NAMESPACE_{target.env_suffix}_RUNS_ON_JSON"
         namespace = _env(env, namespace_env)
         if namespace:
             selector = _load_selector(
@@ -148,6 +157,17 @@ def resolve_runs_on(target_key: str, env: Mapping[str, str] = os.environ) -> dic
         elif target.namespace_label is not None:
             selector = json.dumps(target.namespace_label)
         else:
+            provider = "github-hosted"
+            selector = json.dumps(target.github_hosted_label)
+    else:  # local — self-hosted runner on the maintainer's machine(s)
+        local_env = f"LOCAL_{target.env_suffix}_RUNS_ON_JSON"
+        local = _env(env, local_env)
+        if local:
+            selector = _load_selector(local, target=target, source=local_env)
+        elif target.local_label is not None:
+            selector = json.dumps(target.local_label)
+        else:
+            # No local box for this target (Linux/Windows) — degrade to hosted.
             provider = "github-hosted"
             selector = json.dumps(target.github_hosted_label)
 

--- a/scripts/test_ci_matrix.py
+++ b/scripts/test_ci_matrix.py
@@ -103,6 +103,71 @@ class CiMatrixTests(unittest.TestCase):
         self.assertEqual(json.loads(values["linux_runs_on_json"]), "ubuntu-latest")
         self.assertEqual(values["linux_provider"], "github-hosted")
 
+    def test_local_provider_routes_macos_to_self_hosted_local_mac(self) -> None:
+        row = ci_matrix.resolve_runs_on(
+            "macos-arm64", {"REQUESTED_PROVIDER": "local"}
+        )
+        self.assertEqual(row["provider"], "local")
+        self.assertEqual(
+            json.loads(row["runs_on_json"]),
+            ["self-hosted", "local-mac"],
+        )
+
+    def test_local_provider_falls_back_to_hosted_for_targets_without_local_box(
+        self,
+    ) -> None:
+        for target_key, hosted in (
+            ("linux", "ubuntu-latest"),
+            ("linux-arm64", "ubuntu-24.04-arm"),
+            ("windows", "windows-latest"),
+        ):
+            row = ci_matrix.resolve_runs_on(
+                target_key, {"REQUESTED_PROVIDER": "local"}
+            )
+            self.assertEqual(row["provider"], "github-hosted", target_key)
+            self.assertEqual(json.loads(row["runs_on_json"]), hosted, target_key)
+
+    def test_local_repo_var_overrides_builtin_local_label(self) -> None:
+        row = ci_matrix.resolve_runs_on(
+            "macos-arm64",
+            {
+                "REQUESTED_PROVIDER": "local",
+                "LOCAL_MACOS_ARM64_RUNS_ON_JSON": '["self-hosted","studio"]',
+            },
+        )
+        self.assertEqual(row["provider"], "local")
+        self.assertEqual(
+            json.loads(row["runs_on_json"]),
+            ["self-hosted", "studio"],
+        )
+
+    def test_explicit_selector_wins_over_local_provider(self) -> None:
+        row = ci_matrix.resolve_runs_on(
+            "macos-arm64",
+            {
+                "REQUESTED_PROVIDER": "local",
+                "EXPLICIT_MACOS_ARM64_RUNNER_SELECTOR_JSON": '["self-hosted","macos","arm64"]',
+            },
+        )
+        self.assertEqual(
+            json.loads(row["runs_on_json"]),
+            ["self-hosted", "macos", "arm64"],
+        )
+
+    def test_release_matrix_local_provider_routes_only_macos(self) -> None:
+        matrix = ci_matrix.workflow_matrix(
+            "release", {"REQUESTED_PROVIDER": "local"}
+        )
+        rows = {row["key"]: row for row in matrix["include"]}
+        self.assertEqual(rows["macos-arm64"]["provider"], "local")
+        self.assertEqual(
+            json.loads(rows["macos-arm64"]["runs_on_json"]),
+            ["self-hosted", "local-mac"],
+        )
+        self.assertEqual(rows["linux"]["provider"], "github-hosted")
+        self.assertEqual(rows["linux-arm64"]["provider"], "github-hosted")
+        self.assertEqual(rows["windows"]["provider"], "github-hosted")
+
     def test_workflows_do_not_implicitly_route_macos_to_local_runner(self) -> None:
         root = Path(__file__).resolve().parents[1]
         workflow_dir = root / ".github" / "workflows"

--- a/skills/ci/SKILL.md
+++ b/skills/ci/SKILL.md
@@ -154,6 +154,28 @@ GitHub-hosted default; a trusted self-hosted run should be an explicit per-run
 choice. GitHub dispatches by `runs-on` labels; SSH is only the management layer
 for those machines.
 
+### The `local` provider (self-hosted Mac)
+
+`scripts/ci_matrix.py` recognizes a third provider, `local`, alongside
+`namespace` and `github-hosted`. Set it the same way — repo variable
+`DEFAULT_RUNNER_PROVIDER=local` or per-dispatch `-f runner_provider=local`.
+It routes the **macOS ARM64** leg to the maintainer's self-hosted Mac via the
+built-in label set `["self-hosted","local-mac"]`; Linux and Windows have no
+local box, so they transparently degrade to their GitHub-hosted labels (the
+resolved `provider` for those rows reports `github-hosted`). Override the macOS
+selector with repo var `LOCAL_MACOS_ARM64_RUNS_ON_JSON` if a different label set
+is needed. An explicit `*_runner_selector_json` input still wins over the
+provider default. This is *not* a hidden fallback — `local` only takes effect
+when explicitly requested, and the default remains GitHub-hosted.
+
+To land jobs on the Mac, register a runner carrying the matching labels with
+`shipyard runner register --repo <owner/repo> --labels self-hosted,macos,arm64,local-mac`
+(see the runner-provisioning rows above). This is the mechanism behind routing
+macOS **release** builds to the Mac Studio so they skip GitHub's hosted-macOS
+queue — the Studio's keychain already holds the Developer ID signing identity.
+Use `local` only on private repos / the owner's own machine, never a public repo
+with untrusted PRs.
+
 ## Live mode (`shipyard daemon`) — when it helps and when to ignore it
 
 Shipyard has a long-running webhook receiver that converts GitHub

--- a/skills/shipyard/SKILL.md
+++ b/skills/shipyard/SKILL.md
@@ -219,6 +219,29 @@ and reconciles local `~/actions-runner-*` dirs against GitHub to flag orphans.
   bootstraps (`SSL: CERTIFICATE_VERIFY_FAILED`) — run the bundled
   `Install Certificates.command`.
 
+### Routing Shipyard CI to a registered Mac (the `local` provider)
+
+Registering a runner only stands up the machine; it does not move any job
+onto it. Shipyard's own workflows pick a runner via `scripts/ci_matrix.py`,
+which now understands a `local` provider in addition to `github-hosted` and
+`namespace`. Set repo variable `DEFAULT_RUNNER_PROVIDER=local` (or dispatch
+with `-f runner_provider=local`) and the **macOS ARM64** leg resolves to the
+label set `["self-hosted","local-mac"]`; Linux/Windows have no local box and
+fall back to GitHub-hosted. So to send Shipyard's macOS **release** build to
+the Mac Studio, register a Studio runner that carries those labels —
+
+```bash
+shipyard runner tag --set studio
+shipyard runner register --repo danielraffel/Shipyard --count 1 \
+  --labels self-hosted,macos,arm64,local-mac \
+  --ci-root /Volumes/Workshop/ci/shipyard
+```
+
+— then flip `DEFAULT_RUNNER_PROVIDER=local`. The signing identity already
+lives in the Studio keychain, so the signed/notarized dmg build skips
+GitHub's hosted-macOS queue. Full provider semantics:
+`skills/ci/SKILL.md` → "Runner Provider Defaults" → "The `local` provider".
+
 ## Supervised Subprocess Marker (issue #266)
 
 Every `git` / `gh` child process spawned by the supervised


### PR DESCRIPTION
`scripts/ci_matrix.py` gains a third provider, `local`, alongside
`github-hosted` and `namespace`. With `DEFAULT_RUNNER_PROVIDER=local`
(or `-f runner_provider=local`), the macOS ARM64 leg resolves to the
self-hosted label set `["self-hosted","local-mac"]`; Linux/Windows have
no local box and transparently fall back to their GitHub-hosted labels.
An explicit `*_runner_selector_json` input still wins; an optional
`LOCAL_MACOS_ARM64_RUNS_ON_JSON` repo var overrides the macOS selector.

This is the routing mechanism behind sending Shipyard's macOS release
build to the Mac Studio self-hosted runner so it skips GitHub's
hosted-macOS queue (the Studio keychain holds the Developer ID identity).

- ci_matrix: VALID_PROVIDERS += local; RunnerTarget.local_label; per-
  provider dispatch in resolve_runs_on; macos-arm64 local_label.
- workflows: add `local` to the runner_provider dispatch choice in
  release/ci/package-smoke/sandbox-e2e/cloud-live-smoke.
- tests: cover macOS->local-mac, hosted fallback, override, explicit-wins,
  release-matrix routing.
- docs: ci + shipyard SKILL.md document the provider and registration.

Closes #325

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>