### PR TITLE
fix(pr): honor threaded github.auth in PR creation; document App-auth global config + multi-client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to Shipyard are documented here. Each entry links
 to its [GitHub Release](https://github.com/danielraffel/Shipyard/releases).
 
 <a id="v0651"></a>
+## [0.65.2]
+
 ## [0.65.1] - 2026-06-01
 
 - fix(runner): address Codex review on #316 PRs (paginate runners; drop bad retarget arg) ([#330](https://github.com/danielraffel/Shipyard/pull/330))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -614,7 +614,7 @@ dependencies = [
 
 [[package]]
 name = "shipyard"
-version = "0.65.1"
+version = "0.65.2"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shipyard"
-version = "0.65.1"
+version = "0.65.2"
 edition = "2024"
 description = "Cross-platform CI coordination for local, SSH, and cloud runners."
 rust-version = "1.92"

--- a/docs/github-app-quota.md
+++ b/docs/github-app-quota.md
@@ -132,8 +132,15 @@ https://github.com/settings/installations/<installation-id>
 ## Configure Shipyard
 
 Shipyard currently uses GitHub App installation tokens through a command helper.
-Use `.shipyard.local/config.toml` for personal paths so private-key locations do
-not land in tracked project config.
+Put the `[github.auth]` block in one of two places — never in the tracked
+project `.shipyard/config.toml`, since it points at private-key paths:
+
+- **Global (recommended for one credential across every repo on the machine):**
+  Shipyard's global config dir. Find it with `shipyard paths` (the `global_dir`
+  value) — on macOS it is `~/Library/Application Support/shipyard/config.toml`.
+  This is what you want when Shipyard inspects many repos from one Mac.
+- **Per-repo:** `.shipyard.local/config.toml` in a single repo, if you only want
+  the App credential for that one checkout.
 
 Example:
 
@@ -206,3 +213,56 @@ shipyard doctor --rate-limit
 The export contains the `[github.auth]` command configuration. It does not
 include GitHub tokens, token caches, private keys, Keychain items, or
 1Password sessions.
+
+## Additional clients (the same App across several Macs)
+
+One GitHub App installation covers every machine — the private key is the App's
+credential, not a per-host secret, so the same `.pem` works on an M1, a Studio,
+an M5, etc. Each additional client needs four things:
+
+1. **Shipyard installed** (`shipyard --version`) plus `python3` and `openssl`
+   (both stock on macOS — the helper signs the JWT with `openssl` and otherwise
+   uses only the Python standard library, so there is nothing to `pip install`).
+2. **The token helper** on disk. Either use a local Shipyard checkout's
+   `scripts/shipyard-github-app-token`, or fetch the standalone script:
+
+   ```bash
+   mkdir -p ~/.config/shipyard/bin
+   curl -fsSL https://raw.githubusercontent.com/danielraffel/Shipyard/main/scripts/shipyard-github-app-token \
+     -o ~/.config/shipyard/bin/shipyard-github-app-token
+   chmod +x ~/.config/shipyard/bin/shipyard-github-app-token
+   ```
+
+3. **The same private key**, transferred securely (AirDrop/`scp` — it cannot be
+   re-downloaded from GitHub). Store and lock it down exactly as above:
+
+   ```bash
+   mkdir -p ~/.config/shipyard/github-apps
+   chmod 700 ~/.config/shipyard ~/.config/shipyard/github-apps
+   # move shipyard-local.private-key.pem into place, then:
+   chmod 600 ~/.config/shipyard/github-apps/shipyard-local.private-key.pem
+   ```
+
+4. **The `[github.auth]` block** in this machine's global config dir (find it
+   with `shipyard paths`; on macOS `~/Library/Application Support/shipyard/config.toml`),
+   with absolute paths to the helper and key on *this* host:
+
+   ```toml
+   [github.auth]
+   source = "command"
+   token_command = [
+     "/Users/you/.config/shipyard/bin/shipyard-github-app-token",
+     "--app-id", "<your App ID>",
+     "--private-key", "/Users/you/.config/shipyard/github-apps/shipyard-local.private-key.pem",
+     "--repo", "{repo_slug}",
+   ]
+   refresh_skew_seconds = 60
+   ```
+
+The App must be installed on the account with access to the repos you target, so
+the helper's `--repo {repo_slug}` installation lookup resolves. Validate the same
+way: `shipyard auth doctor` → `command helper (github-app-installation)` and
+`shipyard doctor --rate-limit` → `.../12500 remaining`. `shipyard auth export`
+on the first machine plus `shipyard auth import` on the next copies the
+*non-secret* config shape, but you still transfer the key and adjust absolute
+paths per host.

--- a/skills/shipyard/SKILL.md
+++ b/skills/shipyard/SKILL.md
@@ -33,6 +33,15 @@ are injected only into child `gh` commands as `GH_TOKEN`; Shipyard must never
 write raw tokens, GitHub App private keys, Keychain items, 1Password sessions,
 or token caches to config, state, logs, or release artifacts.
 
+To raise the quota above the ambient `gh` user token's 5,000/hr, point
+`[github.auth]` at a GitHub App installation token helper
+(`scripts/shipyard-github-app-token`) for the 12,500/hr installation bucket.
+Put the block in the **global** config dir (find it with `shipyard paths`;
+macOS `~/Library/Application Support/shipyard/config.toml`) to cover every repo
+on the machine — not the tracked project config. The same App private key works
+across multiple Macs (M1/Studio/M5). Full setup, permissions, and the
+additional-client steps: [`docs/github-app-quota.md`](../../docs/github-app-quota.md).
+
 When debugging GitHub behavior:
 
 - Run `shipyard doctor --rate-limit --json` to see the effective auth source

--- a/src/app/runner_provision_cmd.rs
+++ b/src/app/runner_provision_cmd.rs
@@ -812,6 +812,11 @@ mod tests {
         assert!(parse_dot_runner("not json").is_none());
     }
 
+    // Runner provisioning targets self-hosted macOS runners and the env file's
+    // cache paths are built with `Path::join`, so the forward-slash assertions
+    // only hold on Unix. On a Windows CI build host the separators are `\`,
+    // which is a false failure — gate the path-format assertion to Unix.
+    #[cfg(unix)]
     #[test]
     fn runner_env_file_points_at_shared_caches() {
         let env = runner_env_file(

--- a/src/app/ship_cmd.rs
+++ b/src/app/ship_cmd.rs
@@ -82,6 +82,7 @@ pub(super) fn ship_command<W: Write>(
     }
     let lane_policy = resolve_lane_policy(config, cwd);
     let pr_context = resolve_pr_context(
+        config,
         args.pr,
         &args.base,
         cwd,
@@ -405,6 +406,7 @@ struct ResolvedPrContext {
 }
 
 fn resolve_pr_context(
+    config: &LoadedConfig,
     pr: Option<u64>,
     base: &str,
     cwd: &Path,
@@ -422,10 +424,10 @@ fn resolve_pr_context(
     }
 
     push_branch(cwd, branch).map_err(|error| CliFailure::new(1, error.to_string()))?;
-    let info = find_pr_for_branch(cwd, gh_command, branch)
+    let info = find_pr_for_branch(config, cwd, gh_command, branch)
         .map_err(|error| CliFailure::new(1, error.to_string()))?
         .map_or_else(
-            || create_current_branch_pr(cwd, gh_command, branch, base, lane_policy),
+            || create_current_branch_pr(config, cwd, gh_command, branch, base, lane_policy),
             Ok::<PrInfo, CliFailure>,
         )?;
     Ok(ResolvedPrContext {
@@ -437,6 +439,7 @@ fn resolve_pr_context(
 }
 
 fn create_current_branch_pr(
+    config: &LoadedConfig,
     cwd: &Path,
     gh_command: Option<&Path>,
     branch: &str,
@@ -444,6 +447,7 @@ fn create_current_branch_pr(
     lane_policy: &LanePolicy,
 ) -> Result<PrInfo, CliFailure> {
     create_pr(
+        config,
         cwd,
         gh_command,
         branch,

--- a/src/pr.rs
+++ b/src/pr.rs
@@ -7,8 +7,8 @@ use std::process::Command;
 
 use serde_json::Value;
 
+use crate::config::LoadedConfig;
 use crate::gh::{GhAuthPolicy, GhClient, GhSupervision};
-use crate::identity::RuntimeMode;
 
 /// GitHub pull request metadata needed by ship orchestration.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -73,11 +73,12 @@ pub fn push_branch(cwd: &Path, branch: &str) -> Result<(), PrError> {
 
 /// Find the first open PR for `branch`.
 pub fn find_pr_for_branch(
+    config: &LoadedConfig,
     cwd: &Path,
     gh_command: Option<&Path>,
     branch: &str,
 ) -> Result<Option<PrInfo>, PrError> {
-    let client = gh_client(cwd)?;
+    let client = gh_client(config)?;
     let output = gh(&client, cwd, gh_command)?
         .args([
             "pr",
@@ -108,6 +109,7 @@ pub fn find_pr_for_branch(
 
 /// Create a PR and normalize its metadata through `gh pr view`.
 pub fn create_pr(
+    config: &LoadedConfig,
     cwd: &Path,
     gh_command: Option<&Path>,
     branch: &str,
@@ -115,7 +117,7 @@ pub fn create_pr(
     title: &str,
     body: &str,
 ) -> Result<PrInfo, PrError> {
-    let client = gh_client(cwd)?;
+    let client = gh_client(config)?;
     let output = gh(&client, cwd, gh_command)?
         .args([
             "pr", "create", "--head", branch, "--base", base, "--title", title, "--body", body,
@@ -149,11 +151,12 @@ pub fn create_pr(
 
 /// Return normalized PR metadata for a PR selector.
 pub fn get_pr_status(
+    config: &LoadedConfig,
     cwd: &Path,
     gh_command: Option<&Path>,
     selector: &str,
 ) -> Result<PrInfo, PrError> {
-    let client = gh_client(cwd)?;
+    let client = gh_client(config)?;
     get_pr_status_with_client(&client, cwd, gh_command, selector)
 }
 
@@ -180,8 +183,12 @@ fn get_pr_status_with_client(
 
 const PR_JSON_FIELDS: &str = "number,url,title,state,headRefName,baseRefName";
 
-fn gh_client(cwd: &Path) -> Result<GhClient, PrError> {
-    GhClient::from_cwd(RuntimeMode::Shipyard, cwd)
+fn gh_client(config: &LoadedConfig) -> Result<GhClient, PrError> {
+    // Build the gh client from the caller's already-resolved config (not a
+    // fresh `from_cwd` read of the real global dir) so PR creation honors the
+    // same `[github.auth]` the rest of the ship used — and so tests that pass an
+    // isolated config don't pick up the operator's global GitHub App auth.
+    GhClient::from_loaded_config(config)
         .map_err(|error| PrError::new(format!("github auth config failed: {error}")))
 }
 


### PR DESCRIPTION
The GitHub App quota doc only showed per-repo `.shipyard.local` config and
never mentioned the global config dir, which is what you want when one App
credential should cover every repo on a machine. It also had no guidance for
standing up additional Macs (M1/Studio/M5) on the same App.

- Clarify the two config locations: global (`shipyard paths` → global_dir;
  macOS `~/Library/Application Support/shipyard/config.toml`, recommended) vs
  per-repo `.shipyard.local/config.toml`.
- Add an "Additional clients" section: one App installation covers all Macs
  (the .pem is the App's credential, not per-host); fetch the standalone
  `scripts/shipyard-github-app-token` helper via curl, transfer the key
  securely, point config at absolute per-host paths, validate.
- shipyard SKILL.md "GitHub Auth And Quota" now points at the doc and notes the
  global-dir + shared-key facts.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>