### PR TITLE
feat(ship-state): report orphaned in-flight states in `ship-state list`

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "shipyard",
-  "version": "0.27.0",
+  "version": "0.28.0",
   "description": "Cross-platform CI coordination",
   "min_shipyard_version": "0.22.8",
   "commands": "./commands",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to Shipyard are documented here. Each entry links
 to its [GitHub Release](https://github.com/danielraffel/Shipyard/releases).
 
 <a id="v0730"></a>
+## [0.74.0]
+
 ## [0.73.0] - 2026-07-01
 
 - feat(preflight): opt-in host-health pre-dispatch gate ([#364](https://github.com/danielraffel/Shipyard/pull/364))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -693,7 +693,7 @@ dependencies = [
 
 [[package]]
 name = "shipyard"
-version = "0.73.0"
+version = "0.74.0"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shipyard"
-version = "0.73.0"
+version = "0.74.0"
 edition = "2024"
 description = "Cross-platform CI coordination for local, SSH, and cloud runners."
 rust-version = "1.92"

--- a/docs/ship-state-machine.md
+++ b/docs/ship-state-machine.md
@@ -357,6 +357,29 @@ inspection. `shipyard cleanup --ship-state` ages these out (see T12).
   - Ancestor SHA unknown or diff check fails → falls through to normal dispatch. No false-PASS risk from the reuse path itself.
   - Stage-list drift or validation-contract drift → reuse is refused by `reuse.py`; normal dispatch runs.
 
+## Diagnostic: orphan reporting (no transition)
+
+`STATE_IN_FLIGHT` has no self-healing exit when the owning process dies
+mid-validation (host reboot from a jetsam kill, daemon crash, `cmux` relaunch):
+nothing advances the state, `ship_terminal_verdict` stays `None`, and auto-merge
+reports `InFlight` forever without merging. The queue's killed-worker reaper
+(#351) recovers the sibling `queue.json` `Job`, but the ship-state store has no
+equivalent lifecycle.
+
+`shipyard ship-state list` surfaces these as a **read-only** diagnostic (no state
+transition, no write). A state is reported orphaned when `ship_terminal_verdict`
+is `None` (in flight — the exact predicate the auto-merge gate uses) *and*
+`updated_at` has been idle ≥ 45 minutes (`last_heartbeat_at` is unpopulated on
+ship-state, so `updated_at` is the only liveness signal). It is a staleness
+heuristic, not proof of death — ship-state is written once before a leg runs and
+not again until it reports, so a genuinely slow live leg can also trip it; the
+threshold is chosen above a normally-paced leg to keep that rare, and a false
+positive only invites an operator to look. Human output adds an `ORPHANED?:`
+line; JSON adds an `orphaned: [{pr, stalled_minutes}]` array. It cannot affect merge
+readiness — an orphan is by definition not a terminal `pass`. Recovery stays
+operator-driven (`shipyard ship <pr>` to re-validate, or `ship-state discard`);
+automatic resume is a deferred follow-up (`src/app/ship_state_cmd.rs`).
+
 ## External dependency matrix
 
 | External                               | Transitions         | Failure class               | Symptom + audit note                                                                                                 |

--- a/skills/ci/SKILL.md
+++ b/skills/ci/SKILL.md
@@ -86,6 +86,7 @@ Shipyard coordinates validation across local, SSH, and cloud targets.
 | Rescue a PR whose runs are wedged on a self-hosted runner | `shipyard rescue <pr>` (cancels + redispatches; add `--dry-run` to preview, `--rerun-failed` for completed cancelled/failed/timed-out runs; omit `--to` to re-resolve a failed leg local-first, or pass `--to <provider>` to force) |
 | Rescue every stuck run repo-wide | `shipyard rescue --all-stuck` |
 | Same-PR ship refused by a killed worker (`SamePrShipRunning`) | v0.68.0+ auto-reaps the stale `running` queue job after ~180s — just retry `shipyard pr`. See the `shipyard` skill's "Durable Queue: killed-worker recovery". Don't run two `shipyard pr`s for one PR concurrently. |
+| PR stuck in-flight forever (never auto-merges after a host reboot / daemon crash) | `shipyard ship-state list` flags it `ORPHANED?` when it's been in flight with no `updated_at` for ≥45m (JSON: `orphaned[]`). The owning ship process likely died mid-validation. Re-run `shipyard ship <pr>` to re-validate the head, or `shipyard ship-state discard <pr>` if it's truly dead. Report-only — it never merges or resumes on its own. See the `shipyard` skill's "Orphaned ship-state reporting". |
 | Skip a version-bump gate | `shipyard pr --skip-bump sdk --bump-reason "docs only"` |
 | Skip a skill-sync gate | `shipyard pr --skip-skill-update ci --skill-reason "mechanical"` |
 | Deliberately skip one lane | `shipyard run --skip-target windows` (repeatable; no probe run) |

--- a/skills/shipyard/SKILL.md
+++ b/skills/shipyard/SKILL.md
@@ -329,6 +329,41 @@ starts to the next pass rather than double-running the PR.
   discard <pr>`, then mark the stuck `queue.json` job terminal (or restart the
   daemon to trigger startup recovery).
 
+## Orphaned ship-state reporting
+
+The queue reaper above recovers the *queue* `Job` when a worker dies. The
+durable *ship-state* (`<state>/ship/<pr>.json`) is a separate store with no
+orphan lifecycle: when the owning process dies mid-validation (host reboot from
+a jetsam kill, daemon crash, `cmux` relaunch), the ship-state freezes in an
+in-flight verdict forever. `ship_terminal_verdict` returns `None`, so auto-merge
+reports `InFlight` and refuses to merge — the PR silently stalls with no signal.
+
+`shipyard ship-state list` now flags these. A state is **orphaned** when it is
+still in flight (same `ship_terminal_verdict` predicate the auto-merge gate uses,
+so the two never drift) *and* its `updated_at` has been idle for at least 45
+minutes. It's a staleness heuristic, not proof of death: ship-state is written
+once before a leg runs and not again until the leg reports, so a genuinely slow
+live leg (>45m under saturation) can also be flagged — `last_heartbeat_at` is
+unpopulated on ship-state, so `updated_at` is the only liveness signal. The
+human listing prints an `ORPHANED?: ...` line under the PR; the JSON envelope
+gains an `orphaned: [{pr, stalled_minutes}]` array.
+
+This is **report-only** — it never resumes, re-dispatches, or mutates the store,
+and cannot affect merge readiness (an orphan is by definition not `pass`).
+Recovery is still operator-driven: re-run `shipyard ship <pr>` to re-validate
+the head, or `shipyard ship-state discard <pr>` to drop a dead entry. Automatic
+resume is a deliberately deferred follow-up.
+
+### Gotchas
+
+- The 45-minute threshold trades a rare false positive (a genuinely slow live
+  ship idle >45m between evidence writes) for never mislabeling a normal ship.
+  A false positive is harmless here — it only invites an operator to look; it
+  cannot merge or cancel anything. Don't shorten it toward normal leg durations.
+- Orphan status is computed lazily at `ship-state list` time; there is no daemon
+  startup sweep and nothing is written back. A state stops being reported the
+  moment a live ship touches it again or it reaches a verdict.
+
 ## Runner Provisioning (register / list / remove / tag)
 
 The `runner` family also *provisions* self-hosted GitHub Actions runners, not

--- a/src/app/ship_state_cmd.rs
+++ b/src/app/ship_state_cmd.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 use std::io::Write;
 
-use chrono::Utc;
+use chrono::{DateTime, Utc};
 use serde_json::Value;
 
 use crate::identity::RuntimeMode;
@@ -11,6 +11,42 @@ use crate::reconcile::{
 };
 use crate::ship_state::ShipState;
 use crate::ship_state::ShipStateStore;
+use crate::watch::ship_terminal_verdict;
+
+/// Minutes of `updated_at` staleness past which an in-flight ship state is
+/// treated as (probably) orphaned. When a ship's owning process dies
+/// mid-validation (host reboot from a jetsam kill, daemon crash, `cmux`
+/// relaunch) nothing advances the durable ship state and it stalls in an
+/// in-flight verdict forever.
+///
+/// This is a staleness heuristic, not proof of process death: ship-state is
+/// written once before a target runs and not again until the leg reports, so a
+/// *live* ship whose single leg runs longer than this (heavy validation under
+/// host saturation) can also be flagged. The threshold is chosen well above a
+/// normally-paced leg to keep that rare. The false positive is acceptable
+/// because this is a report-only diagnostic: it costs an operator a second look,
+/// never a wrong merge (an orphan is in-flight, which auto-merge already
+/// refuses).
+const ORPHAN_STALE_MINUTES: i64 = 45;
+
+/// Report-only orphan check for the `ship-state list` diagnostic.
+///
+/// Returns `Some(stalled_minutes)` when a state is still in flight yet has not
+/// been touched for at least [`ORPHAN_STALE_MINUTES`], otherwise `None`.
+///
+/// "In flight" reuses [`ship_terminal_verdict`] — the exact predicate the
+/// auto-merge gate uses — so a flagged state can never be mistaken for
+/// merge-ready: `ship_terminal_verdict` returns `None`, so auto-merge reports
+/// `InFlight` and refuses to merge. Surfacing it here does not resume,
+/// re-dispatch, or mutate anything; it only makes the silent stall visible so
+/// an operator can re-run `shipyard ship`.
+fn orphan_stalled_minutes(state: &ShipState, now: DateTime<Utc>) -> Option<i64> {
+    if ship_terminal_verdict(state).is_some() {
+        return None;
+    }
+    let stalled = now.signed_duration_since(state.updated_at).num_minutes();
+    (stalled >= ORPHAN_STALE_MINUTES).then_some(stalled)
+}
 
 pub(super) fn ship_state_list<W: Write>(
     store: &ShipStateStore,
@@ -18,9 +54,19 @@ pub(super) fn ship_state_list<W: Write>(
     stdout: &mut W,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let states = store.list_active();
+    let now = Utc::now();
     if json {
+        let orphaned = states
+            .iter()
+            .filter_map(|state| {
+                orphan_stalled_minutes(state, now).map(
+                    |stalled| serde_json::json!({ "pr": state.pr, "stalled_minutes": stalled }),
+                )
+            })
+            .collect::<Vec<_>>();
         let mut data = BTreeMap::new();
-        data.insert("states".to_owned(), serde_json::to_value(states)?);
+        data.insert("states".to_owned(), serde_json::to_value(&states)?);
+        data.insert("orphaned".to_owned(), Value::Array(orphaned));
         write_json_envelope(stdout, "ship-state:list", data)?;
         return Ok(());
     }
@@ -28,8 +74,7 @@ pub(super) fn ship_state_list<W: Write>(
         writeln!(stdout, "No active ship state.")?;
         return Ok(());
     }
-    let now = Utc::now();
-    for state in states {
+    for state in &states {
         let age = now
             .signed_duration_since(state.updated_at)
             .num_minutes()
@@ -51,6 +96,14 @@ pub(super) fn ship_state_list<W: Write>(
             age,
             title
         )?;
+        if let Some(stalled) = orphan_stalled_minutes(state, now) {
+            writeln!(
+                stdout,
+                "    ORPHANED?: in flight with no update for {stalled}m (owning process may \
+                 have died mid-validation); auto-merge will not fire until it reaches a verdict \
+                 — re-run `shipyard ship`, or `ship-state discard` if it is truly dead."
+            )?;
+        }
         if !state.pr_url.is_empty() {
             writeln!(stdout, "    {}", state.pr_url)?;
         }
@@ -292,8 +345,8 @@ mod tests {
     use tempfile::TempDir;
 
     use super::{
-        abbreviate_sha, ship_state_discard, ship_state_list, ship_state_reconcile_with,
-        ship_state_show,
+        ORPHAN_STALE_MINUTES, abbreviate_sha, orphan_stalled_minutes, ship_state_discard,
+        ship_state_list, ship_state_reconcile_with, ship_state_show,
     };
     use crate::reconcile::ReconcileFetchError;
     use crate::ship_state::{DispatchedRun, ShipState, ShipStateStore};
@@ -388,6 +441,82 @@ mod tests {
         assert_eq!(payload["schema_version"], 1);
         assert_eq!(payload["states"][0]["pr"], 2);
         assert_eq!(payload["states"][1]["pr"], 9);
+    }
+
+    /// A ship that reached a terminal verdict (all required evidence `pass`) is
+    /// never orphaned, no matter how old — its stall would be a merge/cleanup
+    /// gap, not a dead-process orphan.
+    #[test]
+    fn orphan_ignores_terminal_verdict_states() {
+        let mut state = sample_state(1, "1111111111111111111111111111111111111111");
+        state.update_evidence("linux", "pass");
+        state.dispatched_runs.push(sample_run("linux", "run-1"));
+        state.updated_at = Utc::now() - Duration::hours(6);
+
+        assert!(orphan_stalled_minutes(&state, Utc::now()).is_none());
+    }
+
+    /// A freshly-touched in-flight ship (empty evidence) is in flight but not
+    /// yet stale — a live validation, not an orphan.
+    #[test]
+    fn orphan_ignores_fresh_in_flight_states() {
+        let mut state = sample_state(2, "2222222222222222222222222222222222222222");
+        state.updated_at = Utc::now() - Duration::minutes(ORPHAN_STALE_MINUTES - 5);
+
+        assert!(orphan_stalled_minutes(&state, Utc::now()).is_none());
+    }
+
+    /// An in-flight ship untouched past the threshold is orphaned; the reported
+    /// stall reflects the `updated_at` age.
+    #[test]
+    fn orphan_flags_stale_in_flight_states() {
+        let mut state = sample_state(3, "3333333333333333333333333333333333333333");
+        state.updated_at = Utc::now() - Duration::minutes(ORPHAN_STALE_MINUTES + 20);
+
+        let stalled = orphan_stalled_minutes(&state, Utc::now()).expect("should be orphaned");
+        assert!(stalled >= ORPHAN_STALE_MINUTES + 19, "stalled={stalled}");
+    }
+
+    #[test]
+    fn list_json_reports_orphaned_prs() {
+        let temp = TempDir::new().expect("tempdir");
+        let store = store(&temp);
+        // Stale in-flight → orphaned.
+        let mut orphan = sample_state(3, "3333333333333333333333333333333333333333");
+        orphan.updated_at = Utc::now() - Duration::minutes(ORPHAN_STALE_MINUTES + 10);
+        store.save(&orphan).expect("state should save");
+        // Terminal verdict → not orphaned even though also old.
+        let mut done = sample_state(4, "4444444444444444444444444444444444444444");
+        done.update_evidence("linux", "pass");
+        done.dispatched_runs.push(sample_run("linux", "run-4"));
+        done.updated_at = Utc::now() - Duration::hours(3);
+        store.save(&done).expect("state should save");
+        let mut out = Vec::new();
+
+        ship_state_list(&store, true, &mut out).expect("list should render");
+
+        let payload: Value = serde_json::from_slice(&out).expect("json payload");
+        let orphaned = payload["orphaned"].as_array().expect("orphaned array");
+        assert_eq!(orphaned.len(), 1, "only the stale in-flight PR is orphaned");
+        assert_eq!(orphaned[0]["pr"], 3);
+        assert!(orphaned[0]["stalled_minutes"].as_i64().unwrap() >= ORPHAN_STALE_MINUTES);
+    }
+
+    #[test]
+    fn list_human_marks_orphaned_state() {
+        let temp = TempDir::new().expect("tempdir");
+        let store = store(&temp);
+        let mut state = sample_state(5, "5555555555555555555555555555555555555555");
+        state.updated_at = Utc::now() - Duration::minutes(ORPHAN_STALE_MINUTES + 30);
+        store.save(&state).expect("state should save");
+        let mut out = Vec::new();
+
+        ship_state_list(&store, false, &mut out).expect("list should render");
+
+        let text = String::from_utf8(out).expect("utf8");
+        assert!(text.contains("PR #5"));
+        assert!(text.contains("ORPHANED"), "text was: {text}");
+        assert!(text.contains("re-run `shipyard ship`"));
     }
 
     #[test]


### PR DESCRIPTION
## What

`shipyard ship-state list` now flags **orphaned** ship states — read-only, no behavior change to merging or dispatch.

When a `shipyard ship` process dies mid-validation (host reboot from a jetsam kill, daemon crash, `cmux` relaunch), the durable ship-state has no orphan lifecycle: it freezes in an in-flight verdict, `ship_terminal_verdict` stays `None`, and auto-merge silently never fires. The queue already has a killed-worker reaper (#351) for its sibling `Job`; the ship-state store did not.

## How

A state is flagged when it is **still in flight** — the exact `ship_terminal_verdict` predicate the auto-merge gate uses, so the two can never drift — **and** its `updated_at` has been idle ≥ 45 min.

- Human output gains an `ORPHANED?:` line under the PR.
- JSON envelope gains an `orphaned: [{pr, stalled_minutes}]` array (additive).

It's a **staleness heuristic, not proof of death**: ship-state is written once before a leg runs and not again until it reports, so a genuinely slow live leg (>45 min under saturation) can also be flagged. The threshold sits well above a normally-paced leg to keep that rare, and a false positive only invites an operator to look — it can never merge or cancel anything.

## Safety

- **Report-only.** No `save`/`delete`/`archive`/queue/daemon call. Pure read in a diagnostic command.
- **Cannot affect merge readiness.** A flagged state is in-flight → `ship_terminal_verdict` returns `None` → auto-merge reports `InFlight` and refuses. The harm it surfaces is the *inverse* — a PR that silently never merges.
- Recovery stays operator-driven: `shipyard ship <pr>` to re-validate, or `ship-state discard`. **Automatic resume is a deliberately deferred follow-up.**

## Tests

`orphan_ignores_terminal_verdict_states`, `orphan_ignores_fresh_in_flight_states`, `orphan_flags_stale_in_flight_states`, `list_json_reports_orphaned_prs`, `list_human_marks_orphaned_state`. Full suite: 954 passed; fmt + clippy (`-D warnings`) clean.

## Review

Adversarially reviewed (Codex): **must-fix none**; merge-safety and panic/overflow confirmed clean. One should-fix applied — softened comment/output wording that overstated confidence that the process "died" and that a live ship is "never" mislabeled.

Part 3 of the restart-safe ship-state workstream.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
`shipyard ship-state list` now reports likely orphaned in-flight ship states to surface PRs that will never auto-merge after a crashed/restarted worker. This is read-only and does not change merge behavior.

- **New Features**
  - Flags states still in flight with `updated_at` idle ≥45m (same `ship_terminal_verdict` predicate as auto-merge, so no drift). Heuristic only, not proof of death.
  - Human output adds an `ORPHANED?:` line; JSON adds `orphaned: [{pr, stalled_minutes}]`.
  - No writes or resume logic. To recover, re-run `shipyard ship <pr>` or `shipyard ship-state discard <pr>`.

<sup>Written for commit c8e03b99ae0eba33db421f52066b8bd80e4d0566. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/danielraffel/Shipyard/pull/366?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

