### PR TITLE
feat: add CI routing profile planner

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "shipyard",
-  "version": "0.24.0",
+  "version": "0.25.0",
   "description": "Cross-platform CI coordination",
   "min_shipyard_version": "0.22.8",
   "commands": "./commands",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to Shipyard are documented here. Each entry links
 to its [GitHub Release](https://github.com/danielraffel/Shipyard/releases).
 
 <a id="v0700"></a>
+## [0.71.0]
+
 ## [0.70.0] - 2026-06-04
 
 - feat(run): add command evidence bundles ([#356](https://github.com/danielraffel/Shipyard/pull/356))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -620,7 +620,7 @@ dependencies = [
 
 [[package]]
 name = "shipyard"
-version = "0.70.0"
+version = "0.71.0"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shipyard"
-version = "0.70.0"
+version = "0.71.0"
 edition = "2024"
 description = "Cross-platform CI coordination for local, SSH, and cloud runners."
 rust-version = "1.92"

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ It calls your build commands and cares about one thing: did they pass?
 - [Security & Governance](docs/governance.md) — `solo` vs `multi`
   profiles, branch protection, tag protection.
 - [Profiles & Configuration](docs/profiles.md) — switch between local /
-  cloud / full setups with one command.
+  cloud / full setups with one command, plus repo-owned CI routing profiles.
 - [Manual CLI Workflows](docs/workflows.md) — debugging failed runs,
   managing the queue, partial reruns.
 - [Resuming an interrupted ship](docs/ship-resume.md) — how `shipyard ship`

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -44,6 +44,8 @@ shipyard cleanup --apply       # prune old logs and artifacts
 shipyard config profiles       # list defined profiles
 shipyard config use <profile>  # switch active profile
 shipyard config show           # dump effective merged config
+shipyard ci profile show normal-local-fast
+shipyard ci profile plan normal-local-fast --repo OWNER/REPO --json
 
 # Governance
 shipyard governance status     # declared vs live drift
@@ -98,10 +100,16 @@ schema, intended for AI agent consumption:
 shipyard run --json
 shipyard ship --json
 shipyard status --json
+shipyard ci profile plan normal-local-fast --repo OWNER/REPO --json
 ```
 
 The envelope always carries `schema_version: 1` and the command name, so
 agents can pin to a stable contract.
+
+`shipyard ci profile plan` is provider-neutral and read-only. It parses a
+repo-owned TOML profile from `.tartci/`, `.shipyard/ci-profiles/`, or
+`ci-profiles/`, then reports the concrete GitHub runner variables/selectors
+that would be used for each lane. It does not require tartci to be installed.
 
 `shipyard status` is intentionally limited to queue/target state and does not
 probe GitHub quota. Use `shipyard doctor --rate-limit` when you need to confirm

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -138,3 +138,42 @@ Profiles work at both levels:
 
 Switch profiles globally or per-project. `shipyard status` always shows
 which profile is active and exactly where each target will run.
+
+## tartci routing profiles
+
+For local VM fleets, Shipyard should treat tartci as the host/provider source of
+truth and keep Shipyard as the fleet/router layer.
+
+tartci exposes read-only profile and host status commands:
+
+```bash
+tartci profile list
+tartci profile explain normal-local-fast --repo danielraffel/pulp --json
+tartci profile plan normal-local-fast --repo danielraffel/pulp --json
+tartci status --json
+```
+
+The tartci profile file describes PR, release, coverage, and scheduled policies
+in commented TOML. Its target IDs are stable routing vocabulary, not GitHub
+labels. Each target maps to a concrete `runs-on` selector such as
+`["self-hosted","Windows","ARM64","pulp-build-windows"]` or `"windows-latest"`.
+
+Shipyard's job is to consume those facts across hosts:
+
+1. Read `tartci status --json` from each configured host.
+2. Read `tartci profile explain ... --json` for the repo policy.
+3. Resolve ordered fallback before dispatch, using live capacity.
+4. Apply or pass one concrete GitHub `runs-on` selector per workflow run.
+5. Keep GitHub-hosted x64 scheduled validation authoritative until local x64
+   emulation is explicitly proven.
+
+GitHub Actions cannot change `runs-on` once a job is queued. Do not pass an
+ordered fallback chain into a Pulp workflow and expect GitHub to handle it.
+Fallback must be resolved before repo variables or `workflow_dispatch` inputs are
+set.
+
+For Pulp, the normal fast profile is expected to route PR macOS/Linux/Windows to
+local ARM64 VMs first, then fall back to GitHub where configured, while scheduled
+nightly Intel Linux/Windows validation stays on GitHub-hosted x64 runners.
+Coverage targets must use dedicated ephemeral labels; do not route coverage to a
+warm bare-metal build pool.

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -153,6 +153,19 @@ tartci profile plan normal-local-fast --repo danielraffel/pulp --json
 tartci status --json
 ```
 
+Shipyard can also read the same profile vocabulary directly from a repo checkout
+without requiring tartci:
+
+```bash
+shipyard ci profile show normal-local-fast
+shipyard ci profile plan normal-local-fast --repo danielraffel/pulp --json
+```
+
+The Shipyard command searches `.tartci/<name>.toml`,
+`.shipyard/ci-profiles/<name>.toml`, then `ci-profiles/<name>.toml`. It is
+read-only: it explains the selected target and exact GitHub variable values, but
+does not apply variables or dispatch work.
+
 The tartci profile file describes PR, release, coverage, and scheduled policies
 in commented TOML. Its target IDs are stable routing vocabulary, not GitHub
 labels. Each target maps to a concrete `runs-on` selector such as

--- a/skills/ci/SKILL.md
+++ b/skills/ci/SKILL.md
@@ -100,6 +100,31 @@ Shipyard coordinates validation across local, SSH, and cloud targets.
 | Quarantine a flaky target | `shipyard quarantine add <target> --reason "..."` |
 | Remove from quarantine | `shipyard quarantine remove <target>` |
 
+## tartci local VM routing profiles
+
+When a repo uses tartci-backed local VM lanes, inspect the profile before
+changing GitHub variables or dispatch inputs:
+
+```sh
+tartci profile explain normal-local-fast --repo danielraffel/pulp --json
+tartci profile plan normal-local-fast --repo danielraffel/pulp --json
+tartci status --json
+```
+
+tartci owns host-local facts: Tart/QEMU providers, capacity, golden/cache
+state, and target-to-`runs-on` mappings. Shipyard owns fleet routing: read each
+host's tartci status, choose one concrete target from the ordered fallback chain,
+then apply that selector through repo variables or `workflow_dispatch`.
+
+Do not pass a fallback chain into GitHub Actions. GitHub cannot change `runs-on`
+after a job queues. Pulp workflows should receive one concrete selector per run.
+
+For Pulp's normal fast profile, local ARM64 PR lanes are fast feedback and
+GitHub-hosted nightly Intel Linux/Windows lanes are compatibility surveillance.
+Windows QEMU on Apple Silicon is Windows ARM64; x64 MSVC/Prism execution is
+smoke/debug until proven and should not replace `windows-latest` authority.
+Coverage must use dedicated ephemeral labels, not warm bare-metal build pools.
+
 ## GitHub Auth Diagnostics
 
 Before blaming ambient `gh auth status`, check whether the repo config has

--- a/skills/shipyard/SKILL.md
+++ b/skills/shipyard/SKILL.md
@@ -424,6 +424,16 @@ lives in the Studio keychain, so the signed/notarized dmg build skips
 GitHub's hosted-macOS queue. Full provider semantics:
 `skills/ci/SKILL.md` → "Runner Provider Defaults" → "The `local` provider".
 
+### CI routing profiles
+
+Use `shipyard ci profile show <name>` and
+`shipyard ci profile plan <name> --repo owner/repo` to inspect repo-owned CI
+routing profiles without requiring Tart or any provider-specific CLI. The
+planner reads `.tartci/<name>.toml`, `.shipyard/ci-profiles/<name>.toml`, or
+`ci-profiles/<name>.toml`, then prints the ordered target chain and the GitHub
+variables that would route each lane. It is intentionally read-only; live
+capacity resolution and variable writes happen outside this command.
+
 ## Supervised Subprocess Marker (issue #266)
 
 Every `git` / `gh` child process spawned by the supervised

--- a/src/app.rs
+++ b/src/app.rs
@@ -16,6 +16,7 @@ mod auto_merge_cmd;
 mod branch_cmd;
 mod capacity_cmd;
 mod changelog_cmd;
+mod ci_cmd;
 mod cleanup_cmd;
 mod cli;
 mod cloud_cmd;
@@ -50,6 +51,7 @@ use self::auth_cmd::auth_command;
 use self::auto_merge_cmd::auto_merge;
 use self::branch_cmd::branch_command;
 use self::changelog_cmd::changelog_command;
+use self::ci_cmd::ci_command;
 use self::cleanup_cmd::{
     CleanupCommandOptions, CleanupMode, CleanupOutput, CleanupScope, cleanup_command,
 };
@@ -153,6 +155,9 @@ fn dispatch<W: Write, E: Write>(
         Command::Update(args) => return update_command(&args, cli.json, stdout),
         Command::Config { command } => {
             return config_command(command, cli.mode.into(), &cwd, cli.json, stdout);
+        }
+        Command::Ci { command } => {
+            return ci_command(command, &cwd, cli.json, stdout);
         }
         Command::Auth { command } => {
             return auth_command(
@@ -294,6 +299,7 @@ fn handle_operational_variant<W: Write>(
         Command::Paths
         | Command::Pin { .. }
         | Command::Config { .. }
+        | Command::Ci { .. }
         | Command::Auth { .. }
         | Command::Init { .. }
         | Command::Changelog { .. }

--- a/src/app/ci_cmd.rs
+++ b/src/app/ci_cmd.rs
@@ -1,0 +1,503 @@
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::ExitCode;
+
+use serde::Serialize;
+use toml::{Table, Value};
+
+use crate::app::CliFailure;
+use crate::app::cli::CiCommand;
+use crate::output::write_pretty_json;
+
+#[derive(Serialize)]
+struct ProfilePlan {
+    profile: String,
+    description: String,
+    repo: String,
+    source: String,
+    read_only: bool,
+    lanes: Vec<LanePlan>,
+    changes: Vec<VariableChange>,
+    warnings: Vec<String>,
+    note: String,
+}
+
+#[derive(Serialize)]
+struct LanePlan {
+    context: String,
+    lane: String,
+    strategy: String,
+    targets: Vec<TargetPlan>,
+    selected_now: Option<String>,
+    selected_runs_on_json: Option<String>,
+    github_variable: Option<String>,
+    issue_on_failure: bool,
+    ephemeral_required: bool,
+}
+
+#[derive(Serialize)]
+struct TargetPlan {
+    id: String,
+    provider: Option<String>,
+    host: Option<String>,
+    os: Option<String>,
+    arch: Option<String>,
+    runs_on_json: Option<Value>,
+    missing: bool,
+}
+
+#[derive(Serialize)]
+struct VariableChange {
+    variable: String,
+    value: String,
+    context: String,
+    lane: String,
+    target: String,
+}
+
+pub(super) fn ci_command<W: Write>(
+    command: CiCommand,
+    cwd: &Path,
+    json: bool,
+    stdout: &mut W,
+) -> Result<ExitCode, CliFailure> {
+    match command {
+        CiCommand::Profile { command } => match command {
+            crate::app::cli::CiProfileCommand::Show { name, profile_file } => {
+                let (path, text) = read_profile_text(cwd, &name, profile_file.as_deref())?;
+                if json {
+                    write_pretty_json(
+                        stdout,
+                        &serde_json::json!({
+                            "profile": name,
+                            "source": path,
+                            "text": text,
+                        }),
+                    )
+                    .map_err(|error| CliFailure::new(1, error.to_string()))?;
+                } else {
+                    stdout
+                        .write_all(text.as_bytes())
+                        .map_err(|error| CliFailure::new(1, error.to_string()))?;
+                }
+                Ok(ExitCode::SUCCESS)
+            }
+            crate::app::cli::CiProfileCommand::Plan {
+                name,
+                repo,
+                profile_file,
+            } => {
+                let (path, profile) = load_profile(cwd, &name, profile_file.as_deref())?;
+                let plan = build_plan(&profile, &repo, path.display().to_string())?;
+                if json {
+                    write_pretty_json(stdout, &plan)
+                        .map_err(|error| CliFailure::new(1, error.to_string()))?;
+                } else {
+                    print_plan(stdout, &plan)
+                        .map_err(|error| CliFailure::new(1, error.to_string()))?;
+                }
+                Ok(ExitCode::SUCCESS)
+            }
+        },
+    }
+}
+
+fn read_profile_text(
+    cwd: &Path,
+    name: &str,
+    explicit: Option<&Path>,
+) -> Result<(PathBuf, String), CliFailure> {
+    let path = resolve_profile_path(cwd, name, explicit)?;
+    let text = std::fs::read_to_string(&path).map_err(|error| {
+        CliFailure::new(1, format!("failed to read {}: {error}", path.display()))
+    })?;
+    Ok((path, text))
+}
+
+fn load_profile(
+    cwd: &Path,
+    name: &str,
+    explicit: Option<&Path>,
+) -> Result<(PathBuf, Table), CliFailure> {
+    let (path, text) = read_profile_text(cwd, name, explicit)?;
+    let table = text.parse::<Table>().map_err(|error| {
+        CliFailure::new(1, format!("failed to parse {}: {error}", path.display()))
+    })?;
+    if table.get("name").and_then(Value::as_str) != Some(name) {
+        return Err(CliFailure::new(
+            1,
+            format!(
+                "profile {} does not declare name = {:?}",
+                path.display(),
+                name
+            ),
+        ));
+    }
+    Ok((path, table))
+}
+
+fn resolve_profile_path(
+    cwd: &Path,
+    name: &str,
+    explicit: Option<&Path>,
+) -> Result<PathBuf, CliFailure> {
+    if let Some(path) = explicit {
+        return Ok(if path.is_absolute() {
+            path.to_path_buf()
+        } else {
+            cwd.join(path)
+        });
+    }
+    let candidates = [
+        cwd.join(".tartci").join(format!("{name}.toml")),
+        cwd.join(".shipyard")
+            .join("ci-profiles")
+            .join(format!("{name}.toml")),
+        cwd.join("ci-profiles").join(format!("{name}.toml")),
+    ];
+    candidates
+        .into_iter()
+        .find(|path| path.exists())
+        .ok_or_else(|| {
+            CliFailure::new(
+                1,
+                format!(
+                    "profile {name:?} not found; tried .tartci, .shipyard/ci-profiles, and ci-profiles"
+                ),
+            )
+        })
+}
+
+fn build_plan(profile: &Table, repo: &str, source: String) -> Result<ProfilePlan, CliFailure> {
+    let profile_name = required_str(profile, "name")?.to_owned();
+    let description = optional_str(profile, "description")
+        .unwrap_or("")
+        .to_owned();
+    let repo_table = repo_profile_table(profile, repo)?;
+    let targets = profile
+        .get("targets")
+        .and_then(Value::as_table)
+        .cloned()
+        .unwrap_or_default();
+
+    let mut lanes = Vec::new();
+    let mut changes = Vec::new();
+    let mut warnings = Vec::new();
+
+    for spec in lane_specs(repo_table) {
+        let outcome = plan_lane(&spec, &targets);
+        warnings.extend(outcome.warnings);
+        if let Some(change) = outcome.change {
+            changes.push(change);
+        }
+        lanes.push(outcome.lane);
+    }
+
+    Ok(ProfilePlan {
+        profile: profile_name,
+        description,
+        repo: repo.to_owned(),
+        source,
+        read_only: true,
+        lanes,
+        changes,
+        warnings,
+        note: "read-only plan; resolve ordered fallback with live fleet status before applying GitHub variables".to_owned(),
+    })
+}
+
+struct LaneSpec<'a> {
+    context: &'a str,
+    lane: &'a str,
+    table: &'a Table,
+}
+
+struct LaneOutcome {
+    lane: LanePlan,
+    change: Option<VariableChange>,
+    warnings: Vec<String>,
+}
+
+fn repo_profile_table<'a>(profile: &'a Table, repo: &str) -> Result<&'a Table, CliFailure> {
+    required_table(profile, "repo")?
+        .get(repo)
+        .and_then(Value::as_table)
+        .ok_or_else(|| CliFailure::new(1, format!("profile has no repo entry for {repo}")))
+}
+
+fn lane_specs(repo_table: &Table) -> Vec<LaneSpec<'_>> {
+    let mut specs = Vec::new();
+    for (context, context_value) in repo_table {
+        let Some(context_table) = context_value.as_table() else {
+            continue;
+        };
+        for (lane, lane_value) in context_table {
+            let Some(table) = lane_value.as_table() else {
+                continue;
+            };
+            specs.push(LaneSpec {
+                context,
+                lane,
+                table,
+            });
+        }
+    }
+    specs
+}
+
+fn plan_lane(spec: &LaneSpec<'_>, targets: &Table) -> LaneOutcome {
+    let target_plans = target_ids(spec.table)
+        .iter()
+        .map(|id| target_plan(id, targets))
+        .collect::<Vec<_>>();
+    let selected = target_plans.iter().find(|target| !target.missing);
+    let selected_id = selected.map(|target| target.id.clone());
+    let selected_runs_on_json = selected
+        .and_then(|target| target.runs_on_json.as_ref())
+        .map(compact_json);
+    let github_variable = optional_str(spec.table, "github_variable");
+    let ephemeral_required = optional_bool(spec.table, "ephemeral_required");
+    let lane = LanePlan {
+        context: spec.context.to_owned(),
+        lane: spec.lane.to_owned(),
+        strategy: optional_str(spec.table, "strategy")
+            .unwrap_or("ordered-fallback")
+            .to_owned(),
+        targets: target_plans,
+        selected_now: selected_id.clone(),
+        selected_runs_on_json: selected_runs_on_json.clone(),
+        github_variable: github_variable.map(str::to_owned),
+        issue_on_failure: optional_bool(spec.table, "issue_on_failure"),
+        ephemeral_required,
+    };
+    let change = variable_change(
+        spec,
+        github_variable,
+        selected_runs_on_json.as_ref(),
+        selected_id.as_ref(),
+    );
+    let warnings = lane_warnings(spec, targets, &lane.targets, ephemeral_required);
+    LaneOutcome {
+        lane,
+        change,
+        warnings,
+    }
+}
+
+fn target_ids(lane_table: &Table) -> Vec<String> {
+    lane_table
+        .get("targets")
+        .and_then(Value::as_array)
+        .map(|values| {
+            values
+                .iter()
+                .filter_map(Value::as_str)
+                .map(str::to_owned)
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default()
+}
+
+fn variable_change(
+    spec: &LaneSpec<'_>,
+    variable: Option<&str>,
+    value: Option<&String>,
+    target: Option<&String>,
+) -> Option<VariableChange> {
+    Some(VariableChange {
+        variable: variable?.to_owned(),
+        value: value?.clone(),
+        context: spec.context.to_owned(),
+        lane: spec.lane.to_owned(),
+        target: target?.clone(),
+    })
+}
+
+fn lane_warnings(
+    spec: &LaneSpec<'_>,
+    targets: &Table,
+    target_plans: &[TargetPlan],
+    ephemeral_required: bool,
+) -> Vec<String> {
+    let mut warnings = Vec::new();
+    for target in target_plans {
+        if target.missing {
+            warnings.push(format!(
+                "{}.{}: target {} is not defined",
+                spec.context, spec.lane, target.id
+            ));
+        }
+        if ephemeral_required
+            && !target.is_github()
+            && !target_bool(targets, &target.id, "ephemeral")
+        {
+            warnings.push(format!(
+                "{}.{}: target {} is not marked ephemeral",
+                spec.context, spec.lane, target.id
+            ));
+        }
+    }
+    warnings
+}
+
+fn target_plan(id: &str, targets: &Table) -> TargetPlan {
+    let target = targets.get(id).and_then(Value::as_table);
+    let inferred_provider = if id.starts_with("github.") {
+        Some("github".to_owned())
+    } else {
+        None
+    };
+    TargetPlan {
+        id: id.to_owned(),
+        provider: target
+            .and_then(|t| t.get("provider"))
+            .and_then(Value::as_str)
+            .map(str::to_owned)
+            .or(inferred_provider),
+        host: target
+            .and_then(|t| t.get("host"))
+            .and_then(Value::as_str)
+            .map(str::to_owned),
+        os: target
+            .and_then(|t| t.get("os"))
+            .and_then(Value::as_str)
+            .map(str::to_owned),
+        arch: target
+            .and_then(|t| t.get("arch"))
+            .and_then(Value::as_str)
+            .map(str::to_owned),
+        runs_on_json: target.and_then(|t| t.get("runs_on_json")).cloned(),
+        missing: target.is_none(),
+    }
+}
+
+impl TargetPlan {
+    fn is_github(&self) -> bool {
+        self.provider.as_deref() == Some("github") || self.id.starts_with("github.")
+    }
+}
+
+fn target_bool(targets: &Table, id: &str, key: &str) -> bool {
+    targets
+        .get(id)
+        .and_then(Value::as_table)
+        .and_then(|target| target.get(key))
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+}
+
+fn optional_str<'a>(table: &'a Table, key: &str) -> Option<&'a str> {
+    table.get(key).and_then(Value::as_str)
+}
+
+fn optional_bool(table: &Table, key: &str) -> bool {
+    table.get(key).and_then(Value::as_bool).unwrap_or(false)
+}
+
+fn compact_json(value: &Value) -> String {
+    let json_value = serde_json::to_value(value).expect("toml value serializes");
+    serde_json::to_string(&json_value).expect("json value serializes")
+}
+
+fn required_str<'a>(table: &'a Table, key: &str) -> Result<&'a str, CliFailure> {
+    table
+        .get(key)
+        .and_then(Value::as_str)
+        .ok_or_else(|| CliFailure::new(1, format!("profile missing string key {key:?}")))
+}
+
+fn required_table<'a>(table: &'a Table, key: &str) -> Result<&'a Table, CliFailure> {
+    table
+        .get(key)
+        .and_then(Value::as_table)
+        .ok_or_else(|| CliFailure::new(1, format!("profile missing table {key:?}")))
+}
+
+fn print_plan<W: Write>(stdout: &mut W, plan: &ProfilePlan) -> std::io::Result<()> {
+    writeln!(
+        stdout,
+        "Read-only CI profile plan for {} using {} ({})",
+        plan.repo, plan.profile, plan.source
+    )?;
+    for lane in &plan.lanes {
+        let chain = lane
+            .targets
+            .iter()
+            .map(|target| target.id.as_str())
+            .collect::<Vec<_>>()
+            .join(" -> ");
+        writeln!(stdout, "{}.{}: {}", lane.context, lane.lane, chain)?;
+        if let (Some(variable), Some(value)) = (&lane.github_variable, &lane.selected_runs_on_json)
+        {
+            writeln!(stdout, "  {variable}={value}")?;
+        }
+    }
+    if !plan.warnings.is_empty() {
+        writeln!(stdout, "warnings:")?;
+        for warning in &plan.warnings {
+            writeln!(stdout, "  - {warning}")?;
+        }
+    }
+    writeln!(stdout, "{}", plan.note)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::build_plan;
+
+    #[test]
+    fn builds_provider_neutral_profile_plan() {
+        let profile = r#"
+name = "normal"
+description = "local first"
+
+[repo."owner/repo".pr.linux]
+strategy = "ordered-fallback"
+targets = ["local.linux-arm64", "github.linux-x64"]
+github_variable = "LOCAL_LINUX_RUNS_ON_JSON"
+
+[targets."local.linux-arm64"]
+runs_on_json = ["self-hosted", "Linux", "ARM64", "build"]
+
+[targets."github.linux-x64"]
+runs_on_json = "ubuntu-latest"
+"#
+        .parse()
+        .expect("profile toml");
+
+        let plan = build_plan(&profile, "owner/repo", "test.toml".to_owned()).expect("plan");
+
+        assert_eq!(plan.profile, "normal");
+        assert_eq!(plan.changes.len(), 1);
+        assert_eq!(plan.changes[0].variable, "LOCAL_LINUX_RUNS_ON_JSON");
+        assert_eq!(
+            plan.changes[0].value,
+            "[\"self-hosted\",\"Linux\",\"ARM64\",\"build\"]"
+        );
+        assert!(plan.warnings.is_empty());
+    }
+
+    #[test]
+    fn github_target_id_satisfies_coverage_ephemeral_requirement() {
+        let profile = r#"
+name = "coverage"
+
+[repo."owner/repo".coverage.windows]
+strategy = "github-only"
+targets = ["github.windows-x64"]
+github_variable = "COVERAGE_WINDOWS_RUNS_ON_JSON"
+ephemeral_required = true
+
+[targets."github.windows-x64"]
+runs_on_json = "windows-latest"
+"#
+        .parse()
+        .expect("profile toml");
+
+        let plan = build_plan(&profile, "owner/repo", "test.toml".to_owned()).expect("plan");
+
+        assert!(plan.warnings.is_empty());
+        assert_eq!(plan.changes[0].value, "\"windows-latest\"");
+    }
+}

--- a/src/app/cli.rs
+++ b/src/app/cli.rs
@@ -50,6 +50,12 @@ pub(super) enum Command {
         #[command(subcommand)]
         command: Option<ConfigCommand>,
     },
+    /// Inspect CI routing profiles and repo runner-placement plans.
+    Ci {
+        /// CI subcommand.
+        #[command(subcommand)]
+        command: CiCommand,
+    },
     /// Inspect and move Shipyard GitHub auth config without secrets.
     Auth {
         /// Auth subcommand.
@@ -353,6 +359,41 @@ pub(super) enum EvidenceCommand {
         /// Show all command-evidence bundle summaries.
         #[arg(long)]
         list: bool,
+    },
+}
+
+#[derive(Debug, Subcommand)]
+pub(super) enum CiCommand {
+    /// Inspect CI routing profiles.
+    Profile {
+        /// Profile subcommand.
+        #[command(subcommand)]
+        command: CiProfileCommand,
+    },
+}
+
+#[derive(Debug, Subcommand)]
+pub(super) enum CiProfileCommand {
+    /// Print a profile file.
+    Show {
+        /// Profile name.
+        name: String,
+        /// Explicit profile TOML path. Defaults to .tartci/<name>.toml,
+        /// .shipyard/ci-profiles/<name>.toml, then ci-profiles/<name>.toml.
+        #[arg(long = "profile-file")]
+        profile_file: Option<PathBuf>,
+    },
+    /// Produce a read-only plan of concrete GitHub variables/selectors.
+    Plan {
+        /// Profile name.
+        name: String,
+        /// Owner/repo slug.
+        #[arg(long)]
+        repo: String,
+        /// Explicit profile TOML path. Defaults to .tartci/<name>.toml,
+        /// .shipyard/ci-profiles/<name>.toml, then ci-profiles/<name>.toml.
+        #[arg(long = "profile-file")]
+        profile_file: Option<PathBuf>,
     },
 }
 

--- a/src/app/command_evidence_cmd.rs
+++ b/src/app/command_evidence_cmd.rs
@@ -340,7 +340,7 @@ fn collect_local_artifacts(
                 .strip_prefix(cwd)
                 .map_err(|error| CliFailure::new(1, error.to_string()))?;
             let relative = safe_relative_path(relative)?;
-            let source = relative.display().to_string();
+            let source = slash_relative_path(&relative);
             if !seen.insert(source.clone()) {
                 matched = true;
                 continue;
@@ -513,6 +513,13 @@ fn safe_relative_path(path: &Path) -> Result<PathBuf, CliFailure> {
         return Err(CliFailure::new(1, "artifact path cannot be empty"));
     }
     Ok(output)
+}
+
+fn slash_relative_path(path: &Path) -> String {
+    path.components()
+        .map(|component| component.as_os_str().to_string_lossy())
+        .collect::<Vec<_>>()
+        .join("/")
 }
 
 fn git_identity(cwd: &Path) -> (Option<String>, Option<String>) {


### PR DESCRIPTION
## Summary\n- document tartci-backed routing profiles as a Shipyard fleet-router input\n- add provider-neutral `shipyard ci profile plan/show` support\n- parse repo-local profile TOML from `.tartci/`, `.shipyard/ci-profiles/`, or `ci-profiles/` without requiring tartci\n\n## Validation\n- `cargo fmt --all --check`\n- `cargo test ci_cmd -- --nocapture`\n- `cargo check`\n- `cargo run -- --cwd /Volumes/Workshop/Code/pulp-ci-routing-profile ci profile plan normal-local-fast --repo danielraffel/pulp --json`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a provider-neutral CI routing profile planner and `ci` CLI to inspect and plan GitHub runner placement from repo-owned TOML profiles. Provides read-only planning of concrete `runs-on` selectors and clarifies pre-dispatch fallback resolution.

- **New Features**
  - `shipyard ci profile show <name> [--profile-file <path>]` and `shipyard ci profile plan <name> --repo <owner/repo> [--profile-file <path>] [--json]`.
  - Profile discovery from `.tartci/`, `.shipyard/ci-profiles/`, or `ci-profiles/`; plan shows lane chains, selected target, compact `runs-on` JSON, and warnings for missing targets or non-ephemeral targets when required.
  - Wired `ci` into CLI and JSON outputs; docs updated across `README.md`, `docs/cli-reference.md`, `docs/profiles.md`, `skills/ci/SKILL.md`, and `skills/shipyard/SKILL.md` to clarify tartci host facts vs `shipyard` routing and read-only behavior.
  - Bumped `shipyard` to `0.71.0`; plugin version to `0.25.0`.

- **Bug Fixes**
  - Normalized evidence source paths to use forward slashes for stable cross-platform output.

<sup>Written for commit 3795eda0ac6092093c5b95442d71089d60f5ee19. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/Shipyard/pull/360?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

