### PR TITLE
feat(runner): add VM-slot-aware capacity accounting (#316 Part B)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "shipyard",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "description": "Cross-platform CI coordination",
   "min_shipyard_version": "0.22.8",
   "commands": "./commands",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -614,7 +614,7 @@ dependencies = [
 
 [[package]]
 name = "shipyard"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shipyard"
-version = "0.63.0"
+version = "0.64.0"
 edition = "2024"
 description = "Cross-platform CI coordination for local, SSH, and cloud runners."
 rust-version = "1.92"

--- a/skills/ci/SKILL.md
+++ b/skills/ci/SKILL.md
@@ -48,6 +48,7 @@ Shipyard coordinates validation across local, SSH, and cloud targets.
 | **Runner provisioning: dry-run the registration plan** | `shipyard runner register --repo <owner/repo> --count <N> --dry-run` |
 | **Runner provisioning: live cross-repo pool view** | `shipyard runner list [--repo <owner/repo>]` (groups by machine; flags orphaned local dirs) |
 | **Runner provisioning: audit host-class naming/label drift** | `shipyard runner audit [--repo <owner/repo>]` (flags non-conforming names + missing `<repo>-build` / `<repo>-build-<class>` labels; exit 1 on drift) |
+| **Runner provisioning: VM-slot-aware free macOS capacity** | `shipyard runner capacity [--json]` (reads `tart list` per `[host_class.*]`; `free = Σ max(0, cap − running)`; fail-closed, exit 1 if any host unreadable) |
 | **Runner provisioning: deregister a runner** | `shipyard runner remove --name <repo>-<tag>-NN --yes [--purge-dir]` |
 | **Self-update: check if a new release is available** | `shipyard update --check --json` |
 | **Self-update: apply latest stable** | `shipyard update` (delegates to `install.sh`) |

--- a/skills/shipyard/SKILL.md
+++ b/skills/shipyard/SKILL.md
@@ -226,6 +226,38 @@ confirming a `*-studio-*` runner is on the Studio is `runner capacity`'s job
 (reads the host machine tag over SSH). Full design:
 `planning/2026-06-01-multi-mac-controller.md` (Shipyard #316).
 
+### Capacity (VM-slot accounting)
+
+```bash
+shipyard runner capacity --json   # exit 1 if any host unreadable
+```
+
+macOS caps **2 running VMs per host** (XNU kernel quota; Pulp plan Appendix D).
+`runner capacity` reads each `[host_class.<name>]`'s running macOS VMs (locally
+for the controller's own box, over SSH otherwise) via `tart list` and computes
+`free = Σ max(0, cap − running)`. **Fail-closed:** an unreadable host counts as
+0 free and the command exits non-zero — a silent host must never read as spare
+capacity. Configure host classes (operator-specific, so keep these in
+`~/.config/shipyard/config.toml` or `.shipyard.local/`, not the committed repo
+config):
+
+```toml
+[host_class.studio]
+# ssh omitted → the controller's own box, read locally
+cap = 2                                    # Studio may raise via Appendix-D override
+tart_bin = "/opt/homebrew/bin/tart"        # if tart isn't on the SSH PATH
+labels = ["self-hosted", "macos", "arm64", "shipyard-build-studio"]
+
+[host_class.m1]
+ssh = "Daniels-MacBook-Pro.local"
+cap = 2
+
+# [host_class.m5] arrives later — same shape, inherits cap = 2.
+```
+
+This free-slot count is what the cloud→local reroute watcher (#316 Part C) will
+gate on: drain a still-queued cloud macOS job to local only when `free > 0`.
+
 ### Gotchas
 
 - These four subcommands are newer than the watchdog set; an older installed

--- a/src/app.rs
+++ b/src/app.rs
@@ -14,6 +14,7 @@ use clap::Parser;
 mod auth_cmd;
 mod auto_merge_cmd;
 mod branch_cmd;
+mod capacity_cmd;
 mod changelog_cmd;
 mod cleanup_cmd;
 mod cli;

--- a/src/app/capacity_cmd.rs
+++ b/src/app/capacity_cmd.rs
@@ -1,0 +1,228 @@
+//! CLI handler for `shipyard runner capacity` (#316 Part B).
+//!
+//! Reads each configured `[host_class.<name>]`'s running macOS VMs (locally for
+//! the controller's own box, over SSH for the others), computes free slots
+//! `Σ max(0, cap − running)`, and reports per-host + total. Fail-closed: an
+//! unreadable host contributes 0 free and exits non-zero so a cron/script
+//! notices — silence must not read as success.
+//!
+//! All capacity math + parsing is the pure code in [`crate::capacity`]; this
+//! module is the only place that shells out to `tart` and `ssh`.
+
+use std::collections::BTreeMap;
+use std::io::Write;
+use std::process::{Command, ExitCode};
+
+use serde_json::Value;
+
+use super::CliFailure;
+use crate::capacity::{
+    HostCapacity, HostClassConfig, any_unreadable, parse_host_classes, parse_tart_running,
+    total_free,
+};
+use crate::config::LoadedConfig;
+use crate::output::write_json_envelope;
+
+/// SSH options for a non-interactive, fail-fast probe: no prompts, short
+/// connect timeout, accept new host keys so a fresh host doesn't hang.
+fn ssh_probe_options() -> Vec<String> {
+    [
+        "-o",
+        "BatchMode=yes",
+        "-o",
+        "ConnectTimeout=8",
+        "-o",
+        "StrictHostKeyChecking=accept-new",
+    ]
+    .iter()
+    .map(|s| (*s).to_owned())
+    .collect()
+}
+
+/// Read the running-VM count for one host class. Returns `Ok(count)` or an
+/// `Err(reason)` that the caller records as an unreadable host (fail-closed).
+fn read_running(class: &HostClassConfig) -> Result<u32, String> {
+    let tart_args = ["list", "--format", "json"];
+    let output = if let Some(host) = &class.ssh {
+        let remote = format!("{} list --format json", class.tart_bin);
+        Command::new("ssh")
+            .args(ssh_probe_options())
+            .arg(host)
+            .arg(&remote)
+            .output()
+    } else {
+        Command::new(&class.tart_bin).args(tart_args).output()
+    };
+
+    let output = output.map_err(|error| {
+        if class.ssh.is_some() {
+            format!("ssh spawn failed: {error}")
+        } else {
+            format!("`{}` spawn failed: {error}", class.tart_bin)
+        }
+    })?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let detail = stderr.trim();
+        let detail = if detail.is_empty() {
+            format!("exit {}", output.status.code().unwrap_or(-1))
+        } else {
+            detail.lines().next().unwrap_or(detail).to_owned()
+        };
+        return Err(format!("tart list failed: {detail}"));
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    parse_tart_running(&stdout)
+}
+
+/// Probe one host class and fold the result into a [`HostCapacity`].
+fn probe(class: &HostClassConfig) -> HostCapacity {
+    let (running, source) = match read_running(class) {
+        Ok(count) => (
+            Some(count),
+            if class.ssh.is_some() { "ssh" } else { "local" }.to_owned(),
+        ),
+        Err(reason) => (None, reason),
+    };
+    HostCapacity {
+        class: class.class.clone(),
+        ssh: class.ssh.clone(),
+        cap: class.cap,
+        running,
+        source,
+    }
+}
+
+fn host_to_json(host: &HostCapacity) -> Value {
+    let mut m = serde_json::Map::new();
+    m.insert("class".to_owned(), Value::from(host.class.clone()));
+    m.insert(
+        "ssh".to_owned(),
+        host.ssh.clone().map_or(Value::Null, Value::from),
+    );
+    m.insert("cap".to_owned(), Value::from(host.cap));
+    m.insert(
+        "running".to_owned(),
+        host.running.map_or(Value::Null, Value::from),
+    );
+    m.insert("free".to_owned(), Value::from(host.free()));
+    m.insert("readable".to_owned(), Value::from(host.readable()));
+    m.insert("source".to_owned(), Value::from(host.source.clone()));
+    Value::Object(m)
+}
+
+/// `shipyard runner capacity` — report VM-slot-aware free macOS capacity across
+/// configured host classes. Exit 0 when every host was read; exit 1 when any
+/// host was unreadable (its free slots are counted as 0).
+pub(super) fn capacity_command<W: Write>(
+    config: &LoadedConfig,
+    json: bool,
+    stdout: &mut W,
+) -> Result<ExitCode, CliFailure> {
+    let classes = parse_host_classes(&config.data).map_err(|e| CliFailure::new(2, e))?;
+
+    if classes.is_empty() {
+        let msg = "No [host_class.<name>] entries configured. Add e.g.\n\n  \
+                   [host_class.studio]\n  ssh = \"Daniels-Mac-Studio.local\"  # omit for this box\n  \
+                   cap = 2\n  labels = [\"self-hosted\", \"macos\", \"arm64\", \"shipyard-build-studio\"]\n";
+        if json {
+            let mut data = BTreeMap::new();
+            data.insert("hosts".to_owned(), Value::Array(Vec::new()));
+            data.insert("free".to_owned(), Value::from(0));
+            data.insert("any_unreadable".to_owned(), Value::from(false));
+            data.insert("configured".to_owned(), Value::from(false));
+            write_json_envelope(stdout, "runner.capacity", data)
+                .map_err(|e| CliFailure::new(1, format!("failed to write JSON: {e}")))?;
+            return Ok(ExitCode::SUCCESS);
+        }
+        writeln!(stdout, "{msg}").ok();
+        return Ok(ExitCode::SUCCESS);
+    }
+
+    let hosts: Vec<HostCapacity> = classes.iter().map(probe).collect();
+    let free = total_free(&hosts);
+    let unreadable = any_unreadable(&hosts);
+    let exit = if unreadable {
+        ExitCode::from(1)
+    } else {
+        ExitCode::SUCCESS
+    };
+
+    if json {
+        let mut data = BTreeMap::new();
+        data.insert(
+            "hosts".to_owned(),
+            Value::from(hosts.iter().map(host_to_json).collect::<Vec<_>>()),
+        );
+        data.insert("free".to_owned(), Value::from(free));
+        data.insert("any_unreadable".to_owned(), Value::from(unreadable));
+        data.insert("configured".to_owned(), Value::from(true));
+        write_json_envelope(stdout, "runner.capacity", data)
+            .map_err(|e| CliFailure::new(1, format!("failed to write JSON: {e}")))?;
+        return Ok(exit);
+    }
+
+    // Human output doubles as the per-host decision log.
+    writeln!(
+        stdout,
+        "{:<10}  {:<28}  {:>3}  {:>7}  {:>4}  SOURCE",
+        "CLASS", "SSH", "CAP", "RUNNING", "FREE"
+    )
+    .ok();
+    for host in &hosts {
+        let ssh = host.ssh.clone().unwrap_or_else(|| "(local)".to_owned());
+        let running = host
+            .running
+            .map_or_else(|| "?".to_owned(), |r| r.to_string());
+        writeln!(
+            stdout,
+            "{:<10}  {:<28}  {:>3}  {:>7}  {:>4}  {}",
+            host.class,
+            ssh,
+            host.cap,
+            running,
+            host.free(),
+            host.source,
+        )
+        .ok();
+    }
+    writeln!(stdout, "\nfree macOS slots: {free}").ok();
+    if unreadable {
+        writeln!(
+            stdout,
+            "⚠︎ one or more hosts unreadable — counted as 0 free (fail-closed). \
+             Free slots above are a lower bound."
+        )
+        .ok();
+    }
+    Ok(exit)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ssh_probe_options_are_noninteractive() {
+        let opts = ssh_probe_options();
+        assert!(opts.iter().any(|o| o == "BatchMode=yes"));
+        assert!(opts.iter().any(|o| o.starts_with("ConnectTimeout")));
+    }
+
+    #[test]
+    fn host_to_json_marks_unreadable_host() {
+        let host = HostCapacity {
+            class: "m1".to_owned(),
+            ssh: Some("macpro".to_owned()),
+            cap: 2,
+            running: None,
+            source: "tart list failed: timed out".to_owned(),
+        };
+        let value = host_to_json(&host);
+        assert_eq!(value["readable"], Value::from(false));
+        assert_eq!(value["free"], Value::from(0));
+        assert_eq!(value["running"], Value::Null);
+    }
+}

--- a/src/app/cli.rs
+++ b/src/app/cli.rs
@@ -500,6 +500,9 @@ pub(super) enum RunnerCommand {
         #[arg(long)]
         repo: Vec<String>,
     },
+    /// Report VM-slot-aware free macOS capacity across `[host_class.*]` hosts
+    /// (`Σ max(0, cap − running tart VMs)`). Exit 1 if any host is unreadable.
+    Capacity,
     /// Deregister a runner: stop its launchd service and remove it from GitHub.
     Remove {
         /// Runner name, e.g. `pulp-studio-03`.

--- a/src/app/runner_cmd.rs
+++ b/src/app/runner_cmd.rs
@@ -151,6 +151,7 @@ pub(super) fn runner_command<W: Write>(
         RunnerCommand::Audit { repo } => {
             super::runner_provision_cmd::audit_command(cwd, &actions, &repo, json, stdout)
         }
+        RunnerCommand::Capacity => super::capacity_cmd::capacity_command(config, json, stdout),
         RunnerCommand::Remove {
             name,
             repo,

--- a/src/capacity.rs
+++ b/src/capacity.rs
@@ -1,0 +1,350 @@
+//! VM-slot-aware macOS capacity accounting across host-class members (#316
+//! Part B).
+//!
+//! macOS limits **2 running VMs per host** (XNU kernel quota
+//! `hv_apple_isa_vm_quota`; see Pulp's `planning/2026-06-01-macos-ci-isolation-plan.md`
+//! Appendix D) — not Tart, not a license. A multi-Mac fleet's free macOS
+//! capacity is therefore:
+//!
+//! ```text
+//! free = Σ_hosts max(0, cap_host − running_macos_vms_host)
+//! ```
+//!
+//! `cap_host` defaults to [`DEFAULT_CAP`]; only the dedicated always-on Studio
+//! may raise it (dev-kernel boot-arg). `running_macos_vms_host` is read live
+//! from `tart list` on each host — the Studio also hosts long-lived runner
+//! agents and ephemeral builders that consume its slots, so the live count is
+//! the truth, not a static assumption.
+//!
+//! **Fail-closed:** a host whose VM state can't be read (SSH/`tart` error,
+//! unparseable output) contributes `free = 0` and is flagged unreadable — it is
+//! never counted as spare capacity. Silence must not read as success.
+//!
+//! This module is the pure logic: config parsing, `tart list` parsing, and the
+//! free-slot math. SSH'ing each host and shelling `tart` is the impure edge in
+//! the CLI handler.
+
+use serde::Deserialize;
+use toml::{Table, Value as TomlValue};
+
+/// Default macOS VM slots per host: the XNU kernel quota (Appendix D).
+pub const DEFAULT_CAP: u32 = 2;
+
+/// Parsed `[host_class.<name>]` config.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct HostClassConfig {
+    /// Class name from `[host_class.<name>]`, e.g. `studio`, `m1`, `m5`.
+    pub class: String,
+    /// SSH host (`user@host` or `host`). `None` means the controller's own box,
+    /// read locally without SSH.
+    pub ssh: Option<String>,
+    /// macOS VM slot cap. Defaults to [`DEFAULT_CAP`].
+    pub cap: u32,
+    /// The `tart` binary to invoke. Defaults to `tart`; override when it is not
+    /// on a non-interactive SSH `PATH`.
+    pub tart_bin: String,
+    /// Routing/pin labels this host class's runners carry (informational; the
+    /// reroute watcher uses `<repo>-build-<class>` to target this host).
+    pub labels: Vec<String>,
+}
+
+/// Parse `[host_class]` from merged config. Returns classes sorted by name for
+/// stable output. An empty/absent section yields an empty vec.
+///
+/// # Errors
+/// Returns a human-readable message when a class entry is malformed (not a
+/// table, non-string `ssh`/`tart_bin`, non-integer/negative `cap`, or a
+/// `labels` that is not an array of strings).
+pub fn parse_host_classes(data: &Table) -> Result<Vec<HostClassConfig>, String> {
+    let Some(classes) = data.get("host_class").and_then(TomlValue::as_table) else {
+        return Ok(Vec::new());
+    };
+    let mut out = Vec::with_capacity(classes.len());
+    for (class, value) in classes {
+        let table = value
+            .as_table()
+            .ok_or_else(|| format!("host_class.{class} must be a table"))?;
+        let ssh = match table.get("ssh") {
+            Some(TomlValue::String(s)) if !s.trim().is_empty() => Some(s.trim().to_owned()),
+            None | Some(TomlValue::String(_)) => None,
+            Some(_) => return Err(format!("host_class.{class}.ssh must be a string")),
+        };
+        let cap = match table.get("cap") {
+            None => DEFAULT_CAP,
+            Some(TomlValue::Integer(n)) if *n >= 0 => {
+                u32::try_from(*n).map_err(|_| format!("host_class.{class}.cap is too large"))?
+            }
+            Some(_) => {
+                return Err(format!(
+                    "host_class.{class}.cap must be a non-negative integer"
+                ));
+            }
+        };
+        let tart_bin = match table.get("tart_bin") {
+            None => "tart".to_owned(),
+            Some(TomlValue::String(s)) if !s.trim().is_empty() => s.trim().to_owned(),
+            Some(_) => return Err(format!("host_class.{class}.tart_bin must be a string")),
+        };
+        let labels = match table.get("labels") {
+            None => Vec::new(),
+            Some(TomlValue::Array(items)) => items
+                .iter()
+                .map(|item| {
+                    item.as_str()
+                        .map(str::to_owned)
+                        .ok_or_else(|| format!("host_class.{class}.labels must be strings"))
+                })
+                .collect::<Result<Vec<_>, _>>()?,
+            Some(_) => return Err(format!("host_class.{class}.labels must be an array")),
+        };
+        out.push(HostClassConfig {
+            class: class.clone(),
+            ssh,
+            cap,
+            tart_bin,
+            labels,
+        });
+    }
+    out.sort_by(|a, b| a.class.cmp(&b.class));
+    Ok(out)
+}
+
+/// One VM entry from `tart list --format json`. Tart has used both a
+/// `"State": "running"` string and a `"Running": true` boolean across versions,
+/// so we accept either and ignore everything else.
+#[derive(Debug, Clone, Deserialize)]
+struct TartVm {
+    #[serde(rename = "State", alias = "state")]
+    state: Option<String>,
+    #[serde(rename = "Running", alias = "running")]
+    running: Option<bool>,
+}
+
+impl TartVm {
+    fn is_running(&self) -> bool {
+        if self.running == Some(true) {
+            return true;
+        }
+        self.state
+            .as_deref()
+            .is_some_and(|s| s.eq_ignore_ascii_case("running"))
+    }
+}
+
+/// Count running VMs in `tart list --format json` output.
+///
+/// # Errors
+/// Returns a message when the output is not the expected JSON array — the
+/// caller treats that as an unreadable host (fail-closed), never as zero
+/// running VMs (which would falsely advertise free capacity).
+pub fn parse_tart_running(json: &str) -> Result<u32, String> {
+    let trimmed = json.trim();
+    if trimmed.is_empty() {
+        return Err("empty `tart list` output".to_owned());
+    }
+    let vms: Vec<TartVm> = serde_json::from_str(trimmed)
+        .map_err(|error| format!("could not parse `tart list --format json`: {error}"))?;
+    let running = vms.iter().filter(|vm| vm.is_running()).count();
+    u32::try_from(running).map_err(|_| "implausibly many running VMs".to_owned())
+}
+
+/// Per-host capacity after attempting to read its running VMs.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct HostCapacity {
+    /// Host class name.
+    pub class: String,
+    /// SSH host, or `None` for the local controller box.
+    pub ssh: Option<String>,
+    /// Configured slot cap.
+    pub cap: u32,
+    /// Running macOS VMs, or `None` when the host couldn't be read.
+    pub running: Option<u32>,
+    /// `"local"`, `"ssh"`, or an error reason when unreadable.
+    pub source: String,
+}
+
+impl HostCapacity {
+    /// Whether the host's VM state was read successfully.
+    #[must_use]
+    pub fn readable(&self) -> bool {
+        self.running.is_some()
+    }
+
+    /// Free slots on this host. **Fail-closed:** an unreadable host has 0 free.
+    #[must_use]
+    pub fn free(&self) -> u32 {
+        match self.running {
+            Some(running) => self.cap.saturating_sub(running),
+            None => 0,
+        }
+    }
+}
+
+/// Total free macOS slots across hosts: `Σ max(0, cap − running)`, with
+/// unreadable hosts contributing 0 (fail-closed).
+#[must_use]
+pub fn total_free(hosts: &[HostCapacity]) -> u32 {
+    hosts.iter().map(HostCapacity::free).sum()
+}
+
+/// Whether any host could not be read — the caller should treat the total as a
+/// lower bound and refuse to act if it needs a trustworthy count.
+#[must_use]
+pub fn any_unreadable(hosts: &[HostCapacity]) -> bool {
+    hosts.iter().any(|host| !host.readable())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn table(input: &str) -> Table {
+        input.parse().expect("toml")
+    }
+
+    #[test]
+    fn parse_host_classes_defaults_cap_and_reads_fields() {
+        let cfg = table(
+            r#"
+            [host_class.studio]
+            ssh = "Daniels-Mac-Studio.local"
+            cap = 4
+            labels = ["self-hosted", "shipyard-build-studio"]
+
+            [host_class.m1]
+            ssh = "Daniels-MacBook-Pro.local"
+            "#,
+        );
+        let classes = parse_host_classes(&cfg).expect("parse");
+        assert_eq!(classes.len(), 2);
+        // sorted by name: m1 before studio
+        assert_eq!(classes[0].class, "m1");
+        assert_eq!(classes[0].cap, DEFAULT_CAP);
+        assert_eq!(classes[0].tart_bin, "tart");
+        assert_eq!(classes[1].class, "studio");
+        assert_eq!(classes[1].cap, 4);
+        assert_eq!(classes[1].ssh.as_deref(), Some("Daniels-Mac-Studio.local"));
+        assert_eq!(
+            classes[1].labels,
+            vec!["self-hosted", "shipyard-build-studio"]
+        );
+    }
+
+    #[test]
+    fn parse_host_classes_absent_section_is_empty() {
+        assert!(
+            parse_host_classes(&table("[project]\nname=\"x\"\n"))
+                .expect("parse")
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn parse_host_classes_local_box_has_no_ssh() {
+        let cfg = table("[host_class.studio]\ncap = 2\n");
+        let classes = parse_host_classes(&cfg).expect("parse");
+        assert_eq!(classes[0].ssh, None);
+    }
+
+    #[test]
+    fn parse_host_classes_rejects_bad_cap() {
+        let cfg = table("[host_class.studio]\ncap = -1\n");
+        assert!(parse_host_classes(&cfg).is_err());
+        let cfg = table("[host_class.studio]\ncap = \"two\"\n");
+        assert!(parse_host_classes(&cfg).is_err());
+    }
+
+    #[test]
+    fn parse_tart_running_counts_running_state_string() {
+        let json = r#"[
+            {"Source":"local","Name":"shipyard-build-runner-abc","State":"running"},
+            {"Source":"local","Name":"golden","State":"stopped"},
+            {"Source":"local","Name":"other","State":"Running"}
+        ]"#;
+        assert_eq!(parse_tart_running(json).expect("count"), 2);
+    }
+
+    #[test]
+    fn parse_tart_running_counts_running_boolean() {
+        let json = r#"[
+            {"Name":"a","Running":true},
+            {"Name":"b","Running":false}
+        ]"#;
+        assert_eq!(parse_tart_running(json).expect("count"), 1);
+    }
+
+    #[test]
+    fn parse_tart_running_empty_list_is_zero() {
+        assert_eq!(parse_tart_running("[]").expect("count"), 0);
+        assert_eq!(parse_tart_running("[\n\n]").expect("count"), 0);
+    }
+
+    #[test]
+    fn parse_tart_running_errors_on_garbage_not_zero() {
+        // Crucial: unparseable output must error (→ unreadable host, fail-closed),
+        // never silently count as 0 free-advertising running VMs.
+        assert!(parse_tart_running("").is_err());
+        assert!(parse_tart_running("command not found: tart").is_err());
+        assert!(parse_tart_running("{not an array}").is_err());
+    }
+
+    #[test]
+    fn free_slots_fail_closed_on_unreadable_host() {
+        let readable = HostCapacity {
+            class: "studio".to_owned(),
+            ssh: None,
+            cap: 2,
+            running: Some(1),
+            source: "local".to_owned(),
+        };
+        let unreadable = HostCapacity {
+            class: "m1".to_owned(),
+            ssh: Some("macpro".to_owned()),
+            cap: 2,
+            running: None,
+            source: "ssh error: timed out".to_owned(),
+        };
+        assert_eq!(readable.free(), 1);
+        assert_eq!(
+            unreadable.free(),
+            0,
+            "unreadable host must not advertise capacity"
+        );
+        assert!(!unreadable.readable());
+        assert_eq!(total_free(&[readable, unreadable]), 1);
+    }
+
+    #[test]
+    fn free_slots_saturate_when_running_exceeds_cap() {
+        // 3 VMs on a cap-2 host (e.g. Appendix-D override was reverted) → 0 free,
+        // never a negative/underflowed huge number.
+        let over = HostCapacity {
+            class: "studio".to_owned(),
+            ssh: None,
+            cap: 2,
+            running: Some(3),
+            source: "local".to_owned(),
+        };
+        assert_eq!(over.free(), 0);
+    }
+
+    #[test]
+    fn any_unreadable_flags_partial_reads() {
+        let ok = HostCapacity {
+            class: "studio".to_owned(),
+            ssh: None,
+            cap: 2,
+            running: Some(0),
+            source: "local".to_owned(),
+        };
+        let bad = HostCapacity {
+            class: "m1".to_owned(),
+            ssh: Some("macpro".to_owned()),
+            cap: 2,
+            running: None,
+            source: "ssh error".to_owned(),
+        };
+        assert!(!any_unreadable(std::slice::from_ref(&ok)));
+        assert!(any_unreadable(&[ok, bad]));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,8 @@ pub mod app;
 pub mod branch;
 /// Bundle transfer command construction and path normalization.
 pub mod bundle;
+/// VM-slot-aware macOS capacity accounting across host-class members.
+pub mod capacity;
 /// Changelog tag graph extraction and markdown rendering.
 pub mod changelog;
 /// Coarse failure classification shared by executors.


### PR DESCRIPTION
`shipyard runner capacity` reports free macOS CI capacity across a
multi-Mac fleet: `free = Σ_hosts max(0, cap − running tart VMs)`. macOS
caps 2 running VMs/host (XNU kernel quota; Pulp plan Appendix D), so
`cap` defaults to 2 (the Studio may raise it; M5 inherits 2).

- `src/capacity.rs`: pure logic — `parse_host_classes` ([host_class.*]
  config: ssh/cap/tart_bin/labels), `parse_tart_running` (counts running
  VMs from `tart list --format json`, tolerant of both `State:"running"`
  and `Running:true`), `HostCapacity::free` + `total_free` (fail-closed:
  unreadable host → 0 free, never silently spare), `any_unreadable`.
  13 tests including the "garbage output errors, never counts as 0" guard.
- `src/app/capacity_cmd.rs`: the impure edge — reads the controller's own
  box locally and others over SSH (BatchMode, ConnectTimeout), folds each
  into a HostCapacity, prints a per-host decision table + `--json`
  envelope. Exit 1 when any host is unreadable so a cron notices.
- `shipyard runner capacity` wired into the runner subcommand.
- ci + shipyard SKILL.md document the command + the [host_class.*] schema.

Verified live on the Studio (local read: cap 2, 0 running, 2 free) and
the fail-closed path (bad tart_bin → free 0, exit 1). Part C
(reroute-watch) gates on this free-slot count.

Refs #316

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>