### PR TITLE
docs(targets): wire emulated x86_64 smoke as a local tartci target

### DIFF
--- a/docs/runner-provisioning.md
+++ b/docs/runner-provisioning.md
@@ -19,6 +19,14 @@ which recovers stuck runners. Pure naming/index/label/table logic lives in
   is once per machine and is the repo's own concern (e.g. pulp's
   `tools/ci/bootstrap-macos-host.sh`). Registering *runners* is once per repo
   per machine and is what this command does. It assumes a buildable host.
+- **Non-macOS + emulated lanes are tartci targets, not `shipyard runner`
+  registrations.** This command provisions native macOS Actions runners. Local
+  Linux / Windows build VMs (and the emulated **x86_64** smoke lane —
+  cross-compile + qemu-user / Prism) are driven by
+  [tartci](https://github.com/danielraffel/tartci) and wired into Shipyard as
+  ordinary `backend = "local"` targets whose validation command shells to
+  `tartci up <os> [--target-arch x86_64]` — see
+  [targets.md](./targets.md#emulated-x86_64-smoke-local-via-tartci).
 
 ## Machine tag
 

--- a/docs/targets.md
+++ b/docs/targets.md
@@ -145,6 +145,67 @@ The standard capability vocabulary is `gpu`, `arm64`, `x86_64`,
 your own strings — the matcher is pure set containment, so unknown
 capabilities work as long as the target and the provider agree.
 
+## Emulated x86_64 smoke (local, via tartci)
+
+On an Apple-Silicon Mac the local VM lanes are **ARM64** — there is no x86 guest
+(Apple Virtualization and QEMU-on-hvf are both ARM64). You can still get a *local
+x86_64 signal* by cross-compiling in the guest and running the tests under
+emulation (qemu-user on Linux, Prism on Windows-ARM). Wire it as a plain
+`backend = "local"` target whose validation command shells out to
+[tartci](https://github.com/danielraffel/tartci)'s cross lane — no new Shipyard
+config field is needed, because a target is just a machine + a command:
+
+```toml
+# Emulated x86_64 Linux smoke. Cross-builds x64 and runs the test subset under
+# qemu-user-static inside an ephemeral Tart Linux clone, then discards it.
+[targets.linux-x64-smoke]
+backend  = "local"
+platform = "linux-x64"
+
+[targets.linux-x64-smoke.validation]
+command = "tartci up linux --target-arch x86_64"
+```
+
+```toml
+# Prove just the toolchain + emulator chain (golden-agnostic, no checkout):
+[targets.x64-selftest]
+backend  = "local"
+platform = "linux-x64"
+
+[targets.x64-selftest.validation]
+command = "tartci up linux --target-arch x86_64 --self-test"
+```
+
+This is a **smoke / debug** signal, not a gate: sanitizers, SIMD/Highway
+dispatch, and RT timing are unreliable under emulation. Keep a real x86_64 runner
+(GitHub-hosted, an SSH x64 box, or a Namespace cloud profile) as the
+authoritative x64 gate, and model it as a **separate target** — do **not** chain
+the smoke target to the gate with `fallback`. Fallback fires only when a machine
+is *unreachable* (an infrastructure failure), not when validation *fails* (see
+"Fallback is for infrastructure failures" above), so a failing emulated smoke
+must surface as a failure, never silently fall through to cloud:
+
+```toml
+# Fast local pre-check (manual / pre-push): emulated x64 via tartci, above.
+[targets.linux-x64-smoke]
+backend  = "local"
+platform = "linux-x64"
+
+[targets.linux-x64-smoke.validation]
+command = "tartci up linux --target-arch x86_64"
+
+# The authoritative x64 gate — a real x86_64 runner, an independent target.
+[targets.linux]
+backend  = "cloud"
+platform = "linux-x64"
+```
+
+Run the smoke target when you want a fast local signal; the gate target stays
+the one your PR must pass. The GPU-on cross build needs a separate x86_64 Skia
+tree (both Linux arches collide on one `libskia.a` path); the tartci lane
+defaults GPU-off for the smoke and documents the `--skia-dir` opt-in. See
+tartci's runbook §3.8.
+
 Capabilities are resolved in this order for each backend:
 
 1. An inline `capabilities = [...]` list on the backend entry.


### PR DESCRIPTION
Makes Shipyard "obviously act on" tartci's new x86_64 cross/emulation lane,
without inventing a config field the routing wouldn't consume.

On Apple Silicon the local VM lanes are **ARM64-only** (Apple Virtualization /
QEMU-on-hvf have no x86 guest). x86_64 is reached by cross-compiling in the guest
and running the tests under emulation (qemu-user on Linux, Prism on Windows-ARM,
via [tartci](https://github.com/danielraffel/tartci)). A Shipyard target is just
a machine + a command, so this is expressed today as a `backend = "local"`
target whose validation command shells to `tartci up <os> --target-arch x86_64`.

## Changes (docs-only)
- **docs/targets.md** — new "Emulated x86_64 smoke (local, via tartci)" section:
  the smoke target, the `--self-test` toolchain/emulator proof, and a fallback
  chain keeping a real x64 runner (GitHub-hosted / cloud) as the authoritative
  gate.
- **docs/runner-provisioning.md** — mental-model bullet: non-macOS + emulated
  lanes are tartci targets, not `shipyard runner` registrations.

## Why docs-only
The config model already supports this (`backend`, `platform`, per-target
`validation.command`, `requires`/fallback). Adding a `target_arch`/`emulated`
field to the Rust schema would route nothing — `dispatch.rs` / `LocalExecutor`
consume `platform`/`backend`/commands, not arch metadata. Emulated x64 is a
smoke signal, not a gate.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Document how to run an emulated x86_64 smoke lane on Apple Silicon by wiring `tartci` as a `backend = "local"` target (`validation.command`: `tartci up <os> --target-arch x86_64`). Clarifies that non-macOS and emulated lanes are `tartci` targets, adds a `--self-test` example, and shows a separate real x86_64 gate target (no `fallback`).

- **Migration**
  - No config changes; existing `backend`, `platform`, and per-target `validation.command` cover this.

<sup>Written for commit 0b9129d6044c2f1563701b1f63df40701dadcf71. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/Shipyard/pull/354?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This docs-only PR adds a new section to `docs/targets.md` explaining how to wire an emulated x86_64 smoke lane on Apple Silicon via `tartci` as a `backend = "local"` Shipyard target, and adds a clarifying bullet to `docs/runner-provisioning.md`. No config schema or runtime code changes are included.

- **docs/targets.md**: New "Emulated x86_64 smoke (local, via tartci)" section with TOML examples for `linux-x64-smoke` and `x64-selftest` targets, an explicit warning against using `fallback` for smoke-to-gate chaining, and a combined pattern example showing the two independent targets side-by-side.
- **docs/runner-provisioning.md**: One new mental-model bullet clarifying that non-macOS and emulated lanes are `tartci` targets (not `shipyard runner` registrations), with a link to the new targets.md section.
</details>

<h3>Confidence Score: 5/5</h3>

Documentation-only change with no runtime code or config schema modifications; safe to merge.

Both changed files are Markdown documentation. The cross-reference anchor in runner-provisioning.md matches the actual heading in targets.md, the "Fallback is for infrastructure failures" back-reference points to a real heading at line 81, and the previous review concerns (missing backend field, misleading fallback example) are resolved in this version.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/targets.md | New "Emulated x86_64 smoke" section wiring tartci as a backend="local" target; previous concerns about the fallback chain and missing backend field are resolved in this version |
| docs/runner-provisioning.md | Added a mental-model bullet clarifying non-macOS and emulated lanes are tartci targets; cross-reference anchor to targets.md section appears correct |

</details>

</details>

<sub>Reviews (2): Last reviewed commit: ["docs(targets): wire emulated x86\_64 smok..."](https://github.com/danielraffel/shipyard/commit/0b9129d6044c2f1563701b1f63df40701dadcf71) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35584108)</sub>

<!-- /greptile_comment -->