### PR TITLE
fix: use GET for metrics GitHub import

### DIFF
--- a/planning/2026-06-12-ci-runtime-measurement-plan.md
+++ b/planning/2026-06-12-ci-runtime-measurement-plan.md
@@ -27,13 +27,16 @@ Validation so far:
 - isolated CLI smoke for `metrics record`, `metrics import tartci`,
   `metrics summary`, `metrics watch`, `metrics advise`
 - isolated CLI smoke proving `shipyard run command` writes a metrics summary row
+- merged PR #361: all GitHub checks green
+- merged-code proof: imported 2 real backfilled tartci timing records and 6 live
+  Pulp GitHub Actions job rows into one isolated `metrics.db`; `summary` and
+  `watch` returned agent-readable JSON
 
 Still required before calling the whole project complete:
 
-- Run the full Shipyard validation suite/CI.
-- Import live Pulp GitHub jobs and at least one live tartci runtime export into
-  the same store, then compare GitHub-hosted Windows/Linux against local VM
-  rows.
+- Run a live measured tartci VM job with `TARTCI_RUNTIME_MEASURE=1`; current
+  cross-repo proof uses real historical `timing.tsv` backfill plus live GitHub
+  job import, not a newly emitted VM runtime record.
 - Collect enough samples from `macstudio` and `m5` for the Phase 1 acceptance
   question to be meaningful.
 - Decide whether profile documentation should reference static example metrics

--- a/skills/ci/SKILL.md
+++ b/skills/ci/SKILL.md
@@ -64,6 +64,11 @@ Shipyard coordinates validation across local, SSH, and cloud targets.
 | Show logs for one target | `shipyard logs <job_id> --target windows` |
 | Check merge readiness | `shipyard evidence --json` |
 | Show latest command-evidence bundle | `shipyard evidence command --json` |
+| Import recent GitHub Actions timing into runner metrics | `shipyard metrics import github --repo <owner/repo> --limit 20 --json` |
+| Import tartci VM timing into runner metrics | `tartci runtime export --repo <owner/repo> | shipyard metrics import tartci --json` |
+| Summarize runner timing history | `shipyard metrics summary --project <name> --json` |
+| Ask for agent-readable runner health findings | `shipyard metrics watch --project <name> --since 14d --json` |
+| Compare local vs GitHub runner timing | `shipyard metrics compare --project <name> --baseline github-hosted --candidate macstudio --json` |
 | Bump job priority | `shipyard bump <job_id> high` |
 | Cancel a job | `shipyard cancel <job_id>` |
 | List cloud workflows | `shipyard cloud workflows --json` |
@@ -125,6 +130,38 @@ GitHub-hosted nightly Intel Linux/Windows lanes are compatibility surveillance.
 Windows QEMU on Apple Silicon is Windows ARM64; x64 MSVC/Prism execution is
 smoke/debug until proven and should not replace `windows-latest` authority.
 Coverage must use dedicated ephemeral labels, not warm bare-metal build pools.
+
+## Runner Metrics For Agents
+
+Runner metrics are optional and provider-neutral. Use them when an agent needs
+historical context before changing CI routing, cache policy, or monitoring
+cadence. Shipyard owns the local SQLite store and query surface; tartci, GitHub
+Actions, local commands, SSH targets, or other VM managers can feed the store.
+
+For GitHub-hosted history, import recent job timings:
+
+```sh
+shipyard metrics import github --repo danielraffel/pulp --limit 50 --json
+shipyard metrics watch --project pulp --since 14d --json
+```
+
+For tartci VM history, export runtime records from tartci and import them into
+Shipyard:
+
+```sh
+tartci runtime export --repo danielraffel/pulp |
+  shipyard metrics import tartci --json
+shipyard metrics summary --project pulp --json
+```
+
+The `summary`, `watch`, `advise`, and `compare` commands return structured JSON
+intended for agents. Treat insufficient-sample findings as "keep collecting",
+not as proof of a regression. Escalate only when the finding includes enough
+samples and a material delta for that repo/lane.
+
+When debugging GitHub imports, remember that Shipyard invokes `gh api` with
+absolute `/repos/...` paths and forces `-X GET` when query parameters are passed
+with `-f`; without `-X GET`, `gh api -f` can POST and produce misleading 404s.
 
 ## GitHub Auth Diagnostics
 

--- a/skills/shipyard/SKILL.md
+++ b/skills/shipyard/SKILL.md
@@ -65,6 +65,38 @@ bundles with `shipyard evidence command --list`. Artifact globs are relative to
 the target working directory (`cwd` for local targets, `repo_path` for SSH
 targets, or `--target-cwd` when overridden).
 
+## Runner Metrics
+
+Use `shipyard metrics` when an agent needs historical runner timing, queue, and
+health context before recommending a routing, cache, or monitoring change. The
+metrics store is optional and local to Shipyard state; projects do not need
+tartci to participate. GitHub-hosted workflows, local commands, SSH targets, and
+other VM managers can all record or import rows.
+
+`shipyard run command` writes a best-effort metrics row alongside command
+evidence. Import cloud and VM history explicitly when comparing local hardware
+with GitHub-hosted runners:
+
+```sh
+shipyard metrics import github --repo danielraffel/pulp --limit 50 --json
+tartci runtime export --repo danielraffel/pulp |
+  shipyard metrics import tartci --json
+shipyard metrics summary --project pulp --json
+shipyard metrics watch --project pulp --since 14d --json
+shipyard metrics advise --project pulp --json
+shipyard metrics compare --project pulp --baseline github-hosted --candidate macstudio --json
+```
+
+The agent-facing commands return conservative JSON findings. Low sample counts
+are a collection gap, not a regression. Prefer filing issues or changing
+profiles only when `watch`, `advise`, or `compare` reports enough samples and a
+material delta relative to that repo's baseline.
+
+When fixing GitHub importer bugs, keep Actions list endpoints absolute
+(`/repos/<owner>/<repo>/...`) and force `gh api -X GET` whenever `-f` supplies
+query parameters. `gh api -f` defaults to POST, which can turn a valid list
+endpoint into a misleading 404.
+
 ## GitHub Auth And Quota
 
 Shipyard's operational GitHub calls can be configured with `[github.auth]`.

--- a/src/app/metrics_cmd.rs
+++ b/src/app/metrics_cmd.rs
@@ -255,13 +255,11 @@ fn import_github(
     store: &MetricsStore,
     args: &MetricsImportGithubArgs,
 ) -> Result<usize, CliFailure> {
-    let workflow_path = args.workflow.as_ref().map_or_else(
-        || "/actions/runs".to_owned(),
-        |workflow| format!("/actions/workflows/{workflow}/runs"),
-    );
     let mut run_args = vec![
         "api".to_owned(),
-        format!("repos/{repo}{workflow_path}", repo = args.repo),
+        "-X".to_owned(),
+        "GET".to_owned(),
+        github_runs_api_path(&args.repo, args.workflow.as_deref()),
         "-f".to_owned(),
         format!("per_page={}", args.limit),
     ];
@@ -288,7 +286,9 @@ fn import_github(
     for run_id in run_ids {
         let jobs = gh_json(&[
             "api".to_owned(),
-            format!("repos/{}/actions/runs/{run_id}/jobs", args.repo),
+            "-X".to_owned(),
+            "GET".to_owned(),
+            github_jobs_api_path(&args.repo, run_id),
             "-f".to_owned(),
             "per_page=100".to_owned(),
         ])?;
@@ -307,6 +307,17 @@ fn import_github(
         }
     }
     Ok(imported)
+}
+
+fn github_runs_api_path(repo: &str, workflow: Option<&str>) -> String {
+    workflow.map_or_else(
+        || format!("/repos/{repo}/actions/runs"),
+        |workflow| format!("/repos/{repo}/actions/workflows/{workflow}/runs"),
+    )
+}
+
+fn github_jobs_api_path(repo: &str, run_id: i64) -> String {
+    format!("/repos/{repo}/actions/runs/{run_id}/jobs")
 }
 
 fn gh_json(args: &[String]) -> Result<Value, CliFailure> {
@@ -463,4 +474,25 @@ fn io_error(error: std::io::Error) -> CliFailure {
 #[allow(dead_code)]
 fn _json_debug(value: &impl Serialize) -> Value {
     json!(value)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn github_api_paths_are_absolute() {
+        assert_eq!(
+            github_runs_api_path("danielraffel/pulp", None),
+            "/repos/danielraffel/pulp/actions/runs"
+        );
+        assert_eq!(
+            github_runs_api_path("danielraffel/pulp", Some("build.yml")),
+            "/repos/danielraffel/pulp/actions/workflows/build.yml/runs"
+        );
+        assert_eq!(
+            github_jobs_api_path("danielraffel/pulp", 123),
+            "/repos/danielraffel/pulp/actions/runs/123/jobs"
+        );
+    }
 }


### PR DESCRIPTION
Fixes the GitHub Actions importer added in #361.\n\nWhat changed:\n- Build absolute `/repos/...` API paths for workflow run/job import.\n- Force `gh api -X GET` so `-f per_page=...` is sent as query params instead of turning list endpoints into POST.\n- Records merged-plan proof status.\n\nValidation:\n- `mise exec rust -- cargo test metrics_cmd::tests::github_api_paths_are_absolute --locked`\n- `mise exec rust -- cargo test metrics:: --locked`\n- `mise exec rust -- cargo clippy --all-targets --locked -- -D warnings`\n- live proof: imported 2 tartci timing rows + 6 live Pulp GitHub Actions job rows into one isolated `metrics.db`, then ran `summary` and `watch`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the GitHub Actions metrics importer by using absolute `/repos/...` API paths and forcing GET so pagination works. Updates runner-metrics docs with import commands and `gh api -X GET` troubleshooting notes.

- **Bug Fixes**
  - Use absolute paths for runs and jobs: `/repos/{repo}/actions/...`.
  - Call `gh api` with `-X GET` so `-f per_page=...` is sent as query params.
  - Add helpers for run/job paths and a unit test to prevent regressions.

<sup>Written for commit aeb8b1e8dd52c528e24272f51fe5a51cc23d1a1b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/Shipyard/pull/362?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

