### PR TITLE
fix(reroute): fail fast on cross-repo --apply (Codex review on #330)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to Shipyard are documented here. Each entry links
 to its [GitHub Release](https://github.com/danielraffel/Shipyard/releases).
 
 <a id="v0652"></a>
+## [0.65.3]
+
 ## [0.65.2] - 2026-06-01
 
 - fix(pr): honor threaded github.auth in PR creation; document App-auth global config + multi-client ([#331](https://github.com/danielraffel/Shipyard/pull/331))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -614,7 +614,7 @@ dependencies = [
 
 [[package]]
 name = "shipyard"
-version = "0.65.2"
+version = "0.65.3"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shipyard"
-version = "0.65.2"
+version = "0.65.3"
 edition = "2024"
 description = "Cross-platform CI coordination for local, SSH, and cloud runners."
 rust-version = "1.92"

--- a/skills/shipyard/SKILL.md
+++ b/skills/shipyard/SKILL.md
@@ -288,7 +288,9 @@ cloud retarget … --provider local --apply`, which works for PRs Shipyard is
 shipping (ship-state-backed). `cloud retarget` has no `--repo` flag — it
 resolves the repo from the current checkout — so run `reroute-watch --apply`
 inside the target repo's checkout (its `--repo` only scopes which queued runs
-are listed, not where the reroute acts). **Follow-up (Part C.2):** rerouting a PR with no
+are listed, not where the reroute acts). To prevent retargeting the wrong repo,
+`--apply` **fails fast** when the monitored `--repo` doesn't match the checkout;
+observe mode may monitor any repo. **Follow-up (Part C.2):** rerouting a PR with no
 ship-state, and spinning an ephemeral JIT VM runner on a free-slot host (drive
 Pulp's `tart-run-job.sh` equivalent) — until then a persistent host-class runner
 handles pickup. Full design: `planning/2026-06-01-multi-mac-controller.md`.

--- a/src/app/reroute_cmd.rs
+++ b/src/app/reroute_cmd.rs
@@ -67,6 +67,25 @@ pub(super) fn reroute_watch_command<W: Write>(
         None => super::runner_cmd::resolve_repo_slug(None, cwd)?,
     };
 
+    // `--apply` shells `cloud retarget`, which resolves its repo from cwd (no
+    // `--repo` flag). Refuse to act when the monitored repo isn't this checkout,
+    // or we'd retarget the same-numbered PR in the wrong repo. Observe mode is
+    // unaffected (it only lists candidates).
+    if args.apply {
+        let checkout_repo = super::runner_cmd::resolve_repo_slug(None, cwd)?;
+        if !crate::reroute::apply_repo_is_safe(true, &repo, &checkout_repo) {
+            return Err(CliFailure::new(
+                1,
+                format!(
+                    "--apply monitors {repo} but the current checkout is {checkout_repo}; \
+                     `cloud retarget` resolves the repo from cwd, so run `reroute-watch --apply` \
+                     inside the monitored repo's checkout (or drop --repo). Refusing to retarget \
+                     the wrong repo."
+                ),
+            ));
+        }
+    }
+
     let classes = parse_host_classes(&config.data).map_err(|e| CliFailure::new(2, e))?;
     if classes.is_empty() {
         return Err(CliFailure::new(

--- a/src/reroute.rs
+++ b/src/reroute.rs
@@ -135,6 +135,15 @@ pub fn macos_job_targets_cloud(labels_csv: &str) -> bool {
     CLOUD_MARKERS.iter().any(|marker| lower.contains(marker))
 }
 
+/// Whether `--apply` is safe to act: `cloud retarget` has no `--repo` flag and
+/// resolves its repo from the current checkout, so the monitored repo must match
+/// the checkout — otherwise an `--apply` reroute would target the same-numbered
+/// PR in the *wrong* repo. Observe mode (no apply) may freely monitor any repo.
+#[must_use]
+pub fn apply_repo_is_safe(apply: bool, monitored_repo: &str, checkout_repo: &str) -> bool {
+    !apply || monitored_repo.eq_ignore_ascii_case(checkout_repo)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -224,6 +233,20 @@ mod tests {
             "namespace-profile-generouscorp-macos"
         ));
         assert!(macos_job_targets_cloud("nscloud-macos"));
+    }
+
+    #[test]
+    fn apply_repo_guard_blocks_cross_repo_apply_only() {
+        // Observe mode: any monitored repo is fine.
+        assert!(apply_repo_is_safe(false, "owner/other", "owner/here"));
+        // Apply + matching repo (case-insensitive): safe.
+        assert!(apply_repo_is_safe(
+            true,
+            "danielraffel/Shipyard",
+            "danielraffel/shipyard"
+        ));
+        // Apply + different repo: unsafe (would retarget the wrong repo's PR).
+        assert!(!apply_repo_is_safe(true, "owner/other", "owner/here"));
     }
 
     #[test]


### PR DESCRIPTION
`reroute-watch --apply` shells `cloud retarget`, which has no `--repo` flag and
resolves its repo from cwd. So `--repo OTHER --apply` discovered candidates in
OTHER but would retarget the same-numbered PR in the *current* checkout — the
wrong repo. Add `apply_repo_is_safe` (pure, tested) and refuse `--apply` when
the monitored repo doesn't match the checkout, with a clear message to run
inside the monitored repo (or drop --repo). Observe mode is unaffected.

Addresses the P2 review comment on PR #330.

Refs #316

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Skill-Update: skip skill=ci reason="internal reroute cross-repo guard; shipyard SKILL.md updated, no ci surface change"