### PR TITLE
fix(reroute): compare --apply guard against the effective dispatch repo (Codex review on #332)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to Shipyard are documented here. Each entry links
 to its [GitHub Release](https://github.com/danielraffel/Shipyard/releases).
 
 <a id="v0653"></a>
+## [0.65.4]
+
 ## [0.65.3] - 2026-06-01
 
 - fix(reroute): fail fast on cross-repo --apply (Codex review on #330) ([#332](https://github.com/danielraffel/Shipyard/pull/332))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -614,7 +614,7 @@ dependencies = [
 
 [[package]]
 name = "shipyard"
-version = "0.65.3"
+version = "0.65.4"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shipyard"
-version = "0.65.3"
+version = "0.65.4"
 edition = "2024"
 description = "Cross-platform CI coordination for local, SSH, and cloud runners."
 rust-version = "1.92"

--- a/skills/shipyard/SKILL.md
+++ b/skills/shipyard/SKILL.md
@@ -289,7 +289,9 @@ shipping (ship-state-backed). `cloud retarget` has no `--repo` flag — it
 resolves the repo from the current checkout — so run `reroute-watch --apply`
 inside the target repo's checkout (its `--repo` only scopes which queued runs
 are listed, not where the reroute acts). To prevent retargeting the wrong repo,
-`--apply` **fails fast** when the monitored `--repo` doesn't match the checkout;
+`--apply` **fails fast** unless the monitored `--repo` matches the repo
+`cloud retarget` will dispatch to — the `[cloud].repository` override if set,
+otherwise the checkout (so a configured cross-repo controller setup is allowed);
 observe mode may monitor any repo. **Follow-up (Part C.2):** rerouting a PR with no
 ship-state, and spinning an ephemeral JIT VM runner on a free-slot host (drive
 Pulp's `tart-run-job.sh` equivalent) — until then a persistent host-class runner

--- a/src/app/reroute_cmd.rs
+++ b/src/app/reroute_cmd.rs
@@ -67,20 +67,24 @@ pub(super) fn reroute_watch_command<W: Write>(
         None => super::runner_cmd::resolve_repo_slug(None, cwd)?,
     };
 
-    // `--apply` shells `cloud retarget`, which resolves its repo from cwd (no
-    // `--repo` flag). Refuse to act when the monitored repo isn't this checkout,
-    // or we'd retarget the same-numbered PR in the wrong repo. Observe mode is
-    // unaffected (it only lists candidates).
+    // `--apply` shells `cloud retarget`, which has no `--repo` flag and dispatches
+    // to its *effective* repo: the `[cloud].repository` override if set, else the
+    // current checkout. Refuse to act when the monitored repo isn't that dispatch
+    // target, or we'd retarget the same-numbered PR in the wrong repo. A
+    // configured `[cloud].repository` that matches `--repo` is a supported
+    // cross-repo controller setup and is allowed. Observe mode is unaffected.
     if args.apply {
-        let checkout_repo = super::runner_cmd::resolve_repo_slug(None, cwd)?;
-        if !crate::reroute::apply_repo_is_safe(true, &repo, &checkout_repo) {
+        let dispatch_repo = match config.get_str("cloud.repository") {
+            Some(configured) => configured.to_owned(),
+            None => super::runner_cmd::resolve_repo_slug(None, cwd)?,
+        };
+        if !crate::reroute::apply_repo_is_safe(true, &repo, &dispatch_repo) {
             return Err(CliFailure::new(
                 1,
                 format!(
-                    "--apply monitors {repo} but the current checkout is {checkout_repo}; \
-                     `cloud retarget` resolves the repo from cwd, so run `reroute-watch --apply` \
-                     inside the monitored repo's checkout (or drop --repo). Refusing to retarget \
-                     the wrong repo."
+                    "--apply monitors {repo} but `cloud retarget` would dispatch to {dispatch_repo} \
+                     (set `[cloud].repository` to {repo}, run inside that repo's checkout, or drop \
+                     --repo). Refusing to retarget the wrong repo."
                 ),
             ));
         }


### PR DESCRIPTION
The cross-repo guard compared the monitored `--repo` against the checkout
remote, but `cloud retarget` dispatches to its effective repo — the
`[cloud].repository` override if set, else the checkout. That rejected a
supported controller setup where `[cloud].repository == --repo` differs from the
checkout remote. Compare against the effective dispatch repo instead, so a
configured cross-repo controller can `--apply` while a genuine mismatch still
fails fast.

Addresses the P2 review comment on PR #332.

Refs #316

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Skill-Update: skip skill=ci reason="internal reroute dispatch-repo guard refinement; shipyard SKILL.md updated, no ci surface change"