### PR TITLE
fix(reroute): run the cloud-retarget child in the watcher's cwd (Codex review on #333)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to Shipyard are documented here. Each entry links
 to its [GitHub Release](https://github.com/danielraffel/Shipyard/releases).
 
 <a id="v0654"></a>
+## [0.65.5]
+
 ## [0.65.4] - 2026-06-01
 
 - fix(reroute): compare --apply guard against the effective dispatch repo (Codex review on #332) ([#333](https://github.com/danielraffel/Shipyard/pull/333))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -614,7 +614,7 @@ dependencies = [
 
 [[package]]
 name = "shipyard"
-version = "0.65.4"
+version = "0.65.5"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shipyard"
-version = "0.65.4"
+version = "0.65.5"
 edition = "2024"
 description = "Cross-platform CI coordination for local, SSH, and cloud runners."
 rust-version = "1.92"

--- a/src/app/reroute_cmd.rs
+++ b/src/app/reroute_cmd.rs
@@ -114,7 +114,7 @@ pub(super) fn reroute_watch_command<W: Write>(
     let mut ticks: u32 = 0;
     loop {
         // A failed tick (gh hiccup) logs and continues — never crash the loop.
-        if let Err(e) = tick(args, config, actions, &repo, &mut guard, json, stdout) {
+        if let Err(e) = tick(args, config, actions, &repo, cwd, &mut guard, json, stdout) {
             if json {
                 let mut data = BTreeMap::new();
                 data.insert("error".to_owned(), Value::from(e.message.clone()));
@@ -133,11 +133,13 @@ pub(super) fn reroute_watch_command<W: Write>(
 }
 
 /// One decision tick: probe capacity, list candidates, decide, log, optionally act.
+#[allow(clippy::too_many_arguments)]
 fn tick<W: Write>(
     args: &RerouteWatchArgs,
     config: &LoadedConfig,
     actions: &GitHubActions,
     repo: &str,
+    cwd: &Path,
     guard: &mut FlapGuard,
     json: bool,
     stdout: &mut W,
@@ -152,7 +154,7 @@ fn tick<W: Write>(
     // Perform the action (if applicable) before logging the outcome.
     let action = match &decision {
         RerouteDecision::Reroute(candidate) if args.apply => {
-            match perform_reroute(candidate, &args.target) {
+            match perform_reroute(candidate, &args.target, cwd) {
                 Ok(()) => {
                     guard.record(candidate.pr, now);
                     "rerouted".to_owned()
@@ -307,11 +309,13 @@ fn macos_job_labels(actions: &GitHubActions, repo: &str, run_id: u64) -> String 
 /// --apply` (reuses ship-state + dispatch safety). Mirrors Pulp's watcher
 /// shelling `pulp macos retarget`.
 ///
-/// `cloud retarget` has no `--repo` flag — it resolves the repo from the
-/// current checkout (cwd) and ship-state — so `reroute-watch --apply` must run
-/// inside the target repo's checkout. We deliberately do not pass `--repo`
-/// (clap would reject it and every reroute would fail before acting).
-fn perform_reroute(candidate: &RerouteCandidate, target: &str) -> Result<(), String> {
+/// `cloud retarget` has no `--repo` flag — it resolves the repo from its working
+/// directory + ship-state. We run the child in `cwd` (the same directory the
+/// watcher loaded its config from and the `--apply` guard validated against), so
+/// the child resolves the identical dispatch repo even under a global `--cwd`.
+/// We deliberately do not pass `--repo` (clap would reject it and every reroute
+/// would fail before acting).
+fn perform_reroute(candidate: &RerouteCandidate, target: &str, cwd: &Path) -> Result<(), String> {
     let exe = std::env::current_exe().unwrap_or_else(|_| "shipyard".into());
     let output = Command::new(exe)
         .args([
@@ -325,6 +329,7 @@ fn perform_reroute(candidate: &RerouteCandidate, target: &str) -> Result<(), Str
             "local",
             "--apply",
         ])
+        .current_dir(cwd)
         .output()
         .map_err(|e| format!("spawn failed: {e}"))?;
     if output.status.success() {


### PR DESCRIPTION
The `--apply` guard validates the dispatch repo from config loaded at the
watcher's cwd, but `perform_reroute` shelled `cloud retarget` without setting
`current_dir`, so under a global `--cwd` the child loaded config from the
process cwd and could retarget a different repo than the guard approved. Run the
child in the watcher's `cwd` so it resolves the identical dispatch repo.

Addresses the P2 review comment on PR #333.

Refs #316

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Skill-Update: skip skill=ci reason="internal reroute child-cwd fix; no CLI/skill surface change"
Skill-Update: skip skill=shipyard reason="internal reroute child-cwd fix; no CLI/skill surface change"