### PR TITLE
fix(runner): address Codex review on #316 PRs (paginate runners; drop bad retarget arg)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to Shipyard are documented here. Each entry links
 to its [GitHub Release](https://github.com/danielraffel/Shipyard/releases).
 
 <a id="v0650"></a>
+## [0.65.1]
+
 ## [0.65.0] - 2026-06-01
 
 - fix(build): sync Cargo.lock to 0.65.0 after version bump ([#329](https://github.com/danielraffel/Shipyard/pull/329))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -614,7 +614,7 @@ dependencies = [
 
 [[package]]
 name = "shipyard"
-version = "0.65.0"
+version = "0.65.1"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shipyard"
-version = "0.65.0"
+version = "0.65.1"
 edition = "2024"
 description = "Cross-platform CI coordination for local, SSH, and cloud runners."
 rust-version = "1.92"

--- a/skills/ci/SKILL.md
+++ b/skills/ci/SKILL.md
@@ -47,7 +47,7 @@ Shipyard coordinates validation across local, SSH, and cloud targets.
 | **Runner provisioning: register N runners for a repo** | `shipyard runner register --repo <owner/repo> --count <N> [--ci-root <dir>]` (names `<repo>-<tag>-NN`, continues the index) |
 | **Runner provisioning: dry-run the registration plan** | `shipyard runner register --repo <owner/repo> --count <N> --dry-run` |
 | **Runner provisioning: live cross-repo pool view** | `shipyard runner list [--repo <owner/repo>]` (groups by machine; flags orphaned local dirs) |
-| **Runner provisioning: audit host-class naming/label drift** | `shipyard runner audit [--repo <owner/repo>]` (flags non-conforming names + missing `<repo>-build` / `<repo>-build-<class>` labels; exit 1 on drift) |
+| **Runner provisioning: audit host-class naming/label drift** | `shipyard runner audit [--repo <owner/repo>]` (paginated; flags non-conforming names + missing `<repo>-build` / `<repo>-build-<class>` labels; exit 1 on drift) |
 | **Runner provisioning: VM-slot-aware free macOS capacity** | `shipyard runner capacity [--json]` (reads `tart list` per `[host_class.*]`; `free = Σ max(0, cap − running)`; fail-closed, exit 1 if any host unreadable) |
 | **Drain cloud-queued macOS jobs to local when a slot frees** | `shipyard runner reroute-watch [--apply] [--once] [--interval N] [--flap-window N]` (observe-only without `--apply`; flap-guard, one-reroute-per-tick, slot/fail-closed) |
 | **Runner provisioning: deregister a runner** | `shipyard runner remove --name <repo>-<tag>-NN --yes [--purge-dir]` |

--- a/skills/shipyard/SKILL.md
+++ b/skills/shipyard/SKILL.md
@@ -276,7 +276,10 @@ rerouted within `--flap-window`), **one reroute per tick** (natural pacing), and
 **deterministic** oldest-run-first choice. **Observe by default** — without
 `--apply` it logs each decision but acts on nothing. `--apply` shells `shipyard
 cloud retarget … --provider local --apply`, which works for PRs Shipyard is
-shipping (ship-state-backed). **Follow-up (Part C.2):** rerouting a PR with no
+shipping (ship-state-backed). `cloud retarget` has no `--repo` flag — it
+resolves the repo from the current checkout — so run `reroute-watch --apply`
+inside the target repo's checkout (its `--repo` only scopes which queued runs
+are listed, not where the reroute acts). **Follow-up (Part C.2):** rerouting a PR with no
 ship-state, and spinning an ephemeral JIT VM runner on a free-slot host (drive
 Pulp's `tart-run-job.sh` equivalent) — until then a persistent host-class runner
 handles pickup. Full design: `planning/2026-06-01-multi-mac-controller.md`.

--- a/src/app/reroute_cmd.rs
+++ b/src/app/reroute_cmd.rs
@@ -129,7 +129,7 @@ fn tick<W: Write>(
     // Perform the action (if applicable) before logging the outcome.
     let action = match &decision {
         RerouteDecision::Reroute(candidate) if args.apply => {
-            match perform_reroute(candidate, repo, &args.target) {
+            match perform_reroute(candidate, &args.target) {
                 Ok(()) => {
                     guard.record(candidate.pr, now);
                     "rerouted".to_owned()
@@ -283,7 +283,12 @@ fn macos_job_labels(actions: &GitHubActions, repo: &str, run_id: u64) -> String 
 /// Perform the reroute by shelling `shipyard cloud retarget … --provider local
 /// --apply` (reuses ship-state + dispatch safety). Mirrors Pulp's watcher
 /// shelling `pulp macos retarget`.
-fn perform_reroute(candidate: &RerouteCandidate, repo: &str, target: &str) -> Result<(), String> {
+///
+/// `cloud retarget` has no `--repo` flag — it resolves the repo from the
+/// current checkout (cwd) and ship-state — so `reroute-watch --apply` must run
+/// inside the target repo's checkout. We deliberately do not pass `--repo`
+/// (clap would reject it and every reroute would fail before acting).
+fn perform_reroute(candidate: &RerouteCandidate, target: &str) -> Result<(), String> {
     let exe = std::env::current_exe().unwrap_or_else(|_| "shipyard".into());
     let output = Command::new(exe)
         .args([
@@ -295,8 +300,6 @@ fn perform_reroute(candidate: &RerouteCandidate, repo: &str, target: &str) -> Re
             target,
             "--provider",
             "local",
-            "--repo",
-            repo,
             "--apply",
         ])
         .output()

--- a/src/app/runner_provision_cmd.rs
+++ b/src/app/runner_provision_cmd.rs
@@ -21,10 +21,37 @@ use crate::identity::RuntimeMode;
 use crate::output::write_json_envelope;
 use crate::paths::RuntimePaths;
 use crate::runner_provision::{
-    AuditFinding, PoolRow, audit_runners, default_labels, format_audit_table, format_pool_table,
-    next_index, orphan_local_runners, parse_runners_response, pool_rows, runner_name, short_repo,
+    ApiRunner, AuditFinding, PoolRow, audit_runners, default_labels, format_audit_table,
+    format_pool_table, next_index, orphan_local_runners, pool_rows, runner_name, short_repo,
     validate_machine_tag,
 };
+
+/// Fetch every self-hosted runner for a repo across **all** pages. GitHub caps
+/// `per_page` at 100, so a one-page fetch silently misses runners on a large
+/// fleet — `gh api --paginate` follows the `Link` headers and `--jq '.runners[]'`
+/// streams each runner object (newline-delimited) across pages.
+fn fetch_all_runners(actions: &GitHubActions, slug: &str) -> Result<Vec<ApiRunner>, CliFailure> {
+    let raw = actions
+        .run_gh(&[
+            "api".to_owned(),
+            "--paginate".to_owned(),
+            format!("repos/{slug}/actions/runners?per_page=100"),
+            "--jq".to_owned(),
+            ".runners[]".to_owned(),
+        ])
+        .map_err(|e| CliFailure::new(2, format!("failed to list runners for {slug}: {e}")))?;
+    let mut runners = Vec::new();
+    for line in raw.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let runner: ApiRunner = serde_json::from_str(line)
+            .map_err(|e| CliFailure::new(2, format!("runner JSON parse failed for {slug}: {e}")))?;
+        runners.push(runner);
+    }
+    Ok(runners)
+}
 
 /// jq filter selecting the Apple-silicon macOS runner tarball download URL.
 const RUNNER_ASSET_JQ: &str =
@@ -152,14 +179,12 @@ fn runner_env_file(ci_root: &Path, work: &Path, parallel: usize) -> String {
 /// Existing runner names registered on a repo (any machine), for index
 /// continuation.
 fn existing_runner_names(actions: &GitHubActions, slug: &str) -> Result<Vec<String>, CliFailure> {
-    let raw = actions
-        .run_gh(&[
-            "api".to_owned(),
-            format!("repos/{slug}/actions/runners?per_page=100"),
-        ])
-        .map_err(|e| CliFailure::new(2, format!("failed to list existing runners: {e}")))?;
-    let parsed = parse_runners_response(&raw).map_err(|e| CliFailure::new(2, e))?;
-    Ok(parsed.runners.into_iter().map(|r| r.name).collect())
+    // Paginated: a fleet with >100 runners must not under-count, or the next
+    // index could collide with an existing `<repo>-<tag>-NN`.
+    Ok(fetch_all_runners(actions, slug)?
+        .into_iter()
+        .map(|r| r.name)
+        .collect())
 }
 
 /// `shipyard runner register`.
@@ -486,17 +511,11 @@ pub(super) fn list_command<W: Write>(
     let mut rows: Vec<PoolRow> = Vec::new();
     let mut github_names: Vec<String> = Vec::new();
     for slug in &slugs {
-        let raw = actions
-            .run_gh(&[
-                "api".to_owned(),
-                format!("repos/{slug}/actions/runners?per_page=100"),
-            ])
-            .map_err(|e| CliFailure::new(2, format!("failed to list runners for {slug}: {e}")))?;
-        let parsed = parse_runners_response(&raw).map_err(|e| CliFailure::new(2, e))?;
-        for r in &parsed.runners {
+        let runners = fetch_all_runners(actions, slug)?;
+        for r in &runners {
             github_names.push(r.name.clone());
         }
-        rows.extend(pool_rows(short_repo(slug), &parsed.runners));
+        rows.extend(pool_rows(short_repo(slug), &runners));
     }
 
     let local_names: Vec<String> = locals.iter().map(|l| l.name.clone()).collect();
@@ -589,15 +608,9 @@ pub(super) fn audit_command<W: Write>(
 
     let mut findings: Vec<(String, AuditFinding)> = Vec::new();
     for slug in &slugs {
-        let raw = actions
-            .run_gh(&[
-                "api".to_owned(),
-                format!("repos/{slug}/actions/runners?per_page=100"),
-            ])
-            .map_err(|e| CliFailure::new(2, format!("failed to list runners for {slug}: {e}")))?;
-        let parsed = parse_runners_response(&raw).map_err(|e| CliFailure::new(2, e))?;
+        let runners = fetch_all_runners(actions, slug)?;
         let repo_short = short_repo(slug);
-        for finding in audit_runners(repo_short, &parsed.runners) {
+        for finding in audit_runners(repo_short, &runners) {
             findings.push((repo_short.to_owned(), finding));
         }
     }


### PR DESCRIPTION
Two findings from the automated Codex reviewer on PRs #327 and #329:

- P1 (#329): `reroute-watch --apply` shelled `shipyard cloud retarget …
  --repo <repo>`, but `cloud retarget` has no `--repo` flag, so clap
  rejected the child and every applied reroute failed before draining the
  job. Drop `--repo`; `cloud retarget` resolves the repo from cwd/ship-state
  (so `--apply` must run inside the target repo's checkout — documented).
- P2 (#327): `runner audit` fetched only the first page of runners
  (`?per_page=100`), so it could report success while drift existed on later
  pages. Add a paginated `fetch_all_runners` (`gh api --paginate … --jq
  .runners[]`) and route audit, list, AND register's index-continuation
  (`existing_runner_names`, same latent bug → index collisions) through it.

ci + shipyard SKILL.md note the pagination + the `--apply` in-repo rule.

Refs #316

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>