### PR TITLE
feat(runner): add `runner audit` for host-class naming/label drift (#316 Part A)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "shipyard",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "Cross-platform CI coordination",
   "min_shipyard_version": "0.22.8",
   "commands": "./commands",

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ CHANGELOG.md.pre-shipyard.bak
 
 # PyInstaller
 *.spec
+
+# Claude Code transient scheduler lock
+.claude/scheduled_tasks.lock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to Shipyard are documented here. Each entry links
 to its [GitHub Release](https://github.com/danielraffel/Shipyard/releases).
 
 <a id="v0620"></a>
+## [0.63.0]
+
 ## [0.62.0] - 2026-06-01
 
 - feat(ci): add `local` runner provider to route macOS jobs to a self-hosted Mac ([#326](https://github.com/danielraffel/Shipyard/pull/326))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -614,7 +614,7 @@ dependencies = [
 
 [[package]]
 name = "shipyard"
-version = "0.62.0"
+version = "0.63.0"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shipyard"
-version = "0.62.0"
+version = "0.63.0"
 edition = "2024"
 description = "Cross-platform CI coordination for local, SSH, and cloud runners."
 rust-version = "1.92"

--- a/planning/2026-06-01-multi-mac-controller.md
+++ b/planning/2026-06-01-multi-mac-controller.md
@@ -1,0 +1,133 @@
+# Multi-Mac controller — host-class routing, VM-slot capacity, cloud→local drain
+
+**Date:** 2026-06-01 · **Owner:** daniel.raffel
+**Tracking:** Shipyard #316 · **Builds on:** #325 / v0.62.0 (`local` runner provider,
+`DEFAULT_RUNNER_PROVIDER=local`, self-hosted macOS release).
+**Behavioral references:** Pulp `tools/scripts/macos_reroute_watcher.py` (task #22),
+Pulp `planning/2026-06-01-macos-ci-isolation-plan.md` Appendix D (2-VM/host kernel cap),
+Pulp `tools/ci/tart-*.sh` (golden image + ephemeral runner).
+
+## Why
+
+The operating model is now multi-Mac: an always-on **Mac Studio** (primary capacity +
+Tart VM pool under `/Volumes/Workshop/VMs`), an **M1 MacBook Pro** (dev machine that
+sometimes contributes capacity), and a **future M5** that must inherit policy with zero
+bespoke setup. GitHub-hosted macOS is overflow. Today Shipyard can route the macOS lane
+to a `local` self-hosted runner (#325) but has **no notion of how much local macOS
+capacity exists** across hosts, and no automatic way to claw a cloud-queued macOS job
+back to local when a slot frees up. This plan adds three primitives, smallest-first.
+
+## Host inventory (2026-06-01)
+
+| Host class | Hostname | Runs | VM pool | cap (macOS VMs) |
+|---|---|---|---|---|
+| `studio` | `Daniels-Mac-Studio.local` | pulp-studio-01/02/03, `Shipyard-studio-01`, Tart pool | yes (`/Volumes/Workshop/VMs`) | 2 (kernel quota; raisable per Appendix D, Studio-only) |
+| `m1` | `Daniels-MacBook-Pro.local` (alias `macpro`) | pulp-m1-01/02, `daniels-macbook-shipyard` | dev | 2 |
+| `m5` | (arriving) | — | — | 2 (inherits) |
+
+The 2-VM cap is the XNU kernel `hv_apple_isa_vm_quota` (Appendix D), **not** Tart or a
+license limit. Default `cap = 2` everywhere; only the dedicated Studio may override
+higher (dev-kernel boot-arg, manual re-apply after macOS updates). M5 inherits the
+default.
+
+## Part A — host-class naming/label policy (done first; M5 depends on it)
+
+Shipyard's `src/runner_provision.rs` **already** models the generic scheme:
+
+- Runner name: `<project>-<class>-NN` (`runner_name()`), e.g. `pulp-studio-01`,
+  `shipyard-m1-01`, future `*-m5-01`. The class is the per-box **machine tag**
+  (`shipyard runner tag --set <class>`), never hostname-derived.
+- Default labels (`default_labels()`): `self-hosted, macos, arm64, <project>-build,
+  <project>-build-<class>`. `<project>-build` = shared routing; `<project>-build-<class>`
+  = host-class pin. This matches Pulp's `pulp-build` / `pulp-build-studio|m1|m5`.
+
+**Gap:** no drift detection, and the live fleet has drifted:
+- `Shipyard-studio-01` was registered (#325) with `--labels self-hosted,macos,arm64,local-mac`
+  — it carries the release.yml `local` selector but **not** `Shipyard-build-studio`.
+- `daniels-macbook-shipyard` has a non-conforming name (no `<repo>-<class>-NN`), so its
+  class can only be guessed from labels.
+
+**Deliverable:** pure-logic `audit_runners(repo_short, runners)` + `shipyard runner audit`
+that flags, per runner: non-conforming name, missing `<project>-build` / `<project>-build-<class>`
+label, and name-class vs label-class mismatch. Exit non-zero on drift (CI-friendly).
+Physical host verification ("is `*-studio-*` actually on the Studio?") is a *hint* in Part A
+and becomes authoritative once Part B can SSH the host and read its machine tag.
+
+The `local-mac` label (#325) and the host-class labels coexist: `local-mac` is the broad
+"any local Mac" selector release.yml uses today; `<project>-build-<class>` is the pin the
+reroute watcher (Part C) uses to target a *specific* free host.
+
+## Part B — VM-slot-aware capacity accounting
+
+New config section, parsed like `parse_host_pools` (`src/host_pool.rs`):
+
+```toml
+[host_class.studio]
+ssh = "Daniels-Mac-Studio.local"   # or user@host; omit for the controller's own box
+cap = 2                            # macOS VM slots (kernel quota); Studio may raise
+labels = ["self-hosted", "macos", "arm64", "shipyard-build-studio"]
+
+[host_class.m1]
+ssh = "Daniels-MacBook-Pro.local"
+cap = 2
+labels = ["self-hosted", "macos", "arm64", "shipyard-build-m1"]
+
+# [host_class.m5] added when it arrives — same shape, inherits cap = 2.
+```
+
+`shipyard runner capacity [--json]`:
+1. For each configured host class, read `running_macos_vms` by SSH'ing the host and
+   running `tart list` (count VMs in the `running` state). The controller's own box is
+   read locally (no SSH).
+2. `free_host = max(0, cap_host − running_macos_vms_host)`; `free = Σ free_host`.
+3. **Fail-closed:** an unreadable host (SSH/`tart` error, unparseable output) contributes
+   `free_host = 0` and is flagged `readable = false` — never counted as free capacity.
+4. Emit per-host `{class, ssh, cap, running, free, readable, source}` and the total.
+   **Log every capacity decision** (host, cap, running, free) — silence must not read as
+   success.
+
+Pure-logic core (`compute_free_slots`, `parse_tart_running`) is unit-tested with injected
+`tart list` output; SSH is the only impure edge. Note the Studio also hosts the long-lived
+pulp/Shipyard runner agents and any ephemeral builders — those consume its slots, so the
+`running` count from `tart list` is the truth, not a static assumption.
+
+## Part C — cloud→local queue-drain watcher
+
+`shipyard runner reroute-watch [--interval 30] [--flap-window 300] [--json]`, modeled on
+the `runner watch` loop and Pulp's `macos_reroute_watcher.py`, generalized to multi-host
+slot accounting:
+
+Each tick:
+1. `free = compute_free_slots()` (Part B). If `free <= 0`, log + skip (fail-closed if any
+   host unreadable lowers free).
+2. List repo `queued` workflow runs whose macOS job is dispatched to a **cloud** target
+   (`macos-15` / `nscloud-` / `namespace-profile-`) and not yet picked up. (`_macos_job_targets_cloud`
+   logic ported to Rust over the jobs API.)
+3. For the first eligible PR not in the flap-guard window: retarget its macOS lane to a
+   **specific free host** via the existing `cloud retarget` path, re-firing on that host's
+   `<project>-build-<class>` label, and ensure an ephemeral VM runner is available on a
+   host with a free slot.
+4. Preserve the four safety properties: **flap-guard** (one PR per `--flap-window`),
+   **one reroute per tick** (natural pacing), **idle/slot-safe** (only when `free > 0`),
+   **fail-closed** on unreadable host state.
+
+**Ephemeral VM runner** (avoid double-pickup): Shipyard drives Pulp's
+`tart-run-job.sh`-equivalent (mint a JIT runner via `gh ... generate-jitconfig`, clone the
+golden, boot, run one job, destroy). First slice may target an already-registered
+persistent host-class runner and treat ephemeral spin-up as a follow-up — flagged below.
+
+## Sequencing & PR slices
+
+1. **PR 1 (this):** design doc + Part A (`runner audit`) + reconcile the drifted
+   `Shipyard-studio-01` label set.
+2. **PR 2:** Part B (`[host_class.*]` config + `runner capacity`).
+3. **PR 3:** Part C (`runner reroute-watch`) on top of B, persistent-runner target first.
+4. **PR 4 (follow-up):** ephemeral JIT VM runner spin-up + Studio kernel-cap override
+   runbook.
+
+## Non-goals (first slices)
+
+Full controller/client RPC (the broader #316 product goal), distributed locking across
+Macs, Tart/Tartelet isolation changes, replacing GitHub Actions as the required-check
+source of truth. The Studio remains the canonical state owner; laptops use GitHub-backed
+status/dispatch/retarget.

--- a/skills/ci/SKILL.md
+++ b/skills/ci/SKILL.md
@@ -47,6 +47,7 @@ Shipyard coordinates validation across local, SSH, and cloud targets.
 | **Runner provisioning: register N runners for a repo** | `shipyard runner register --repo <owner/repo> --count <N> [--ci-root <dir>]` (names `<repo>-<tag>-NN`, continues the index) |
 | **Runner provisioning: dry-run the registration plan** | `shipyard runner register --repo <owner/repo> --count <N> --dry-run` |
 | **Runner provisioning: live cross-repo pool view** | `shipyard runner list [--repo <owner/repo>]` (groups by machine; flags orphaned local dirs) |
+| **Runner provisioning: audit host-class naming/label drift** | `shipyard runner audit [--repo <owner/repo>]` (flags non-conforming names + missing `<repo>-build` / `<repo>-build-<class>` labels; exit 1 on drift) |
 | **Runner provisioning: deregister a runner** | `shipyard runner remove --name <repo>-<tag>-NN --yes [--purge-dir]` |
 | **Self-update: check if a new release is available** | `shipyard update --check --json` |
 | **Self-update: apply latest stable** | `shipyard update` (delegates to `install.sh`) |

--- a/skills/shipyard/SKILL.md
+++ b/skills/shipyard/SKILL.md
@@ -208,6 +208,24 @@ shipyard runner remove --name pulp-studio-03 --yes [--purge-dir]
 `list` aggregates across machines straight from GitHub (no controller needed)
 and reconciles local `~/actions-runner-*` dirs against GitHub to flag orphans.
 
+### Audit (host-class drift)
+
+```bash
+shipyard runner audit --repo danielraffel/Shipyard   # exit 1 on any drift
+```
+
+`audit` checks every runner against the host-class scheme — a conforming
+`<repo>-<class>-NN` name, the shared `<repo>-build` routing label, the
+`<repo>-build-<class>` pin label, and agreement between the class in the name
+and the class in the labels. It flags non-conforming names (e.g. a hand-named
+`daniels-macbook-shipyard`) and missing labels (e.g. a runner registered with a
+bespoke `--labels` that dropped `<repo>-build-<class>`), exiting non-zero so CI
+or a cron can gate on a clean fleet. This is the foundation for the M5 joining
+by class with zero bespoke setup. Pure naming/label logic; physically
+confirming a `*-studio-*` runner is on the Studio is `runner capacity`'s job
+(reads the host machine tag over SSH). Full design:
+`planning/2026-06-01-multi-mac-controller.md` (Shipyard #316).
+
 ### Gotchas
 
 - These four subcommands are newer than the watchdog set; an older installed

--- a/src/app/cli.rs
+++ b/src/app/cli.rs
@@ -492,6 +492,14 @@ pub(super) enum RunnerCommand {
         #[arg(long = "all-repos")]
         all_repos: bool,
     },
+    /// Audit runners for host-class naming/label drift (`<repo>-<class>-NN` +
+    /// `<repo>-build` / `<repo>-build-<class>`). Exit 1 when any runner drifts.
+    Audit {
+        /// Owner/repo slug. Repeatable. Defaults to repos discovered from
+        /// local `actions-runner-*` dirs plus the current repo.
+        #[arg(long)]
+        repo: Vec<String>,
+    },
     /// Deregister a runner: stop its launchd service and remove it from GitHub.
     Remove {
         /// Runner name, e.g. `pulp-studio-03`.

--- a/src/app/runner_cmd.rs
+++ b/src/app/runner_cmd.rs
@@ -148,6 +148,9 @@ pub(super) fn runner_command<W: Write>(
         RunnerCommand::List { repo, all_repos } => {
             super::runner_provision_cmd::list_command(cwd, &actions, &repo, all_repos, json, stdout)
         }
+        RunnerCommand::Audit { repo } => {
+            super::runner_provision_cmd::audit_command(cwd, &actions, &repo, json, stdout)
+        }
         RunnerCommand::Remove {
             name,
             repo,

--- a/src/app/runner_provision_cmd.rs
+++ b/src/app/runner_provision_cmd.rs
@@ -21,8 +21,9 @@ use crate::identity::RuntimeMode;
 use crate::output::write_json_envelope;
 use crate::paths::RuntimePaths;
 use crate::runner_provision::{
-    PoolRow, default_labels, format_pool_table, next_index, orphan_local_runners,
-    parse_runners_response, pool_rows, runner_name, short_repo, validate_machine_tag,
+    AuditFinding, PoolRow, audit_runners, default_labels, format_audit_table, format_pool_table,
+    next_index, orphan_local_runners, parse_runners_response, pool_rows, runner_name, short_repo,
+    validate_machine_tag,
 };
 
 /// jq filter selecting the Apple-silicon macOS runner tarball download URL.
@@ -540,6 +541,128 @@ pub(super) fn list_command<W: Write>(
         }
     }
     Ok(ExitCode::SUCCESS)
+}
+
+// ---------- audit ----------
+
+/// Resolve the repo slugs to audit, mirroring `list_command`'s resolution:
+/// explicit `--repo`, local runner dirs, then the current checkout.
+fn resolve_audit_slugs(cwd: &Path, repo: &[String]) -> Result<Vec<String>, CliFailure> {
+    let locals = scan_local_runners();
+    let mut slugs: Vec<String> = Vec::new();
+    let mut push = |slug: String| {
+        if !slug.is_empty() && !slugs.iter().any(|s| s.eq_ignore_ascii_case(&slug)) {
+            slugs.push(slug);
+        }
+    };
+    for r in repo {
+        push(r.clone());
+    }
+    if repo.is_empty() {
+        for local in &locals {
+            push(local.repo_slug.clone());
+        }
+        if let Ok(current) = resolve_repo_slug(None, cwd) {
+            push(current);
+        }
+    }
+    if slugs.is_empty() {
+        return Err(CliFailure::new(
+            1,
+            "No repos to audit. Pass --repo OWNER/REPO, or run where local runner dirs exist.",
+        ));
+    }
+    Ok(slugs)
+}
+
+/// `shipyard runner audit` — flag host-class naming/label drift across a repo's
+/// runners. Exit 0 when every runner conforms; exit 1 when any drift is found
+/// (CI-friendly). Pure logic lives in [`crate::runner_provision::audit_runners`].
+pub(super) fn audit_command<W: Write>(
+    cwd: &Path,
+    actions: &GitHubActions,
+    repo: &[String],
+    json: bool,
+    stdout: &mut W,
+) -> Result<ExitCode, CliFailure> {
+    let slugs = resolve_audit_slugs(cwd, repo)?;
+
+    let mut findings: Vec<(String, AuditFinding)> = Vec::new();
+    for slug in &slugs {
+        let raw = actions
+            .run_gh(&[
+                "api".to_owned(),
+                format!("repos/{slug}/actions/runners?per_page=100"),
+            ])
+            .map_err(|e| CliFailure::new(2, format!("failed to list runners for {slug}: {e}")))?;
+        let parsed = parse_runners_response(&raw).map_err(|e| CliFailure::new(2, e))?;
+        let repo_short = short_repo(slug);
+        for finding in audit_runners(repo_short, &parsed.runners) {
+            findings.push((repo_short.to_owned(), finding));
+        }
+    }
+
+    let with_issues = findings.iter().filter(|(_, f)| f.has_issues()).count();
+    let drift = findings.iter().any(|(_, f)| f.is_drift());
+    let exit = if with_issues == 0 {
+        ExitCode::SUCCESS
+    } else {
+        ExitCode::from(1)
+    };
+
+    if json {
+        let mut data = BTreeMap::new();
+        data.insert("repos".to_owned(), Value::from(slugs.clone()));
+        let finding_values: Vec<Value> = findings
+            .iter()
+            .map(|(repo_short, f)| {
+                let mut m = serde_json::Map::new();
+                m.insert("name".to_owned(), Value::from(f.name.clone()));
+                m.insert("repo".to_owned(), Value::from(repo_short.clone()));
+                m.insert(
+                    "name_class".to_owned(),
+                    f.name_class.clone().map_or(Value::Null, Value::from),
+                );
+                m.insert(
+                    "label_class".to_owned(),
+                    f.label_class.clone().map_or(Value::Null, Value::from),
+                );
+                m.insert("ok".to_owned(), Value::from(!f.has_issues()));
+                m.insert("drift".to_owned(), Value::from(f.is_drift()));
+                m.insert(
+                    "issues".to_owned(),
+                    Value::from(
+                        f.issues
+                            .iter()
+                            .map(|i| Value::from(i.code()))
+                            .collect::<Vec<_>>(),
+                    ),
+                );
+                Value::Object(m)
+            })
+            .collect();
+        data.insert("findings".to_owned(), Value::from(finding_values));
+        data.insert("with_issues".to_owned(), Value::from(with_issues));
+        data.insert("drift".to_owned(), Value::from(drift));
+        envelope(stdout, "runner.audit", data)?;
+        return Ok(exit);
+    }
+
+    let bare: Vec<AuditFinding> = findings.into_iter().map(|(_, f)| f).collect();
+    writeln!(stdout, "{}", format_audit_table(&bare)).ok();
+    if with_issues == 0 {
+        writeln!(stdout, "\n✓ All runners conform to the host-class scheme.").ok();
+    } else {
+        writeln!(
+            stdout,
+            "\n⚠︎ {with_issues} runner(s) drift from the host-class scheme \
+             (<repo>-<class>-NN + <repo>-build / <repo>-build-<class>).\n  \
+             Fix labels with `shipyard runner register --labels …` or re-tag/re-register \
+             the host; physical host class is confirmed by `shipyard runner capacity`."
+        )
+        .ok();
+    }
+    Ok(exit)
 }
 
 // ---------- remove ----------

--- a/src/runner_provision.rs
+++ b/src/runner_provision.rs
@@ -177,6 +177,196 @@ pub fn infer_machine_tag(name: &str, label_names: &[String]) -> Option<String> {
     None
 }
 
+/// The host class encoded in a conforming `<repo>-<class>-NN` runner name.
+///
+/// Conforming means: the lowercased name starts with `<repo>-`, ends with a
+/// purely-numeric index segment, and has a non-empty class in between. Returns
+/// `None` for anything else (wrong repo prefix, no numeric index, empty class),
+/// which the audit treats as a non-conforming name. The class is lowercased.
+#[must_use]
+pub fn class_from_name(name: &str, repo_short: &str) -> Option<String> {
+    let lower = name.to_lowercase();
+    let prefix = format!("{}-", repo_short.to_lowercase());
+    let rest = lower.strip_prefix(&prefix)?;
+    let (class, index) = rest.rsplit_once('-')?;
+    if class.is_empty() || index.is_empty() || !index.chars().all(|c| c.is_ascii_digit()) {
+        return None;
+    }
+    Some(class.to_owned())
+}
+
+/// The host class declared by a `<repo>-build-<class>` label, if present.
+/// `label_names` are expected already lowercased (see [`ApiRunner::label_names`]).
+#[must_use]
+pub fn class_from_labels(label_names: &[String], repo_short: &str) -> Option<String> {
+    let prefix = format!("{}-build-", repo_short.to_lowercase());
+    label_names.iter().find_map(|label| {
+        let class = label.strip_prefix(&prefix)?;
+        (!class.is_empty()).then(|| class.to_owned())
+    })
+}
+
+/// Whether the runner carries the shared `<repo>-build` routing label.
+#[must_use]
+pub fn has_routing_label(label_names: &[String], repo_short: &str) -> bool {
+    let want = format!("{}-build", repo_short.to_lowercase());
+    label_names.contains(&want)
+}
+
+/// A specific kind of host-class naming/label drift on a runner.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AuditIssue {
+    /// Name is not `<repo>-<class>-NN`, so its host class can't be read from the name.
+    NonConformingName,
+    /// Missing the shared `<repo>-build` routing label.
+    MissingRoutingLabel,
+    /// Missing the `<repo>-build-<class>` host-class pin label.
+    MissingHostClassLabel,
+    /// The class in the name and the class in the labels disagree — the name
+    /// may be lying about which host the runner is on.
+    NameLabelClassMismatch,
+}
+
+impl AuditIssue {
+    /// Stable machine-readable code for `--json` consumers.
+    #[must_use]
+    pub fn code(self) -> &'static str {
+        match self {
+            Self::NonConformingName => "non_conforming_name",
+            Self::MissingRoutingLabel => "missing_routing_label",
+            Self::MissingHostClassLabel => "missing_host_class_label",
+            Self::NameLabelClassMismatch => "name_label_class_mismatch",
+        }
+    }
+
+    /// A class-vs-name mismatch is the only drift that means the name is
+    /// untrustworthy; everything else is a fixable label gap.
+    #[must_use]
+    pub fn is_drift(self) -> bool {
+        matches!(self, Self::NameLabelClassMismatch)
+    }
+
+    /// Human-readable description for the audit table.
+    #[must_use]
+    pub fn describe(self) -> &'static str {
+        match self {
+            Self::NonConformingName => "name is not <repo>-<class>-NN",
+            Self::MissingRoutingLabel => "missing shared <repo>-build routing label",
+            Self::MissingHostClassLabel => "missing <repo>-build-<class> pin label",
+            Self::NameLabelClassMismatch => "name class and label class disagree",
+        }
+    }
+}
+
+/// Audit result for one runner.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AuditFinding {
+    /// Runner name.
+    pub name: String,
+    /// Host class read from the name, if conforming.
+    pub name_class: Option<String>,
+    /// Host class declared by labels, if present.
+    pub label_class: Option<String>,
+    /// Issues found, in stable order. Empty means the runner conforms.
+    pub issues: Vec<AuditIssue>,
+}
+
+impl AuditFinding {
+    /// Whether this finding has any issue at all.
+    #[must_use]
+    pub fn has_issues(&self) -> bool {
+        !self.issues.is_empty()
+    }
+
+    /// Whether any issue is name-untrustworthy drift (vs a fixable label gap).
+    #[must_use]
+    pub fn is_drift(&self) -> bool {
+        self.issues.iter().any(|issue| issue.is_drift())
+    }
+}
+
+/// Audit a repo's runners for host-class naming/label drift. Each runner is
+/// checked for a conforming `<repo>-<class>-NN` name, the shared `<repo>-build`
+/// routing label, a `<repo>-build-<class>` pin label, and agreement between the
+/// class in the name and the class in the labels.
+///
+/// This is pure naming/label logic. Physically confirming that a `*-studio-*`
+/// runner is really on the Studio requires reading the host's machine tag over
+/// SSH (Part B / `runner capacity`); the audit surfaces the claimed class so
+/// that check has something to compare against.
+#[must_use]
+pub fn audit_runners(repo_short: &str, runners: &[ApiRunner]) -> Vec<AuditFinding> {
+    runners
+        .iter()
+        .map(|runner| {
+            let labels = runner.label_names();
+            let name_class = class_from_name(&runner.name, repo_short);
+            let label_class = class_from_labels(&labels, repo_short);
+            let mut issues = Vec::new();
+            if name_class.is_none() {
+                issues.push(AuditIssue::NonConformingName);
+            }
+            if !has_routing_label(&labels, repo_short) {
+                issues.push(AuditIssue::MissingRoutingLabel);
+            }
+            if label_class.is_none() {
+                issues.push(AuditIssue::MissingHostClassLabel);
+            }
+            if let (Some(name_c), Some(label_c)) = (&name_class, &label_class)
+                && name_c != label_c
+            {
+                issues.push(AuditIssue::NameLabelClassMismatch);
+            }
+            AuditFinding {
+                name: runner.name.clone(),
+                name_class,
+                label_class,
+                issues,
+            }
+        })
+        .collect()
+}
+
+/// Render audit findings as an aligned table. Conforming runners are shown as
+/// `ok`; runners with issues list their codes. Sorted by name for stable output.
+#[must_use]
+pub fn format_audit_table(findings: &[AuditFinding]) -> String {
+    if findings.is_empty() {
+        return "No self-hosted runners found.".to_owned();
+    }
+    let mut sorted = findings.to_vec();
+    sorted.sort_by(|a, b| a.name.cmp(&b.name));
+
+    let name_w = sorted
+        .iter()
+        .map(|f| f.name.len())
+        .chain(std::iter::once("RUNNER".len()))
+        .max()
+        .unwrap_or(6);
+
+    let mut out = String::new();
+    let _ = writeln!(out, "{:<name_w$}  {:<10}  ISSUES", "RUNNER", "CLASS");
+    for finding in &sorted {
+        let class = finding
+            .name_class
+            .clone()
+            .or_else(|| finding.label_class.clone())
+            .unwrap_or_else(|| "?".to_owned());
+        let issues = if finding.issues.is_empty() {
+            "ok".to_owned()
+        } else {
+            finding
+                .issues
+                .iter()
+                .map(|issue| issue.describe())
+                .collect::<Vec<_>>()
+                .join("; ")
+        };
+        let _ = writeln!(out, "{:<name_w$}  {class:<10}  {issues}", finding.name);
+    }
+    out.trim_end().to_owned()
+}
+
 /// A single row in the `shipyard runner list` pool view.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PoolRow {
@@ -456,6 +646,151 @@ mod tests {
     #[test]
     fn format_pool_table_empty_is_friendly() {
         assert_eq!(format_pool_table(&[]), "No self-hosted runners found.");
+    }
+
+    fn runner_with(name: &str, labels: &[&str]) -> ApiRunner {
+        ApiRunner {
+            name: name.to_owned(),
+            status: "online".to_owned(),
+            busy: false,
+            labels: labels
+                .iter()
+                .map(|l| ApiLabel {
+                    name: (*l).to_owned(),
+                })
+                .collect(),
+        }
+    }
+
+    #[test]
+    fn class_from_name_reads_conforming_names() {
+        assert_eq!(
+            class_from_name("Shipyard-studio-01", "Shipyard"),
+            Some("studio".to_owned())
+        );
+        assert_eq!(class_from_name("pulp-m1-02", "pulp"), Some("m1".to_owned()));
+        // Case-insensitive on the repo prefix.
+        assert_eq!(
+            class_from_name("SHIPYARD-m5-01", "shipyard"),
+            Some("m5".to_owned())
+        );
+    }
+
+    #[test]
+    fn class_from_name_rejects_non_conforming() {
+        assert_eq!(
+            class_from_name("daniels-macbook-shipyard", "Shipyard"),
+            None
+        );
+        assert_eq!(class_from_name("pulp-studio", "pulp"), None); // no index
+        assert_eq!(class_from_name("other-studio-01", "pulp"), None); // wrong repo
+    }
+
+    #[test]
+    fn class_from_labels_and_routing_label() {
+        let labels = vec![
+            "self-hosted".to_owned(),
+            "shipyard-build".to_owned(),
+            "shipyard-build-studio".to_owned(),
+        ];
+        assert_eq!(
+            class_from_labels(&labels, "Shipyard"),
+            Some("studio".to_owned())
+        );
+        assert!(has_routing_label(&labels, "Shipyard"));
+        assert!(!has_routing_label(&["local-mac".to_owned()], "Shipyard"));
+    }
+
+    #[test]
+    fn audit_clean_runner_has_no_issues() {
+        let runners = vec![runner_with(
+            "shipyard-studio-01",
+            &[
+                "self-hosted",
+                "macos",
+                "arm64",
+                "shipyard-build",
+                "shipyard-build-studio",
+            ],
+        )];
+        let findings = audit_runners("shipyard", &runners);
+        assert_eq!(findings.len(), 1);
+        assert!(!findings[0].has_issues(), "clean runner should pass");
+        assert_eq!(findings[0].name_class, Some("studio".to_owned()));
+    }
+
+    #[test]
+    fn audit_flags_missing_host_class_label_for_local_mac_runner() {
+        // The #325 Shipyard-studio-01: conforming name + local-mac, but missing
+        // the shipyard-build / shipyard-build-studio labels.
+        let runners = vec![runner_with(
+            "Shipyard-studio-01",
+            &["self-hosted", "macos", "arm64", "local-mac"],
+        )];
+        let findings = audit_runners("Shipyard", &runners);
+        assert_eq!(findings[0].name_class, Some("studio".to_owned()));
+        assert!(
+            findings[0]
+                .issues
+                .contains(&AuditIssue::MissingRoutingLabel)
+        );
+        assert!(
+            findings[0]
+                .issues
+                .contains(&AuditIssue::MissingHostClassLabel)
+        );
+        // Name is fine, so this is a fixable label gap, not name-drift.
+        assert!(!findings[0].is_drift());
+    }
+
+    #[test]
+    fn audit_flags_non_conforming_name() {
+        let runners = vec![runner_with(
+            "daniels-macbook-shipyard",
+            &["self-hosted", "macos", "arm64", "local-mac"],
+        )];
+        let findings = audit_runners("Shipyard", &runners);
+        assert!(findings[0].issues.contains(&AuditIssue::NonConformingName));
+        assert_eq!(findings[0].name_class, None);
+    }
+
+    #[test]
+    fn audit_flags_name_label_class_mismatch_as_drift() {
+        // Name says studio, label pins m1 — the name is untrustworthy.
+        let runners = vec![runner_with(
+            "shipyard-studio-01",
+            &["self-hosted", "shipyard-build", "shipyard-build-m1"],
+        )];
+        let findings = audit_runners("shipyard", &runners);
+        assert_eq!(findings[0].name_class, Some("studio".to_owned()));
+        assert_eq!(findings[0].label_class, Some("m1".to_owned()));
+        assert!(
+            findings[0]
+                .issues
+                .contains(&AuditIssue::NameLabelClassMismatch)
+        );
+        assert!(findings[0].is_drift());
+    }
+
+    #[test]
+    fn format_audit_table_shows_ok_and_issues() {
+        let findings = audit_runners(
+            "shipyard",
+            &[
+                runner_with(
+                    "shipyard-studio-01",
+                    &["shipyard-build", "shipyard-build-studio"],
+                ),
+                runner_with("daniels-macbook-shipyard", &["local-mac"]),
+            ],
+        );
+        let table = format_audit_table(&findings);
+        assert!(table.contains("ok"));
+        assert!(table.contains("name is not"));
+        // sorted by name: daniels- before shipyard-
+        let d = table.find("daniels-macbook").expect("row");
+        let s = table.find("shipyard-studio-01").expect("row");
+        assert!(d < s);
     }
 
     #[test]


### PR DESCRIPTION
First slice of the multi-Mac controller (#316). Adds the host-class
naming/label audit that the M5 bring-up depends on, plus the design doc
covering Parts A/B/C.

- `runner_provision.rs`: pure-logic `class_from_name`, `class_from_labels`,
  `has_routing_label`, and `audit_runners` → per-runner findings for
  non-conforming names, missing `<repo>-build` / `<repo>-build-<class>`
  labels, and name-vs-label class mismatch (the one drift that means the
  name is untrustworthy). `format_audit_table` for human output. 9 tests.
- `shipyard runner audit [--repo …]`: queries the runners API (reusing the
  list resolution), renders findings, emits `--json`, exits 1 on any drift.
- Reconciled the live `Shipyard-studio-01` (added `shipyard-build` +
  `shipyard-build-studio` additively; kept `local-mac` for release.yml's
  `local` provider). `daniels-macbook-shipyard` remains flagged — it needs
  re-registration with a conforming `shipyard-m1-01` name on the M1.
- planning/2026-06-01-multi-mac-controller.md: design for host-class policy
  (A), VM-slot capacity accounting (B), cloud→local reroute watcher (C).
- ci + shipyard SKILL.md document `runner audit`.

Part B (`runner capacity`) and Part C (`runner reroute-watch`) follow.

Refs #316

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>