### PR TITLE
feat(config): config use --local + active-source provenance + ship-state repo_root

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "shipyard",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "description": "Cross-platform CI coordination",
   "min_shipyard_version": "0.22.8",
   "commands": "./commands",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -614,7 +614,7 @@ dependencies = [
 
 [[package]]
 name = "shipyard"
-version = "0.65.1"
+version = "0.66.0"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shipyard"
-version = "0.65.1"
+version = "0.66.0"
 edition = "2024"
 description = "Cross-platform CI coordination for local, SSH, and cloud runners."
 rust-version = "1.92"

--- a/commands/config.md
+++ b/commands/config.md
@@ -3,19 +3,39 @@ name: config
 description: Inspect Shipyard configuration files and effective cloud defaults
 ---
 
-Shipyard does not have a `shipyard config` subcommand yet.
+`shipyard config` inspects configuration and switches the active profile.
 
-Use these entry points instead:
+Subcommands:
 
-- Project config: `.shipyard/config.toml`
-- Machine-local overrides: `.shipyard.local/config.toml`
-- Environment and tool health: `shipyard doctor --json`
-- Effective cloud workflow/provider resolution: `shipyard cloud defaults --json`
-- Active job and target state: `shipyard status --json`
+- `shipyard config show` — print the effective merged configuration (global →
+  tracked `.shipyard/config.toml` → local `.shipyard.local/config.toml`).
+- `shipyard config profiles` — list defined profiles and which one is active.
+  The `--json` form also reports `active_source`
+  (`local` | `tracked` | `global` | `none`) plus the resolved config paths, so a
+  tool can tell whether the active profile is a per-machine override or the repo
+  default.
+- `shipyard config use <profile>` — switch the active profile by writing
+  `[project].profile` to the **tracked** `.shipyard/config.toml` (a committed,
+  everyone change).
+- `shipyard config use <profile> --local` — switch it for **this machine only**
+  by writing the **local overlay** `.shipyard.local/config.toml` instead; the
+  tracked config is left untouched, so the switch never affects collaborators.
+  In a git worktree this writes the current checkout's own overlay, not a
+  borrowed main-checkout one.
 
 If the user asks to "switch profiles", "go local", or "go cloud", use
 `shipyard config profiles` to inspect options and `shipyard config use <profile>`
-to switch an existing profile.
+(add `--local` to keep the switch per-machine).
+
+> GitHub repo Variables that route *everyone's* CI (e.g.
+> `PULP_LOCAL_MACOS_RUNS_ON_JSON`) are a separate, repo-wide layer — manage those
+> with `gh variable`, not `shipyard config`.
+
+Other entry points:
+
+- Environment and tool health: `shipyard doctor --json`
+- Effective cloud workflow/provider resolution: `shipyard cloud defaults --json`
+- Active job and target state: `shipyard status --json`
 
 Examples:
 

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -35,6 +35,24 @@ $ shipyard config use normal         # Mac + GitHub-hosted cloud
 $ shipyard config use full           # Mac + VMs + cloud fallback
 ```
 
+### Per-machine switching (`--local`)
+
+`config use` writes the **tracked** `.shipyard/config.toml` — a committed change
+that switches the profile for everyone. To switch only for **your machine**, add
+`--local`:
+
+```bash
+$ shipyard config use cloud --local  # this machine ships via cloud; repo default unchanged
+```
+
+`--local` writes the active profile to the gitignored `.shipyard.local/config.toml`
+overlay, which merges over the tracked config. Collaborators are unaffected, and
+nothing shows up in `git status`. `config profiles --json` reports
+`active_source` (`local` | `tracked` | `global`) so tooling (e.g. the menu-bar
+app) can show whether you're on a per-machine override or the repo default. In a
+git worktree, `--local` writes the current checkout's own overlay rather than a
+borrowed main-checkout overlay.
+
 ## See what's active
 
 ```bash

--- a/skills/ci/SKILL.md
+++ b/skills/ci/SKILL.md
@@ -574,6 +574,17 @@ When multiple jobs are queued (common with parallel worktrees):
 - `shipyard bump <id> low` — deprioritize a job
 - `shipyard cancel <id>` — cancel a pending or running job
 
+## Profiles (`config use`, and `--local` for per-machine)
+
+`shipyard config use <profile>` switches the active validation profile by writing
+the tracked `.shipyard/config.toml`. Add `--local` to switch it for **this
+machine only** (writes the gitignored `.shipyard.local/config.toml` overlay,
+leaving the committed config untouched) — use this on a machine that should
+validate differently (e.g. a VM-only laptop routing to cloud) without changing CI
+for collaborators. `config use ... --json` and `config profiles --json` report
+`active_source` (`local`/`tracked`/`global`) so tooling can show which is in
+effect. See the `shipyard` skill for the full profile/routing model.
+
 ## Target configuration
 
 Targets are defined in `.shipyard/config.toml`:

--- a/skills/shipyard/SKILL.md
+++ b/skills/shipyard/SKILL.md
@@ -159,6 +159,25 @@ watch_interval_seconds = 300
 auto_fix = false
 ```
 
+## Profiles & per-machine routing
+
+`shipyard config profiles` lists profiles + the active one; `config use <profile>`
+switches it. The `--json` form reports `active_source` (`local` | `tracked` |
+`global` | `none`) and the resolved config paths.
+
+- `config use <profile>` writes the **tracked** `.shipyard/config.toml` — changes
+  the active profile for everyone (a committed change).
+- `config use <profile> --local` writes the per-machine `.shipyard.local/config.toml`
+  overlay instead: switches routing for **this machine only**, tracked config
+  untouched, nothing in `git status`. In a git worktree it writes the current
+  checkout's own overlay, never a borrowed main-checkout one.
+- `repo_root` now rides in `ship-state list --json` so a GUI (the menu-bar app)
+  can run repo-scoped config commands in the right checkout dir.
+
+GitHub repo Variables that route *everyone's* CI (e.g.
+`PULP_LOCAL_MACOS_RUNS_ON_JSON`) are a separate, repo-wide layer — manage those
+with `gh variable`, not `shipyard config`.
+
 ## Runner Provisioning (register / list / remove / tag)
 
 The `runner` family also *provisions* self-hosted GitHub Actions runners, not

--- a/src/app.rs
+++ b/src/app.rs
@@ -1317,6 +1317,170 @@ mod tests {
     }
 
     #[test]
+    fn config_use_local_creates_overlay_and_preserves_tracked_config() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let project_dir = temp.path().join(".shipyard");
+        let tracked = project_dir.join("config.toml");
+        std::fs::create_dir_all(&project_dir).expect("project dir");
+        std::fs::write(
+            &tracked,
+            r#"
+            [project]
+            profile = "fast"
+
+            [profiles.fast]
+            targets = ["mac"]
+
+            [profiles.full]
+            targets = ["mac", "linux"]
+            "#,
+        )
+        .expect("config");
+        let tracked_before = std::fs::read_to_string(&tracked).expect("read tracked");
+
+        let cli = Cli::parse_from([
+            "shipyard",
+            "--json",
+            "--cwd",
+            temp.path().to_str().expect("temp path"),
+            "config",
+            "use",
+            "full",
+            "--local",
+        ]);
+        let mut stdout = Vec::new();
+        let mut stderr = Vec::new();
+        let code = run_with(cli, &mut stdout, &mut stderr);
+
+        assert_eq!(code, ExitCode::SUCCESS);
+        assert!(stderr.is_empty());
+        let value: Value = serde_json::from_slice(&stdout).expect("json");
+        assert_eq!(value["command"], "config.use");
+        assert_eq!(value["scope"], "local");
+        assert_eq!(value["active_source"], "local");
+
+        // Central locked decision: the tracked config is byte-for-byte unchanged.
+        assert_eq!(
+            std::fs::read_to_string(&tracked).expect("read tracked after"),
+            tracked_before
+        );
+        // The per-machine overlay is created with the chosen profile.
+        let overlay = temp.path().join(".shipyard.local").join("config.toml");
+        let overlay_text = std::fs::read_to_string(&overlay).expect("read overlay");
+        assert!(overlay_text.contains("profile = \"full\""));
+    }
+
+    #[test]
+    fn config_profiles_json_reports_active_source_local_over_tracked() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let project_dir = temp.path().join(".shipyard");
+        std::fs::create_dir_all(&project_dir).expect("project dir");
+        std::fs::write(
+            project_dir.join("config.toml"),
+            r#"
+            [project]
+            profile = "fast"
+
+            [profiles.fast]
+            targets = ["mac"]
+
+            [profiles.full]
+            targets = ["mac", "linux"]
+            "#,
+        )
+        .expect("tracked");
+        let local_dir = temp.path().join(".shipyard.local");
+        std::fs::create_dir_all(&local_dir).expect("local dir");
+        std::fs::write(
+            local_dir.join("config.toml"),
+            "[project]\nprofile = \"full\"\n",
+        )
+        .expect("local");
+
+        let cli = Cli::parse_from([
+            "shipyard",
+            "--json",
+            "--cwd",
+            temp.path().to_str().expect("temp path"),
+            "config",
+            "profiles",
+        ]);
+        let mut stdout = Vec::new();
+        let mut stderr = Vec::new();
+        let code = run_with(cli, &mut stdout, &mut stderr);
+
+        assert_eq!(code, ExitCode::SUCCESS);
+        let value: Value = serde_json::from_slice(&stdout).expect("json");
+        assert_eq!(value["active"], "full");
+        assert_eq!(value["active_source"], "local");
+        assert_eq!(value["local_overlay_source"], "direct");
+    }
+
+    #[test]
+    fn config_profiles_json_reports_tracked_active_source() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let project_dir = temp.path().join(".shipyard");
+        std::fs::create_dir_all(&project_dir).expect("project dir");
+        std::fs::write(
+            project_dir.join("config.toml"),
+            "[project]\nprofile = \"fast\"\n\n[profiles.fast]\ntargets = [\"mac\"]\n",
+        )
+        .expect("tracked");
+
+        let cli = Cli::parse_from([
+            "shipyard",
+            "--json",
+            "--cwd",
+            temp.path().to_str().expect("temp path"),
+            "config",
+            "profiles",
+        ]);
+        let mut stdout = Vec::new();
+        let mut stderr = Vec::new();
+        let code = run_with(cli, &mut stdout, &mut stderr);
+
+        assert_eq!(code, ExitCode::SUCCESS);
+        let value: Value = serde_json::from_slice(&stdout).expect("json");
+        assert_eq!(value["active"], "fast");
+        assert_eq!(value["active_source"], "tracked");
+    }
+
+    #[test]
+    fn config_use_local_rejects_unknown_profile_without_writing() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let project_dir = temp.path().join(".shipyard");
+        std::fs::create_dir_all(&project_dir).expect("project dir");
+        std::fs::write(
+            project_dir.join("config.toml"),
+            "[profiles.fast]\ntargets = [\"mac\"]\n",
+        )
+        .expect("tracked");
+
+        let cli = Cli::parse_from([
+            "shipyard",
+            "--cwd",
+            temp.path().to_str().expect("temp path"),
+            "config",
+            "use",
+            "nope",
+            "--local",
+        ]);
+        let mut stdout = Vec::new();
+        let mut stderr = Vec::new();
+        let code = run_with(cli, &mut stdout, &mut stderr);
+
+        assert_ne!(code, ExitCode::SUCCESS);
+        // Rejected before any write: no overlay created.
+        assert!(
+            !temp
+                .path()
+                .join(".shipyard.local")
+                .join("config.toml")
+                .exists()
+        );
+    }
+
+    #[test]
     fn queue_json_reports_empty_state() {
         let temp = tempfile::tempdir().expect("tempdir");
         let cli = Cli::parse_from([

--- a/src/app/cli.rs
+++ b/src/app/cli.rs
@@ -632,6 +632,11 @@ pub(super) enum ConfigCommand {
     Use {
         /// Profile name to activate.
         profile_name: String,
+        /// Write the active profile to the per-machine repo overlay
+        /// (`.shipyard.local/config.toml`) instead of the tracked config, so the
+        /// switch is local to this machine and never dirties committed config.
+        #[arg(long)]
+        local: bool,
     },
 }
 

--- a/src/app/config_cmd.rs
+++ b/src/app/config_cmd.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 use std::fs;
 use std::io::Write;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
 use serde::Serialize;
@@ -9,8 +9,8 @@ use serde_json::Value;
 use toml::{Table, Value as TomlValue};
 
 use super::{CliFailure, cli::ConfigCommand};
-use crate::config::LoadedConfig;
-use crate::identity::RuntimeMode;
+use crate::config::{LoadedConfig, LocalOverlaySource};
+use crate::identity::{ProductIdentity, RuntimeMode};
 use crate::output::{write_json_envelope, write_pretty_json};
 
 pub(super) fn config_command<W: Write>(
@@ -25,7 +25,10 @@ pub(super) fn config_command<W: Write>(
     match command.unwrap_or(ConfigCommand::Show) {
         ConfigCommand::Show => config_show(&config, json, stdout)?,
         ConfigCommand::Profiles => config_profiles(&config, json, stdout)?,
-        ConfigCommand::Use { profile_name } => config_use(&config, &profile_name, json, stdout)?,
+        ConfigCommand::Use {
+            profile_name,
+            local,
+        } => config_use(&config, mode, cwd, &profile_name, local, json, stdout)?,
     }
     Ok(ExitCode::SUCCESS)
 }
@@ -57,8 +60,8 @@ fn config_profiles<W: Write>(
     stdout: &mut W,
 ) -> Result<(), CliFailure> {
     let rows = profile_rows(config);
-    let active = active_profile(config);
     if json {
+        let provenance = resolve_active_profile_provenance(config);
         let mut data = BTreeMap::new();
         data.insert(
             "profiles".to_owned(),
@@ -66,9 +69,33 @@ fn config_profiles<W: Write>(
         );
         data.insert(
             "active".to_owned(),
-            active
+            provenance
+                .profile
                 .as_ref()
                 .map_or(Value::Null, |profile| Value::String(profile.clone())),
+        );
+        data.insert(
+            "active_source".to_owned(),
+            Value::String(provenance.source.to_owned()),
+        );
+        data.insert("active_path".to_owned(), path_value(provenance.path.as_ref()));
+        data.insert(
+            "local_overlay_source".to_owned(),
+            Value::String(local_overlay_source_str(config.local_overlay_source).to_owned()),
+        );
+        data.insert(
+            "local_overlay_path".to_owned(),
+            path_value(config.local_dir.as_ref().map(|d| d.join("config.toml")).as_ref()),
+        );
+        data.insert(
+            "tracked_config_path".to_owned(),
+            path_value(
+                config
+                    .project_dir
+                    .as_ref()
+                    .map(|d| d.join("config.toml"))
+                    .as_ref(),
+            ),
         );
         write_json_envelope(stdout, "config.profiles", data)
             .map_err(|error| CliFailure::new(1, error.to_string()))?;
@@ -101,7 +128,10 @@ fn config_profiles<W: Write>(
 
 fn config_use<W: Write>(
     config: &LoadedConfig,
+    mode: RuntimeMode,
+    cwd: &Path,
     profile_name: &str,
+    local: bool,
     json: bool,
     stdout: &mut W,
 ) -> Result<(), CliFailure> {
@@ -129,22 +159,55 @@ fn config_use<W: Write>(
         ));
     }
 
-    let config_path = project_dir.join("config.toml");
-    rewrite_profile_in_config(&config_path, profile_name)?;
+    // `--local` writes the per-machine overlay for THIS checkout, never the
+    // committed tracked config and never a borrowed worktree-fallback overlay.
+    let (config_path, scope) = if local {
+        (local_overlay_config_path(mode, cwd, config), "local")
+    } else {
+        (project_dir.join("config.toml"), "tracked")
+    };
+    upsert_profile_in_config(&config_path, profile_name)?;
     if json {
         let mut data = BTreeMap::new();
         data.insert("profile".to_owned(), Value::String(profile_name.to_owned()));
+        data.insert("scope".to_owned(), Value::String(scope.to_owned()));
+        data.insert(
+            "path".to_owned(),
+            Value::String(config_path.display().to_string()),
+        );
+        data.insert(
+            "active_source".to_owned(),
+            Value::String(scope.to_owned()),
+        );
         write_json_envelope(stdout, "config.use", data)
             .map_err(|error| CliFailure::new(1, error.to_string()))?;
     } else {
         writeln!(
             stdout,
-            "Switched to profile '{profile_name}' in {}",
+            "Switched to profile '{profile_name}' ({scope}) in {}",
             config_path.display()
         )
         .map_err(|error| CliFailure::new(1, error.to_string()))?;
     }
     Ok(())
+}
+
+/// Resolve the per-machine local-overlay `config.toml` write path for this
+/// checkout. Mirrors `auth_cmd::config_path_for_scope`'s Local arm: use the
+/// directly-resolved overlay when present, otherwise the current checkout's own
+/// overlay dir — never a borrowed worktree-fallback overlay.
+fn local_overlay_config_path(mode: RuntimeMode, cwd: &Path, config: &LoadedConfig) -> PathBuf {
+    let identity = ProductIdentity::for_mode(mode);
+    let dir = match config.local_overlay_source {
+        LocalOverlaySource::Direct => config
+            .local_dir
+            .clone()
+            .unwrap_or_else(|| cwd.join(identity.local_overlay_dir_name)),
+        LocalOverlaySource::WorktreeFallback | LocalOverlaySource::None => {
+            cwd.join(identity.local_overlay_dir_name)
+        }
+    };
+    dir.join("config.toml")
 }
 
 #[derive(Debug, Eq, PartialEq, Serialize)]
@@ -238,12 +301,93 @@ fn active_profile(config: &LoadedConfig) -> Option<String> {
         .map(ToOwned::to_owned)
 }
 
-fn rewrite_profile_in_config(config_path: &Path, profile_name: &str) -> Result<(), CliFailure> {
-    let contents =
-        fs::read_to_string(config_path).map_err(|error| CliFailure::new(1, error.to_string()))?;
-    let mut table = contents
-        .parse::<Table>()
-        .map_err(|error| CliFailure::new(1, error.to_string()))?;
+struct ActiveProvenance {
+    profile: Option<String>,
+    source: &'static str,
+    path: Option<PathBuf>,
+}
+
+/// Report the effective active profile (merged, non-empty) AND which config layer
+/// supplied it, by re-reading each layer's raw `[project].profile`. Precedence
+/// matches the merge order: local overlay > tracked project > global. Keeping the
+/// reported `active` equal to `active_profile(config)` ensures CLI output never
+/// disagrees with effective runtime config.
+fn resolve_active_profile_provenance(config: &LoadedConfig) -> ActiveProvenance {
+    let Some(active) = active_profile(config) else {
+        return ActiveProvenance {
+            profile: None,
+            source: "none",
+            path: None,
+        };
+    };
+    let layers: [(Option<PathBuf>, &'static str); 3] = [
+        (
+            config.local_dir.as_ref().map(|d| d.join("config.toml")),
+            "local",
+        ),
+        (
+            config.project_dir.as_ref().map(|d| d.join("config.toml")),
+            "tracked",
+        ),
+        (Some(config.global_dir.join("config.toml")), "global"),
+    ];
+    for (path, source) in layers {
+        if let Some(path) = path
+            && raw_project_profile(&path).as_deref() == Some(active.as_str())
+        {
+            return ActiveProvenance {
+                profile: Some(active),
+                source,
+                path: Some(path),
+            };
+        }
+    }
+    // Active is set in merged data but no raw layer matched (unexpected).
+    ActiveProvenance {
+        profile: Some(active),
+        source: "unknown",
+        path: None,
+    }
+}
+
+/// Read the raw, non-empty `[project].profile` string from a single config file.
+fn raw_project_profile(path: &Path) -> Option<String> {
+    let table = fs::read_to_string(path).ok()?.parse::<Table>().ok()?;
+    table
+        .get("project")?
+        .as_table()?
+        .get("profile")?
+        .as_str()
+        .filter(|profile| !profile.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+fn local_overlay_source_str(source: LocalOverlaySource) -> &'static str {
+    match source {
+        LocalOverlaySource::Direct => "direct",
+        LocalOverlaySource::WorktreeFallback => "worktree_fallback",
+        LocalOverlaySource::None => "none",
+    }
+}
+
+fn path_value(path: Option<&PathBuf>) -> Value {
+    path.map_or(Value::Null, |p| Value::String(p.display().to_string()))
+}
+
+/// Create-or-update: set `[project].profile` in the TOML at `config_path`,
+/// creating the file and its parent dir when absent (the local-overlay case).
+fn upsert_profile_in_config(config_path: &Path, profile_name: &str) -> Result<(), CliFailure> {
+    let mut table = if config_path.exists() {
+        fs::read_to_string(config_path)
+            .map_err(|error| CliFailure::new(1, error.to_string()))?
+            .parse::<Table>()
+            .map_err(|error| CliFailure::new(1, error.to_string()))?
+    } else {
+        if let Some(parent) = config_path.parent() {
+            fs::create_dir_all(parent).map_err(|error| CliFailure::new(1, error.to_string()))?;
+        }
+        Table::new()
+    };
     let project = table
         .entry("project".to_owned())
         .or_insert_with(|| TomlValue::Table(Table::new()))
@@ -255,4 +399,51 @@ fn rewrite_profile_in_config(config_path: &Path, profile_name: &str) -> Result<(
     );
     fs::write(config_path, format!("{table}\n"))
         .map_err(|error| CliFailure::new(1, error.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use toml::Table;
+
+    fn config_with(local_dir: Option<PathBuf>, source: LocalOverlaySource) -> LoadedConfig {
+        LoadedConfig {
+            data: Table::new(),
+            global_dir: PathBuf::from("/global"),
+            project_dir: Some(PathBuf::from("/repo/.shipyard")),
+            local_dir,
+            local_overlay_source: source,
+        }
+    }
+
+    #[test]
+    fn local_write_uses_direct_overlay_when_present() {
+        let config = config_with(
+            Some(PathBuf::from("/repo/.shipyard.local")),
+            LocalOverlaySource::Direct,
+        );
+        let path = local_overlay_config_path(RuntimeMode::Shipyard, Path::new("/repo"), &config);
+        assert_eq!(path, PathBuf::from("/repo/.shipyard.local/config.toml"));
+    }
+
+    #[test]
+    fn local_write_targets_current_checkout_not_borrowed_worktree_fallback() {
+        // `local_dir` points at a BORROWED main-checkout overlay (worktree
+        // fallback). A `--local` write must target the CURRENT checkout's own
+        // overlay, never the borrowed one.
+        let config = config_with(
+            Some(PathBuf::from("/main/.shipyard.local")),
+            LocalOverlaySource::WorktreeFallback,
+        );
+        let path =
+            local_overlay_config_path(RuntimeMode::Shipyard, Path::new("/worktree"), &config);
+        assert_eq!(path, PathBuf::from("/worktree/.shipyard.local/config.toml"));
+    }
+
+    #[test]
+    fn local_write_falls_back_to_cwd_when_no_overlay() {
+        let config = config_with(None, LocalOverlaySource::None);
+        let path = local_overlay_config_path(RuntimeMode::Shipyard, Path::new("/repo"), &config);
+        assert_eq!(path, PathBuf::from("/repo/.shipyard.local/config.toml"));
+    }
 }

--- a/src/app/ship_cmd.rs
+++ b/src/app/ship_cmd.rs
@@ -101,9 +101,14 @@ pub(super) fn ship_command<W: Write>(
     let warm_pool = WarmPool::new(default_pool_path(&runtime_paths.state_dir));
     let dispatcher =
         ExecutorDispatcher::new_with_state_dir(Some(prepared), &runtime_paths.state_dir);
+    // Absolute repo checkout root (dir holding `.shipyard/`) so ship-state can
+    // tell a GUI where to run repo-scoped config commands. Re-derived on resume.
+    let repo_root = git_optional(cwd, &["rev-parse", "--show-toplevel"])
+        .unwrap_or_else(|| cwd.display().to_string());
     let request = ShipExecutionRequest {
         pr: pr_context.number,
         repo,
+        repo_root,
         branch,
         base_branch: pr_context.base_branch,
         sha,

--- a/src/queue_request.rs
+++ b/src/queue_request.rs
@@ -366,6 +366,10 @@ pub struct QueuedShipRequest {
     pub pr: u64,
     /// Repository slug.
     pub repo: String,
+    /// Absolute repo checkout root (dir containing `.shipyard/`); preserved so a
+    /// resumed ship keeps it. Empty for legacy snapshots written before this field.
+    #[serde(default)]
+    pub repo_root: String,
     /// Head branch.
     pub branch: String,
     /// Base branch.
@@ -399,6 +403,7 @@ impl From<&ShipExecutionRequest> for QueuedShipRequest {
         Self {
             pr: request.pr,
             repo: request.repo.clone(),
+            repo_root: request.repo_root.clone(),
             branch: request.branch.clone(),
             base_branch: request.base_branch.clone(),
             sha: request.sha.clone(),
@@ -422,6 +427,7 @@ impl QueuedShipRequest {
         Ok(ShipExecutionRequest {
             pr: self.pr,
             repo: self.repo.clone(),
+            repo_root: self.repo_root.clone(),
             branch: self.branch.clone(),
             base_branch: self.base_branch.clone(),
             sha: self.sha.clone(),
@@ -1584,6 +1590,7 @@ mod tests {
         ShipExecutionRequest {
             pr: 42,
             repo: "danielraffel/shipyard".to_owned(),
+            repo_root: "/tmp/shipyard".to_owned(),
             branch: "feat/ship".to_owned(),
             base_branch: "main".to_owned(),
             sha: "def456".to_owned(),
@@ -1687,6 +1694,7 @@ mod tests {
         let state = ShipState {
             pr: request.pr,
             repo: request.repo.clone(),
+            repo_root: request.repo_root.clone(),
             branch: request.branch.clone(),
             base_branch: request.base_branch.clone(),
             head_sha: request.sha.clone(),

--- a/src/queue_scheduler.rs
+++ b/src/queue_scheduler.rs
@@ -767,6 +767,7 @@ mod tests {
                 request: QueuedExecutionRequest::Ship(QueuedShipRequest {
                     pr,
                     repo: repo.to_owned(),
+                    repo_root: String::new(),
                     branch: "feature".to_owned(),
                     base_branch: "main".to_owned(),
                     sha: "abc123".to_owned(),

--- a/src/ship.rs
+++ b/src/ship.rs
@@ -55,6 +55,9 @@ pub struct ShipExecutionRequest {
     pub pr: u64,
     /// Repository slug.
     pub repo: String,
+    /// Absolute path to the repo checkout root (dir containing `.shipyard/`),
+    /// carried into ship-state so a GUI can run repo-scoped config commands.
+    pub repo_root: String,
     /// Head branch.
     pub branch: String,
     /// Base branch.
@@ -774,6 +777,7 @@ fn execute_run_worker_with_options<D: ShipTargetDispatcher>(
     let shim = ShipExecutionRequest {
         pr: 0,
         repo: String::new(),
+        repo_root: String::new(),
         branch: request.branch.clone(),
         base_branch: String::new(),
         sha: request.sha.clone(),
@@ -1265,6 +1269,7 @@ fn unsaved_ship_state(request: &ShipExecutionRequest, target_names: &[String]) -
         request.sha.clone(),
         policy_signature(&request.targets, target_names, request.mode),
     );
+    state.repo_root.clone_from(&request.repo_root);
     refresh_pr_metadata(&mut state, request);
     state
 }
@@ -1437,6 +1442,7 @@ fn load_or_create_state(
         request.sha.clone(),
         policy,
     );
+    state.repo_root.clone_from(&request.repo_root);
     refresh_pr_metadata(&mut state, request);
     if state.pr_url.is_empty() && !request.repo.is_empty() {
         state.pr_url = format!("https://github.com/{}/pull/{}", request.repo, request.pr);
@@ -1835,6 +1841,7 @@ mod tests {
         ShipExecutionRequest {
             pr: 42,
             repo: "danielraffel/pulp".to_owned(),
+            repo_root: String::new(),
             branch: "feature/test".to_owned(),
             base_branch: "main".to_owned(),
             sha: "abc".to_owned(),

--- a/src/ship_state.rs
+++ b/src/ship_state.rs
@@ -59,6 +59,11 @@ pub struct ShipState {
     pub pr: u64,
     /// Repository slug.
     pub repo: String,
+    /// Absolute path to the repo checkout root (the dir that contains
+    /// `.shipyard/`). Lets a GUI run repo-scoped config commands in the right
+    /// directory. Empty (`""`) for legacy records written before this field.
+    #[serde(default)]
+    pub repo_root: String,
     /// Head branch name.
     pub branch: String,
     /// Base branch name.
@@ -108,6 +113,7 @@ impl ShipState {
             schema_version: SHIP_STATE_SCHEMA_VERSION,
             pr,
             repo: repo.into(),
+            repo_root: String::new(),
             branch: branch.into(),
             base_branch: base_branch.into(),
             head_sha: head_sha.into(),
@@ -740,5 +746,23 @@ mod tests {
         assert!(state.updated_at >= original);
         assert!(!state.is_sha_drift("abc"));
         assert!(state.is_sha_drift("def"));
+    }
+
+    #[test]
+    fn deserializes_legacy_state_without_repo_root() {
+        // A record written before the `repo_root` field must decode with
+        // `repo_root == ""` (serde default), not fail.
+        let json = r#"{
+            "pr": 7,
+            "repo": "danielraffel/pulp",
+            "branch": "feature/x",
+            "base_branch": "main",
+            "head_sha": "abc123",
+            "created_at": "2026-01-01T00:00:00Z",
+            "updated_at": "2026-01-01T00:00:00Z"
+        }"#;
+        let state: ShipState = serde_json::from_str(json).expect("decode legacy state");
+        assert_eq!(state.repo_root, "");
+        assert_eq!(state.repo, "danielraffel/pulp");
     }
 }


### PR DESCRIPTION
Shipyard half of the menu-bar Routing settings feature (spec: `shipyard-macos-gui/docs/implementation-plan-routing-settings.md`). Additive + backward-compatible.

## What
- **`shipyard config use <profile> --local`** — writes `[project].profile` to the per-machine `.shipyard.local/config.toml` overlay instead of the tracked config, so a machine can switch its validation routing without dirtying committed config or affecting collaborators. In a git worktree it writes the current checkout's own overlay, never a borrowed main-checkout one.
- **`config profiles --json` / `config use --json`** now report `active_source` (`local`/`tracked`/`global`/`none`) + resolved config paths (`active_path`, `local_overlay_path`, `tracked_config_path`, `local_overlay_source`). Source is derived by re-reading each layer's raw `[project].profile`, with the reported `active` kept equal to the merged effective profile so CLI output never disagrees with runtime.
- **`ship-state list --json`** records carry **`repo_root`** (the checkout dir holding `.shipyard/`) so a GUI can run repo-scoped config commands in the right place. Threaded through `ShipExecutionRequest` + queue snapshots so resumed ships preserve it; serde-default `""` for legacy records.

## Why
Lets the macOS menu-bar app expose a per-machine, per-repo "Routing" switch (local/normal/cloud/full profiles) backed by the CLI, without hand-editing TOML. GitHub repo Variables (everyone's-CI routing) intentionally stay CLI/`gh`-only.

## Tests
- `config use --local` creates the overlay AND leaves tracked config byte-for-byte unchanged (central locked decision).
- `active_source` = local-over-tracked, and tracked-only.
- `config use --local` rejects an unknown profile without writing.
- Worktree-safe local-write path (unit).
- Legacy ship-state decodes with `repo_root == ""`.
Full lib suite green (859) in a clean env.

## Notes
- Empty-string `profile` semantics: an empty local `profile` is "no active selection" (matches `deep_merge` + `active_profile`); the GUI only ever sets valid names — a `--local --clear` is future work.
- Docs: `commands/config.md`, `docs/profiles.md`, `ci` + `shipyard` SKILLs. Versions bumped (CLI 0.66.0, plugin 0.21.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)